### PR TITLE
Adding styling tests for copyright link

### DIFF
--- a/cypress/integration/footerSpec.js
+++ b/cypress/integration/footerSpec.js
@@ -75,4 +75,20 @@ describe('Footer Tests', () => {
       .should('have.attr', 'href')
       .and('contain', '/help/web/links');
   });
+  it('should contain a link in the copyright text, which have hover and focus states', () => {
+    const link = getElement('footer p a');
+    link.focus();
+    const linkSpan = link.get('footer p a span');
+    shouldContainStyles(
+      linkSpan,
+      'border-bottom',
+      '2px solid rgb(255, 255, 255)',
+    );
+    link.invoke('mouseover');
+    shouldContainStyles(
+      linkSpan,
+      'border-bottom',
+      '2px solid rgb(255, 255, 255)',
+    );
+  });
 });


### PR DESCRIPTION
_Adding styling tests for the inline link within the copyright section of the footer._

**Testing**
Run Commands:
`npm run test:e2e` or `npm run test:e2e:interactive`

- [ ] Tests added for new features
- [ ] Test engineer approval
