### PR TITLE
Pass previous rendered block type, and render a hr on adjacent text blocks

### DIFF
--- a/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MainContent/__snapshots__/index.test.jsx.snap
@@ -45,6 +45,7 @@ exports[`MainContent should render correctly 1`] = `
       ]
     }
     type="subheading"
+    typeOfPreviousBlock="headline"
   />
   <TextContainer
     blocks={
@@ -59,6 +60,7 @@ exports[`MainContent should render correctly 1`] = `
       ]
     }
     type="text"
+    typeOfPreviousBlock="subheading"
   />
   <BlockString
     blocks={
@@ -71,6 +73,7 @@ exports[`MainContent should render correctly 1`] = `
       ]
     }
     type="test"
+    typeOfPreviousBlock="text"
   />
   <ImageContainer
     blocks={
@@ -135,6 +138,7 @@ exports[`MainContent should render correctly 1`] = `
       ]
     }
     type="image"
+    typeOfPreviousBlock="test"
   />
 </MainContent>
 `;

--- a/src/app/containers/MainContent/index.jsx
+++ b/src/app/containers/MainContent/index.jsx
@@ -19,12 +19,21 @@ const Blocks = {
 };
 
 const render = blocks =>
-  blocks.map(block => {
+  blocks.map((block, index) => {
     const { type, blockId, model } = block;
+
+    const { type: typeOfPreviousBlock } = blocks[index - 1] || {};
 
     const Block = Blocks[type] || BlockString;
 
-    return <Block key={blockId} type={type} {...model} />;
+    return (
+      <Block
+        key={blockId}
+        type={type}
+        typeOfPreviousBlock={typeOfPreviousBlock}
+        {...model}
+      />
+    );
   });
 
 const MainContentContainer = ({ blocks }) => {

--- a/src/app/containers/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Text/__snapshots__/index.test.jsx.snap
@@ -1,67 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextContainer with data should render correctly 1`] = `
-<Router
-  history={
-    Object {
-      "action": "POP",
-      "block": [Function],
-      "createHref": [Function],
-      "go": [Function],
-      "goBack": [Function],
-      "goForward": [Function],
-      "listen": [Function],
-      "location": Object {
-        "hash": "",
-        "pathname": "/",
-        "search": "",
-        "state": undefined,
-      },
-      "push": [Function],
-      "replace": [Function],
+exports[`TextContainer should render correctly 1`] = `
+<React.Fragment>
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
     }
-  }
->
-  <TextContainer
-    blocks={
-      Array [
-        Object {
-          "blockId": "01",
-          "model": Object {
-            "text": "It was designed by London-based florist Philippa Craddock, who also created the floral displays for St George's Chapel and St George's Hall using locally sourced foliage, [which were later donated to local hospices](/news/articles/c000000000ro).",
-          },
-          "type": "paragraph",
-        },
-        Object {
-          "blockId": "02",
-          "model": Object {
-            "text": "This is another paragraph with some **bold** text.",
-          },
-          "type": "paragraph",
-        },
-        Object {
-          "blockId": "03",
-          "model": Object {
-            "text": "This is a paragraph with _italic_ text.",
-          },
-          "type": "paragraph",
-        },
-        Object {
-          "blockId": "04",
-          "model": Object {
-            "text": "~~This is a paragraph with some strike-through text~~.",
-          },
-          "type": "paragraph",
-        },
-        Object {
-          "blockId": "05",
-          "model": Object {
-            "text": "This is a paragraph with some \`inline code.\`",
-          },
-          "type": "paragraph",
-        },
-      ]
-    }
+    text="This is a 1st paragraph block."
   />
-</Router>
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 2nd paragraph block."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 3rd paragraph block."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 4th paragraph block.."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 5th paragraph block."
+  />
+</React.Fragment>
 `;

--- a/src/app/containers/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Text/__snapshots__/index.test.jsx.snap
@@ -3,113 +3,23 @@
 exports[`TextContainer with data should render correctly 1`] = `
 <React.Fragment>
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 1st paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 2nd paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 3rd paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 4th paragraph block.."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 5th paragraph block."
   />
 </React.Fragment>
