### PR TITLE
Change Header Component styling to reflect UX rules

### DIFF
--- a/cypress/integration/articleSpec.js
+++ b/cypress/integration/articleSpec.js
@@ -13,8 +13,8 @@ describe('News Article', () => {
 
   it('should render the BBC News branding', () => {
     const headerElement = getElement('header');
-    shouldContainStyles(headerElement, 'height', '40px');
-    shouldContainStyles(headerElement, 'background-color', 'rgb(187, 25, 25)');
+    shouldContainStyles(headerElement, 'height', '80px');
+    shouldContainStyles(headerElement, 'background-color', 'rgb(184, 0, 0)');
 
     const anchorElement = getElement('header a');
     shouldContainText(anchorElement, 'BBC News');

--- a/src/app/components/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Article/__snapshots__/index.test.jsx.snap
@@ -3,8 +3,8 @@
 exports[`Article should render correctly 1`] = `
 Array [
   .c0 {
-  background-color: #BB1919;
-  height: 40px;
+  background-color: #B80000;
+  height: 80px;
   width: 100%;
   padding: 16px;
 }

--- a/src/app/components/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Header/__snapshots__/index.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Header should render correctly 1`] = `
 .c0 {
-  background-color: #BB1919;
-  height: 40px;
+  background-color: #B80000;
+  height: 80px;
   width: 100%;
   padding: 16px;
 }

--- a/src/app/components/Header/index.jsx
+++ b/src/app/components/Header/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { C_RED, GEL_SPACING_DBL } from '../../lib/constants/styles';
+import { C_POSTBOX, GEL_SPACING_DBL } from '../../lib/constants/styles';
 
 const StyledHeader = styled.header`
-  background-color: ${C_RED};
+  background-color: ${C_POSTBOX};
   height: 80px;
   width: 100%;
   padding: ${GEL_SPACING_DBL}px;

--- a/src/app/components/Header/index.jsx
+++ b/src/app/components/Header/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { C_POSTBOX, GEL_SPACING_DBL } from '../../lib/constants/styles';
+import { C_RED, GEL_SPACING_DBL } from '../../lib/constants/styles';
 
 const StyledHeader = styled.header`
-  background-color: ${C_POSTBOX};
-  height: 40px;
+  background-color: ${C_RED};
+  height: 80px;
   width: 100%;
   padding: ${GEL_SPACING_DBL}px;
 `;

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -3,8 +3,8 @@
 exports[`ArticleContainer Component should render correctly 1`] = `
 Array [
   .c0 {
-  background-color: #BB1919;
-  height: 40px;
+  background-color: #B80000;
+  height: 80px;
   width: 100%;
   padding: 16px;
 }

--- a/src/app/lib/constants/styles.js
+++ b/src/app/lib/constants/styles.js
@@ -6,6 +6,7 @@ export const C_EBON = '#222222';
 export const C_POSTBOX = '#BB1919';
 export const C_STORM = '#404040';
 export const C_WHITE = '#FFFFFF';
+export const C_RED = '#B80000';
 
 // Colours from other services
 export const C_ORBIT_GREY = '#4C4C4C';

--- a/src/app/lib/constants/styles.js
+++ b/src/app/lib/constants/styles.js
@@ -3,10 +3,9 @@
 
 // Colours
 export const C_EBON = '#222222';
-export const C_POSTBOX = '#BB1919';
+export const C_POSTBOX = '#B80000';
 export const C_STORM = '#404040';
 export const C_WHITE = '#FFFFFF';
-export const C_RED = '#B80000';
 
 // Colours from other services
 export const C_ORBIT_GREY = '#4C4C4C';


### PR DESCRIPTION
Changes the background colour and height of the Header Component so that it it reflects UX guidelines.

<img width="1025" alt="screen shot of header component with 80px padding and colour update" src="https://user-images.githubusercontent.com/916416/43323575-f753e040-91a9-11e8-80b1-d8085851c7a4.png">


* [x] Fixes https://github.com/bbc/simorgh/issues/342
* [x] Snapshots updated

* [ ] Test engineer approval
