### PR TITLE
Jenkins only on 'latest' branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,9 @@ pipeline {
   }
   stages {
     stage ('Run Pipeline') {
+      when {
+        expression { env.BRANCH_NAME == 'latest' }
+      }
       agent any
       steps {
         build(


### PR DESCRIPTION
Add condition to only run Jenkins CI when branch is `latest`. 

Note - this currently skips the Jenkins build but still shows the green tick.  If there is another way to not run Jenkins at all on non-`latest` branches, I'd prefer that.  Perhaps an admin has that access in the application settings? 

* [ ] N/A
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] ~Tests added for new features~ N/A
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
