### PR TITLE
Add routing for articles

### DIFF
--- a/cypress/integration/routingSpec.js
+++ b/cypress/integration/routingSpec.js
@@ -1,0 +1,10 @@
+import services from '../support/testData/services';
+
+describe('Routing tests', () => {
+  it('accepts different service params', () => {
+    cy.wrap(services).each(service => {
+      cy.visit(service.name + service.path);
+      cy.get('html').should('have.attr', 'lang', service.lang);
+    });
+  });
+});

--- a/cypress/support/testData/services.js
+++ b/cypress/support/testData/services.js
@@ -1,0 +1,6 @@
+const services = [
+  { name: '/news', path: '/articles/c0000000027o', lang: 'en-gb' },
+  { name: '/persian', path: '/articles/c0000000028o', lang: 'fa' },
+];
+
+export default services;

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -16,15 +16,15 @@ class ArticleContainer extends Component {
       const routeMatches = id.match(regex);
       const serviceMatch = services.includes(service);
 
-      if (!serviceMatch) {
-        throw new Error(
-          `Invalid route parameter: ${service}. Service parameter must be news or persian.`,
-        );
-      }
-
       if (!routeMatches) {
         throw new Error(
           `Invalid route parameter: ${id}. ID parameter must be in format 'c[xxxxxxxxxx]o', where the middle part could be 0000000001 to 0000000027.`,
+        );
+      }
+
+      if (!serviceMatch) {
+        throw new Error(
+          `Invalid route parameter: ${service}. Service parameter must be news or persian.`,
         );
       }
 

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -9,10 +9,18 @@ class ArticleContainer extends Component {
   static async getInitialProps({ req, match } = {}) {
     try {
       const { path } = match;
-      const { id } = match.params;
+      const { id, service } = match.params;
 
+      const services = ['news', 'persian'];
       const regex = '^(c[a-zA-Z0-9]{10}o)$';
       const routeMatches = id.match(regex);
+      const serviceMatch = services.includes(service);
+
+      if (!serviceMatch) {
+        throw new Error(
+          `Invalid route parameter: ${service}. Service parameter must be news or persian.`,
+        );
+      }
 
       if (!routeMatches) {
         throw new Error(

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -1,30 +1,36 @@
-import React, { Component } from 'react';
+import React from 'react';
 import 'isomorphic-fetch';
 import Article from '../../components/Article';
 import MainContent from '../MainContent';
 import articlePropTypes from '../../models/propTypes/article';
 import isAmpPath from '../../helpers/isAmpPath';
 
-class ArticleContainer extends Component {
+const serviceValidator = service => {
+  const services = ['news', 'persian'];
+
+  const serviceMatch = services.includes(service);
+
+  if (!serviceMatch) {
+    throw new Error(
+      `Invalid route parameter: ${service}. Service parameter must be news or persian.`,
+    );
+  }
+};
+
+class ArticleContainer extends React.Component {
   static async getInitialProps({ req, match } = {}) {
     try {
       const { path } = match;
       const { id, service } = match.params;
 
-      const services = ['news', 'persian'];
       const regex = '^(c[a-zA-Z0-9]{10}o)$';
       const routeMatches = id.match(regex);
-      const serviceMatch = services.includes(service);
+
+      serviceValidator(service);
 
       if (!routeMatches) {
         throw new Error(
           `Invalid route parameter: ${id}. ID parameter must be in format 'c[xxxxxxxxxx]o', where the middle part could be 0000000001 to 0000000027.`,
-        );
-      }
-
-      if (!serviceMatch) {
-        throw new Error(
-          `Invalid route parameter: ${service}. Service parameter must be news or persian.`,
         );
       }
 

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import 'isomorphic-fetch';
 import Article from '../../components/Article';
 import MainContent from '../MainContent';
 import articlePropTypes from '../../models/propTypes/article';
 import isAmpPath from '../../helpers/isAmpPath';
 
-const serviceValidator = service => {
+const validateService = service => {
   const services = ['news', 'persian'];
-
   const serviceMatch = services.includes(service);
 
   if (!serviceMatch) {
@@ -17,22 +16,25 @@ const serviceValidator = service => {
   }
 };
 
-class ArticleContainer extends React.Component {
+const validateId = id => {
+  const regex = '^(c[a-zA-Z0-9]{10}o)$';
+  const routeMatches = id.match(regex);
+
+  if (!routeMatches) {
+    throw new Error(
+      `Invalid route parameter: ${id}. ID parameter must be in format 'c[xxxxxxxxxx]o', where the middle part could be 0000000001 to 0000000027.`,
+    );
+  }
+};
+
+class ArticleContainer extends Component {
   static async getInitialProps({ req, match } = {}) {
     try {
       const { path } = match;
       const { id, service } = match.params;
 
-      const regex = '^(c[a-zA-Z0-9]{10}o)$';
-      const routeMatches = id.match(regex);
-
-      serviceValidator(service);
-
-      if (!routeMatches) {
-        throw new Error(
-          `Invalid route parameter: ${id}. ID parameter must be in format 'c[xxxxxxxxxx]o', where the middle part could be 0000000001 to 0000000027.`,
-        );
-      }
+      validateService(service);
+      validateId(id);
 
       let url = `/data/${id}.json`;
 

--- a/src/app/containers/Article/index.test.jsx
+++ b/src/app/containers/Article/index.test.jsx
@@ -143,10 +143,12 @@ describe('ArticleContainer', () => {
     });
 
     describe('Validate route parameter ', () => {
-      it('to check the id is invalid before returning an empty object', async () => {
+      it('checks the id is invalid before returning an empty object', async () => {
         jest.spyOn(global.console, 'log');
         const invalidIdParam = 'route-21';
-        const invalidContext = { match: { params: { id: invalidIdParam } } };
+        const invalidContext = {
+          match: { params: { id: invalidIdParam, service: 'news' } },
+        };
         const response = await callGetInitialProps(invalidContext);
 
         expect(fetch).not.toHaveBeenCalled();
@@ -155,6 +157,29 @@ describe('ArticleContainer', () => {
         expect(console.log).toBeCalledWith(
           new Error(
             `Invalid route parameter: ${invalidIdParam}. ID parameter must be in format 'c[xxxxxxxxxx]o', where the middle part could be 0000000001 to 0000000027.`,
+          ),
+        );
+        /* eslint-enable no-console */
+
+        expect(response).toEqual({});
+      });
+
+      it('checks the service is invalid before returning an empty object', async () => {
+        jest.spyOn(global.console, 'log');
+        const invalidServiceParam = 'route-21';
+        const invalidContext = {
+          match: {
+            params: { id: 'c0000000027o', service: invalidServiceParam },
+          },
+        };
+        const response = await callGetInitialProps(invalidContext);
+
+        expect(fetch).not.toHaveBeenCalled();
+
+        /* eslint-disable no-console */
+        expect(console.log).toBeCalledWith(
+          new Error(
+            `Invalid route parameter: ${invalidServiceParam}. Service parameter must be news or persian.`,
           ),
         );
         /* eslint-enable no-console */

--- a/src/app/containers/Article/index.test.jsx
+++ b/src/app/containers/Article/index.test.jsx
@@ -100,7 +100,15 @@ describe('ArticleContainer', () => {
 
   describe('getInitialProps', () => {
     const defaultIdParam = 'c0000000001o';
-    const defaultContext = { match: { params: { id: defaultIdParam } } };
+    const defaultServiceParam = 'news';
+    const defaultContext = {
+      match: {
+        params: {
+          id: defaultIdParam,
+          service: defaultServiceParam,
+        },
+      },
+    };
     const mockSuccessfulResponse = { data: '12345' };
 
     const mockFetchSuccess = () =>

--- a/src/app/containers/Article/index.test.jsx
+++ b/src/app/containers/Article/index.test.jsx
@@ -147,7 +147,12 @@ describe('ArticleContainer', () => {
         jest.spyOn(global.console, 'log');
         const invalidIdParam = 'route-21';
         const invalidContext = {
-          match: { params: { id: invalidIdParam, service: 'news' } },
+          match: {
+            params: {
+              id: invalidIdParam,
+              service: defaultServiceParam,
+            },
+          },
         };
         const response = await callGetInitialProps(invalidContext);
 

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -2,7 +2,7 @@ import Article from '../containers/Article';
 
 const routes = [
   {
-    path: '/news/articles/:id',
+    path: '/:service/articles/:id',
     exact: true,
     component: Article,
   },

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -7,7 +7,7 @@ const routes = [
     component: Article,
   },
   {
-    path: '/news/articles/amp/:id',
+    path: '/:service/articles/amp/:id',
     exact: true,
     component: Article,
   },


### PR DESCRIPTION
Resolves #610 

**PR Changes:**
Updated the routing logic to accept a "service" param that is validated in the article's container class against a list of services. 
Refactored the "getInitialProps" function to be suitable for code climate

**Testing instructions:** 
"news" & "persian" are the only valid service params.
Please check that the validator works by visiting these links like these (locally): 

http://localhost:7080/khoa/articles/notvalid
http://localhost:7080/news/articles/notvalid
http://localhost:7080/khoa/articles/c0000000027o
http://localhost:7080/khoa/articles/amp/c0000000027o
http://localhost:7080/persian/articles/amp/c0000000027o
http://localhost:7080/news/articles/amp/c0000000027o

http://localhost:7080/news/articles/c0000000027o
http://localhost:7080/news/articles/amp/c0000000027o
http://localhost:7080/persian/articles/c0000000028o
http://localhost:7080/persian/articles/amp/c0000000028o

- [x] Tests added for new features
- [ ] Test engineer approval
