### PR TITLE
Creates minion typography group

### DIFF
--- a/src/app/lib/constants/typography.js
+++ b/src/app/lib/constants/typography.js
@@ -66,3 +66,8 @@ export const T_TRAFALGAR = css`
     line-height: 2.25rem;
   }
 `;
+
+export const T_MINION = css`
+  font-size: 0.75em;
+  line-height: 1em;
+`;


### PR DESCRIPTION
Part of #456 

Minion typography group is needed for the Copyright HTML element.

- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~
