### PR TITLE
increase timeout 60 mins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
   agent any
   options {
-    timeout(time: 30, unit: 'MINUTES')
+    timeout(time: 60, unit: 'MINUTES')
     timestamps ()
   }
   stages {


### PR DESCRIPTION
_Increase timeout on CI deployments_

* ~[ ] Fixes https://github.com/bbc/simorgh/issues/NUMBER~
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* ~[ ] Tests added for new features~
* ~[ ] Tests pass - `npm test`~
* ~[ ] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)~

* ~[ ] Test engineer approval~
