### PR TITLE
Display image copyright in HTML element

### DIFF
--- a/src/app/components/Figure/Copyright/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/Copyright/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Copyright should render correctly 1`] = `
+.c0 {
+  font-size: 0.75em;
+  line-height: 1em;
+  background-color: #222222;
+  color: #FFFFFF;
+  padding: 0.5rem;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+<span
+  className="c0"
+>
+  © 
+  Getty Images
+</span>
+`;

--- a/src/app/components/Figure/Copyright/index.jsx
+++ b/src/app/components/Figure/Copyright/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { node } from 'prop-types';
+import styled from 'styled-components';
+import {
+  FF_NEWS_SANS_REG,
+  C_WHITE,
+  C_EBON,
+  GEL_SPACING,
+} from '../../../lib/constants/styles';
+import { T_MINION } from '../../../lib/constants/typography';
+
+// const copyrightSymbolPrefix = '&#169; ';
+const copyrightSymbolPrefix = '© ';
+
+const StyledCopyright = styled.span`
+  ${T_MINION};
+  background-color: ${C_EBON};
+  color: ${C_WHITE};
+  padding: ${GEL_SPACING};
+  font-family: ${FF_NEWS_SANS_REG};
+  position: absolute;
+  bottom: 0;
+  right: 0;
+`;
+
+const Copyright = ({ children }) => (
+  <StyledCopyright>
+    {copyrightSymbolPrefix}
+    {children}
+  </StyledCopyright>
+);
+
+Copyright.propTypes = {
+  children: node.isRequired,
+};
+
+export default Copyright;

--- a/src/app/components/Figure/Copyright/index.test.jsx
+++ b/src/app/components/Figure/Copyright/index.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../../helpers/tests/testHelpers';
+import Copyright from './index';
+
+describe('Copyright', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <Copyright>Getty Images</Copyright>,
+  );
+});

--- a/src/app/components/Figure/ImageWrapper/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/ImageWrapper/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImageWrapper with Copright should render correctly 1`] = `
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  display: block;
+  width: 100%;
+}
+
+.c2 {
+  font-size: 0.75em;
+  line-height: 1em;
+  background-color: #222222;
+  color: #FFFFFF;
+  padding: 0.5rem;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+<div
+  className="c0"
+>
+  <img
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    className="c1"
+    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+  />
+  <span
+    className="c2"
+  >
+    © 
+    Getty Images
+  </span>
+</div>
+`;
+
+exports[`ImageWrapper without Copyright should render correctly 1`] = `
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  display: block;
+  width: 100%;
+}
+
+<div
+  className="c0"
+>
+  <img
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    className="c1"
+    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+  />
+</div>
+`;

--- a/src/app/components/Figure/ImageWrapper/index.jsx
+++ b/src/app/components/Figure/ImageWrapper/index.jsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ImageWrapper = styled.div`
+  position: relative;
+`;
+
+export default ImageWrapper;

--- a/src/app/components/Figure/ImageWrapper/index.test.jsx
+++ b/src/app/components/Figure/ImageWrapper/index.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../../helpers/tests/testHelpers';
+import ImageWrapper from '.';
+import Image from '../Image';
+import Copyright from '../Copyright';
+
+const imageAlt =
+  'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.';
+const imageSrc =
+  'https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png';
+
+describe('ImageWrapper with Copright', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+      <Copyright>Getty Images</Copyright>
+    </ImageWrapper>,
+  );
+});
+
+describe('ImageWrapper without Copyright', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+    </ImageWrapper>,
+  );
+});

