### PR TITLE
Fix copyright for fragmented data

### DIFF
--- a/data/fragmented/prod/news/c0000000025o.json
+++ b/data/fragmented/prod/news/c0000000025o.json
@@ -136,7 +136,7 @@
                   "height": 576,
                   "locator": "http://c.files.bbci.co.uk/A933/production/_101651334_bouquet_pa.jpg",
                   "originCode": "cpsprodpb",
-                  "copyrightHolder": "BBC"
+                  "copyrightHolder": "PA"
                 }
               },
               {


### PR DESCRIPTION
_Corrects the copyright in fragmented data from `BBC` to `PA` to match the copyright of images in the published version: https://www.bbc.co.uk/news/uk-44188656._
