### PR TITLE
Parameterise Article route

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To run this application locally, with hot-reloading, run: `npm run dev`.
 
 The application will start on [http://localhost:7080/article/article-id](http://localhost:7080/article/article-id).
 
-These is a single route, `/article/[id]`, where `id` is the id of the static data, for example `scenario-01`.
+These is a single route, `/article/:id`, where `id` is the filename of the static Article data, for example `scenario-01`.
 
 **NOTE:** the `id` that is passed is redundant as the Article component is hard-coded to fetch data from [scenario-01](https://github.com/bbc/simorgh/blob/latest/data/test/scenario-01.json). However, it also does not do anything with that data.
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm install
 
 To run this application locally, with hot-reloading, run: `npm run dev`.
 
-The application will start on [http://localhost:7080/article/article-id](http://localhost:7080/article/article-id).
+The application will start on [http://localhost:7080/article/scenario-id](http://localhost:7080/article/scenario-id).
 
 These is a single route, `/article/:id`, where `id` is the filename of the static Article data, for example `scenario-01`.
 
-**NOTE:** the `id` that is passed is redundant as the Article component is hard-coded to fetch data from [scenario-01](https://github.com/bbc/simorgh/blob/latest/data/test/scenario-01.json). However, it also does not do anything with that data.
+**NOTE:** the `id` parameter is currently redundant as the Article component is hard-coded to fetch data from [scenario-01](https://github.com/bbc/simorgh/blob/latest/data/test/scenario-01.json). Furthermore, the Article component does not do anything with that data.
 
 ### Storybook (UI Development Environment/Style Guide)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ npm install
 
 To run this application locally, with hot-reloading, run: `npm run dev`.
 
-The application will start on [http://localhost:7080/](http://localhost:7080/). These is a single route, `/`.
+The application will start on [http://localhost:7080/article/article-id](http://localhost:7080/article/article-id).
+
+These is a single route, `/article/[id]`, where `id` is the id of the static data, for example `scenario-01`.
+
+**NOTE:** the `id` that is passed is redundant as the Article component is hard-coded to fetch data from [scenario-01](https://github.com/bbc/simorgh/blob/latest/data/test/scenario-01.json). However, it also does not do anything with that data.
 
 ### Storybook (UI Development Environment/Style Guide)
 

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -7,7 +7,7 @@ import {
 describe('News Article', () => {
   // eslint-disable-next-line no-undef
   before(() => {
-    cy.visit('/');
+    cy.visit('/article/article-id');
   });
 
   it('should render the BBC News branding', () => {

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -2,7 +2,7 @@ import Article from './components/Article';
 
 const routes = [
   {
-    path: '/',
+    path: '/article/:id',
     exact: true,
     component: Article,
   },


### PR DESCRIPTION
_Changes the Article component route to `/article/:id`, where the parameter`id` will be the filename of the static Article data.._

* [x] Fixes https://github.com/bbc/simorgh/issues/135
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] ~~Tests added for new features~~
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
