### PR TITLE
Add schema from swagger

### DIFF
--- a/data/schema.yaml
+++ b/data/schema.yaml
@@ -1,0 +1,338 @@
+openapi: 3.0.0
+servers:
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/no-name2/article/1.0.0
+info:
+  description: This is an early draft of an Article API definition for web and apps.
+  version: "1.1.1"
+  title: News web and apps article API
+  contact:
+    email: benjamin.hobbs@bbc.co.uk
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: news-developers
+    description: Operations available to and wanted by news developers
+paths:
+  /article:
+    get:
+      tags:
+      - news-developers
+      summary: returns article/s
+      operationId: getArticles
+      description: |
+        By passing in the appropriate parameters, you can return the appropriate article/s body from the system
+      parameters:
+        - in: query
+          name: searchString
+          description: pass the optional search string for looking up articles
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: skip
+          description: number of records to skip for pagination
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: maximum number of records to return
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 50
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Article'
+        '400':
+          description: bad input parameter/s
+components:
+  schemas:
+    Article:
+      type: object
+      required:
+      - locator
+      - language
+      - publishedDateTime
+      - lastUpdatedDateTime
+      - passport
+      - seoHeadline
+      - socialHeadline
+      - metaDescription
+      - blocks
+      properties:
+        locator:
+          type: string
+          format: uuid
+          example: urn:bjk:hello:asset:c000zk2l88wo
+        passport:
+          type: object
+          required:
+          - home
+          - language
+          - articleType
+          properties:
+            language:
+              type: string
+              example: en-gb
+            home:
+              type: string
+              example: http://www.bbc.co.uk/ontologies/passport/home/News
+            articleType:
+              type: string
+              enum: [analysis, feature]
+              example: analysis
+        seoHeadline:
+          type: string
+          example: UK pledges extra £44m for Channel border security
+        socialHeadline:
+          type: string
+          example: You will never believe how much money UK pledges for Channel border security
+        publishedDateTime:
+          type: string
+          format: date-time
+          example: 2017-07-21T17:32:28Z
+        lastUpdatedDateTime:
+          type: string
+          format: date-time
+          example: 2017-12-21T17:32:28Z
+        MetaDescription:
+          type: boolean
+          example: null
+        model:
+          type: object
+          properties:
+            blocks:
+              properties:
+                blockId:
+                  type: string
+                  example: 0f29a57f-3492-3c0d-af51-837208b657fb
+                type:
+                  type: string
+                  enum: [Headline, Text,altText, paragraph, Image, caption, Video, rawImage, rawVideo]
+                model:
+                  oneOf:
+                  - $ref: '#/components/schemas/Article/properties/model/properties/blocks'
+                  - $ref: '#/components/schemas/Text'
+                  - $ref: '#/components/schemas/Image'
+                  - $ref: '#/components/schemas/Headline'
+                  - $ref: '#/components/schemas/altText'
+                  - $ref: '#/components/schemas/Paragraph'
+                  - $ref: '#/components/schemas/Caption'
+                  - $ref: '#/components/schemas/Video'
+                  - $ref: '#/components/schemas/rawVideo'
+                  - $ref: '#/components/schemas/rawImage'
+                  - $ref: '#/components/schemas/Model'
+                  - $ref: '#/components/schemas/rawImageBlock'
+                  - $ref: '#/components/schemas/rawVideoBlock'
+
+              example:
+                  blockid: 0f29a57f-3492-3c0d-af51-837208b657fb
+                  type: image
+                  model:
+                    # Properties of a referenced object
+    Image:
+      type: object
+      required:
+      - blockId
+      - type
+      - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [text]
+        model:
+          $ref: '#/components/schemas/rawImageBlock'
+    Text:
+      type: object
+      required:
+      - blockId
+      - type
+      - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [text]
+        model:
+          $ref: '#/components/schemas/Article/properties/model'
+    Headline:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [headline]
+        model:
+          $ref: '#/components/schemas/Article/properties/model'
+    altText:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [altText]
+        model:
+          $ref: '#/components/schemas/Article/properties/model'
+    Paragraph:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [paragraph]
+        model:
+          $ref: '#/components/schemas/Article/properties/model'
+    Caption:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [caption]
+        model:
+          $ref: '#/components/schemas/Article/properties/model'
+    Video:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [Video]
+        model:
+          $ref: '#/components/schemas/rawVideoBlock'
+    rawVideo:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [rawVideo]
+        model:
+          type: object
+          required:
+          - guidance
+          - isLive
+          - duration
+          - allowOffsiteEmbedding
+          - locator
+          properties:
+            guidance:
+              type: boolean
+              example: null
+            isLive:
+              type: string
+              example: false
+            duration:
+              type: string
+              example: PTSVHD02
+            allowffsiteEmbedding:
+              type: string
+              example: false
+            locator:
+              type: string
+              example:
+    rawImage:
+      type: object
+      required:
+        - blockId
+        - type
+        - model
+      properties:
+        blockId:
+          type: string
+          example: 0f29a57f-3492-3c0d-af51-837208b657fb
+        type:
+          type: string
+          enum: [rawImage]
+        model:
+          type: object
+          required:
+          - width
+          - height
+          - locator
+          - originCode
+          - copyrightHolder
+          properties:
+            width:
+              type: integer
+              example: 640
+            height:
+              type: integer
+              example: 420
+            locator:
+              type: string
+              example: https://fishchips.co.uk/images/ic/640x360/p052ww1r.jpg
+            originCode:
+              type: boolean
+              example: null
+            copyrightHolder:
+              type: string
+              example: BBC
+    Model:
+      type: object
+      required:
+        - text
+      properties:
+        text:
+          type: string
+          example: Aliquam quis sodales nisl.
+    rawImageBlock:
+      properties:
+        blocks:
+            $ref: '#/components/schemas/rawImage'
+    rawVideoBlock:
+      properties:
+        blocks:
+            $ref: '#/components/schemas/rawVideo'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6709,6 +6709,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
+    },
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
@@ -9770,6 +9776,18 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-ref-parser": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.0.3.tgz",
+      "integrity": "sha512-RCZE9RpvMG2zY+dSSQkqHxsCYaqBYlh/u2PWWRdWMvtaH718YqR73lYu4IW4cGNxJIkUnIgTMuJtp+A1tIn4+w==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "js-yaml": "^3.11.0",
+        "ono": "^4.0.3"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -9815,6 +9833,18 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "jsonschema-draft4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
+      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -10544,6 +10574,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isarguments": {
@@ -11601,6 +11637,26 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "ono": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.5.tgz",
+      "integrity": "sha512-ZVNuV9kJbr/2tWs83I2snrYo+WIS0DISF/xUfX9p9b6GyDD6F5N9PzHjW+p/dep6IGwSYylf1HCub5I/nM0R5Q==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
+    "openapi-schema-validation": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.1.tgz",
+      "integrity": "sha512-kYeHZJczkO8ipoFZgBLCY70C6Zqtu1Q4NqD6kXh3/5BRx1C2N4ge4syLbdemVc89tqLIqx64LenIEjZQ7uyPeQ==",
+      "dev": true,
+      "requires": {
+        "jsonschema": "1.2.4",
+        "jsonschema-draft4": "^1.0.0",
+        "swagger-schema-official": "2.0.0-bab6bed"
       }
     },
     "opn": {
@@ -16615,6 +16671,121 @@
         }
       }
     },
