### PR TITLE
silence console.log() when running jest tests

### DIFF
--- a/src/app/components/Article/index.test.jsx
+++ b/src/app/components/Article/index.test.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
 import Article from './index';
 
+// explicitly ignore console.log errors for Article/index:getInitialProps() error logging
+global.console.log = jest.fn();
+
 describe('Article', () => {
   describe('Component', () => {
     shouldMatchSnapshot('should render correctly', <Article />);

--- a/src/app/helpers/tests/jest-setup.js
+++ b/src/app/helpers/tests/jest-setup.js
@@ -1,3 +1,5 @@
 import fetch from 'jest-fetch-mock'; // eslint-disable-line import/no-extraneous-dependencies
 
+// ignore console.error() in testing suite to silence node_dependency console statements
+global.console.error = jest.fn();
 global.fetch = fetch;

--- a/src/app/helpers/tests/jest-setup.js
+++ b/src/app/helpers/tests/jest-setup.js
@@ -1,5 +1,3 @@
 import fetch from 'jest-fetch-mock'; // eslint-disable-line import/no-extraneous-dependencies
 
-// ignore console.error() in testing suite to silence node_dependency console statements
-global.console.error = jest.fn();
 global.fetch = fetch;


### PR DESCRIPTION
_Silence the console.error() called by our node dependencies. Also silence console.log() for a specific test_

* [x] Fixes https://github.com/bbc/simorgh/issues/259
* ~[ ] Tests added for new features~

* ~[ ] Test engineer approval~
