### PR TITLE
Remove naming of global styles import

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,5 @@
 import { configure } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import globalStyles from '../src/app/lib/globalStyles'; // eslint-disable-line no-unused-vars
+import '../src/app/lib/globalStyles';
 
 const req = require.context('../src/app', true, /\.stories\.jsx$/);
 

--- a/src/app/components/Document.jsx
+++ b/src/app/components/Document.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { AfterRoot, AfterData } from '@jaredpalmer/after';
 import { ServerStyleSheet } from 'styled-components';
-import globalStyles from '../lib/globalStyles'; // eslint-disable-line no-unused-vars
+import '../lib/globalStyles';
 
 const resourceHints = () => (
   <Fragment>


### PR DESCRIPTION
_The import of global styles is currently named. However, this introduces ambiguity as the module does not have a default export and we just wish to import all of the functionality. Removing the naming of the import clears this up._

* [ ] ~~Fixes https://github.com/bbc/simorgh/issues/NUMBER~~
* [ ] ~~Tests added for new features~~

* [ ] ~~Test engineer approval~~
