### PR TITLE
Prioritise woff2

### DIFF
--- a/src/app/lib/globalStyles.js
+++ b/src/app/lib/globalStyles.js
@@ -10,55 +10,55 @@ injectGlobal`
     font-family: ReithSansNewsLight;
     font-style: normal;
     font-weight: 300;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSansNewsRegular;
     font-style: normal;
     font-weight: 400;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSansNewsMedium;
     font-style: normal;
     font-weight: 600;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSansNewsBold;
     font-style: normal;
     font-weight: 700;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSerifNewsLight;
     font-style: normal;
     font-weight: 300;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSerifNewsRegular;
     font-style: normal;
     font-weight: 400;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSerifNewsMedium;
     font-style: normal;
     font-weight: 600;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff') format('woff');
   }
   @font-face {
     font-display: optional;
     font-family: ReithSerifNewsBold;
     font-style: normal;
     font-weight: 700;
-    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff') format('woff'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2') format('woff2');
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff') format('woff');
   }
 `;


### PR DESCRIPTION
_Prioritise WOFF2 font over WOFF. This delivers approximately 17% in size over the wire using ReithSansNewsRegular._

![screen shot 2018-07-26 at 21 47 23](https://user-images.githubusercontent.com/16549467/43287787-eb86b0e4-911d-11e8-85f0-36f214b6d840.png)