### PR TITLE
Rmv redundancy in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,6 @@
 _PR changes summary to go here._
 
 * [ ] Fixes https://github.com/bbc/simorgh/issues/NUMBER
-* [ ] Up-to-date with latest - `git pull --rebase origin latest`
-* [ ] Runs locally - `npm run dev` & [http://localhost:7080/](http://localhost:7080/)
 * [ ] Tests added for new features
-* [ ] Tests pass - `npm test`
-* [ ] E2E tests pass - `npm run test:e2e` (requires server running see [README](https://github.com/bbc/simorgh#tests) for details)
 
 * [ ] Test engineer approval


### PR DESCRIPTION
We have automated checks on i. it being up to date ii. npm test passing and iii. e2e test passing. So why have manual checkboxes? re it running locally, I don't know what I'm even meant to check for this, if my tests pass, e2e tests pass and it doesn't run locally what kind of work have I done?