### PR TITLE
Increase timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
   agent any
   options {
-    timeout(time: 10, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     timestamps ()
   }
   stages {


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/NEWSART-541

Increases the timeout of the job to 30 minutes.

- [x] JIRA ticket added
- [x] Pull request URL added to JIRA ticket
- [x] Up-to-date with latest - `git pull --rebase origin latest`
- [x] Runs locally - `npm run dev` & [http://localhost:3000/](http://localhost:3000/)
- [ ] ~~Tests added for new features~~
- [x] Tests pass - `npm test`

- [ ] Test engineer approval
