### PR TITLE
Add Fragment component

### DIFF
--- a/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Fragment with bold and italic attributes should render correctly 1`] = `
 <i>
   <b>
-    This is some text with italic attributes
+    This is some text with bold and italic attributes
   </b>
 </i>
 `;

--- a/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fragment with bold and italic attributes should render correctly 1`] = `
+<i>
+  <b>
+    This is some text with italic attributes
+  </b>
+</i>
+`;
+
+exports[`Fragment with bold attributes should render correctly 1`] = `
+<b>
+  This is some text with bold attributes
+</b>
+`;
+
+exports[`Fragment with italic attributes should render correctly 1`] = `
+<i>
+  This is some text with italic attributes
+</i>
+`;
+
+exports[`Fragment with no attributes should render correctly 1`] = `"This is some text with no attributes"`;

--- a/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Fragment with an unknown attribute should ignore the attribute 1`] = `
+<b>
+  This is some text with a bold and unknown attribute
+</b>
+`;
+
 exports[`Fragment with bold and italic attributes should render text wrapped in bold and italic DOM elements 1`] = `
 <i>
   <b>

--- a/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Fragment/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Fragment with bold and italic attributes should render correctly 1`] = `
+exports[`Fragment with bold and italic attributes should render text wrapped in bold and italic DOM elements 1`] = `
 <i>
   <b>
     This is some text with bold and italic attributes
@@ -8,16 +8,16 @@ exports[`Fragment with bold and italic attributes should render correctly 1`] = 
 </i>
 `;
 
-exports[`Fragment with bold attributes should render correctly 1`] = `
+exports[`Fragment with bold attributes should render text wrapped in a bold DOM element 1`] = `
 <b>
   This is some text with bold attributes
 </b>
 `;
 
-exports[`Fragment with italic attributes should render correctly 1`] = `
+exports[`Fragment with italic attributes should render text wrapped in an italic DOM element 1`] = `
 <i>
   This is some text with italic attributes
 </i>
 `;
 
-exports[`Fragment with no attributes should render correctly 1`] = `"This is some text with no attributes"`;
+exports[`Fragment with no attributes should render just text 1`] = `"This is some text with no attributes"`;

--- a/src/app/containers/Fragment/index.jsx
+++ b/src/app/containers/Fragment/index.jsx
@@ -9,6 +9,8 @@ const attributeComponents = {
   bold,
 };
 
+const fallbackAttributeComponent = ({ children }) => children;
+
 const Fragment = ({ text, attributes }) =>
   /*
     Iterates through the attribute array and returns a component based on the attribute type (i.e. 'italic' or 'bold').
@@ -16,7 +18,8 @@ const Fragment = ({ text, attributes }) =>
     The text string is passed in as the initial value, so it is the first child or the returned value if there are no attributes.
   */
   attributes.reduce((previousAttribute, attribute) => {
-    const Attribute = attributeComponents[attribute];
+    const Attribute =
+      attributeComponents[attribute] || fallbackAttributeComponent; // If attribute is unknown, will use a fallback component that just returns the passed children
     return <Attribute>{previousAttribute}</Attribute>;
   }, text);
 

--- a/src/app/containers/Fragment/index.jsx
+++ b/src/app/containers/Fragment/index.jsx
@@ -4,7 +4,7 @@ import { string, node, arrayOf } from 'prop-types';
 const italic = ({ children }) => <i>{children}</i>;
 const bold = ({ children }) => <b>{children}</b>;
 
