### PR TITLE
Refactored non-null returning components & their tests

### DIFF
--- a/src/app/components/Headline/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Headline/__snapshots__/index.test.jsx.snap
@@ -13,15 +13,3 @@ exports[`Headline with data should render correctly 1`] = `
   This is a headline!
 </h1>
 `;
-
-exports[`Headline with no data should not render anything 1`] = `
-.c0 {
-  color: #222222;
-  font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  font-size: 2em;
-}
-
-<h1
-  className="c0"
-/>
-`;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -13,7 +13,7 @@ const StyledHeadline = styled.h1`
 const Headline = ({ blocks }) => {
   const { text } = extractText(blocks);
 
-  if(!text){
+  if (!text) {
     return null;
   }
 

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { extractText } from '../../helpers/blocks';
 import { textPropTypes, textDefaultPropTypes } from '../../helpers/proptypes';
 import { C_EBON, FF_NEWS_SANS_REG } from '../../../lib/constants/styles';
 
@@ -10,7 +11,7 @@ const StyledHeadline = styled.h1`
 `;
 
 const Headline = ({ blocks }) => {
-  const { text } = blocks[0].model.blocks[0].model;
+  const { text } = extractText(blocks);
 
   if(!text){
     return null;

--- a/src/app/components/Headline/index.jsx
+++ b/src/app/components/Headline/index.jsx
@@ -12,6 +12,10 @@ const StyledHeadline = styled.h1`
 const Headline = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
+  if(!text){
+    return null;
+  }
+
   return (
     <StyledHeadline>
       {text}

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Headline from './index';
 import { textBlock } from '../../models/blocks';
-import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
+import {shouldMatchSnapshot, isNull} from '../../helpers/tests/testHelpers';
 
 describe('Headline', () => {
   describe('with no data', () => {
-    shouldMatchSnapshot(
+    isNull(
       'should not render anything',
       <Headline />,
     );

--- a/src/app/components/Headline/index.test.jsx
+++ b/src/app/components/Headline/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Headline from './index';
 import { textBlock } from '../../models/blocks';
-import {shouldMatchSnapshot, isNull} from '../../helpers/tests/testHelpers';
+import { shouldMatchSnapshot, isNull } from '../../helpers/tests/testHelpers';
 
 describe('Headline', () => {
   describe('with no data', () => {

--- a/src/app/components/Image/index.jsx
+++ b/src/app/components/Image/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import filterForBlockType from '../../helpers/blocks';
+import { filterForBlockType } from '../../helpers/blocks';
 import { imagePropTypes, imageDefaultPropTypes } from '../../helpers/proptypes';
 import { FF_NEWS_SANS_REG } from '../../../lib/constants/styles';
 

--- a/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/SubHeading/__snapshots__/index.test.jsx.snap
@@ -11,5 +11,3 @@ exports[`SubHeading with data should display the subheading containing various s
   !@#$%^&*()'"?/[]{}
 </h2>
 `;
-
-exports[`SubHeading with no data should not render anything 1`] = `<h2 />`;

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { extractText } from '../../helpers/blocks';
 import { textPropTypes, textDefaultPropTypes } from '../../helpers/proptypes';
 
 const SubHeading = ({ blocks }) => {
-  const { text } = blocks[0].model.blocks[0].model;
+  const { text } = extractText(blocks);
 
   if(!text){
     return null;

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -4,6 +4,10 @@ import { textPropTypes, textDefaultPropTypes } from '../../helpers/proptypes';
 const SubHeading = ({ blocks }) => {
   const { text } = blocks[0].model.blocks[0].model;
 
+  if(!text){
+    return null;
+  }
+
   return (
     <h2>
       {text}

--- a/src/app/components/SubHeading/index.jsx
+++ b/src/app/components/SubHeading/index.jsx
@@ -5,7 +5,7 @@ import { textPropTypes, textDefaultPropTypes } from '../../helpers/proptypes';
 const SubHeading = ({ blocks }) => {
   const { text } = extractText(blocks);
 
-  if(!text){
+  if (!text) {
     return null;
   }
 

--- a/src/app/components/SubHeading/index.test.jsx
+++ b/src/app/components/SubHeading/index.test.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import SubHeading from './index';
 import { textBlock } from '../../models/blocks';
-import {shouldMatchSnapshot} from '../../helpers/tests/testHelpers';
+import {shouldMatchSnapshot, isNull} from '../../helpers/tests/testHelpers';
 
 describe('SubHeading', () => {
   describe('with no data', () => {
-    shouldMatchSnapshot(
+    isNull(
       'should not render anything',
       <SubHeading />,
     );

--- a/src/app/components/Video/index.jsx
+++ b/src/app/components/Video/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { videoPropTypes, videoDefaultPropTypes } from '../../helpers/proptypes';
-import filterForBlockType from '../../helpers/blocks';
+import { filterForBlockType } from '../../helpers/blocks';
 
 const Video = ({ model }) => {
   const subBlocks = model.blocks;

--- a/src/app/helpers/blocks.js
+++ b/src/app/helpers/blocks.js
@@ -3,7 +3,7 @@
 // elements and blocks within them
 
 // Filters array of blocks for a single block of given type
-const filterForBlockType = (arrayOfBlocks, type) =>
+export const filterForBlockType = (arrayOfBlocks, type) =>
   arrayOfBlocks.filter(block => (block) ? block.type === type : null)[0];
 
-export default filterForBlockType;
+export const extractText = (arrayOfBlocks) => arrayOfBlocks[0].model.blocks[0].model


### PR DESCRIPTION
The Headline and SubHeading now return a full null when its props are null. The null test for these components have been refactored. These are the last two components that need to be changed. 

* [x] Fixes https://github.com/bbc/simorgh/issues/209
* [x] Tests added for new features

* [ ] Test engineer approval
