### PR TITLE
Add amp prop in Articles container & component

### DIFF
--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -1,4 +1,4 @@
-import { testNonHTMLResponseCode } from '../support/testHelper';
+import { getElement, testNonHTMLResponseCode } from '../support/testHelper';
 
 describe('AMP Tests', () => {
   // eslint-disable-next-line no-undef
@@ -11,5 +11,17 @@ describe('AMP Tests', () => {
     it('should return 200', () => {
       testNonHTMLResponseCode('/news/articles/amp/c0000000027o', 200);
     });
+  });
+
+  it('should have AMP attribute', () => {
+    const regex = /true/;
+
+    getElement('html')
+      .should('have.attr', 'amp')
+      .and('match', regex);
+  });
+  it('should not have an AMP attribute on the main article', () => {
+    cy.visit('/news/articles/c0000000027o');
+    getElement('html').should('not.have.attr', 'amp');
   });
 });

--- a/src/app/components/Article/index.jsx
+++ b/src/app/components/Article/index.jsx
@@ -6,10 +6,15 @@ import Footer from '../../containers/Footer';
 
 const Article = ({ amp, lang, title, id, children }) => {
   const canonicalLink = `https://www.bbc.com/news/articles/${id}`;
+  const htmlAttributes = { lang };
+
+  if (amp) {
+    htmlAttributes.amp = amp;
+  }
 
   return (
     <Fragment>
-      <Helmet htmlAttributes={{ amp, lang }}>
+      <Helmet htmlAttributes={htmlAttributes}>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, minimum-scale=1"

--- a/src/app/components/Article/index.jsx
+++ b/src/app/components/Article/index.jsx
@@ -1,15 +1,15 @@
 import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
-import { string, node } from 'prop-types';
+import { bool, string, node } from 'prop-types';
 import Header from '../Header';
 import Footer from '../../containers/Footer';
 
-const Article = ({ lang, title, id, children }) => {
+const Article = ({ amp, lang, title, id, children }) => {
   const canonicalLink = `https://www.bbc.com/news/articles/${id}`;
 
   return (
     <Fragment>
-      <Helmet htmlAttributes={{ lang }}>
+      <Helmet htmlAttributes={{ amp, lang }}>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, minimum-scale=1"
@@ -25,6 +25,7 @@ const Article = ({ lang, title, id, children }) => {
 };
 
 Article.propTypes = {
+  amp: bool.isRequired,
   children: node.isRequired,
   id: string.isRequired,
   lang: string.isRequired,

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`ArticleContainer Component no data should render correctly 1`] = `"Load
 
 exports[`ArticleContainer Component should render correctly 1`] = `
 <Article
+  amp={false}
   blocks={
     Array [
       Object {

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -3,10 +3,12 @@ import 'isomorphic-fetch';
 import Article from '../../components/Article';
 import MainContent from '../MainContent';
 import articlePropTypes from '../../models/propTypes/article';
+import isAmpPath from '../../helpers/isAmpPath';
 
 class ArticleContainer extends Component {
   static async getInitialProps({ req, match } = {}) {
     try {
+      const { path } = match;
       const { id } = match.params;
 
       const regex = '^(c[a-zA-Z0-9]{10}o)$';
@@ -26,8 +28,9 @@ class ArticleContainer extends Component {
 
       const response = await fetch(url);
       const data = await response.json();
+      const amp = isAmpPath(path);
 
-      return { data };
+      return { amp, data };
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
       return {};
@@ -35,8 +38,7 @@ class ArticleContainer extends Component {
   }
 
   render() {
-    const { data } = this.props;
-
+    const { amp, data } = this.props;
     /*
       This handles async data fetching, and a 'loading state', which we should look to handle more intelligently.
       After.JS gives no explicit loading state, so we just have to check for a lack of data.
@@ -54,6 +56,7 @@ class ArticleContainer extends Component {
 
     return (
       <Article
+        amp={amp}
         id={id}
         lang={metadata.passport.language}
         title={promo.headlines.seoHeadline}
@@ -68,6 +71,7 @@ class ArticleContainer extends Component {
 ArticleContainer.propTypes = articlePropTypes;
 
 ArticleContainer.defaultProps = {
+  amp: false,
   data: null,
 };
 

--- a/src/app/containers/Article/index.test.jsx
+++ b/src/app/containers/Article/index.test.jsx
@@ -121,7 +121,7 @@ describe('ArticleContainer', () => {
 
     it('should return the fetch response', async () => {
       const response = await callGetInitialProps();
-      expect(response).toEqual({ data: mockSuccessfulResponse });
+      expect(response).toEqual({ amp: false, data: mockSuccessfulResponse });
     });
 
     describe('On client', () => {

--- a/src/app/helpers/isAmpPath.js
+++ b/src/app/helpers/isAmpPath.js
@@ -1,4 +1,4 @@
-const AMP_PATH_REGEX = /^\/news\/articles\/amp\/:id$/;
+const AMP_PATH_REGEX = /\/articles\/amp\/:id$/;
 
 const isAmpPath = path => AMP_PATH_REGEX.test(path);
 

--- a/src/app/helpers/isAmpPath.js
+++ b/src/app/helpers/isAmpPath.js
@@ -1,0 +1,5 @@
+const AMP_PATH_REGEX = /^\/news\/articles\/amp\/:id$/;
+
+const isAmpPath = path => AMP_PATH_REGEX.test(path);
+
+export default isAmpPath;

--- a/src/app/helpers/isAmpPath.test.js
+++ b/src/app/helpers/isAmpPath.test.js
@@ -5,9 +5,9 @@ describe('isAmpPath', () => {
     expect(isAmpPath('/random')).toEqual(false);
   });
   it('should return false when passed a non-AMP article path', () => {
-    expect(isAmpPath('/news/articles/c0000000001o')).toEqual(false);
+    expect(isAmpPath('/news/articles/:id')).toEqual(false);
   });
   it('should return true when passed an AMP article path', () => {
-    expect(isAmpPath('/news/articles/amp/c0000000001o')).toEqual(false);
+    expect(isAmpPath('/news/articles/amp/:id')).toEqual(true);
   });
 });

--- a/src/app/helpers/isAmpPath.test.js
+++ b/src/app/helpers/isAmpPath.test.js
@@ -1,0 +1,13 @@
+import isAmpPath from './isAmpPath';
+
+describe('isAmpPath', () => {
+  it('should return false when passed a non-article path', () => {
+    expect(isAmpPath('/random')).toEqual(false);
+  });
+  it('should return false when passed a non-AMP article path', () => {
+    expect(isAmpPath('/news/articles/c0000000001o')).toEqual(false);
+  });
+  it('should return true when passed an AMP article path', () => {
+    expect(isAmpPath('/news/articles/amp/c0000000001o')).toEqual(false);
+  });
+});

--- a/src/app/helpers/isAmpPath.test.js
+++ b/src/app/helpers/isAmpPath.test.js
@@ -5,9 +5,9 @@ describe('isAmpPath', () => {
     expect(isAmpPath('/random')).toEqual(false);
   });
   it('should return false when passed a non-AMP article path', () => {
-    expect(isAmpPath('/news/articles/:id')).toEqual(false);
+    expect(isAmpPath('/articles/:id')).toEqual(false);
   });
   it('should return true when passed an AMP article path', () => {
-    expect(isAmpPath('/news/articles/amp/:id')).toEqual(true);
+    expect(isAmpPath('/articles/amp/:id')).toEqual(true);
   });
 });

--- a/src/app/models/propTypes/article/index.js
+++ b/src/app/models/propTypes/article/index.js
@@ -1,7 +1,8 @@
-import { arrayOf, number, shape, string } from 'prop-types';
+import { arrayOf, bool, number, shape, string } from 'prop-types';
 import mainContentPropTypes from '../mainContent';
 
 const articlePropTypes = {
+  amp: bool,
   data: shape({
     metadata: shape({
       id: string.isRequired,


### PR DESCRIPTION
Resolves #583

Sets `amp` prop to true when the path matches the AMP route. `/news/articles/amp/:id`

Currently, this will just add the amp attribute to the `<html>` element. 

The work for using `<amp-img>` instead of `<img>` and other required AMP-compatibility work will be carried out in separate PRs. 

*Testing instructions*
```
git checkout amp-prop
npm install
npm run dev
```
When you visit an AMP route for an article page, (http://localhost:7080/news/articles/amp/c0000000027o) on the `<html>` element you should see the attribute `amp="true"`.
When you visit a standard article route, (http://localhost:7080/news/articles/c0000000027o) on the `<html>` element you should *not* see the attribute `amp`.

- [x] Tests added for new features
- [x] Test engineer approval
