### PR TITLE
Speedier tests

### DIFF
--- a/.storybook/cypress/integration/storybook_spec.js
+++ b/.storybook/cypress/integration/storybook_spec.js
@@ -1,5 +1,3 @@
-import { testResponseCode } from '../../../cypress/integration/test-helper';
-
 describe('Storybook Article', () => {
   // eslint-disable-next-line no-undef
   before(() => {
@@ -8,11 +6,5 @@ describe('Storybook Article', () => {
 
   it('should render a title', () => {
     cy.title().should('eq', 'Storybook');
-  });
-});
-
-describe('Page Status', () => {
-  it('should display 200', () => {
-    testResponseCode('/', 200);
   });
 });

--- a/.storybook/cypress/integration/storybook_spec.js
+++ b/.storybook/cypress/integration/storybook_spec.js
@@ -1,7 +1,8 @@
 import { testResponseCode } from '../../../cypress/integration/test-helper';
 
 describe('Storybook Article', () => {
-  beforeEach(() => {
+  // eslint-disable-next-line no-undef
+  before(() => {
     cy.visit('/');
   });
 

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -28,7 +28,6 @@ describe('News Article', () => {
   it('should render a headline', () => {
     const h1 = getElement('h1');
     shouldContainText(h1, 'Article Headline');
-    // cy.get('h1').should('contain', 'Article Headline');
   });
 
   it('should render a title', () => {

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -6,7 +6,8 @@ import {
 } from './test-helper';
 
 describe('News Article', () => {
-  beforeEach(() => {
+  // eslint-disable-next-line no-undef
+  before(() => {
     cy.visit('/');
   });
 
@@ -26,7 +27,9 @@ describe('News Article', () => {
   });
 
   it('should render a headline', () => {
-    cy.get('h1').should('contain', 'Article Headline');
+    const h1 = getElement('h1');
+    shouldContainText(h1, 'Article Headline');
+    // cy.get('h1').should('contain', 'Article Headline');
   });
 
   it('should render a title', () => {

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -1,5 +1,4 @@
 import {
-  testResponseCode,
   getElement,
   shouldContainText,
   shouldContainStyles,
@@ -34,17 +33,5 @@ describe('News Article', () => {
 
   it('should render a title', () => {
     cy.title().should('eq', 'Article Headline');
-  });
-});
-
-describe('Page Status', () => {
-  it('should display 200', () => {
-    testResponseCode('/', 200);
-  });
-});
-
-describe('Renderer Status', () => {
-  it('should display 200', () => {
-    testResponseCode('/status', 200);
   });
 });

--- a/cypress/integration/data_spec.js
+++ b/cypress/integration/data_spec.js
@@ -1,7 +1,7 @@
-import { testResponseCode } from './test-helper';
+import { testNonHTMLResponseCode } from './test-helper';
 
 describe('Static Articles data', () => {
   it('should return a 200 status code', () => {
-    testResponseCode('/data/test/scenario-01.json', 200);
+    testNonHTMLResponseCode('/data/test/scenario-01.json', 200);
   });
 });

--- a/cypress/integration/status_spec.js
+++ b/cypress/integration/status_spec.js
@@ -1,0 +1,7 @@
+import { testNonHTMLResponseCode } from './test-helper';
+
+describe('Simorgh Status', () => {
+  it('should return 200', () => {
+    testNonHTMLResponseCode('/status', 200);
+  });
+});

--- a/cypress/integration/test-helper.js
+++ b/cypress/integration/test-helper.js
@@ -1,4 +1,4 @@
-const testResponseCode = (path, responseCode) => {
+const testNonHTMLResponseCode = (path, responseCode) => {
   cy.request(path).then(({ status }) => {
     expect(status).to.eq(responseCode);
   });
@@ -17,7 +17,7 @@ const shouldContainStyles = (element, css, styling) => {
 };
 
 export default {
-  testResponseCode,
+  testNonHTMLResponseCode,
   shouldContainText,
   shouldContainStyles,
   getElement,


### PR DESCRIPTION
My rough approximation are that this saves just under a minute, it also keeps code cleaner and tests all the same things.

1. Cypress implicitly tests 200 response on .visit() so no 200 response tests are necessary
2. The status test should never have been with the article tests, it is clearly separate
3. before rather than beforeEach massively speeds up tests because it doesn't re .visit() the page for every test in the spec

* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
