### PR TITLE
Include SMP player with example video

### DIFF
--- a/src/app/components/Document.jsx
+++ b/src/app/components/Document.jsx
@@ -26,6 +26,7 @@ class Document extends React.Component {
           <link rel="manifest" href="manifest.json" />
           {helmet.title.toComponent()}
           {styleTags}
+          {helmet.script.toComponent()}
         </head>
         <body>
           <AfterRoot />

--- a/src/app/components/Video/index.jsx
+++ b/src/app/components/Video/index.jsx
@@ -1,0 +1,59 @@
+import React, { Fragment } from 'react';
+import Helmet from 'react-helmet';
+
+const Video = () => {
+  const mediaPlayerStyles = {
+    height: 270,
+    width: 480,
+  };
+
+  return (
+    <Fragment>
+      <Helmet htmlAttributes={{ lang: 'en-GB' }}>
+        <script
+          type="text/javascript"
+          src="https://static.bbci.co.uk/frameworks/requirejs/0.13.0/sharedmodules/require.js"
+        />
+        <script type="text/javascript">
+          {`
+          const bbcRequireMap = {
+            "bump-4": "//emp.bbci.co.uk/emp/bump-4/bump-4",
+          };
+          require({ paths: bbcRequireMap });
+        `}
+        </script>
+      </Helmet>
+      <div id="mediaPlayer12345678" style={mediaPlayerStyles} />
+      <script
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          __html: `
+            const settings = {
+              product: 'news',
+              responsive: true,
+              playlistObject: {
+                title: 'Butterfly photobombs koala film shoot at Australia zoo',
+                holdingImageURL:
+                  'https://ichef.bbci.co.uk/images/ic/$recipe/p049srmr.jpg',
+                items: [
+                  {
+                    versionID: 'p049sq7k',
+                    kind: 'programme',
+                    duration: 37,
+                  },
+                ],
+              },
+            };
+
+            require(['bump-4'], function (bump) {
+              var mediaPlayer = bump.player(document.getElementById('mediaPlayer12345678'),settings);
+              mediaPlayer.load();
+            });
+          `,
+        }}
+      />
+    </Fragment>
+  );
+};
+
+export default Video;

--- a/src/app/components/Video/index.stories.jsx
+++ b/src/app/components/Video/index.stories.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import Video from './index';
+
+storiesOf('Video', module).add('default', () => <Video />);


### PR DESCRIPTION
SMP is the Standard Media Player. 
We pass in values relating to the video's ID, a holding image url and duration of video in seconds. RequireJS downloads bump-4.js. When bump is on the page, we render the media player, in a given DOM node, within an iframe. 

Current state - when this Video component is included in the Article, it renders correctly:

<img width="510" alt="media player with image of a koala bear and the duration on the play icon" src="https://user-images.githubusercontent.com/3028997/42044742-aba24d86-7af1-11e8-9b97-f72cb898e7be.png">

When it is viewed in Storybook, RequireJS does not seem to pull in bump-4.js and so the JavaScript does not run to instantiate the media player. Will need to investigate why this is the case. 

See here for the Video component example in Storybook, in full-screen: 
http://localhost:9001/?selectedKind=Video&selectedStory=default&full=1&addons=1&stories=1&panelRight=0

* [ ] Fixes https://github.com/bbc/simorgh/issues/134
* [ ] Tests added for new features

* [ ] Test engineer approval