--- a/src/app/components/Figure/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/__snapshots__/index.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`Figure with a caption should render correctly 1`] = `
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
+  position: relative;
 }
 
 .c1 {
@@ -65,6 +66,7 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
+  position: relative;
 }
 
 .c1 {
@@ -72,7 +74,7 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
   width: 100%;
 }
 
-.c2 {
+.c4 {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -93,6 +95,18 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
   width: 100%;
 }
 
+.c2 {
+  font-size: 0.75em;
+  line-height: 1em;
+  background-color: #222222;
+  color: #FFFFFF;
+  padding: 0.5rem;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
 @media (min-width:37.5em) {
   .c3 {
     padding: 0.5rem 1rem;
@@ -110,13 +124,14 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
   <span
     className="c2"
   >
-    Copyright Getty images
+    © 
+    Getty Images
   </span>
   <figcaption
     className="c3"
   >
     <span
-      className="c2"
+      className="c4"
     >
       Image caption, 
     </span>
@@ -130,6 +145,7 @@ exports[`Figure with non-BBC copyright should render correctly 1`] = `
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
+  position: relative;
 }
 
 .c1 {
@@ -138,16 +154,15 @@ exports[`Figure with non-BBC copyright should render correctly 1`] = `
 }
 
 .c2 {
+  font-size: 0.75em;
+  line-height: 1em;
+  background-color: #222222;
+  color: #FFFFFF;
+  padding: 0.5rem;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
   position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  top: 0;
+  bottom: 0;
+  right: 0;
 }
 
 <figure
@@ -161,7 +176,8 @@ exports[`Figure with non-BBC copyright should render correctly 1`] = `
   <span
     className="c2"
   >
-    Copyright Getty images
+    © 
+    Getty Images
   </span>
 </figure>
 `;
@@ -171,6 +187,7 @@ exports[`Figure without a caption should render correctly 1`] = `
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
+  position: relative;
 }
 
 .c1 {

--- a/src/app/components/Figure/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/__snapshots__/index.test.jsx.snap
@@ -5,71 +5,9 @@ exports[`Figure with a caption should render correctly 1`] = `
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
-  position: relative;
-}
-
-.c1 {
-  display: block;
-  width: 100%;
-}
-
-.c3 {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  top: 0;
 }
 
 .c2 {
-  background-color: #D5D0CD;
-  color: #404040;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding: 0.5rem;
-  width: 100%;
-}
-
-@media (min-width:37.5em) {
-  .c2 {
-    padding: 0.5rem 1rem;
-  }
-}
-
-<figure
-  className="c0"
->
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-    className="c1"
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
-  <figcaption
-    className="c2"
-  >
-    <span
-      className="c3"
-    >
-      Image caption, 
-    </span>
-    This is a caption
-  </figcaption>
-</figure>
-`;
-
-exports[`Figure with caption and non-BBC copyright should render correctly 1`] = `
-.c0 {
-  margin: 0;
-  padding-bottom: 1rem;
-  width: 100%;
-  position: relative;
-}
-
-.c1 {
   display: block;
   width: 100%;
 }
@@ -95,16 +33,8 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
   width: 100%;
 }
 
-.c2 {
-  font-size: 0.75em;
-  line-height: 1em;
-  background-color: #222222;
-  color: #FFFFFF;
-  padding: 0.5rem;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  position: absolute;
-  bottom: 0;
-  right: 0;
+.c1 {
+  position: relative;
 }
 
 @media (min-width:37.5em) {
@@ -116,17 +46,15 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
 <figure
   className="c0"
 >
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <div
     className="c1"
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
-  <span
-    className="c2"
   >
-    © 
-    Getty Images
-  </span>
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      className="c2"
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg"
+    />
+  </div>
   <figcaption
     className="c3"
   >
@@ -140,20 +68,40 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
 </figure>
 `;
 
-exports[`Figure with non-BBC copyright should render correctly 1`] = `
+exports[`Figure with caption and non-BBC copyright should render correctly 1`] = `
 .c0 {
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
-  position: relative;
 }
 
-.c1 {
+.c2 {
   display: block;
   width: 100%;
 }
 
-.c2 {
+.c5 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  top: 0;
+}
+
+.c4 {
+  background-color: #D5D0CD;
+  color: #404040;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding: 0.5rem;
+  width: 100%;
+}
+
+.c3 {
   font-size: 0.75em;
   line-height: 1em;
   background-color: #222222;
@@ -165,20 +113,93 @@ exports[`Figure with non-BBC copyright should render correctly 1`] = `
   right: 0;
 }
 
+.c1 {
+  position: relative;
+}
+
+@media (min-width:37.5em) {
+  .c4 {
+    padding: 0.5rem 1rem;
+  }
+}
+
 <figure
   className="c0"
 >
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <div
     className="c1"
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
-  <span
-    className="c2"
   >
-    © 
-    Getty Images
-  </span>
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      className="c2"
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg"
+    />
+    <span
+      className="c3"
+    >
+      © 
+      Getty Images
+    </span>
+  </div>
+  <figcaption
+    className="c4"
+  >
+    <span
+      className="c5"
+    >
+      Image caption, 
+    </span>
+    This is a caption
+  </figcaption>
+</figure>
+`;
+
+exports[`Figure with non-BBC copyright should render correctly 1`] = `
+.c0 {
+  margin: 0;
+  padding-bottom: 1rem;
+  width: 100%;
+}
+
+.c2 {
+  display: block;
+  width: 100%;
+}
+
+.c3 {
+  font-size: 0.75em;
+  line-height: 1em;
+  background-color: #222222;
+  color: #FFFFFF;
+  padding: 0.5rem;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
+.c1 {
+  position: relative;
+}
+
+<figure
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      className="c2"
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg"
+    />
+    <span
+      className="c3"
+    >
+      © 
+      Getty Images
+    </span>
+  </div>
 </figure>
 `;
 
@@ -187,21 +208,28 @@ exports[`Figure without a caption should render correctly 1`] = `
   margin: 0;
   padding-bottom: 1rem;
   width: 100%;
-  position: relative;
+}
+
+.c2 {
+  display: block;
+  width: 100%;
 }
 
 .c1 {
-  display: block;
-  width: 100%;
+  position: relative;
 }
 
 <figure
   className="c0"
 >
-  <img
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+  <div
     className="c1"
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
+  >
+    <img
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      className="c2"
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg"
+    />
+  </div>
 </figure>
 `;

--- a/src/app/components/Figure/fixtureData.jsx
+++ b/src/app/components/Figure/fixtureData.jsx
@@ -3,6 +3,7 @@ import Figure from './index';
 import Image from './Image';
 import Caption from './Caption';
 import Copyright from './Copyright';
+import ImageWrapper from './ImageWrapper';
 
 const imageAlt =
   'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.';
@@ -13,28 +14,36 @@ const copyrightText = 'Getty Images';
 
 export const FigureImage = (
   <Figure>
-    <Image alt={imageAlt} src={imageSrc} />
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+    </ImageWrapper>
   </Figure>
 );
 
 export const FigureImageWithCaption = (
   <Figure>
-    <Image alt={imageAlt} src={imageSrc} />
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+    </ImageWrapper>
     <Caption>{captionValue}</Caption>
   </Figure>
 );
 
 export const FigureImageWithCopyright = (
   <Figure>
-    <Image alt={imageAlt} src={imageSrc} />
-    <Copyright>{copyrightText}</Copyright>
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+      <Copyright>{copyrightText}</Copyright>
+    </ImageWrapper>
   </Figure>
 );
 
 export const FigureImageWithCopyrightAndCaption = (
   <Figure>
-    <Image alt={imageAlt} src={imageSrc} />
-    <Copyright>{copyrightText}</Copyright>
+    <ImageWrapper>
+      <Image alt={imageAlt} src={imageSrc} />
+      <Copyright>{copyrightText}</Copyright>
+    </ImageWrapper>
     <Caption>{captionValue}</Caption>
   </Figure>
 );

--- a/src/app/components/Figure/fixtureData.jsx
+++ b/src/app/components/Figure/fixtureData.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import Figure from './index';
 import Image from './Image';
 import Caption from './Caption';
-import VisuallyHiddenText from '../VisuallyHiddenText';
+import Copyright from './Copyright';
 
 const imageAlt =
   'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.';
 const imageSrc =
   'https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png';
 const captionValue = 'This is a caption';
-const copyrightText = 'Copyright Getty images';
+const copyrightText = 'Getty Images';
 
 export const FigureImage = (
   <Figure>
@@ -27,14 +27,14 @@ export const FigureImageWithCaption = (
 export const FigureImageWithCopyright = (
   <Figure>
     <Image alt={imageAlt} src={imageSrc} />
-    <VisuallyHiddenText>{copyrightText}</VisuallyHiddenText>
+    <Copyright>{copyrightText}</Copyright>
   </Figure>
 );
 
 export const FigureImageWithCopyrightAndCaption = (
   <Figure>
     <Image alt={imageAlt} src={imageSrc} />
-    <VisuallyHiddenText>{copyrightText}</VisuallyHiddenText>
+    <Copyright>{copyrightText}</Copyright>
     <Caption>{captionValue}</Caption>
   </Figure>
 );

--- a/src/app/components/Figure/fixtureData.jsx
+++ b/src/app/components/Figure/fixtureData.jsx
@@ -7,7 +7,7 @@ import Copyright from './Copyright';
 const imageAlt =
   'Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17.';
 const imageSrc =
-  'https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png';
+  'https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg';
 const captionValue = 'This is a caption';
 const copyrightText = 'Getty Images';
 

--- a/src/app/components/Figure/index.jsx
+++ b/src/app/components/Figure/index.jsx
@@ -5,7 +5,6 @@ const Figure = styled.figure`
   margin: 0;
   padding-bottom: ${GEL_SPACING_DBL};
   width: 100%;
-  position: relative;
 `;
 
 export default Figure;

--- a/src/app/components/Figure/index.jsx
+++ b/src/app/components/Figure/index.jsx
@@ -5,6 +5,7 @@ const Figure = styled.figure`
   margin: 0;
   padding-bottom: ${GEL_SPACING_DBL};
   width: 100%;
+  position: relative;
 `;
 
 export default Figure;

--- a/src/app/containers/Figure/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Figure/__snapshots__/index.test.jsx.snap
@@ -2,19 +2,23 @@
 
 exports[`Figure should render an image with alt text 1`] = `
 <Figure>
-  <Image
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
+  <ImageWrapper>
+    <Image
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    />
+  </ImageWrapper>
 </Figure>
 `;
 
 exports[`Figure should render caption text 1`] = `
 <Figure>
-  <Image
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
+  <ImageWrapper>
+    <Image
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    />
+  </ImageWrapper>
   <Caption>
     This is a caption
   </Caption>
@@ -23,12 +27,14 @@ exports[`Figure should render caption text 1`] = `
 
 exports[`Figure should render copyright text 1`] = `
 <Figure>
-  <Image
-    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  />
-  <VisuallyHiddenText>
-    Copyright Getty images
-  </VisuallyHiddenText>
+  <ImageWrapper>
+    <Image
+      alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+      src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    />
+    <Copyright>
+      Copyright Getty images
+    </Copyright>
+  </ImageWrapper>
 </Figure>
 `;

--- a/src/app/containers/Figure/index.jsx
+++ b/src/app/containers/Figure/index.jsx
@@ -2,19 +2,22 @@ import React from 'react';
 import { string } from 'prop-types';
 import Figure from '../../components/Figure';
 import Image from '../../components/Figure/Image';
-import VisuallyHiddenText from '../../components/VisuallyHiddenText';
 import Caption from '../../components/Figure/Caption';
+import ImageWrapper from '../../components/Figure/ImageWrapper';
+import Copyright from '../../components/Figure/Copyright';
 
 const renderCopyright = copyright =>
-  copyright ? <VisuallyHiddenText>{copyright}</VisuallyHiddenText> : null;
+  copyright ? <Copyright>{copyright}</Copyright> : null;
 
 const renderCaption = captionValue =>
   captionValue ? <Caption>{captionValue}</Caption> : null;
 
 const FigureContainer = ({ src, alt, copyright, caption }) => (
   <Figure>
-    <Image alt={alt} src={src} />
-    {renderCopyright(copyright)}
+    <ImageWrapper>
+      <Image alt={alt} src={src} />
+      {renderCopyright(copyright)}
+    </ImageWrapper>
     {renderCaption(caption)}
   </Figure>
 );

--- a/src/app/containers/Image/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Image/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`Image with data should render an image with alt text and offscreen copy
 <FigureContainer
   alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
   caption={null}
-  copyright="Copyright Getty images"
+  copyright="Getty images"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
 />
 `;

--- a/src/app/containers/Image/index.jsx
+++ b/src/app/containers/Image/index.jsx
@@ -17,10 +17,7 @@ const getCopyright = copyrightHolder => {
     return null;
   }
 
-  const copyrightOffscreenText = 'Copyright';
-  const copyrightText = `${copyrightOffscreenText} ${copyrightHolder}`;
-
-  return copyrightText;
+  return copyrightHolder;
 };
 
 const ImageContainer = ({ blocks }) => {

--- a/src/app/lib/constants/typography.js
+++ b/src/app/lib/constants/typography.js
@@ -66,3 +66,8 @@ export const T_TRAFALGAR = css`
     line-height: 2.25rem;
   }
 `;
+
+export const T_MINION = css`
+  font-size: 0.75em;
+  line-height: 1em;
+`;


### PR DESCRIPTION
Resolves #456 

Displays image copyright as a HTML element, overlaid on the bottom-right of the image. At some point we expect this to be unnecessary as it will be burnt into the image, but currently we have no indication as to how soon that might be the case.

* Creates copyright component with unit test
* Ensures both visual & AT text should read "© <Copyright Holder>", e.g. "© Getty Images"
* Creates Minion typography group
* Creates ImageWrapper with unit test, required to ensure correct placement of the copyright element with regards to both the image & the caption.
* Changes fixture data image, to one more typical -- previous had embedded source & logo. [Previous](https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png) | [New](https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg)
* Changes fixture data copyright value, as it is no longer visually hidden text.
* Updates fixture to include ImageWrapper

[Relevant Storybook page](http://localhost:9001/?selectedKind=Figure&selectedStory=with%20non-BBC%20copyright&full=1&addons=1&stories=1&panelRight=0).

Note also [this accessibility note from Catharine](https://github.com/bbc/simorgh/issues/456#issuecomment-418804230).

- [x] Tests added for new features
- [ ] Test engineer approval