### PR TITLE
Image CSS absolute is not needed yet

### DIFF
--- a/src/app/components/Figure/Image/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/Image/__snapshots__/index.test.jsx.snap
@@ -3,8 +3,6 @@
 exports[`Image should render correctly 1`] = `
 .c0 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 

--- a/src/app/components/Figure/Image/index.jsx
+++ b/src/app/components/Figure/Image/index.jsx
@@ -2,8 +2,6 @@ import styled from 'styled-components';
 
 const Image = styled.img`
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 `;
 

--- a/src/app/components/Figure/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Figure/__snapshots__/index.test.jsx.snap
@@ -9,8 +9,6 @@ exports[`Figure with a caption containing a link should render correctly 1`] = `
 
 .c2 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 
@@ -118,8 +116,6 @@ exports[`Figure with a caption should render correctly 1`] = `
 
 .c2 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 
@@ -196,8 +192,6 @@ exports[`Figure with caption and non-BBC copyright should render correctly 1`] =
 
 .c2 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 
@@ -299,8 +293,6 @@ exports[`Figure with non-BBC copyright should render correctly 1`] = `
 
 .c2 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 
@@ -370,8 +362,6 @@ exports[`Figure without a caption should render correctly 1`] = `
 
 .c2 {
   display: block;
-  height: 100%;
-  position: absolute;
   width: 100%;
 }
 


### PR DESCRIPTION
Left over code from the splitting of the image placeholder work, stabilises latest between #668 and #762 

_CSS left over after splitting the above PRs_

- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~
