### PR TITLE
Integrate Subheading container into MainContent container

### DIFF
--- a/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
@@ -13,6 +13,11 @@ exports[`MainContent should render correctly 1`] = `
   >
     This is a headline!
   </h1>
+  <h2
+    className=""
+  >
+    This is a subheading!
+  </h2>
   <p>
     This is some text content!
   </p>

--- a/src/app/containers/MainContent/index.jsx
+++ b/src/app/containers/MainContent/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import headline from '../Headings';
+import headings from '../Headings';
 import text from '../Text';
 import mainContentModelPropTypes from '../../models/propTypes/mainContent';
 import MainContent from '../../components/MainContent';
@@ -11,7 +11,8 @@ const BlockString = props => {
 };
 
 const Blocks = {
-  headline,
+  headline: headings,
+  subheading: headings,
   text,
 };
 

--- a/src/app/containers/MainContent/index.stories.jsx
+++ b/src/app/containers/MainContent/index.stories.jsx
@@ -27,6 +27,29 @@ const blocks = [
     },
   },
   {
+    type: 'subheading',
+    blockId: '1',
+    model: {
+      blocks: [
+        {
+          type: 'text',
+          blockId: 't-1',
+          model: {
+            blocks: [
+              {
+                type: 'paragraph',
+                blockId: 'p-1',
+                model: {
+                  text: 'This is a subheading!',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
     type: 'text',
     blockId: '2',
     model: {

--- a/src/app/containers/MainContent/index.test.jsx
+++ b/src/app/containers/MainContent/index.test.jsx
@@ -28,6 +28,29 @@ describe('MainContent', () => {
       },
     },
     {
+      type: 'subheading',
+      blockId: '1',
+      model: {
+        blocks: [
+          {
+            type: 'text',
+            blockId: 't-1',
+            model: {
+              blocks: [
+                {
+                  type: 'paragraph',
+                  blockId: 'p-1',
+                  model: {
+                    text: 'This is a subheading!',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
       type: 'text',
       blockId: '2',
       model: {


### PR DESCRIPTION
This PR whitelists the Subheading container so it can be rendered by the MainContent container.

* [x] Fixes https://github.com/bbc/simorgh/issues/334
* [x] Tests added for new features (i.e., snapshots updated)

* [ ] Test engineer approval
