### PR TITLE
Add Headline component

### DIFF
--- a/src/app/components/Headline/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Headline/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Headline with data should render correctly 1`] = `
+<h1>
+  This is a headline!
+</h1>
+`;
+
+exports[`Headline with no data should not render anything 1`] = `<h1 />`;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,9 +1,42 @@
 import React from 'react';
+import propTypes from 'prop-types';
 
 const Headline = ({ model }) => {
   const { text } = model.blocks[0].model.blocks[0].model;
 
   return <h1>{text}</h1>;
+};
+
+Headline.propTypes = {
+  model: propTypes.shape({
+    blocks: propTypes.arrayOf(
+      propTypes.shape({
+        model: propTypes.shape({
+          blocks: propTypes.arrayOf(
+            propTypes.shape({
+              text: propTypes.string,
+            }),
+          ),
+        }),
+      }),
+    ),
+  }),
+};
+
+Headline.defaultProps = {
+  model: {
+    blocks: [
+      {
+        model: {
+          blocks: [
+            {
+              model: {},
+            },
+          ],
+        },
+      },
+    ],
+  },
 };
 
 export default Headline;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,42 +1,38 @@
 import React from 'react';
 import propTypes from 'prop-types';
 
-const Headline = ({ model }) => {
-  const { text } = model.blocks[0].model.blocks[0].model;
+const Headline = ({ blocks }) => {
+  const { text } = blocks[0].model.blocks[0].model;
 
   return <h1>{text}</h1>;
 };
 
 Headline.propTypes = {
-  model: propTypes.shape({
-    blocks: propTypes.arrayOf(
-      propTypes.shape({
-        model: propTypes.shape({
-          blocks: propTypes.arrayOf(
-            propTypes.shape({
-              text: propTypes.string,
-            }),
-          ),
-        }),
+  blocks: propTypes.arrayOf(
+    propTypes.shape({
+      model: propTypes.shape({
+        blocks: propTypes.arrayOf(
+          propTypes.shape({
+            text: propTypes.string,
+          }),
+        ),
       }),
-    ),
-  }),
+    }),
+  ),
 };
 
 Headline.defaultProps = {
-  model: {
-    blocks: [
-      {
-        model: {
-          blocks: [
-            {
-              model: {},
-            },
-          ],
-        },
+  blocks: [
+    {
+      model: {
+        blocks: [
+          {
+            model: {},
+          },
+        ],
       },
-    ],
-  },
+    },
+  ],
 };
 
 export default Headline;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Headline = ({ model }) => {
+  const { text } = model.blocks[0].model.blocks[0].model;
+
+  return <h1>{text}</h1>;
+};
+
+export default Headline;

--- a/src/app/components/Headline/index.stories.jsx
+++ b/src/app/components/Headline/index.stories.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import Headline from './index';
+
+const props = {
+  model: {
+    blocks: [
+      {
+        model: {
+          blocks: [
+            {
+              model: {
+                text: 'This is a headline!',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+storiesOf('Headline', module).add('default', () => <Headline {...props} />);

--- a/src/app/components/Headline/index.stories.jsx
+++ b/src/app/components/Headline/index.stories.jsx
@@ -3,21 +3,19 @@ import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-e
 import Headline from './index';
 
 const props = {
-  model: {
-    blocks: [
-      {
-        model: {
-          blocks: [
-            {
-              model: {
-                text: 'This is a headline!',
-              },
+  blocks: [
+    {
+      model: {
+        blocks: [
+          {
+            model: {
+              text: 'This is a headline!',
             },
-          ],
-        },
+          },
+        ],
       },
-    ],
-  },
+    },
+  ],
 };
 
 storiesOf('Headline', module).add('default', () => <Headline {...props} />);

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -12,21 +12,19 @@ describe('Headline', () => {
 
   describe('with data', () => {
     const data = {
-      model: {
-        blocks: [
-          {
-            model: {
-              blocks: [
-                {
-                  model: {
-                    text: 'This is a headline!',
-                  },
+      blocks: [
+        {
+          model: {
+            blocks: [
+              {
+                model: {
+                  text: 'This is a headline!',
                 },
-              ],
-            },
+              },
+            ],
           },
-        ],
-      },
+        },
+      ],
     };
 
     it('should render correctly', () => {

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Headline from './index';
+
+describe('Headline', () => {
+  describe('with no data', () => {
+    it('should not render anything', () => {
+      const tree = renderer.create(<Headline />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('with data', () => {
+    const data = {
+      model: {
+        blocks: [
+          {
+            model: {
+              blocks: [
+                {
+                  model: {
+                    text: 'This is a headline!',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    it('should render correctly', () => {
+      const tree = renderer.create(<Headline {...data} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import Headline from './index';
 
 describe('Headline', () => {
   describe('with no data', () => {
-    it('should not render anything', () => {
-      const tree = renderer.create(<Headline />).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
+    snapshotTestHelper.shouldMatchSnapshot(
+      'should not render anything',
+      <Headline />,
+    );
   });
 
   describe('with data', () => {
@@ -27,9 +27,9 @@ describe('Headline', () => {
       ],
     };
 
-    it('should render correctly', () => {
-      const tree = renderer.create(<Headline {...data} />).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
+    snapshotTestHelper.shouldMatchSnapshot(
+      'should render correctly',
+      <Headline {...data} />,
+    );
   });
 });


### PR DESCRIPTION
_Creates a Headline component with a headline block as its prop. The component reaches into the block, extracts the `text` property, and passes it to a `h1` element._

* [x] Fixes https://github.com/bbc/simorgh/issues/116
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
