### PR TITLE
Define article props

### DIFF
--- a/src/app/components/Article/index.jsx
+++ b/src/app/components/Article/index.jsx
@@ -1,8 +1,9 @@
 import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
-import { string, any } from 'prop-types';
+import { string } from 'prop-types';
 import Header from '../Header';
 import MainContent from '../MainContent';
+import mainContentPropTypes from '../../models/propTypes/mainContent';
 
 const Article = ({ lang, title, blocks }) => (
   <Fragment>
@@ -17,7 +18,7 @@ const Article = ({ lang, title, blocks }) => (
 Article.propTypes = {
   lang: string.isRequired,
   title: string.isRequired,
-  blocks: any.isRequired, // eslint-disable-line
+  ...mainContentPropTypes.isRequired,
 };
 
 export default Article;

--- a/src/app/components/Article/index.jsx
+++ b/src/app/components/Article/index.jsx
@@ -4,20 +4,20 @@ import { string, any } from 'prop-types';
 import Header from '../Header';
 import MainContent from '../MainContent';
 
-const Article = ({ lang, title, data }) => (
+const Article = ({ lang, title, blocks }) => (
   <Fragment>
     <Helmet htmlAttributes={{ lang }}>
       <title>{title}</title>
     </Helmet>
     <Header />
-    <MainContent {...data} />
+    <MainContent blocks={blocks} />
   </Fragment>
 );
 
 Article.propTypes = {
   lang: string.isRequired,
   title: string.isRequired,
-  data: any.isRequired, // eslint-disable-line
+  blocks: any.isRequired, // eslint-disable-line
 };
 
 export default Article;

--- a/src/app/components/Article/index.stories.jsx
+++ b/src/app/components/Article/index.stories.jsx
@@ -6,73 +6,66 @@ import { textBlock } from '../../models/blocks';
 const title = 'This is a title!';
 const lang = 'en-GB';
 
-const data = {
-  blocks: [
-    {
-      type: 'headline',
-      blockId: '1',
-      model: textBlock('This is a headline!'),
-    },
-    {
-      type: 'text',
-      blockId: '2',
-      model: {
-        blocks: [
-          {
-            blockId: '2-1',
-            type: 'paragraph',
-            model: {
-              text: 'This is some text content!',
-            },
+const blocks = [
+  {
+    type: 'headline',
+    blockId: '1',
+    model: textBlock('This is a headline!'),
+  },
+  {
+    type: 'text',
+    blockId: '2',
+    model: {
+      blocks: [
+        {
+          blockId: '2-1',
+          type: 'paragraph',
+          model: {
+            text: 'This is some text content!',
           },
-          {
-            blockId: '2-2',
-            type: 'paragraph',
-            model: {
-              text: 'More text content!',
-            },
+        },
+        {
+          blockId: '2-2',
+          type: 'paragraph',
+          model: {
+            text: 'More text content!',
           },
-        ],
-      },
+        },
+      ],
     },
-    {
-      type: 'test',
-      blockId: '3',
-      model: {
-        blocks: [
-          {
-            blockId: '3-1',
-            type: 'test-something',
-            model: {
-              text: 'This is some test content!',
-            },
+  },
+  {
+    type: 'test',
+    blockId: '3',
+    model: {
+      blocks: [
+        {
+          blockId: '3-1',
+          type: 'test-something',
+          model: {
+            text: 'This is some test content!',
           },
-        ],
-      },
+        },
+      ],
     },
-  ],
-};
-
-const filterData = filter => {
-  const filteredBlocks = data.blocks.filter(filter);
-  const blocks = { blocks: filteredBlocks };
-
-  return blocks;
-};
+  },
+];
 
 storiesOf('Article', module)
   .add('with just a headline', () => {
-    const dataOnlyHeadline = filterData(({ type }) => type === 'headline');
+    const blocksOnlyHeadline = blocks.filter(({ type }) => type === 'headline');
 
-    return <Article title={title} lang={lang} data={dataOnlyHeadline} />;
+    return <Article title={title} lang={lang} blocks={blocksOnlyHeadline} />;
   })
   .add('with a headline and text', () => {
-    const dataOnlyHeadlineText = filterData(
+    const blocksOnlyHeadlineText = blocks.filter(
       ({ type }) => type === 'headline' || type === 'text',
     );
 
-    return <Article title={title} lang={lang} data={dataOnlyHeadlineText} />;
+    return (
+      <Article title={title} lang={lang} blocks={blocksOnlyHeadlineText} />
+    );
   })
   .add('with a headline, text, and other blocks', () => (
-    <Article title={title} lang={lang} data={data} />
+    <Article title={title} lang={lang} blocks={blocks} />
   ));

--- a/src/app/components/Article/index.test.jsx
+++ b/src/app/components/Article/index.test.jsx
@@ -6,56 +6,54 @@ import { textBlock } from '../../models/blocks';
 const title = 'This is a title!';
 const lang = 'en-GB';
 
-const data = {
-  blocks: [
-    {
-      type: 'headline',
-      blockId: '1',
-      model: textBlock('This is a headline!'),
-    },
-    {
-      type: 'text',
-      blockId: '2',
-      model: {
-        blocks: [
-          {
-            blockId: '2-1',
-            type: 'paragraph',
-            model: {
-              text: 'This is some text content!',
-            },
+const blocks = [
+  {
+    type: 'headline',
+    blockId: '1',
+    model: textBlock('This is a headline!'),
+  },
+  {
+    type: 'text',
+    blockId: '2',
+    model: {
+      blocks: [
+        {
+          blockId: '2-1',
+          type: 'paragraph',
+          model: {
+            text: 'This is some text content!',
           },
-          {
-            blockId: '2-2',
-            type: 'paragraph',
-            model: {
-              text: 'More text content!',
-            },
+        },
+        {
+          blockId: '2-2',
+          type: 'paragraph',
+          model: {
+            text: 'More text content!',
           },
-        ],
-      },
+        },
+      ],
     },
-    {
-      type: 'test',
-      blockId: '3',
-      model: {
-        blocks: [
-          {
-            blockId: '3-1',
-            type: 'test-something',
-            model: {
-              text: 'This is some test content!',
-            },
+  },
+  {
+    type: 'test',
+    blockId: '3',
+    model: {
+      blocks: [
+        {
+          blockId: '3-1',
+          type: 'test-something',
+          model: {
+            text: 'This is some test content!',
           },
-        ],
-      },
+        },
+      ],
     },
-  ],
-};
+  },
+];
 
 describe('Article', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <Article title={title} lang={lang} data={data} />,
+    <Article title={title} lang={lang} blocks={blocks} />,
   );
 });

--- a/src/app/components/Article/index.test.jsx
+++ b/src/app/components/Article/index.test.jsx
@@ -35,7 +35,7 @@ const blocks = [
     },
   },
   {
-    type: 'test',
+    type: 'test', // causes prop validation errors
     blockId: '3',
     model: {
       blocks: [

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -44,7 +44,7 @@ class ArticleContainer extends Component {
     const { data } = this.state;
     const { title, model, passport } = data;
 
-    return <Article lang={passport.language} title={title} data={model} />;
+    return <Article lang={passport.language} title={title} {...model} />;
   }
 }
 


### PR DESCRIPTION
_Pass `blocks` to Article component, rather than a generic `data` object. Defines the `block` props as the MainContent props._

* [x] Fixes https://github.com/bbc/simorgh/issues/337
* [ ] ~~Tests added for new features~~

* [ ] ~~Test engineer approval~~
