### PR TITLE
Adding test and helper for verifying nofollow tag presence

### DIFF
--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -36,6 +36,7 @@ describe('News Article', () => {
   });
 
   it('should have a nofollow meta tag', () => {
-    shouldHaveMetadata('robots', 'nofollow');
+    const metaElement = getElement('head meta[name="robots"]');
+    shouldHaveMetadata(metaElement, 'nofollow');
   });
 });

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -2,6 +2,7 @@ import {
   getElement,
   shouldContainText,
   shouldContainStyles,
+  shouldHaveMetadata,
 } from './test-helper';
 
 describe('News Article', () => {
@@ -32,5 +33,9 @@ describe('News Article', () => {
 
   it('should render a title', () => {
     cy.title().should('eq', 'Article Headline');
+  });
+
+  it('should have a nofollow meta tag', () => {
+    shouldHaveMetadata('robots', 'nofollow');
   });
 });

--- a/cypress/integration/article_spec.js
+++ b/cypress/integration/article_spec.js
@@ -2,7 +2,7 @@ import {
   getElement,
   shouldContainText,
   shouldContainStyles,
-  shouldHaveMetadata,
+  shouldHaveAttribute,
 } from './test-helper';
 
 describe('News Article', () => {
@@ -37,6 +37,6 @@ describe('News Article', () => {
 
   it('should have a nofollow meta tag', () => {
     const metaElement = getElement('head meta[name="robots"]');
-    shouldHaveMetadata(metaElement, 'nofollow');
+    shouldHaveAttribute(metaElement, 'content', 'nofollow');
   });
 });

--- a/cypress/integration/test-helper.js
+++ b/cypress/integration/test-helper.js
@@ -16,9 +16,14 @@ const shouldContainStyles = (element, css, styling) => {
   });
 };
 
+const shouldHaveMetadata = (name, content) => {
+  cy.get(`head meta[name=${name}]`).should('have.attr', 'content', content);
+};
+
 export default {
   testNonHTMLResponseCode,
   shouldContainText,
   shouldContainStyles,
   getElement,
+  shouldHaveMetadata,
 };

--- a/cypress/integration/test-helper.js
+++ b/cypress/integration/test-helper.js
@@ -16,8 +16,8 @@ const shouldContainStyles = (element, css, styling) => {
   });
 };
 
-const shouldHaveMetadata = (name, content) => {
-  cy.get(`head meta[name=${name}]`).should('have.attr', 'content', content);
+const shouldHaveMetadata = (element, content) => {
+  element.should('have.attr', 'content', content);
 };
 
 export default {

--- a/cypress/integration/test-helper.js
+++ b/cypress/integration/test-helper.js
@@ -16,8 +16,8 @@ const shouldContainStyles = (element, css, styling) => {
   });
 };
 
-const shouldHaveMetadata = (element, content) => {
-  element.should('have.attr', 'content', content);
+const shouldHaveAttribute = (element, attribute, value) => {
+  element.should('have.attr', attribute, value);
 };
 
 export default {
@@ -25,5 +25,5 @@ export default {
   shouldContainText,
   shouldContainStyles,
   getElement,
-  shouldHaveMetadata,
+  shouldHaveAttribute,
 };


### PR DESCRIPTION
Added a test to check for the presence of a nofollow meta tag.

* [x] Fixes https://github.com/bbc/simorgh/issues/152
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [x] Tests added for new features
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [x] Test engineer approval
