### PR TITLE
Fix proptype error

### DIFF
--- a/src/app/models/propTypes/article/index.js
+++ b/src/app/models/propTypes/article/index.js
@@ -21,10 +21,10 @@ const articlePropTypes = {
         articleType: string.isRequired,
         genre: string,
       }),
-      tags: {
+      tags: shape({
         about: string,
         mentions: string,
-      },
+      }),
       version: string,
       blockTypes: arrayOf(string),
     }).isRequired,


### PR DESCRIPTION
Currently, when you run `npm run dev` you get this error:

```
Warning: Failed prop type: checker is not a function
    in ArticleContainer
    in Route
    in Switch
    in Afterparty
    in Route
    in withRouter(Afterparty) (at index.jsx:9)
    in StyleSheetManager
    in Router
    in StaticRouter
```

This PR fixes this.

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
