### PR TITLE
Refactor to reduce duplication across files

### DIFF
--- a/src/__test__/blockHelpers.js
+++ b/src/__test__/blockHelpers.js
@@ -1,0 +1,22 @@
+export const textBlock = text => ({
+  blocks: [
+    {
+      type: 'text',
+      model: {
+        blocks: [
+          {
+            type: 'paragraph',
+            model: {
+              text,
+            },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const blockContainingText = (type, text) => ({
+  type,
+  model: textBlock(text),
+});

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,42 +1,14 @@
 import React from 'react';
-import propTypes from 'prop-types';
+import { textPropTypes, textDefaultPropTypes } from '../../proptypes';
 
 const Headline = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
-  return (
-    <h1>
-      {text}
-    </h1>
-  );
+  return <h1>{text}</h1>;
 };
 
-Headline.propTypes = {
-  blocks: propTypes.arrayOf(
-    propTypes.shape({
-      model: propTypes.shape({
-        blocks: propTypes.arrayOf(
-          propTypes.shape({
-            text: propTypes.string,
-          }),
-        ),
-      }),
-    }),
-  ),
-};
+Headline.propTypes = textPropTypes;
 
-Headline.defaultProps = {
-  blocks: [
-    {
-      model: {
-        blocks: [
-          {
-            model: {},
-          },
-        ],
-      },
-    },
-  ],
-};
+Headline.defaultProps = textDefaultPropTypes;
 
 export default Headline;

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import Headline from './index';
+import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
+import { textBlock } from '../../../__test__/blockHelpers';
 
 describe('Headline', () => {
   describe('with no data', () => {
@@ -11,21 +12,7 @@ describe('Headline', () => {
   });
 
   describe('with data', () => {
-    const data = {
-      blocks: [
-        {
-          model: {
-            blocks: [
-              {
-                model: {
-                  text: 'This is a headline!',
-                },
-              },
-            ],
-          },
-        },
-      ],
-    };
+    const data = textBlock('This is a headline!');
 
     snapshotTestHelper.shouldMatchSnapshot(
       'should render correctly',

--- a/src/app/components/Image/index.jsx
+++ b/src/app/components/Image/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import propTypes from 'prop-types';
 import styled from 'styled-components';
+import { imagePropTypes, imageDefaultPropTypes } from '../../proptypes';
 
 // Filters array of blocks for a single block of given type
 const filterForBlockType = (arrayOfBlocks, type) =>
@@ -20,11 +20,7 @@ const renderCaption = block => {
   `;
   const caption = getText(block);
 
-  return (
-    <StyledFigCaption>
-      {caption}
-    </StyledFigCaption>
-  );
+  return <StyledFigCaption>{caption}</StyledFigCaption>;
 };
 
 const Image = ({ model }) => {
@@ -50,24 +46,8 @@ const Image = ({ model }) => {
   );
 };
 
-Image.propTypes = {
-  model: propTypes.shape({
-    blocks: propTypes.arrayOf(
-      propTypes.shape({
-        locator: propTypes.string,
-      }),
-    ),
-  }),
-};
+Image.propTypes = imagePropTypes;
 
-Image.defaultProps = {
-  model: {
-    blocks: [
-      {
-        model: {},
-      },
-    ],
-  },
-};
+Image.defaultProps = imageDefaultPropTypes;
 
 export default Image;

--- a/src/app/components/Image/index.jsx
+++ b/src/app/components/Image/index.jsx
@@ -20,7 +20,11 @@ const renderCaption = block => {
   `;
   const caption = getText(block);
 
-  return <StyledFigCaption>{caption}</StyledFigCaption>;
+  return (
+    <StyledFigCaption>
+      {caption}
+    </StyledFigCaption>
+  );
 };
 
 const Image = ({ model }) => {

--- a/src/app/components/Image/index.stories.jsx
+++ b/src/app/components/Image/index.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import Image from './index';
+import { blockContainingText } from '../../../__test__/blockHelpers';
 
 const imageData = arrayOfBlocks => ({
   type: 'image',
@@ -17,30 +18,9 @@ const rawImageBlock = {
   },
 };
 
-const textBlock = (type, text) => ({
-  type,
-  model: {
-    blocks: [
-      {
-        type: 'text',
-        model: {
-          blocks: [
-            {
-              type: 'paragraph',
-              model: {
-                text,
-              },
-            },
-          ],
-        },
-      },
-    ],
-  },
-});
-
 const dataWithAltText = imageData([
   rawImageBlock,
-  textBlock(
+  blockContainingText(
     'altText',
     'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.',
   ),
@@ -48,11 +28,11 @@ const dataWithAltText = imageData([
 
 const dataWithCaption = imageData([
   rawImageBlock,
-  textBlock(
+  blockContainingText(
     'altText',
     'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.',
   ),
-  textBlock(
+  blockContainingText(
     'caption',
     'Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme',
   ),

--- a/src/app/components/Image/index.test.jsx
+++ b/src/app/components/Image/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import Image from './index';
+import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
+import { blockContainingText } from '../../../__test__/blockHelpers';
 
 describe('Image', () => {
   describe('with no data', () => {
@@ -30,30 +31,9 @@ describe('Image', () => {
       },
     };
 
-    const textBlock = (type, text) => ({
-      type,
-      model: {
-        blocks: [
-          {
-            type: 'text',
-            model: {
-              blocks: [
-                {
-                  type: 'paragraph',
-                  model: {
-                    text,
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    });
-
     const dataWithAltText = imageData([
       rawImageBlock,
-      textBlock(
+      blockContainingText(
         'altText',
         'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.',
       ),
@@ -65,11 +45,11 @@ describe('Image', () => {
     );
     const dataWithCaption = imageData([
       rawImageBlock,
-      textBlock(
+      blockContainingText(
         'altText',
         'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.',
       ),
-      textBlock(
+      blockContainingText(
         'caption',
         'Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme',
       ),

--- a/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
@@ -6,10 +6,10 @@ exports[`SubHeading with data should display the provided sub-heading 1`] = `
 </h2>
 `;
 
-exports[`SubHeading with no data should not render anything 1`] = `<h2 />`;
-
-exports[`SubHeading with subheading containing various symbols should still display the heading 1`] = `
+exports[`SubHeading with data should display the subheading containing various symbols 1`] = `
 <h2>
   !@#$%^&*()'"?/[]{}
 </h2>
 `;
+
+exports[`SubHeading with no data should not render anything 1`] = `<h2 />`;

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -4,7 +4,11 @@ import { textPropTypes, textDefaultPropTypes } from '../../proptypes';
 const SubHeading = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
-  return <h2>{text}</h2>;
+  return (
+    <h2>
+      {text}
+    </h2>
+  );
 };
 
 SubHeading.propTypes = textPropTypes;

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -1,42 +1,14 @@
 import React from 'react';
-import propTypes from 'prop-types';
+import { textPropTypes, textDefaultPropTypes } from '../../proptypes';
 
 const SubHeading = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
-  return (
-    <h2>
-      {text}
-    </h2>
-  );
+  return <h2>{text}</h2>;
 };
 
-SubHeading.propTypes = {
-  blocks: propTypes.arrayOf(
-    propTypes.shape({
-      model: propTypes.shape({
-        blocks: propTypes.arrayOf(
-          propTypes.shape({
-            text: propTypes.string,
-          }),
-        ),
-      }),
-    }),
-  ),
-};
+SubHeading.propTypes = textPropTypes;
 
-SubHeading.defaultProps = {
-  blocks: [
-    {
-      model: {
-        blocks: [
-          {
-            model: {},
-          },
-        ],
-      },
-    },
-  ],
-};
+SubHeading.defaultProps = textDefaultPropTypes;
 
 export default SubHeading;

--- a/src/app/components/SubHeading/index.stories.jsx
+++ b/src/app/components/SubHeading/index.stories.jsx
@@ -1,21 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import SubHeading from './index';
+import { textBlock } from '../../../__test__/blockHelpers';
 
 const props = {
-  blocks: [
-    {
-      model: {
-        blocks: [
-          {
-            model: {
-              text: 'This is a SubHeading!',
-            },
-          },
-        ],
-      },
-    },
-  ],
+  type: 'subheading',
+  model: textBlock('This is a SubHeading!'),
 };
 
 storiesOf('SubHeading', module).add('default', () => <SubHeading {...props} />);

--- a/src/app/components/SubHeading/index.test.jsx
+++ b/src/app/components/SubHeading/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import SubHeading from './index';
+import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import { textBlock } from '../../../__test__/blockHelpers';
 
 describe('SubHeading', () => {
@@ -12,20 +12,14 @@ describe('SubHeading', () => {
   });
 
   describe('with data', () => {
-    const data = textBlock('The amazing sub-heading!?');
-
     snapshotTestHelper.shouldMatchSnapshot(
       'should display the provided sub-heading',
-      <SubHeading {...data} />,
+      <SubHeading {...textBlock('The amazing sub-heading!?')} />,
     );
-  });
-
-  describe('with subheading containing various symbols', () => {
-    const data = textBlock('!@#$%^&*()\'"?/[]{}');
 
     snapshotTestHelper.shouldMatchSnapshot(
-      'should still display the heading',
-      <SubHeading {...data} />,
+      'should display the subheading containing various symbols',
+      <SubHeading {...textBlock('!@#$%^&*()\'"?/[]{}')} />,
     );
   });
 });

--- a/src/app/components/SubHeading/index.test.jsx
+++ b/src/app/components/SubHeading/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import snapshotTestHelper from '../../../__test__/snapshotTestHelper';
 import SubHeading from './index';
+import { textBlock } from '../../../__test__/blockHelpers';
 
 describe('SubHeading', () => {
   describe('with no data', () => {
@@ -11,21 +12,7 @@ describe('SubHeading', () => {
   });
 
   describe('with data', () => {
-    const data = {
-      blocks: [
-        {
-          model: {
-            blocks: [
-              {
-                model: {
-                  text: 'The amazing sub-heading!?',
-                },
-              },
-            ],
-          },
-        },
-      ],
-    };
+    const data = textBlock('The amazing sub-heading!?');
 
     snapshotTestHelper.shouldMatchSnapshot(
       'should display the provided sub-heading',
@@ -34,21 +21,7 @@ describe('SubHeading', () => {
   });
 
   describe('with subheading containing various symbols', () => {
-    const data = {
-      blocks: [
-        {
-          model: {
-            blocks: [
-              {
-                model: {
-                  text: '!@#$%^&*()\'"?/[]{}',
-                },
-              },
-            ],
-          },
-        },
-      ],
-    };
+    const data = textBlock('!@#$%^&*()\'"?/[]{}');
 
     snapshotTestHelper.shouldMatchSnapshot(
       'should still display the heading',

--- a/src/app/proptypes.js
+++ b/src/app/proptypes.js
@@ -1,6 +1,6 @@
 import propTypes from 'prop-types';
 
-const textPropTypes = {
+export const textPropTypes = {
   blocks: propTypes.arrayOf(
     propTypes.shape({
       model: propTypes.shape({
@@ -28,4 +28,22 @@ export const textDefaultPropTypes = {
   ],
 };
 
-export default textPropTypes;
+export const imagePropTypes = {
+  model: propTypes.shape({
+    blocks: propTypes.arrayOf(
+      propTypes.shape({
+        locator: propTypes.string,
+      }),
+    ),
+  }),
+};
+
+export const imageDefaultPropTypes = {
+  model: {
+    blocks: [
+      {
+        model: {},
+      },
+    ],
+  },
+};

--- a/src/app/proptypes.js
+++ b/src/app/proptypes.js
@@ -1,5 +1,15 @@
 import propTypes from 'prop-types';
 
+export const imagePropTypes = {
+  model: propTypes.shape({
+    blocks: propTypes.arrayOf(
+      propTypes.shape({
+        locator: propTypes.string,
+      }),
+    ),
+  }),
+};
+
 export const textPropTypes = {
   blocks: propTypes.arrayOf(
     propTypes.shape({
@@ -14,31 +24,7 @@ export const textPropTypes = {
   ),
 };
 
-export const textDefaultPropTypes = {
-  blocks: [
-    {
-      model: {
-        blocks: [
-          {
-            model: {},
-          },
-        ],
-      },
-    },
-  ],
-};
-
-export const imagePropTypes = {
-  model: propTypes.shape({
-    blocks: propTypes.arrayOf(
-      propTypes.shape({
-        locator: propTypes.string,
-      }),
-    ),
-  }),
-};
-
-export const imageDefaultPropTypes = {
+const baseDefaultPropTypes = {
   model: {
     blocks: [
       {
@@ -46,4 +32,10 @@ export const imageDefaultPropTypes = {
       },
     ],
   },
+};
+
+export const imageDefaultPropTypes = baseDefaultPropTypes;
+
+export const textDefaultPropTypes = {
+  blocks: [baseDefaultPropTypes],
 };

--- a/src/app/proptypes.js
+++ b/src/app/proptypes.js
@@ -1,0 +1,31 @@
+import propTypes from 'prop-types';
+
+const textPropTypes = {
+  blocks: propTypes.arrayOf(
+    propTypes.shape({
+      model: propTypes.shape({
+        blocks: propTypes.arrayOf(
+          propTypes.shape({
+            text: propTypes.string,
+          }),
+        ),
+      }),
+    }),
+  ),
+};
+
+export const textDefaultPropTypes = {
+  blocks: [
+    {
+      model: {
+        blocks: [
+          {
+            model: {},
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export default textPropTypes;


### PR DESCRIPTION
A refactor to address some of the codeclimate warnings about duplication.
These have been refactored:
- PropTypes in `index.jsx` files
- Text blocks in `index.test.jsx` and `index.stories.jsx` files

This will not fix these warnings, which will be addressed in a separate PR:
```
== src/app/components/Headline/index.jsx (1 issue) ==
4-8: Similar blocks of code found in 2 locations. Consider refactoring. [duplication]
== src/app/components/SubHeading/index.jsx (1 issue) ==
4-8: Similar blocks of code found in 2 locations. Consider refactoring. [duplication]
```

* [x] Addresses https://github.com/bbc/simorgh/issues/141
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] ~Tests added for new features~ N/A
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
