### PR TITLE
Remove and Refactor snapshot tests looking at null

### DIFF
--- a/src/app/components/Article.test.jsx
+++ b/src/app/components/Article.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import snapshotTestHelper from '../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../helpers/tests/testHelpers';
 import Article from './Article';
 
 describe('Article', () => {
   describe('Component', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render correctly',
       <Article />,
     );

--- a/src/app/components/Footer/index.test.jsx
+++ b/src/app/components/Footer/index.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Footer from './index';
 
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
 
 describe(`Footer`, () => {
-  snapshotTestHelper.shouldMatchSnapshot('should render correctly', <Footer />);
+  shouldMatchSnapshot('should render correctly', <Footer />);
 });

--- a/src/app/components/Header/index.test.jsx
+++ b/src/app/components/Header/index.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Header from './index';
 
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
 
 describe(`Header`, () => {
-  snapshotTestHelper.shouldMatchSnapshot('should render correctly', <Header />);
+  shouldMatchSnapshot('should render correctly', <Header />);
 });

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Headline from './index';
 import { textBlock } from '../../models/blocks';
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
 
 describe('Headline', () => {
   describe('with no data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <Headline />,
     );
@@ -14,7 +14,7 @@ describe('Headline', () => {
   describe('with data', () => {
     const data = textBlock('This is a headline!');
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render correctly',
       <Headline {...data} />,
     );

--- a/src/app/components/Image/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Image/__snapshots__/index.test.jsx.snap
@@ -29,5 +29,3 @@ exports[`Image with data should render an image with alt text and caption 1`] = 
   </figcaption>
 </figure>
 `;
-
-exports[`Image with no data should not render anything 1`] = `null`;

--- a/src/app/components/Image/index.test.jsx
+++ b/src/app/components/Image/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Image from './index';
-import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { shouldMatchSnapshot, isNullComponent } from '../../helpers/tests/testHelpers';
 import { blockContainingText } from '../../models/blocks';
 
 describe('Image', () => {
   describe('with no data', () => {
-    shouldMatchSnapshot(
+    isNullComponent(
       'should not render anything',
       <Image />,
     );

--- a/src/app/components/Image/index.test.jsx
+++ b/src/app/components/Image/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Image from './index';
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
 import { blockContainingText } from '../../models/blocks';
 
 describe('Image', () => {
   describe('with no data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <Image />,
     );
@@ -39,7 +39,7 @@ describe('Image', () => {
       ),
     ]);
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render an image with alt text',
       <Image {...dataWithAltText} />,
     );
@@ -55,7 +55,7 @@ describe('Image', () => {
       ),
     ]);
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render an image with alt text and caption',
       <Image {...dataWithCaption} />,
     );

--- a/src/app/components/Image/index.test.jsx
+++ b/src/app/components/Image/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Image from './index';
-import { shouldMatchSnapshot, isNullComponent } from '../../helpers/tests/testHelpers';
+import { shouldMatchSnapshot, isNull } from '../../helpers/tests/testHelpers';
 import { blockContainingText } from '../../models/blocks';
 
 describe('Image', () => {
   describe('with no data', () => {
-    isNullComponent(
+    isNull(
       'should return null',
       <Image />,
     );

--- a/src/app/components/Image/index.test.jsx
+++ b/src/app/components/Image/index.test.jsx
@@ -6,7 +6,7 @@ import { blockContainingText } from '../../models/blocks';
 describe('Image', () => {
   describe('with no data', () => {
     isNullComponent(
-      'should not render anything',
+      'should return null',
       <Image />,
     );
   });

--- a/src/app/components/SubHeading/index.test.jsx
+++ b/src/app/components/SubHeading/index.test.jsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import SubHeading from './index';
 import { textBlock } from '../../models/blocks';
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
 
 describe('SubHeading', () => {
   describe('with no data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <SubHeading />,
     );
   });
 
   describe('with data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should display the provided sub-heading',
       <SubHeading {...textBlock('The amazing sub-heading!?')} />,
     );
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should display the subheading containing various symbols',
       <SubHeading {...textBlock('!@#$%^&*()\'"?/[]{}')} />,
     );

--- a/src/app/components/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Text/__snapshots__/index.test.jsx.snap
@@ -13,5 +13,3 @@ Array [
 </p>,
 ]
 `;
-
-exports[`Text with no data should not render anything 1`] = `null`;

--- a/src/app/components/Text/index.test.jsx
+++ b/src/app/components/Text/index.test.jsx
@@ -5,7 +5,7 @@ import Text from './index';
 describe('Text', () => {
   describe('with no data', () => {
     isNullComponent(
-      'should not render anything',
+      'should return null',
       <Text />,
     );
   });

--- a/src/app/components/Text/index.test.jsx
+++ b/src/app/components/Text/index.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
+import {shouldMatchSnapshot, isNullComponent} from '../../helpers/tests/testHelpers';
 import Text from './index';
 
 describe('Text', () => {
   describe('with no data', () => {
-    shouldMatchSnapshot(
+    isNullComponent(
       'should not render anything',
       <Text />,
     );

--- a/src/app/components/Text/index.test.jsx
+++ b/src/app/components/Text/index.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
 import Text from './index';
 
 describe('Text', () => {
   describe('with no data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <Text />,
     );
@@ -26,7 +26,7 @@ describe('Text', () => {
       ],
     };
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render correctly',
       <Text {...data} />,
     );

--- a/src/app/components/Text/index.test.jsx
+++ b/src/app/components/Text/index.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {shouldMatchSnapshot, isNullComponent} from '../../helpers/tests/testHelpers';
+import {shouldMatchSnapshot, isNull} from '../../helpers/tests/testHelpers';
 import Text from './index';
 
 describe('Text', () => {
   describe('with no data', () => {
-    isNullComponent(
+    isNull(
       'should return null',
       <Text />,
     );

--- a/src/app/components/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Video/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video with data but no image should not render anything 1`] = `null`;
-
 exports[`Video with data but no image should only render the video 1`] = `null`;
 
 exports[`Video with data but no raw image should not render anything 1`] = `null`;

--- a/src/app/components/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Video/__snapshots__/index.test.jsx.snap
@@ -2,8 +2,6 @@
 
 exports[`Video with data but no image should only render the video 1`] = `null`;
 
-exports[`Video with data but no raw image should not render anything 1`] = `null`;
-
 exports[`Video with data should render the important props in divs 1`] = `
 <div>
   <div>

--- a/src/app/components/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Video/__snapshots__/index.test.jsx.snap
@@ -2,6 +2,8 @@
 
 exports[`Video with data but no image should not render anything 1`] = `null`;
 
+exports[`Video with data but no image should only render the video 1`] = `null`;
+
 exports[`Video with data but no raw image should not render anything 1`] = `null`;
 
 exports[`Video with data should render the important props in divs 1`] = `

--- a/src/app/components/Video/index.test.jsx
+++ b/src/app/components/Video/index.test.jsx
@@ -70,8 +70,6 @@ describe('Video', () => {
     isNull(
       'should be null',
       <Video {...data} />
-    )
-
-    
+    )  
   });
 });

--- a/src/app/components/Video/index.test.jsx
+++ b/src/app/components/Video/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shouldMatchSnapshot, isNullComponent } from '../../helpers/tests/testHelpers';
+import { shouldMatchSnapshot, isNull } from '../../helpers/tests/testHelpers';
 import { videoBlock, rawVideoModel, rawVideoBlock, imageBlock } from '../../models/blocks';
 import Video from './index';
 
@@ -67,7 +67,7 @@ describe('Video', () => {
     const img = imageBlock(rIB);
     const data = videoBlock(rVB, img)
     
-    isNullComponent(
+    isNull(
       'should be null',
       <Video {...data} />
     )

--- a/src/app/components/Video/index.test.jsx
+++ b/src/app/components/Video/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import snapshotTestHelper from '../../helpers/tests/snapshotTestHelper';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
 import { videoBlock, rawVideoModel, rawVideoBlock, imageBlock } from '../../models/blocks';
 import Video from './index';
 
@@ -7,7 +7,7 @@ describe('Video', () => {
   const rVB = rawVideoBlock(rawVideoModel("urn:bbc:pips:pid:p064nsyw", "p064nsz3", "clip", 299 ));
   
   describe('with no data', () => {
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <Video />,
     );
@@ -45,7 +45,7 @@ describe('Video', () => {
       },
     };
 
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should render the important props in divs',
       <Video {...videoData} />,
     );
@@ -55,10 +55,10 @@ describe('Video', () => {
 
     const data = videoBlock(rVB, null);
 
-    snapshotTestHelper.shouldMatchSnapshot(
-      'should not render anything',
-      <Video {...data} />,
-    );
+    shouldMatchSnapshot(
+      'should only render the video',
+      <Video {...data} />
+    )
   });
 
   describe('with data but no raw image', () => {
@@ -67,7 +67,7 @@ describe('Video', () => {
     const img = imageBlock(rIB);
     const data = videoBlock(rVB, img)
     
-    snapshotTestHelper.shouldMatchSnapshot(
+    shouldMatchSnapshot(
       'should not render anything',
       <Video {...data} />
     )

--- a/src/app/components/Video/index.test.jsx
+++ b/src/app/components/Video/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { shouldMatchSnapshot, isNullComponent } from '../../helpers/tests/testHelpers';
 import { videoBlock, rawVideoModel, rawVideoBlock, imageBlock } from '../../models/blocks';
 import Video from './index';
 
@@ -67,9 +67,11 @@ describe('Video', () => {
     const img = imageBlock(rIB);
     const data = videoBlock(rVB, img)
     
-    shouldMatchSnapshot(
-      'should not render anything',
+    isNullComponent(
+      'should be null',
       <Video {...data} />
     )
+
+    
   });
 });

--- a/src/app/helpers/tests/testHelpers.js
+++ b/src/app/helpers/tests/testHelpers.js
@@ -8,11 +8,10 @@ export const shouldMatchSnapshot = (title, component) => {
   });
 };
 
-export const isNullComponent = (title, component) => {
+export const isNull = (title, component) => {
   it(title, () => {
     const tree = renderer.create(component).toJSON();
     expect(tree).toBeNull();
   });
 };
 
-export default { shouldMatchSnapshot };

--- a/src/app/helpers/tests/testHelpers.js
+++ b/src/app/helpers/tests/testHelpers.js
@@ -1,10 +1,16 @@
 import renderer from 'react-test-renderer'; // eslint-disable-line import/no-extraneous-dependencies
 import 'jest-styled-components'; // eslint-disable-line import/no-extraneous-dependencies
 
-const shouldMatchSnapshot = (title, component) => {
+export const shouldMatchSnapshot = (title, component) => {
   it(title, () => {
     const tree = renderer.create(component).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+};
+
+export const isNullComponent = (title, component) => {
+  it(title, () => {
+    expect(component).toBeNull();
   });
 };
 

--- a/src/app/helpers/tests/testHelpers.js
+++ b/src/app/helpers/tests/testHelpers.js
@@ -10,7 +10,8 @@ export const shouldMatchSnapshot = (title, component) => {
 
 export const isNullComponent = (title, component) => {
   it(title, () => {
-    expect(component).toBeNull();
+    const tree = renderer.create(component).toJSON();
+    expect(tree).toBeNull();
   });
 };
 


### PR DESCRIPTION
Create a standardized function that tests if the component returns null, instead of testing null using a full snapshot. 

* [x] Progress of https://github.com/bbc/simorgh/issues/209
* [x] Tests added for new features
* [ ] Test engineer approval
