### PR TITLE
add testing notes prompt to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,5 +13,8 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Testing notes**
+Will Cypress tests be required or are unit tests sufficient?
+
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Following retro point, ensure testing notes are addressed in the issue refinement.
