### PR TITLE
Box-sizing border-box

### DIFF
--- a/src/app/lib/globalStyles.js
+++ b/src/app/lib/globalStyles.js
@@ -5,6 +5,10 @@ import { injectGlobal } from 'styled-components';
 injectGlobal`
   ${styledNormalize}
 
+  * {
+    box-sizing: border-box;
+  }
+
   @font-face {
     font-display: optional;
     font-family: ReithSansNewsLight;

--- a/src/app/lib/globalStyles.js
+++ b/src/app/lib/globalStyles.js
@@ -5,8 +5,12 @@ import { injectGlobal } from 'styled-components';
 injectGlobal`
   ${styledNormalize}
 
-  * {
+  // Box Sizing https://bit.ly/1A91I0J
+  html {
     box-sizing: border-box;
+  }
+  *, *:before, *:after {
+    box-sizing: inherit;
   }
 
   @font-face {


### PR DESCRIPTION
Added `box-sizing: border-box;` to injectGlobal.

Before this PR, this lighthouse test fails `Content is sized correctly for the viewport`. After this PR, it passes. 

We chose to put this into the global styles rather than Article, so that the other components would appear the same when viewed within the Storybook component library or within the Article.  


Before PR:
<img width="824" alt="screen shot of lighthouse with failing test" src="https://user-images.githubusercontent.com/3028997/43513527-da67add4-9575-11e8-9411-0fd505e0235c.png">

After PR:
<img width="818" alt="screen shot of lighthouse with passing test" src="https://user-images.githubusercontent.com/3028997/43513310-58ff3c76-9575-11e8-8b4c-ec89eb0b5f03.png">


* [x] Fixes https://github.com/bbc/simorgh/issues/410
* [ ] Tests added for new features

* [ ] Test engineer approval