@@ -119,113 +29,23 @@ exports[`TextContainer with data with a passed previous block type should render
 <React.Fragment>
   <hr />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 1st paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 2nd paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 3rd paragraph block."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 4th paragraph block.."
   />
   <Text
-    options={
-      Object {
-        "forceBlock": true,
-        "overrides": Object {
-          "a": Object {
-            "component": [Function],
-          },
-          "em": Object {
-            "component": [Function],
-          },
-          "p": Object {
-            "component": [Function],
-          },
-          "strong": Object {
-            "component": [Function],
-          },
-        },
-      }
-    }
+    paragraphOverride={[Function]}
     text="This is a 5th paragraph block."
   />
 </React.Fragment>

--- a/src/app/containers/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Text/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextContainer should render correctly 1`] = `
+exports[`TextContainer with data should render correctly 1`] = `
 <React.Fragment>
   <Text
     options={
@@ -115,7 +115,7 @@ exports[`TextContainer should render correctly 1`] = `
 </React.Fragment>
 `;
 
-exports[`TextContainer with a passed previous block type should render correctly 1`] = `
+exports[`TextContainer with data with a passed previous block type should render correctly 1`] = `
 <React.Fragment>
   <hr />
   <Text

--- a/src/app/containers/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Text/__snapshots__/index.test.jsx.snap
@@ -114,3 +114,119 @@ exports[`TextContainer should render correctly 1`] = `
   />
 </React.Fragment>
 `;
+
+exports[`TextContainer with a passed previous block type should render correctly 1`] = `
+<React.Fragment>
+  <hr />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 1st paragraph block."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 2nd paragraph block."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 3rd paragraph block."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 4th paragraph block.."
+  />
+  <Text
+    options={
+      Object {
+        "forceBlock": true,
+        "overrides": Object {
+          "a": Object {
+            "component": [Function],
+          },
+          "em": Object {
+            "component": [Function],
+          },
+          "p": Object {
+            "component": [Function],
+          },
+          "strong": Object {
+            "component": [Function],
+          },
+        },
+      }
+    }
+    text="This is a 5th paragraph block."
+  />
+</React.Fragment>
+`;

--- a/src/app/containers/Text/index.jsx
+++ b/src/app/containers/Text/index.jsx
@@ -3,10 +3,12 @@ import { string } from 'prop-types';
 import { textModelPropTypes } from '../../models/propTypes/text';
 import Text from '../../components/Text';
 
-const TextContainer = ({ type, blocks, typeOfPreviousBlock }) => {
+const shouldPrependHR = typeOfPreviousBlock => typeOfPreviousBlock === 'text';
+
+const TextContainer = ({ blocks, typeOfPreviousBlock }) => {
   if (!blocks) return null;
 
-  const HorizontalRule = typeOfPreviousBlock === type ? <hr /> : null;
+  const HorizontalRule = shouldPrependHR(typeOfPreviousBlock) ? <hr /> : null;
 
   const textBlocks = blocks.map(({ blockId, model }) => (
     <Text key={blockId} {...model} />

--- a/src/app/containers/Text/index.jsx
+++ b/src/app/containers/Text/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { string } from 'prop-types';
 import { textModelPropTypes } from '../../models/propTypes/text';
 import Text from '../../components/Text';
 
@@ -19,6 +20,13 @@ const TextContainer = ({ type, blocks, typeOfPreviousBlock }) => {
   );
 };
 
-TextContainer.propTypes = textModelPropTypes;
+TextContainer.propTypes = {
+  ...textModelPropTypes,
+  typeOfPreviousBlock: string,
+};
+
+TextContainer.defaultProps = {
+  typeOfPreviousBlock: null,
+};
 
 export default TextContainer;

--- a/src/app/containers/Text/index.jsx
+++ b/src/app/containers/Text/index.jsx
@@ -2,10 +2,21 @@ import React from 'react';
 import { textModelPropTypes } from '../../models/propTypes/text';
 import Text from '../../components/Text';
 
-const TextContainer = ({ blocks }) => {
+const TextContainer = ({ type, blocks, typeOfPreviousBlock }) => {
   if (!blocks) return null;
 
-  return blocks.map(({ blockId, model }) => <Text key={blockId} {...model} />);
+  const HorizontalRule = typeOfPreviousBlock === type ? <hr /> : null;
+
+  const textBlocks = blocks.map(({ blockId, model }) => (
+    <Text key={blockId} {...model} />
+  ));
+
+  return (
+    <React.Fragment>
+      {HorizontalRule}
+      {textBlocks}
+    </React.Fragment>
+  );
 };
 
 TextContainer.propTypes = textModelPropTypes;

--- a/src/app/containers/Text/index.stories.jsx
+++ b/src/app/containers/Text/index.stories.jsx
@@ -25,6 +25,11 @@ const props = {
   ],
 };
 
-storiesOf('TextContainer', module).add('default', () => (
-  <TextContainer {...props} />
-));
+storiesOf('TextContainer', module)
+  .add('default', () => <TextContainer {...props} />)
+  .add('adjacent text blocks', () => (
+    <React.Fragment>
+      <TextContainer {...props} type="text" />
+      <TextContainer {...props} type="text" typeOfPreviousBlock="text" />
+    </React.Fragment>
+  ));

--- a/src/app/containers/Text/index.test.jsx
+++ b/src/app/containers/Text/index.test.jsx
@@ -28,6 +28,13 @@ describe('TextContainer', () => {
     isNull('should return null', <TextContainer />);
   });
 
+  describe('with a passed previous block type', () => {
+    shouldShallowMatchSnapshot(
+      'should render correctly',
+      <TextContainer {...data} type="text" typeOfPreviousBlock="text" />,
+    );
+  });
+
   shouldShallowMatchSnapshot(
     'should render correctly',
     <TextContainer {...data} />,

--- a/src/app/containers/Text/index.test.jsx
+++ b/src/app/containers/Text/index.test.jsx
@@ -6,37 +6,39 @@ import {
 import TextContainer from './index';
 
 describe('TextContainer', () => {
-  const paragraphBlock = (blockId, text) => ({
-    blockId,
-    type: 'paragraph',
-    model: {
-      text,
-    },
-  });
-
-  const data = {
-    blocks: [
-      paragraphBlock('01', 'This is a 1st paragraph block.'),
-      paragraphBlock('02', 'This is a 2nd paragraph block.'),
-      paragraphBlock('03', 'This is a 3rd paragraph block.'),
-      paragraphBlock('04', 'This is a 4th paragraph block..'),
-      paragraphBlock('05', 'This is a 5th paragraph block.'),
-    ],
-  };
-
   describe('with no data', () => {
     isNull('should return null', <TextContainer />);
   });
 
-  describe('with a passed previous block type', () => {
+  describe('with data', () => {
+    const paragraphBlock = (blockId, text) => ({
+      blockId,
+      type: 'paragraph',
+      model: {
+        text,
+      },
+    });
+
+    const data = {
+      blocks: [
+        paragraphBlock('01', 'This is a 1st paragraph block.'),
+        paragraphBlock('02', 'This is a 2nd paragraph block.'),
+        paragraphBlock('03', 'This is a 3rd paragraph block.'),
+        paragraphBlock('04', 'This is a 4th paragraph block..'),
+        paragraphBlock('05', 'This is a 5th paragraph block.'),
+      ],
+    };
+
     shouldShallowMatchSnapshot(
       'should render correctly',
-      <TextContainer {...data} type="text" typeOfPreviousBlock="text" />,
+      <TextContainer {...data} />,
     );
-  });
 
-  shouldShallowMatchSnapshot(
-    'should render correctly',
-    <TextContainer {...data} />,
-  );
+    describe('with a passed previous block type', () => {
+      shouldShallowMatchSnapshot(
+        'should render correctly',
+        <TextContainer {...data} type="text" typeOfPreviousBlock="text" />,
+      );
+    });
+  });
 });

--- a/src/app/containers/Text/index.test.jsx
+++ b/src/app/containers/Text/index.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { StaticRouter } from 'react-router-dom';
 import {
   shouldShallowMatchSnapshot,
   isNull,
@@ -7,46 +6,30 @@ import {
 import TextContainer from './index';
 
 describe('TextContainer', () => {
+  const paragraphBlock = (blockId, text) => ({
+    blockId,
+    type: 'paragraph',
+    model: {
+      text,
+    },
+  });
+
+  const data = {
+    blocks: [
+      paragraphBlock('01', 'This is a 1st paragraph block.'),
+      paragraphBlock('02', 'This is a 2nd paragraph block.'),
+      paragraphBlock('03', 'This is a 3rd paragraph block.'),
+      paragraphBlock('04', 'This is a 4th paragraph block..'),
+      paragraphBlock('05', 'This is a 5th paragraph block.'),
+    ],
+  };
+
   describe('with no data', () => {
     isNull('should return null', <TextContainer />);
   });
 
-  describe('with data', () => {
-    const paragraphBlock = (blockId, text) => ({
-      blockId,
-      type: 'paragraph',
-      model: {
-        text,
-      },
-    });
-
-    const data = {
-      blocks: [
-        paragraphBlock(
-          '01',
-          "It was designed by London-based florist Philippa Craddock, who also created the floral displays for St George's Chapel and St George's Hall using locally sourced foliage, [which were later donated to local hospices](/news/articles/c000000000ro).",
-        ),
-        paragraphBlock(
-          '02',
-          'This is another paragraph with some **bold** text.',
-        ),
-        paragraphBlock('03', 'This is a paragraph with _italic_ text.'),
-        paragraphBlock(
-          '04',
-          '~~This is a paragraph with some strike-through text~~.',
-        ),
-        paragraphBlock('05', 'This is a paragraph with some `inline code.`'),
-      ],
-    };
-
-    shouldShallowMatchSnapshot(
-      'should render correctly',
-      /*
-        for the value it would bring, it is much simpler to wrap a react-router Link in a Router, rather than mock a Router or pass come mocked context.
-      */
-      <StaticRouter>
-        <TextContainer {...data} />
-      </StaticRouter>,
-    );
-  });
+  shouldShallowMatchSnapshot(
+    'should render correctly',
+    <TextContainer {...data} />,
+  );
 });


### PR DESCRIPTION
Resolves #560

_Abstracts the type of the previous rendered block and passes it to the component of a block. Then renders a horizontal rule if the previous block type matches `text`._

- [x] Tests added for new features
- [ ] Test engineer approval
