### PR TITLE
Use snapshot test for global styles

### DIFF
--- a/cypress/integration/metaSpec.js
+++ b/cypress/integration/metaSpec.js
@@ -31,32 +31,6 @@ describe('Article Meta Tests', () => {
       });
   });
 
-  it('should include the font faces', () => {
-    const expectedFonts = [
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff',
-      'https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2',
-    ];
-    const styleTag = getElement('head style');
-
-    expectedFonts.forEach(font => {
-      styleTag.should('contain', font);
-    });
-  });
-
   // Testing the actual fetch is not currently possible
   it('should have script to fetch bundle', () => {
     cy.get('script')

--- a/src/app/lib/__snapshots__/globalStyles.test.js.snap
+++ b/src/app/lib/__snapshots__/globalStyles.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`injectGlobal should be called with args matching snapshot 1`] = `
+exports[`globalStyles should call injectGlobal with args matching snapshot 1`] = `
 Array [
   Array [
     "

--- a/src/app/lib/__snapshots__/globalStyles.test.js.snap
+++ b/src/app/lib/__snapshots__/globalStyles.test.js.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`injectGlobal should be called with args matching snapshot 1`] = `
+Array [
+  Array [
+    "
+  ",
+    "
+
+  // Box Sizing https://bit.ly/1A91I0J
+  html {
+    box-sizing: border-box;
+  }
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
+
+  @font-face {
+    font-display: optional;
+    font-family: ReithSansNewsLight;
+    font-style: normal;
+    font-weight: 300;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Lt.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSansNewsRegular;
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Rg.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSansNewsMedium;
+    font-style: normal;
+    font-weight: 600;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Md.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSansNewsBold;
+    font-style: normal;
+    font-weight: 700;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSans_W_Bd.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSerifNewsLight;
+    font-style: normal;
+    font-weight: 300;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Lt.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSerifNewsRegular;
+    font-style: normal;
+    font-weight: 400;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Rg.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSerifNewsMedium;
+    font-style: normal;
+    font-weight: 600;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Md.woff') format('woff');
+  }
+  @font-face {
+    font-display: optional;
+    font-family: ReithSerifNewsBold;
+    font-style: normal;
+    font-weight: 700;
+    src: url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff2') format('woff2'), url('https://gel.files.bbci.co.uk/r2.302/BBCReithSerif_W_Bd.woff') format('woff');
+  }
+",
+  ],
+  Array [
+    "
+html {
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+a {
+  background-color: transparent;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+b,
+strong {
+  font-weight: bolder;
+}
+code,
+kbd,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+img {
+  border-style: none;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+button,
+input {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+[type=\\"button\\"],
+[type=\\"reset\\"],
+[type=\\"submit\\"] {
+  -webkit-appearance: button;
+}
+button::-moz-focus-inner,
+[type=\\"button\\"]::-moz-focus-inner,
+[type=\\"reset\\"]::-moz-focus-inner,
+[type=\\"submit\\"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+button:-moz-focusring,
+[type=\\"button\\"]:-moz-focusring,
+[type=\\"reset\\"]:-moz-focusring,
+[type=\\"submit\\"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+progress {
+  vertical-align: baseline;
+}
+textarea {
+  overflow: auto;
+}
+[type=\\"checkbox\\"],
+[type=\\"radio\\"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type=\\"number\\"]::-webkit-inner-spin-button,
+[type=\\"number\\"]::-webkit-outer-spin-button {
+  height: auto;
+}
+[type=\\"search\\"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type=\\"search\\"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+details {
+  display: block;
+}
+summary {
+  display: list-item;
+}
+template {
+  display: none;
+}
+[hidden] {
+  display: none;
+}
+
+",
+  ],
+]
+`;

--- a/src/app/lib/globalStyles.test.js
+++ b/src/app/lib/globalStyles.test.js
@@ -1,7 +1,7 @@
 import * as styledComponents from 'styled-components';
 
-describe('injectGlobal', () => {
-  it('should be called with args matching snapshot', async () => {
+describe('globalStyles', () => {
+  it('should call injectGlobal with args matching snapshot', async () => {
     jest.spyOn(styledComponents, 'injectGlobal');
 
     await import('./globalStyles');

--- a/src/app/lib/globalStyles.test.js
+++ b/src/app/lib/globalStyles.test.js
@@ -1,0 +1,13 @@
+import * as styledComponents from 'styled-components';
+
+describe('injectGlobal', () => {
+  it('should be called with args matching snapshot', async () => {
+    jest.spyOn(styledComponents, 'injectGlobal');
+
+    await import('./globalStyles');
+
+    const injectGlobalArgs = styledComponents.injectGlobal.mock.calls[0];
+
+    expect(injectGlobalArgs).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Resolves #496

_Removes Cypress spec that tests the global font faces injected with `injectGlobal` in favour of a snapshot test. The justification for this is that we are not able to succinctly and coherently test injected global styles in Cypress. Furthermore, a Cypress test is not the appropriate type of test for such assertions, and a unit test is more appropriate, and is able to give a comprehensive test coverage._

- [x] Tests added for new features
- [x] Test engineer approval
