### PR TITLE
Single command for E2E tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We use [Cypress](https://www.cypress.io/) for our end-to-end tests. For running 
 npm run test:e2e
 ```
 
-It will spin up a development server and run the Cypress tests against that.
+It will spin up a production server on port 7080 and run the Cypress tests against that.
 
 Further details on using the Cypress CLI can be found at https://docs.cypress.io/guides/guides/command-line.html
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ We have [Jest](https://facebook.github.io/jest) unit tests that can be run with 
 
 #### Main application
 
-We use [Cypress](https://www.cypress.io/) for our end-to-end tests. For running the tests locally we need two terminals running:
+We use [Cypress](https://www.cypress.io/) for our end-to-end tests. For running the tests locally, run this single command:
 
-1. `npm run dev` with the application,
-2. `npm run test:e2e` with the Cypress integration tests.
+```
+npm run test:e2e
+```
 
-Tests can also be run in isolation like this `npm run test:e2e -- --spec cypress/integration/article_spec.js`.
+It will spin up a development server and run the Cypress tests against that.
+
 Further details on using the Cypress CLI can be found at https://docs.cypress.io/guides/guides/command-line.html
+
 Cypress can be run interactively using `npm run test:e2e:interactive`. This loads a user interface which easily allows for indivdual tests to be run alongside a visual stream of the browser, as the tests run.
 
 #### Storybook

--- a/package-lock.json
+++ b/package-lock.json
@@ -5465,6 +5465,21 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -6127,6 +6142,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -9784,6 +9805,12 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9843,6 +9870,12 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "meow": {
       "version": "3.7.0",
@@ -10300,6 +10333,86 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.3.tgz",
+      "integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.4",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "ps-tree": "^1.1.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -10824,6 +10937,15 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
         "pify": "^2.0.0"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -12867,6 +12989,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "~3.3.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -14984,6 +15115,15 @@
         "meow": "^3.7.0"
       }
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15070,6 +15210,15 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress",
+    "test:e2e": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress",
     "test:e2e:ci": "npm run build && run-p --race start cypress",
-    "test:e2e:interactive": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress:interactive",
+    "test:e2e:interactive": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
     "test:e2e": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress",
+    "test:e2e:ci": "npm run build && run-p --race start cypress",
     "test:e2e:dev": "kill $(lsof -t -i:7080) && run-p --race dev cypress",
     "test:e2e:dev:interactive": "kill $(lsof -t -i:7080) && run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "run-p --race dev cypress",
+    "test:e2e": "run-p --race start cypress",
+    "test:e2e:dev": "run-p --race dev cypress",
     "test:e2e:interactive": "run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "run-p --race start cypress",
+    "test:e2e": "npm run build && run-p --race start cypress",
     "test:e2e:dev": "run-p --race dev cypress",
     "test:e2e:interactive": "run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "start": "NODE_ENV=production node build/server.js",
     "speculate": "speculate",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "cypress": "npx cypress run",
+    "cypress:run": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "run-p --race dev cypress",
+    "test:e2e": "run-p --race dev cypress:run",
     "test:e2e:interactive": "run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "cypress:interactive": "npx cypress open",
     "test:e2e": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress",
     "test:e2e:ci": "npm run build && run-p --race start cypress",
-    "test:e2e:dev": "kill $(lsof -t -i:7080) && run-p --race dev cypress",
-    "test:e2e:dev:interactive": "kill $(lsof -t -i:7080) && run-p --race dev cypress:interactive",
+    "test:e2e:interactive": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "start": "NODE_ENV=production node build/server.js",
     "speculate": "speculate",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "test:e2e": "npx cypress run",
-    "test:e2e:interactive": "npx cypress open",
+    "cypress": "npx cypress run",
+    "cypress:interactive": "npx cypress open",
+    "test:e2e": "run-p --race dev cypress",
+    "test:e2e:interactive": "run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"
   },
@@ -60,6 +62,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "jest-fetch-mock": "^1.6.2",
     "lighthouse": "^2.9.4",
+    "npm-run-all": "^4.1.3",
     "prettier": "1.13.5",
     "supertest": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "npm run build && run-p --race start cypress",
-    "test:e2e:dev": "run-p --race dev cypress",
-    "test:e2e:interactive": "run-p --race dev cypress:interactive",
+    "test:e2e": "kill $(lsof -t -i:7080) && npm run build && run-p --race start cypress",
+    "test:e2e:dev": "kill $(lsof -t -i:7080) && run-p --race dev cypress",
+    "test:e2e:dev:interactive": "kill $(lsof -t -i:7080) && run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"
   },

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "start": "NODE_ENV=production node build/server.js",
     "speculate": "speculate",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "cypress:run": "npx cypress run",
+    "cypress": "npx cypress run",
     "cypress:interactive": "npx cypress open",
-    "test:e2e": "run-p --race dev cypress:run",
+    "test:e2e": "run-p --race dev cypress",
     "test:e2e:interactive": "run-p --race dev cypress:interactive",
     "test:storybook": "npx cypress run --project ./.storybook/",
     "lighthouse": "lighthouse http://localhost:7080/ --output-path=./reports/report.html --view"


### PR DESCRIPTION
Fixes #53 

Updates the `test:e2e` and `test:e2e:interactive` scripts to run without needing two terminals.
Adds a `test:e2e:ci` script, suitable for running on CI.

```
"scripts": {
  "cypress": "npx cypress run",
  "cypress:interactive": "npx cypress open",
  "test:e2e": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress",
  "test:e2e:ci": "npm run build && run-p --race start cypress",
  "test:e2e:interactive": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress:interactive",
}
```
`run-p` runs jobs in parallel. It's a binary that is included with the npm module `npm-run-all`.
This command will start the dev server, execute all end to end tests and then will close the server.

`run-p` is preferable to using `&`, since it also works on Windows machines and when passed the `--race` flag it closes the server after the other command exits.  

To test that the server is closed, when the tests finish, run `ps`. There should not be any node processes.

**Which should I use?**
`test:e2e:ci` runs the production server with cypress (suitable for ci)
`test:e2e` checks if there is an existing process on port 7080 and if there is kills it, then runs the production server with cypress (suitable for local use)
`test:e2e:interactive` checks if there is an existing process on port 7080 and if there is kills it, then runs the production  server with interactive cypress (suitable for local use)

**References:** 
https://www.cypress.io/blog/2017/05/30/cypress-and-immutable-deploys/#Run-end-to-end-tests-locally
https://github.com/mysticatea/npm-run-all/blob/master/docs/run-p.md#npm-scripts 

* [x] Issue linked https://github.com/bbc/simorgh/issues/53
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* ~[ ] Tests added for new features~ N/A
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval

There will be a separate issue to run this on Travis and Jenkins CIs. 