### PR TITLE
Brings coverage of src/server/index.js to 100%

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,11 +3,11 @@ import { render } from '@jaredpalmer/after';
 import routes from '../app/routes';
 import Document from '../app/components/Document';
 
-const getPublicDirectory = () =>
-  process.env.NODE_ENV === 'production'
+export function getPublicDirectory() {
+  return process.env.NODE_ENV === 'production'
     ? process.env.RAZZLE_PUBLIC_DIR
     : process.env.RAZZLE_PUBLIC_DIR_DEV;
-
+}
 /*
   Safely imports the assets manifest file in any edge-case that the 'RAZZLE_ASSETS_MANIFEST' does not exist.
   Enables unit testing of this file.

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -12,9 +12,14 @@ describe('Server', () => {
 
       envs.forEach(env => {
         const key = Object.keys(env).shift();
+        // sets the env globally
         process.env.NODE_ENV = key;
         expect(getPublicDirectory()).toBe(env[key]);
       });
+    });
+
+    afterEach(() => {
+      delete process.env.NODE_ENV;
     });
   });
 

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -3,8 +3,6 @@ import * as after from '@jaredpalmer/after';
 import server, { getPublicDirectory } from './index';
 
 describe('Server', () => {
-  const makeRequest = async path => request(server).get(path);
-
   describe('getPublicDirectory', () => {
     it(`should set the directory path based on env`, () => {
       const envs = [{ production: 'build/public' }, { notProd: 'public' }];
@@ -16,6 +14,8 @@ describe('Server', () => {
       });
     });
   });
+
+  const makeRequest = async path => request(server).get(path);
 
   it(`should not pass an 'x-powered-by' response header`, async () => {
     const { headers } = await makeRequest('/status');

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -1,9 +1,21 @@
 import request from 'supertest';
 import * as after from '@jaredpalmer/after';
-import server from './index';
+import server, { getPublicDirectory } from './index';
 
 describe('Server', () => {
   const makeRequest = async path => request(server).get(path);
+
+  describe('getPublicDirectory', () => {
+    it(`should set the directory path based on env`, () => {
+      const envs = [{ production: 'build/public' }, { notProd: 'public' }];
+
+      envs.forEach(el => {
+        const key = Object.keys(el).shift();
+        process.env.NODE_ENV = key;
+        expect(getPublicDirectory()).toBe(el[key]);
+      });
+    });
+  });
 
   it(`should not pass an 'x-powered-by' response header`, async () => {
     const { headers } = await makeRequest('/status');

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -12,7 +12,7 @@ describe('Server', () => {
 
       envs.forEach(env => {
         const key = Object.keys(env).shift();
-        // sets the env globally
+        // sets an env variable globally for the running test process
         process.env.NODE_ENV = key;
         expect(getPublicDirectory()).toBe(env[key]);
       });

--- a/src/server/server.test.js
+++ b/src/server/server.test.js
@@ -5,12 +5,15 @@ import server, { getPublicDirectory } from './index';
 describe('Server', () => {
   describe('getPublicDirectory', () => {
     it(`should set the directory path based on env`, () => {
-      const envs = [{ production: 'build/public' }, { notProd: 'public' }];
+      const envs = [
+        { production: 'build/public' },
+        { notProduction: 'public' },
+      ];
 
-      envs.forEach(el => {
-        const key = Object.keys(el).shift();
+      envs.forEach(env => {
+        const key = Object.keys(env).shift();
         process.env.NODE_ENV = key;
-        expect(getPublicDirectory()).toBe(el[key]);
+        expect(getPublicDirectory()).toBe(env[key]);
       });
     });
   });


### PR DESCRIPTION
Arises from https://github.com/bbc/simorgh/issues/210. Adds coverage for `src/server/index.js`'s  `getPublicDirectory`, a function that sets a public directory based on the global `NODE_ENV` variable set.

* [x] Fixes (partially) https://github.com/bbc/simorgh/issues/210 (note multiple PRs required for this ticket)
* [x] Tests added for new features

* [ ] Test engineer approval