+    "swagger-cli": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-cli/-/swagger-cli-2.1.0.tgz",
+      "integrity": "sha512-MwZwtIN+Oj/m+nd0UxaDFZJdjlKwxbhsbQTyAWXUfFhMtR9KsuEnJCQeGeKgi4rlM1Tr273oz7tVSBOFV6/oXQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "js-yaml": "^3.12.0",
+        "mkdirp": "^0.5.1",
+        "swagger-parser": "^5.0.0",
+        "yargs": "^11.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
+    "swagger-methods": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.4.tgz",
+      "integrity": "sha512-xrKFLbrZ6VxRsg+M3uJozJtsEpNI/aPfZsOkoEjXw8vhAqdMIqwTYGj1f4dmUgvJvCdZhV5iArgtqXgs403ltg==",
+      "dev": true
+    },
+    "swagger-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-5.0.0.tgz",
+      "integrity": "sha512-/+xSTd7h6tqQqN3L8c0aq/H38FpeiAtfWzrVmCdOcqPryPW5i+5PutdmFRrGerfQw9UDuFQbSlC/nikyiUgreQ==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "json-schema-ref-parser": "^5.0.3",
+        "ono": "^4.0.5",
+        "openapi-schema-validation": "^0.4.1",
+        "swagger-methods": "^1.0.4",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "z-schema": "^3.19.1"
+      }
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=",
+      "dev": true
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -17319,6 +17490,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.3.0.tgz",
+      "integrity": "sha512-bn7dcJcdkpSjcujYlf8lrY9VL660h5njEkFzQzQOFMQgJ3Id1C4+MkazHKgHE45NoGsyQYEPmo4dCIbDQ7eTdw==",
+      "dev": true
     },
     "value-equal": {
       "version": "0.4.0",
@@ -18096,6 +18273,18 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.0.1"
+      }
+    },
+    "z-schema": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.22.0.tgz",
+      "integrity": "sha512-Oq82unxX2PTcJ031gFGcksDHE5PNBs5CbcQ1tbre0Sl4Mu5habZTVmEAkuZS4cK//VgIdNg9UG9PMgMlN6KmiA==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^10.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:e2e:storybook": "(lsof -t -i:9001 | xargs kill) && run-p --race storybook cypress:storybook",
     "test:e2e:storybook:ci": "run-p --race storybook cypress:storybook",
     "test:lighthouse": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start lighthouse",
-    "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook",
+    "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook && swagger-cli validate data/schema.yaml",
     "test:unit": "razzle test --env=jsdom --coverage"
   },
   "repository": {
@@ -72,7 +72,8 @@
     "lighthouse": "^2.9.4",
     "npm-run-all": "^4.1.3",
     "prettier": "1.13.5",
-    "supertest": "^3.1.0"
+    "supertest": "^3.1.0",
+    "swagger-cli": "^2.1.0"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Adding a schema which we have defined for the article in swagger using OpenAPI 3.0 schema: 
https://app.swaggerhub.com/apis/articles-vivaldi/article/1.1.1#/news-developers/getArticles
This PR adds this schema to our repo.

* [x] Relates to https://github.com/bbc/simorgh/issues/91
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
