### PR TITLE
Copy the styled headline to the Headline Component

### DIFF
--- a/src/app/components/Headline/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Headline/__snapshots__/index.test.jsx.snap
@@ -1,9 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Headline with data should render correctly 1`] = `
-<h1>
+<h1
+  className="sc-bdVaJa iyXvgZ"
+>
   This is a headline!
 </h1>
 `;
 
-exports[`Headline with no data should not render anything 1`] = `<h1 />`;
+exports[`Headline with no data should not render anything 1`] = `
+<h1
+  className="sc-bdVaJa iyXvgZ"
+/>
+`;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import styled from 'styled-components';
+import { C_EBON, FF_NEWS } from '../../../lib/constants/styles';
+
+const StyledHeadline = styled.h1`
+  color: ${C_EBON};
+  font-family: ${FF_NEWS};
+  font-size: 2em;
+`;
 
 const Headline = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
   return (
-    <h1>
+    <StyledHeadline>
       {text}
-    </h1>
+    </StyledHeadline>
   );
 };
 


### PR DESCRIPTION
Implemented a styled component of h1 and injected it into the Headline Component in place of the actual h1 tag. The story does not remove the already created styled component in MainComponent and Article, it also does not implement the Headline Component into the MainComponent as mentioned in #132 . 

* [x] Fixes https://github.com/bbc/simorgh/issues/132
* [x] Up-to-date with latest - `git pull --rebase origin latest`
* [x] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
* [ ] ~Tests added for new features~
* [x] Tests pass - `npm test`
* [x] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)

* [ ] Test engineer approval
