### PR TITLE
Increase threshold for maximum bundle size

### DIFF
--- a/razzle.config.js
+++ b/razzle.config.js
@@ -30,7 +30,7 @@ module.exports = {
     if (process.env.CI) {
       appConfig.performance = {
         maxAssetSize: 400000,
-        maxEntrypointSize: 400000,
+        maxEntrypointSize: 500000,
       };
     }
 

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -29,7 +29,7 @@ module.exports = {
     // This is to override bundle performance test
     if (process.env.CI) {
       appConfig.performance = {
-        maxAssetSize: 400000,
+        maxAssetSize: 500000,
         maxEntrypointSize: 500000,
       };
     }


### PR DESCRIPTION
Temporary fix to unblock PRs. Full fix will be forthcoming as part of https://github.com/bbc/simorgh/issues/466

This is needed, since we have errors on other PRs:
```
asset size limit: The following asset(s) exceed the recommended size limit (391 KiB).
This can impact web performance.
Assets: 
  static/js/bundle.1d4f8ad6.js (391 KiB)
entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (391 KiB). This can impact web performance.
Entrypoints:
  client (391 KiB)
      static/js/bundle.1d4f8ad6.js
```
* [x] Part of https://github.com/bbc/simorgh/issues/466
* [ ] ~Tests added for new features~
* [ ] ~Test engineer approval~
