### PR TITLE
Reduce parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
 env:
   - TEST_SUITE=
   - TEST_SUITE=:e2e:ci
-  - TEST_SUITE=:storybook:ci
 notifications:
   email: false
   slack:

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run test:lint && npm run test:unit",
     "test:e2e": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress",
-    "test:e2e:ci": "npm run build && run-p --race start cypress",
+    "test:e2e:ci": "npm run build && run-p --race start cypress && run-p --race storybook cypress:storybook",
     "test:e2e:interactive": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start cypress:interactive",
+    "test:e2e:storybook": "(lsof -t -i:9001 | xargs kill) && run-p --race storybook cypress:storybook",
     "test:lighthouse": "(lsof -t -i:7080 | xargs kill) && npm run build && run-p --race start lighthouse",
     "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook",
-    "test:storybook": "(lsof -t -i:9001 | xargs kill) && run-p --race storybook cypress:storybook",
-    "test:storybook:ci": "run-p --race storybook cypress:storybook",
     "test:unit": "razzle test --env=jsdom --coverage"
   },
   "repository": {


### PR DESCRIPTION
The parallelisation in TravisCI was ineffective because of how travis runs each set of tests on a new machine, it clearly favours the earlier machines, meaning a long delay can be experienced for each subsequent set of tests/machine. I've therefore reduced it to run only two parallel VMs.

* [x] part-fixes https://github.com/bbc/simorgh/issues/109
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
