### PR TITLE
Removing the hover tests from Cypress

### DIFF
--- a/cypress/integration/footerSpec.js
+++ b/cypress/integration/footerSpec.js
@@ -28,17 +28,6 @@ describe('Footer Tests', () => {
       '4px solid rgb(255, 255, 255)',
     );
   });
-
-  it('should have a hover state', () => {
-    const anchorElement = getElement('footer a');
-    anchorElement.invoke('mouseover');
-
-    shouldContainStyles(
-      getElement('footer a span'),
-      'border-bottom',
-      '4px solid rgb(255, 255, 255)',
-    );
-  });
   it('should have working links', () => {
     getElement('footer ul').within(() => {
       checkFooterLinks('0', '/news/help-41670342');

--- a/cypress/integration/headerSpec.js
+++ b/cypress/integration/headerSpec.js
@@ -28,15 +28,4 @@ describe('Header Tests', () => {
       '4px solid rgb(255, 255, 255)',
     );
   });
-
-  it('should have a hover state', () => {
-    const anchorElement = getElement('header a');
-    anchorElement.invoke('mouseover');
-
-    shouldContainStyles(
-      getElement('header a span'),
-      'border-bottom',
-      '4px solid rgb(255, 255, 255)',
-    );
-  });
 });


### PR DESCRIPTION
Resolves #588 

_We currently have a Cypress test for checking the hover styles of the brand within the header and footer. This is actually a bug as the test only passing as the previous test Focuses the element and does not remove focus (element.blur()) at the end of the test. Because of this the hover test appears to pass but this is actually due to the focus state adding the same styling as the hover.._

- [ ] Software engineer approval

How to run Cypress tests:
`npm run test:e2e`
