### PR TITLE
Greenkeeper/styled components 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15234,8 +15234,7 @@
     "react-is": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
-      "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==",
-      "dev": true
+      "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -16823,18 +16822,18 @@
       }
     },
     "styled-components": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.1.6.tgz",
-      "integrity": "sha1-nEQxRvqCxmWan2TdSTvyICSANC4=",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.2.tgz",
+      "integrity": "sha512-eTmIiWstyDLccHZAyp+aCPirlkTvYiHlYGgWQxOYDv8Ko0o6mfnDo0+DnUnKinO8NzAfQXEDP7Bh0qlazwJgrw==",
       "requires": {
         "buffer": "^5.0.3",
         "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.9",
-        "hoist-non-react-statics": "^1.2.0",
-        "is-plain-object": "^2.0.1",
+        "fbjs": "^0.8.16",
+        "hoist-non-react-statics": "^2.5.0",
         "prop-types": "^15.5.4",
-        "stylis": "^3.4.0",
-        "stylis-rule-sheet": "^0.0.7",
+        "react-is": "^16.3.1",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
         "supports-color": "^3.2.3"
       },
       "dependencies": {
@@ -16851,11 +16850,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
         },
         "supports-color": {
           "version": "3.2.3",
@@ -16878,9 +16872,9 @@
       "integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
     },
     "stylis-rule-sheet": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.7.tgz",
-      "integrity": "sha512-qxzlUBO40tgcGMhYxk2gXAPcaZYpfCqHMoVHj92lFMyiFotcqaEl7Jb5eW1ccCanGwf1N9dVBKF9+i/gmDfzyQ=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "sumchecker": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1",
     "speculate": "^1.7.4",
-    "styled-components": "3.1.6",
+    "styled-components": "3.4.2",
     "styled-normalize": "^8.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1",
     "speculate": "^1.7.4",
-    "styled-components": "3.4.2",
+    "styled-components": "^3.4.2",
     "styled-normalize": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades styled-components to `^3.4.2`.

While styled-components is broken on client-side hydration if there are imported components that are not used on the page (https://github.com/bbc/simorgh/issues/381) with static data, this is not an issue for [dynamic data](https://github.com/bbc/simorgh/pull/429).

I still recommend aiming to resolve the issue of unused imports on static data, but it does not need to block this.
