### PR TITLE
Remove explicit require of stories from components directory

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 
-const req = require.context('../src/app/components', true, /\.stories\.jsx$/);
+const req = require.context('../src/app', true, /\.stories\.jsx$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));


### PR DESCRIPTION
The stories for container components are not showing up because stories are required only from the components directory. This fixes that._

* [x] Part of https://github.com/bbc/simorgh/issues/246
* [ ] ~~Tests added for new features~~

* [ ] ~~Test engineer approval~~
