### PR TITLE
Investigation lazy loading images option 2 [POC]

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
+    "react-lazy-load-image-component": "^1.1.1",
     "react-router-dom": "^4.3.1",
     "speculate": "^1.7.4",
     "styled-components": "^3.4.2",

--- a/src/app/components/Figure/index.jsx
+++ b/src/app/components/Figure/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { string } from 'prop-types';
 import styled from 'styled-components';
 import Caption from './Caption';
@@ -13,15 +14,11 @@ const StyledFigure = styled.figure`
   width: 100%;
 `;
 
-const Image = styled.img`
-  display: block;
-  width: 100%;
-`;
-
 const Figure = ({ src, alt, caption }) => (
   <StyledFigure>
-    <Image src={src} alt={alt} />
-    {renderCaption(caption)}
+    <LazyLoadImage src={src} alt={alt}>
+      {renderCaption(caption)}
+    </LazyLoadImage>
   </StyledFigure>
 );
 

--- a/src/app/components/Figure/index.jsx
+++ b/src/app/components/Figure/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
-import { string } from 'prop-types';
+import { string, node } from 'prop-types';
 import styled from 'styled-components';
 import Caption from './Caption';
 import { GEL_SPACING_DBL } from '../../lib/constants/styles';
@@ -14,21 +14,20 @@ const StyledFigure = styled.figure`
   width: 100%;
 `;
 
-const Figure = ({ src, alt, caption }) => (
+const Figure = ({ image, caption }) => (
   <StyledFigure>
-    <LazyLoadImage src={src} alt={alt}>
-      {renderCaption(caption)}
-    </LazyLoadImage>
+    <LazyLoadImage src={image.src} alt={image.alt} />
+    {renderCaption(caption)}
   </StyledFigure>
 );
 
 Figure.propTypes = {
-  alt: string.isRequired,
-  src: string.isRequired,
+  image: node,
   caption: string,
 };
 
 Figure.defaultProps = {
+  image: null,
   caption: null,
 };
 


### PR DESCRIPTION
Resolves #520 

_Demo 2 as part of #520 PoC demonstrating lazy loading images with `react-lazy-load-image-component`. This demo currently returns an empty JSON object on http://localhost:7080/news/articles/c0000000027o._

- [ ] Tests added for new features
- [ ] Test engineer approval
