### PR TITLE
Subheading component

### DIFF
--- a/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SubHeading with data should display the provided sub-heading 1`] = `
+<h2>
+  The amazing sub-heading!?
+</h2>
+`;
+
+exports[`SubHeading with no data should not render anything 1`] = `<h2 />`;
+
+exports[`SubHeading with subheading containing various symbols should still display the heading 1`] = `
+<h2>
+  !@#$%^&*()'"?/[]{}
+</h2>
+`;

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+const SubHeading = ({ blocks }) => {
+  const { text } = blocks[0].model.blocks[0].model;
+
+  return <h2>{text}</h2>;
+};
+
+SubHeading.propTypes = {
+  blocks: propTypes.arrayOf(
+    propTypes.shape({
+      model: propTypes.shape({
+        blocks: propTypes.arrayOf(
+          propTypes.shape({
+            text: propTypes.string,
+          }),
+        ),
+      }),
+    }),
+  ),
+};
+
+SubHeading.defaultProps = {
+  blocks: [
+    {
+      model: {
+        blocks: [
+          {
+            model: {},
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export default SubHeading;

--- a/src/app/components/SubHeading/index.stories.jsx
+++ b/src/app/components/SubHeading/index.stories.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import SubHeading from './index';
+
+const props = {
+  blocks: [
+    {
+      model: {
+        blocks: [
+          {
+            model: {
+              text: 'Testing the SubHeading!',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+storiesOf('SubHeading', module).add('default', () => <SubHeading {...props} />);

--- a/src/app/components/SubHeading/index.stories.jsx
+++ b/src/app/components/SubHeading/index.stories.jsx
@@ -9,7 +9,7 @@ const props = {
         blocks: [
           {
             model: {
-              text: 'Testing the SubHeading!',
+              text: 'This is a SubHeading!',
             },
           },
         ],

--- a/src/app/components/SubHeading/index.test.jsx
+++ b/src/app/components/SubHeading/index.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
+import SubHeading from './index';
+
+describe('SubHeading', () => {
+  describe('with no data', () => {
+    snapshotTestHelper.shouldMatchSnapshot(
+      'should not render anything',
+      <SubHeading />,
+    );
+  });
+
+  describe('with data', () => {
+    const data = {
+      blocks: [
+        {
+          model: {
+            blocks: [
+              {
+                model: {
+                  text: 'The amazing sub-heading!?',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    snapshotTestHelper.shouldMatchSnapshot(
+      'should display the provided sub-heading',
+      <SubHeading {...data} />,
+    );
+  });
+
+  describe('with subheading containing various symbols', () => {
+    const data = {
+      blocks: [
+        {
+          model: {
+            blocks: [
+              {
+                model: {
+                  text: '!@#$%^&*()\'"?/[]{}',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    snapshotTestHelper.shouldMatchSnapshot(
+      'should still display the heading',
+      <SubHeading {...data} />,
+    );
+  });
+});


### PR DESCRIPTION
This PR is related to issue #133 , added the SubHeading component to the components. Added the corresponding tests and the storybook file.  
This code should be addressed on issue #141 since there is code duplication relating to the PropTypes and the Headline component

This PR adds a SubHeading component and the

* [x] Fixes https://github.com/bbc/simorgh/issues/133
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
