### PR TITLE
Remove copyright symbol and simplify Copyright component

### DIFF
--- a/src/app/components/Figure/Copyright/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/Copyright/__snapshots__/index.test.jsx.snap
@@ -22,6 +22,6 @@ exports[`Copyright should render correctly 1`] = `
   className="c0"
   role="text"
 >
-  © Getty Images
+  Getty Images
 </span>
 `;

--- a/src/app/components/Figure/Copyright/index.jsx
+++ b/src/app/components/Figure/Copyright/index.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { string } from 'prop-types';
 import styled from 'styled-components';
 import {
   FF_NEWS_SANS_REG,
@@ -9,9 +7,9 @@ import {
 } from '../../../lib/constants/styles';
 import { T_MINION } from '../../../lib/constants/typography';
 
-const copyrightSymbolPrefix = '\u00A9';
-
-const StyledCopyright = styled.span`
+const Copyright = styled.span.attrs({
+  role: 'text',
+})`
   ${T_MINION};
   background-color: ${C_EBON};
   color: ${C_WHITE};
@@ -30,17 +28,5 @@ const StyledCopyright = styled.span`
     color: ${C_EBON}; /* This needs to match the background-color */
   }
 `;
-
-const copyrightRole = 'text';
-
-const Copyright = ({ text }) => (
-  <StyledCopyright role={copyrightRole}>
-    {`${copyrightSymbolPrefix} ${text}`}
-  </StyledCopyright>
-);
-
-Copyright.propTypes = {
-  text: string.isRequired,
-};
 
 export default Copyright;

--- a/src/app/components/Figure/Copyright/index.stories.jsx
+++ b/src/app/components/Figure/Copyright/index.stories.jsx
@@ -3,5 +3,5 @@ import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-e
 import Copyright from './index';
 
 storiesOf('Copyright', module).add('default', () => (
-  <Copyright text="Getty Images" />
+  <Copyright>Getty Images</Copyright>
 ));

--- a/src/app/components/Figure/Copyright/index.test.jsx
+++ b/src/app/components/Figure/Copyright/index.test.jsx
@@ -5,6 +5,6 @@ import Copyright from './index';
 describe('Copyright', () => {
   shouldMatchSnapshot(
     'should render correctly',
-    <Copyright text="Getty Images" />,
+    <Copyright>Getty Images</Copyright>,
   );
 });


### PR DESCRIPTION
Resolves #651

_Removes the copyright symbol, which enables simplification of the Copyright component to use styled-component APIs to set a `role` and exporting just the styled component. Offscreen text will be added in #652._

- [x] Tests added for new features
- [x] Test engineer approval