### PR TITLE
Remove references to After from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Named Simorgh after the Persian mythological bird. The Simorgh is the amalgam of
 
 ## Overview
 
-Simorgh is a universal react renderer it uses [razzle](https://github.com/jaredpalmer/razzle) which is built on [after](https://github.com/jaredpalmer/after.js/blob/master/README.md). This repo is publicly accessible and the application will be used to generate the future pan-BBC article.
+Simorgh is a universal react renderer. It uses [Razzle](https://github.com/jaredpalmer/razzle) and is built on [Uni](https://github.com/jtart/uni/blob/master/README.md). This repo is publicly accessible and the application will be used to generate the future, pan-BBC article.
 
 It currently has an embedded components library which will be split out as the number of components grow.
 

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -45,8 +45,6 @@ const metadataProps = (amp, config, id, metadata, promo, service) => {
 
 /*
   [1] This handles async data fetching, and a 'loading state', which we should look to handle more intelligently.
-    After.JS gives no explicit loading state, so we just have to check for a lack of data.
-    After.JS should handle async data fetching in a more informative way, which will be become an issue for error handling.
 */
 const ArticleContainer = ({ loading, error, data }) => {
   if (loading) return 'Loading...'; /* [1] */


### PR DESCRIPTION
Resolves N/A.

Although After.js was no longer present anywhere in the project, & absent from the `package.json`, there were a couple of remaining references to it in documentation:
* Lines 46 through 50 of the Article container
* Line 9 of the README

- ~~[ ] Tests added for new features~~
- ~~[ ] Test engineer approval~~