### PR TITLE
Run another para test for prod build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ jobs:
       script: xvfb-run npm run test:e2e:ci
     - stage: test
       script: xvfb-run npm run test:e2e:storybook:ci
+    - stage: test
+      install: npm install --production
+      script: npm run build
     - stage: deploy
       if: type = push AND branch = latest
       before_script: npm install now --no-save


### PR DESCRIPTION
Forces us to check the production build will run. Cannot be run with other tests as the node module cache will become unusable.

~~* [ ] Fixes https://github.com/bbc/simorgh/issues/NUMBER~~
~~* [ ] Tests added for new features~~

~~* [ ] Test engineer approval~~
