### PR TITLE
add label prompts to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,3 +33,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+- [ ] Intially labelled with "bug"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,4 +34,4 @@ If applicable, add screenshots to help explain your problem.
 **Additional context**
 Add any other context about the problem here.
 
-- [ ] Intially labelled with "bug"
+- [ ] Intially labelled with ["bug"](https://github.com/BBC-News/simorgh/labels/bug)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,5 @@ Will Cypress tests be required or are unit tests sufficient?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+- [ ] Intially labelled with "Refinement needed"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,4 +19,4 @@ Will Cypress tests be required or are unit tests sufficient?
 **Additional context**
 Add any other context or screenshots about the feature request here.
 
-- [ ] Intially labelled with "Refinement needed"
+- [ ] Intially labelled with ["Refinement needed"](https://github.com/BBC-News/simorgh/labels/Refinement%20Needed)


### PR DESCRIPTION
Following retro updates the issues templates to prompt adding labels when creating new issues_

- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~
