### PR TITLE
Replace references to JIRA with Github issues

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
-JIRA: https://jira.dev.bbc.co.uk/browse/YOUR-TICKET
-
 _PR changes summary to go here._
 
-* [ ] JIRA ticket added
-* [ ] Pull request URL added to JIRA ticket
+* [ ] Issue linked https://github.com/bbc/simorgh/issues/NUMBER
 * [ ] Up-to-date with latest - `git pull --rebase origin latest`
 * [ ] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
 * [ ] Tests added for new features


### PR DESCRIPTION
Replace references to JIRA in ` PULL_REQUEST_TEMPLATE.md` with Github issues
Addresses this Issue https://github.com/bbc/simorgh/issues/61

* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* ~[ ] Tests added for new features~ N/A
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
