### PR TITLE
Headings colour, padding-top, & font-family

### DIFF
--- a/src/app/components/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Article/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,8 @@ Array [
   .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 32px;
+  margin: 0;
+  padding: 32px 0 16px 0;
   font-size: 1.75em;
   line-height: 2em;
 }

--- a/src/app/components/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Article/__snapshots__/index.test.jsx.snap
@@ -22,6 +22,7 @@ Array [
   .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 32px;
   font-size: 1.75em;
   line-height: 2em;
 }

--- a/src/app/components/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Headings/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,8 @@ exports[`Headline component should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 32px;
+  margin: 0;
+  padding: 32px 0 16px 0;
   font-size: 1.75em;
   line-height: 2em;
 }
@@ -34,7 +35,8 @@ exports[`SubHeading component should render correctly 1`] = `
 .c0 {
   color: #404040;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 16px;
+  margin: 0;
+  padding: 16px 0;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/components/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Headings/__snapshots__/index.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`Headline component should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 32px;
   font-size: 1.75em;
   line-height: 2em;
 }
@@ -31,6 +32,9 @@ exports[`Headline component should render correctly 1`] = `
 
 exports[`SubHeading component should render correctly 1`] = `
 .c0 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 16px;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/components/Headings/index.jsx
+++ b/src/app/components/Headings/index.jsx
@@ -11,7 +11,8 @@ import mediaQuery from '../../helpers/mediaQueries';
 export const Headline = styled.h1`
   color: ${C_EBON};
   font-family: ${FF_NEWS_SANS_REG};
-  padding-top: ${GEL_SPACING_QUAD}px;
+  margin: 0; // Reset
+  padding: ${GEL_SPACING_QUAD}px 0 ${GEL_SPACING_DBL}px 0;
 
   // Font styling below is a subset of BBC GEL Typography "Canon"
   font-size: 1.75em;
@@ -29,7 +30,8 @@ export const Headline = styled.h1`
 export const SubHeading = styled.h2`
   color: ${C_STORM};
   font-family: ${FF_NEWS_SANS_REG};
-  padding-top: ${GEL_SPACING_DBL}px;
+  margin: 0; // Reset
+  padding: ${GEL_SPACING_DBL}px 0;
 
   // Font styling below is a subset of BBC GEL Typography "Trafalgar"
   font-size: 1.25em;

--- a/src/app/components/Headings/index.jsx
+++ b/src/app/components/Headings/index.jsx
@@ -1,10 +1,17 @@
 import styled from 'styled-components';
-import { C_EBON, FF_NEWS_SANS_REG } from '../../lib/constants/styles';
+import {
+  C_EBON,
+  C_STORM,
+  FF_NEWS_SANS_REG,
+  GEL_SPACING_DBL,
+  GEL_SPACING_QUAD,
+} from '../../lib/constants/styles';
 import mediaQuery from '../../helpers/mediaQueries';
 
 export const Headline = styled.h1`
   color: ${C_EBON};
   font-family: ${FF_NEWS_SANS_REG};
+  padding-top: ${GEL_SPACING_QUAD}px;
 
   // Font styling below is a subset of BBC GEL Typography "Canon"
   font-size: 1.75em;
@@ -20,6 +27,10 @@ export const Headline = styled.h1`
 `;
 
 export const SubHeading = styled.h2`
+  color: ${C_STORM};
+  font-family: ${FF_NEWS_SANS_REG};
+  padding-top: ${GEL_SPACING_DBL}px;
+
   // Font styling below is a subset of BBC GEL Typography "Trafalgar"
   font-size: 1.25em;
   line-height: 1.5em;

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,8 @@ Array [
   .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 32px;
+  margin: 0;
+  padding: 32px 0 16px 0;
   font-size: 1.75em;
   line-height: 2em;
 }

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -22,6 +22,7 @@ Array [
   .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 32px;
   font-size: 1.75em;
   line-height: 2em;
 }

--- a/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`Headings with headline data should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 32px;
   font-size: 1.75em;
   line-height: 2em;
 }
@@ -31,6 +32,9 @@ exports[`Headings with headline data should render correctly 1`] = `
 
 exports[`Headings with subheading data should render correctly 1`] = `
 .c0 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 16px;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,8 @@ exports[`Headings with headline data should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 32px;
+  margin: 0;
+  padding: 32px 0 16px 0;
   font-size: 1.75em;
   line-height: 2em;
 }
@@ -34,7 +35,8 @@ exports[`Headings with subheading data should render correctly 1`] = `
 .c0 {
   color: #404040;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 16px;
+  margin: 0;
+  padding: 16px 0;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,8 @@ exports[`MainContent should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 32px;
+  margin: 0;
+  padding: 32px 0 16px 0;
   font-size: 1.75em;
   line-height: 2em;
 }
@@ -12,7 +13,8 @@ exports[`MainContent should render correctly 1`] = `
 .c1 {
   color: #404040;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
-  padding-top: 16px;
+  margin: 0;
+  padding: 16px 0;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
@@ -4,11 +4,15 @@ exports[`MainContent should render correctly 1`] = `
 .c0 {
   color: #222222;
   font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 32px;
   font-size: 1.75em;
   line-height: 2em;
 }
 
 .c1 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Arial,Helvetica,freesans,sans-serif;
+  padding-top: 16px;
   font-size: 1.25em;
   line-height: 1.5em;
 }

--- a/src/app/lib/constants/styles.js
+++ b/src/app/lib/constants/styles.js
@@ -24,6 +24,7 @@ export const FF_NEWS_SERIF_BLD = `ReithSerifNewsBold${fontFamilyBase}`;
 // GEL Spacing
 export const GEL_SPACING = 8;
 export const GEL_SPACING_DBL = GEL_SPACING * 2;
+export const GEL_SPACING_QUAD = GEL_SPACING * 4;
 
 /*
    Screen sizes for GEL Typography


### PR DESCRIPTION
Styling fixes for Heading

* [x] Fixes https://github.com/bbc/simorgh/issues/398 #398 #396 
* [x] Tests added for new features

* [x] Test engineer approval

Headline / h1: 32px padding on top, 16px padding on bottom. 0 on left and right.
<img width="374" alt="screen shot headline" src="https://user-images.githubusercontent.com/3028997/43470060-9008e0c8-94df-11e8-9593-c8bdf3ebf868.png">

SubHeading /h2: 16px padding on top and bottom. 0 on left and right.
<img width="352" alt="screen shot subheading" src="https://user-images.githubusercontent.com/3028997/43470057-8fd8e684-94df-11e8-83f2-6db7f6e5e99a.png">
Note that padding was added to the top only, not both top and bottom. This is so that spacing is not duplicated within the article. 