-const attributesToRender = {
+const attributeComponents = {
   italic,
   bold,
 };
@@ -14,7 +14,7 @@ const Fragment = ({ text, attributes }) =>
     Iterates through the attribute array and returns a component based on the attribute type (i.e. 'italic' or 'bold'). These components are nested inside each other as children as the array is iterated through. The text string is passed in as the initial value, so it is the first child or the returned value if there are no attributes.
   */
   attributes.reduce((previousAttribute, attribute) => {
-    const Attribute = attributesToRender[attribute];
+    const Attribute = attributeComponents[attribute];
     return <Attribute>{previousAttribute}</Attribute>;
   }, text);
 

--- a/src/app/containers/Fragment/index.jsx
+++ b/src/app/containers/Fragment/index.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { string, node, arrayOf } from 'prop-types';
+
+const italic = ({ children }) => <i>{children}</i>;
+const bold = ({ children }) => <b>{children}</b>;
+
+const attributesToRender = {
+  italic,
+  bold,
+};
+
+const Fragment = ({ text, attributes }) =>
+  attributes.reduce((fragment, attribute) => {
+    const Attribute = attributesToRender[attribute];
+    return <Attribute>{fragment}</Attribute>;
+  }, text);
+
+Fragment.propTypes = {
+  text: string.isRequired,
+  attributes: arrayOf(string).isRequired,
+};
+
+bold.propTypes = {
+  children: node.isRequired,
+};
+
+italic.propTypes = {
+  children: node.isRequired,
+};
+
+export default Fragment;

--- a/src/app/containers/Fragment/index.jsx
+++ b/src/app/containers/Fragment/index.jsx
@@ -11,7 +11,9 @@ const attributeComponents = {
 
 const Fragment = ({ text, attributes }) =>
   /*
-    Iterates through the attribute array and returns a component based on the attribute type (i.e. 'italic' or 'bold'). These components are nested inside each other as children as the array is iterated through. The text string is passed in as the initial value, so it is the first child or the returned value if there are no attributes.
+    Iterates through the attribute array and returns a component based on the attribute type (i.e. 'italic' or 'bold').
+    These components are nested inside each other as children as the array is iterated through.
+    The text string is passed in as the initial value, so it is the first child or the returned value if there are no attributes.
   */
   attributes.reduce((previousAttribute, attribute) => {
     const Attribute = attributeComponents[attribute];

--- a/src/app/containers/Fragment/index.jsx
+++ b/src/app/containers/Fragment/index.jsx
@@ -10,9 +10,12 @@ const attributesToRender = {
 };
 
 const Fragment = ({ text, attributes }) =>
-  attributes.reduce((fragment, attribute) => {
+  /*
+    Iterates through the attribute array and returns a component based on the attribute type (i.e. 'italic' or 'bold'). These components are nested inside each other as children as the array is iterated through. The text string is passed in as the initial value, so it is the first child or the returned value if there are no attributes.
+  */
+  attributes.reduce((previousAttribute, attribute) => {
     const Attribute = attributesToRender[attribute];
-    return <Attribute>{fragment}</Attribute>;
+    return <Attribute>{previousAttribute}</Attribute>;
   }, text);
 
 Fragment.propTypes = {

--- a/src/app/containers/Fragment/index.test.jsx
+++ b/src/app/containers/Fragment/index.test.jsx
@@ -39,4 +39,14 @@ describe('Fragment', () => {
       />,
     );
   });
+
+  describe('with an unknown attribute', () => {
+    shouldMatchSnapshot(
+      'should ignore the attribute',
+      <Fragment
+        text="This is some text with a bold and unknown attribute"
+        attributes={['bold', 'unknown']}
+      />,
+    );
+  });
 });

--- a/src/app/containers/Fragment/index.test.jsx
+++ b/src/app/containers/Fragment/index.test.jsx
@@ -34,7 +34,7 @@ describe('Fragment', () => {
     shouldMatchSnapshot(
       'should render correctly',
       <Fragment
-        text="This is some text with italic attributes"
+        text="This is some text with bold and italic attributes"
         attributes={['bold', 'italic']}
       />,
     );

--- a/src/app/containers/Fragment/index.test.jsx
+++ b/src/app/containers/Fragment/index.test.jsx
@@ -5,14 +5,14 @@ import Fragment from './index';
 describe('Fragment', () => {
   describe('with no attributes', () => {
     shouldMatchSnapshot(
-      'should render correctly',
+      'should render just text',
       <Fragment text="This is some text with no attributes" attributes={[]} />,
     );
   });
 
   describe('with bold attributes', () => {
     shouldMatchSnapshot(
-      'should render correctly',
+      'should render text wrapped in a bold DOM element',
       <Fragment
         text="This is some text with bold attributes"
         attributes={['bold']}
@@ -22,7 +22,7 @@ describe('Fragment', () => {
 
   describe('with italic attributes', () => {
     shouldMatchSnapshot(
-      'should render correctly',
+      'should render text wrapped in an italic DOM element',
       <Fragment
         text="This is some text with italic attributes"
         attributes={['italic']}
@@ -32,7 +32,7 @@ describe('Fragment', () => {
 
   describe('with bold and italic attributes', () => {
     shouldMatchSnapshot(
-      'should render correctly',
+      'should render text wrapped in bold and italic DOM elements',
       <Fragment
         text="This is some text with bold and italic attributes"
         attributes={['bold', 'italic']}

--- a/src/app/containers/Fragment/index.test.jsx
+++ b/src/app/containers/Fragment/index.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import Fragment from './index';
+
+describe('Fragment', () => {
+  describe('with no attributes', () => {
+    shouldMatchSnapshot(
+      'should render correctly',
+      <Fragment text="This is some text with no attributes" attributes={[]} />,
+    );
+  });
+
+  describe('with bold attributes', () => {
+    shouldMatchSnapshot(
+      'should render correctly',
+      <Fragment
+        text="This is some text with bold attributes"
+        attributes={['bold']}
+      />,
+    );
+  });
+
+  describe('with italic attributes', () => {
+    shouldMatchSnapshot(
+      'should render correctly',
+      <Fragment
+        text="This is some text with italic attributes"
+        attributes={['italic']}
+      />,
+    );
+  });
+
+  describe('with bold and italic attributes', () => {
+    shouldMatchSnapshot(
+      'should render correctly',
+      <Fragment
+        text="This is some text with italic attributes"
+        attributes={['bold', 'italic']}
+      />,
+    );
+  });
+});


### PR DESCRIPTION
Part of #672 

_Adds a fragment component that iterates through attributes and returns a component that renders out text that is wrapped in the required DOM element for the attribute type, i.e. `i` for `italic`._

_This component is not integrated anywhere on purpose. It will be integrated when blocks of a `Paragraph` block are iterated through using the [`Blocks` component](https://github.com/bbc/simorgh/issues/676)_.

- [x] Tests added for new features
- [ ] Test engineer approval