### PR TITLE
Update originCode data type

### DIFF
--- a/data/schema.yaml
+++ b/data/schema.yaml
@@ -350,8 +350,8 @@ components:
               example: "https://fishchips.co.uk/images/ic/640x360/p052ww1r.jpg"
               type: string
             originCode:
-              example: true
-              type: boolean
+              example: "cpsprodpb"
+              type: string
             width:
               example: 640
               type: number


### PR DESCRIPTION
The `originCode` in the `rawImage` block was defined with the wrong data type previously (`boolean`). It has now been updated to reflect the data source, with its parameter validated as a `string`.

This is needed by #493