### PR TITLE
Add base theming to Articles Component

### DIFF
--- a/src/app/components/Article.jsx
+++ b/src/app/components/Article.jsx
@@ -4,9 +4,11 @@ import 'isomorphic-fetch';
 import styled from 'styled-components';
 import Header from './Header';
 
+import { C_EBON, FF_NEWS } from '../../lib/constants/styles';
+
 const Headline = styled.h1`
-  color: #222;
-  font-family: ReithSans, Arial, Helvetica, freesans, sans-serif;
+  color: ${C_EBON};
+  font-family: ${FF_NEWS};
   font-size: 2em;
 `;
 

--- a/src/app/components/__snapshots__/Article.test.jsx.snap
+++ b/src/app/components/__snapshots__/Article.test.jsx.snap
@@ -14,7 +14,7 @@ Array [
     </a>
 </header>,
   <h1
-    className="sc-htpNat kEwiJ"
+    className="sc-htpNat NbMos"
 >
     Article Headline
 </h1>,


### PR DESCRIPTION
This pull request is still up for discussion. Right now I have pulled the already made styles from styles.js and implemented them into the Styled headline component in the article. The assumption is that the font familly and the font color will be reused between different components. There are 3 ways to do this:

- Passing the constant styles around
- Pass in the styles through the props.theme (This uses the ThemeWrapper, so it edits the article HTML)
- Pass the styles using the css modifier of styled components

The final version of this is to be decided. Right now the most promising outcome is the use of styled components css module in styles.js and then passing them into the styled components. 

UPDATE: Styled components are not created to funamentally perform what was wanted in this issue. However some cleanup was done to limit the amount of code duplication. The Styled Component used as a Headline in Articles has had its styles adapted from styles.js

 

* [x] Fixes (kind of) https://github.com/bbc/simorgh/issues/150
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] ~Tests added for new features~
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
