### PR TITLE
Newsart 526 make cypress tests configurable per env

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-	"video": false
+	"video": false,
+	"baseUrl": "http://localhost:7080"
 }

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -1,8 +1,7 @@
-const url = 'http://localhost:7080';
 describe('News Article', () => {
 
     beforeEach(() => {
-        cy.visit(url)
+        cy.visit('/')
     })
 
     it('should render a headline', () => {
@@ -17,7 +16,7 @@ describe('News Article', () => {
 
 describe('Renderer Status', () => {
     it('should display 200/OK', () => {
-        cy.request(url + '/status').then((response) => {
+        cy.request('/status').then((response) => {
             expect(response.status).to.eq(200)
         })
     })


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/NEWSART-526

_This PR changes the Cypress config to use the baseUrl value which can then be changed on CI environments. See https://docs.cypress.io/guides/guides/environment-variables.html#Option-4-env for more details. My suggestions are to use option 3 or 4._

* [x] JIRA ticket added
* [x] Pull request URL added to JIRA ticket
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`

* [x] Test engineer approval
