### PR TITLE
Make client side data fetch relative

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PORT=7080
-RAZZLE_BASE_PATH=http://localhost:7080/data
+RAZZLE_BASE_PATH=http://localhost:7080
 RAZZLE_PUBLIC_DIR=build/public
 RAZZLE_PUBLIC_DIR_DEV=public

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -4,7 +4,6 @@ const getInitialData = async ({ match }) => {
   try {
     const { id, service, amp } = match.params;
 
-    // we have to hardcode the /data here until
     let url = `/data/${service}/articles/${id}.json`;
 
     // URL on server

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -4,9 +4,13 @@ const getInitialData = async ({ match }) => {
   try {
     const { id, service, amp } = match.params;
 
-    const url = `${
-      process.env.RAZZLE_BASE_PATH
-    }/${service}/articles/${id}.json`;
+    // we have to hardcode the /data here until
+    let url = `/data/${service}/articles/${id}.json`;
+
+    // URL on server
+    if (process.env.NODE) {
+      url = `${process.env.RAZZLE_BASE_PATH}${url}`;
+    }
 
     const response = await fetch(url);
 

--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -62,6 +62,31 @@ describe('getInitialData', () => {
     });
   });
 
+  describe('On client', () => {
+    beforeEach(() => {
+      process.env = {};
+    });
+    it('should call fetch with a relative URL', () => {
+      callGetInitialData();
+      expect(fetch.mock.calls[0][0]).toEqual(
+        `/data/${defaultServiceParam}/articles/${defaultIdParam}.json`,
+      );
+    });
+  });
+  describe('On Server', () => {
+    const BASE_PATH = 'https://test.com';
+    beforeEach(() => {
+      process.env.NODE = true;
+      process.env.RAZZLE_BASE_PATH = BASE_PATH;
+    });
+    it('should call fetch with an absolute URL using BASE_PATH environment variable', () => {
+      callGetInitialData();
+      expect(fetch.mock.calls[0][0]).toEqual(
+        `${BASE_PATH}/data/${defaultServiceParam}/articles/${defaultIdParam}.json`,
+      );
+    });
+  });
+
   describe('Rejected fetch', () => {
     it('should return an empty object', async () => {
       const response = await callGetInitialData({}, mockFetchFailure);


### PR DESCRIPTION
Resolves #811 

This PR stabilises the build after the merge of https://github.com/BBC-News/simorgh/pull/796 broken the E2E tests on the TEST env. This was because the RAZZLE_BASE_PATH is not currently set on test and therefore the logic to remove relative data fetches caused a CORS error trying to request `localhost:/7080/data*` instead of `/data*`. This PR undoes the logic to make the data fetch path's absolute. 

- [x] Tests added for new features
- [ ] Test engineer approval
