### PR TITLE
Statically serve files in /data

### DIFF
--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -5,9 +5,11 @@ describe('Static Articles data', () => {
     });
   });
 
-  it('should output valid JSON', () => {
-    cy.request('/data/scenario-01.json').then(({ body }) => {
-      expect(body).to.be.an('object');
+  describe('Response Body', () => {
+    it('should be an object', () => {
+      cy.request('/data/scenario-01.json').then(({ body }) => {
+        expect(body).to.be.an('object');
+      });
     });
   });
 });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,21 +1,31 @@
 describe('Static Articles data', () => {
-  const testScenarioRequest = (testTitle, testAssertion) => {
-    it(testTitle, () => {
-      cy.request(`/data/scenario-01.json`).then(testAssertion);
+  let responseStatus;
+  let responseBody;
+
+  const testScenarioResponse = (title, assertion) => {
+    it(title, () => {
+      assertion();
     });
   };
 
-  testScenarioRequest('should return a 200 status code', ({ status }) => {
-    expect(status).to.eq(200);
+  beforeEach(() => {
+    cy.request(`/data/scenario-01.json`).then(({ status, body }) => {
+      responseStatus = status;
+      responseBody = body;
+    });
+  });
+
+  testScenarioResponse('should return a 200 status code', () => {
+    expect(responseStatus).to.eq(200);
   });
 
   describe('Response Body', () => {
-    testScenarioRequest('should be an object', ({ body }) => {
-      expect(body).to.be.an('object');
+    testScenarioResponse('should be an object', () => {
+      expect(responseBody).to.be.an('object');
     });
 
-    testScenarioRequest('should contain a blocks object', ({ body }) => {
-      expect(body).to.have.property('blocks');
+    testScenarioResponse('should contain a blocks object', () => {
+      expect(responseBody).to.have.property('blocks');
     });
   });
 });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -11,5 +11,11 @@ describe('Static Articles data', () => {
         expect(body).to.be.an('object');
       });
     });
+
+    it('should contain a blocks object', () => {
+      cy.request('/data/scenario-01.json').then(({ body }) => {
+        expect(body).to.have.property('blocks');
+      });
+    });
   });
 });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,5 +1,5 @@
 describe('Static Articles data', () => {
-  it('should display 200/OK', () => {
+  it('should return a status code of 200', () => {
     cy.request('/data/scenario-01.json').then(({ status }) => {
       expect(status).to.eq(200);
     });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,21 +1,25 @@
 describe('Static Articles data', () => {
-  it('should return a status code of 200', () => {
-    cy.request('/data/scenario-01.json').then(({ status }) => {
-      expect(status).to.eq(200);
+  const testScenarioRequest = (testTitle, scenarioNumber, testAssertion) => {
+    it(testTitle, () => {
+      cy.request(`/data/scenario-${scenarioNumber}.json`).then(testAssertion);
     });
-  });
+  };
+
+  testScenarioRequest(
+    'should return a status code of 200',
+    '01',
+    ({ status }) => {
+      expect(status).to.eq(200);
+    },
+  );
 
   describe('Response Body', () => {
-    it('should be an object', () => {
-      cy.request('/data/scenario-01.json').then(({ body }) => {
-        expect(body).to.be.an('object');
-      });
+    testScenarioRequest('should be an object', '01', ({ body }) => {
+      expect(body).to.be.an('object');
     });
 
-    it('should contain a blocks object', () => {
-      cy.request('/data/scenario-01.json').then(({ body }) => {
-        expect(body).to.have.property('blocks');
-      });
+    testScenarioRequest('should contain a blocks object', '01', ({ body }) => {
+      expect(body).to.have.property('blocks');
     });
   });
 });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -5,13 +5,9 @@ describe('Static Articles data', () => {
     });
   };
 
-  testScenarioRequest(
-    'should return a status code of 200',
-    '01',
-    ({ status }) => {
-      expect(status).to.eq(200);
-    },
-  );
+  testScenarioRequest('should return a 200 status code', '01', ({ status }) => {
+    expect(status).to.eq(200);
+  });
 
   describe('Response Body', () => {
     testScenarioRequest('should be an object', '01', ({ body }) => {

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,15 +1,13 @@
 describe('Static Articles data', () => {
-
   it('should display 200/OK', () => {
     cy.request('/data/scenario-01.json').then(({ status }) => {
-        expect(status).to.eq(200)
-
-  })
-})
+      expect(status).to.eq(200);
+    });
+  });
 
   it('should output valid JSON', () => {
-      cy.request('/data/scenario-01.json').then(({ body}) => {
-          expect(body).to.be.an("object")
-      })
-  })
-})
+    cy.request('/data/scenario-01.json').then(({ body }) => {
+      expect(body).to.be.an('object');
+    });
+  });
+});

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,20 +1,20 @@
 describe('Static Articles data', () => {
-  const testScenarioRequest = (testTitle, scenarioNumber, testAssertion) => {
+  const testScenarioRequest = (testTitle, testAssertion) => {
     it(testTitle, () => {
-      cy.request(`/data/scenario-${scenarioNumber}.json`).then(testAssertion);
+      cy.request(`/data/scenario-01.json`).then(testAssertion);
     });
   };
 
-  testScenarioRequest('should return a 200 status code', '01', ({ status }) => {
+  testScenarioRequest('should return a 200 status code', ({ status }) => {
     expect(status).to.eq(200);
   });
 
   describe('Response Body', () => {
-    testScenarioRequest('should be an object', '01', ({ body }) => {
+    testScenarioRequest('should be an object', ({ body }) => {
       expect(body).to.be.an('object');
     });
 
-    testScenarioRequest('should contain a blocks object', '01', ({ body }) => {
+    testScenarioRequest('should contain a blocks object', ({ body }) => {
       expect(body).to.have.property('blocks');
     });
   });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,0 +1,15 @@
+describe('Static Articles data', () => {
+
+  it('should display 200/OK', () => {
+    cy.request('/data/scenario-01.json').then(({ status }) => {
+        expect(status).to.eq(200)
+
+  })
+})
+
+  it('should output valid JSON', () => {
+      cy.request('/data/scenario-01.json').then(({ body}) => {
+          expect(body).to.be.an("object")
+      })
+  })
+})

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,7 +9,7 @@ const assets = require(process.env.RAZZLE_ASSETS_MANIFEST);
 const server = express();
 server
   .disable('x-powered-by')
-  .use("/data", express.static('data'))
+  .use('/data', express.static('data'))
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR))
   .get('/status', (req, res) => {
     res.sendStatus(200);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,6 +9,7 @@ const assets = require(process.env.RAZZLE_ASSETS_MANIFEST);
 const server = express();
 server
   .disable('x-powered-by')
+  .use("/data", express.static('data'))
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR))
   .get('/status', (req, res) => {
     res.sendStatus(200);


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/NEWSART-546

_Statically serves all files in the `/data` directory over `/data`._

* [x] JIRA ticket added
* [x] Pull request URL added to JIRA ticket
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
