### PR TITLE
Fix SubHeading Story

### DIFF
--- a/src/app/components/SubHeading/index.stories.jsx
+++ b/src/app/components/SubHeading/index.stories.jsx
@@ -3,9 +3,5 @@ import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-e
 import SubHeading from './index';
 import { textBlock } from '../../../__test__/blockHelpers';
 
-const props = {
-  type: 'subheading',
-  model: textBlock('This is a SubHeading!'),
-};
 
-storiesOf('SubHeading', module).add('default', () => <SubHeading {...props} />);
+storiesOf('SubHeading', module).add('default', () => <SubHeading {...textBlock('This is a SubHeading')} />);


### PR DESCRIPTION
Pass in data of the correct shape to SubHeading Story, so it renders in Storybook.
Fix can be seen locally in storybook, at http://localhost:9001/?selectedKind=SubHeading&selectedStory=default

* [ ] ~Fixes https://github.com/bbc/simorgh/issues/NUMBER~
* [ ] ~Tests added for new features~

* [ ] Test engineer approval
