### PR TITLE
Extract paragraph from text

### DIFF
--- a/src/app/components/Paragraph/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Paragraph/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Paragraph should render correctly 1`] = `
+.c0 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-size: 0.9375em;
+  line-height: 1.25rem;
+}
+
+@media (min-width:20em) {
+  .c0 {
+    font-size: 1em;
+    line-height: 1.375rem;
+  }
+}
+
+<p
+  className="c0"
+>
+  This is some paragraph content.
+</p>
+`;

--- a/src/app/components/Paragraph/index.jsx
+++ b/src/app/components/Paragraph/index.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import {
+  C_STORM,
+  FF_NEWS_SANS_REG,
+  GEL_SPACING_DBL,
+} from '../../lib/constants/styles';
+import { T_BODY_COPY } from '../../lib/constants/typography';
+
+const Paragraph = styled.p`
+  color: ${C_STORM};
+  font-family: ${FF_NEWS_SANS_REG};
+  padding-bottom: ${GEL_SPACING_DBL};
+  margin: 0;
+  ${T_BODY_COPY};
+`;
+
+export default Paragraph;

--- a/src/app/components/Paragraph/index.stories.jsx
+++ b/src/app/components/Paragraph/index.stories.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import Paragraph from './index';
+
+storiesOf('Paragraph', module).add('default', () => (
+  <Paragraph>This is some paragraph content.</Paragraph>
+));

--- a/src/app/components/Paragraph/index.test.jsx
+++ b/src/app/components/Paragraph/index.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import Paragraph from './index';
+
+describe('Paragraph', () => {
+  shouldMatchSnapshot(
+    'should render correctly',
+    <Paragraph>This is some paragraph content.</Paragraph>,
+  );
+});

--- a/src/app/components/Text/index.jsx
+++ b/src/app/components/Text/index.jsx
@@ -1,22 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import { string, node, func } from 'prop-types';
 import Markdown from 'markdown-to-jsx';
 import InlineLink from '../../containers/InlineLink';
-import {
-  C_STORM,
-  FF_NEWS_SANS_REG,
-  GEL_SPACING_DBL,
-} from '../../lib/constants/styles';
-import { T_BODY_COPY } from '../../lib/constants/typography';
+import Paragraph from '../Paragraph';
 
-const StyledParagraph = styled.p`
-  color: ${C_STORM};
-  font-family: ${FF_NEWS_SANS_REG};
-  padding-bottom: ${GEL_SPACING_DBL};
-  margin: 0;
-  ${T_BODY_COPY};
-`;
 const Italic = ({ children }) => <i>{children}</i>;
 const Bold = ({ children }) => <b>{children}</b>;
 
@@ -58,7 +45,7 @@ Text.propTypes = {
 };
 
 Text.defaultProps = {
-  paragraphOverride: StyledParagraph,
+  paragraphOverride: Paragraph,
 };
 
 export default Text;


### PR DESCRIPTION
Part of #672 

_Extracts the `StyledParagraph` component from the `Text` component to its own component._

_This is a pre-requisite for rendering fragments; the `Text` component will no longer exist when rendering fragments, as container will deal with the logic by [rendering `Blocks` with components passed to them](https://github.com/bbc/simorgh/pull/676)._

- [x] Tests added for new features
- [ ] Test engineer approval
