### PR TITLE
Make seoHeadline optional and default to an empty string

### DIFF
--- a/data/schema.yaml
+++ b/data/schema.yaml
@@ -182,9 +182,9 @@ components:
           properties:
             headlines:
               type: object
-              required:
-                - seoHeadline
-                - promoHeadline
+              # required:
+              #   - seoHeadline   currently not in the test optimo datafeed
+              #   - promoHeadline   currently not in the test optimo datafeed
               properties:
                 seoHeadline:
                   example: 'UK pledges extra £44m for Channel border security'

--- a/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
@@ -239,6 +239,122 @@ exports[`Metadata News article should render correctly 1`] = `
 </HelmetWrapper>
 `;
 
+exports[`Metadata News article with title value should render correctly 1`] = `
+<HelmetWrapper
+  defer={true}
+  encodeSpecialCharacters={true}
+  htmlAttributes={
+    Object {
+      "lang": "en-GB",
+    }
+  }
+>
+  <meta
+    content="width=device-width, initial-scale=1, minimum-scale=1"
+    name="viewport"
+  />
+  <title>
+     – 
+    BBC News
+  </title>
+  <link
+    href="https://www.bbc.com/news/articles/c0000000001o"
+    rel="canonical"
+  />
+  <meta
+    content="BBC News"
+    name="article:author"
+  />
+  <meta
+    content={1514811600000}
+    name="article:modified_time"
+  />
+  <meta
+    content={1514811600000}
+    name="article:published_time"
+  />
+  <meta
+    content="tagA"
+    name="article:tag"
+  />
+  <meta
+    content="tagB"
+    name="article:tag"
+  />
+  <meta
+    content="This is a description"
+    name="description"
+  />
+  <meta
+    content={101010}
+    name="fb:admins"
+  />
+  <meta
+    content={202020}
+    name="fb:app_id"
+  />
+  <meta
+    content="This is a description"
+    name="og:description"
+  />
+  <meta
+    content="https://www.bbc.com/news/image.png"
+    name="og:image"
+  />
+  <meta
+    content="BBC News"
+    name="og:image:alt"
+  />
+  <meta
+    content="en_GB"
+    name="og:locale"
+  />
+  <meta
+    content="BBC News"
+    name="og:site_name"
+  />
+  <meta
+    content={null}
+    name="og:title"
+  />
+  <meta
+    name="og:type"
+  />
+  <meta
+    content="https://www.bbc.com/news/articles/c0000000001o"
+    name="og:url"
+  />
+  <meta
+    content="summary_large_image"
+    name="twitter:card"
+  />
+  <meta
+    content="@BBCNews"
+    name="twitter:creator"
+  />
+  <meta
+    content="This is a description"
+    name="twitter:description"
+  />
+  <meta
+    content="BBC News"
+    name="twitter:image:alt"
+  />
+  <meta
+    content="https://www.bbc.com/news/image.png"
+    name="twitter:image:src"
+  />
+  <meta
+    content="@BBCNews"
+    name="twitter:site"
+  />
+  <meta
+    content={null}
+    name="twitter:title"
+  />
+</HelmetWrapper>
+`;
+
 exports[`Metadata Persian AMP article should render correctly 1`] = `
 <HelmetWrapper
   defer={true}

--- a/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
@@ -239,7 +239,7 @@ exports[`Metadata News article should render correctly 1`] = `
 </HelmetWrapper>
 `;
 
-exports[`Metadata News article with title value should render correctly 1`] = `
+exports[`Metadata News article with null title value should render correctly 1`] = `
 <HelmetWrapper
   defer={true}
   encodeSpecialCharacters={true}

--- a/src/app/components/Metadata/index.jsx
+++ b/src/app/components/Metadata/index.jsx
@@ -91,7 +91,7 @@ Metadata.propTypes = {
   metaTags: arrayOf(string).isRequired,
   timeFirstPublished: string.isRequired,
   timeLastUpdated: string.isRequired,
-  title: string.isRequired,
+  title: string,
   twitterCreator: string.isRequired,
   twitterSite: string.isRequired,
   type: string.isRequired,
@@ -99,6 +99,7 @@ Metadata.propTypes = {
 
 Metadata.defaultProps = {
   articleSection: null,
+  title: '', // defaulting as an empty string because Optimo cannot produce seoHeadlines at this time
 };
 
 export default Metadata;

--- a/src/app/components/Metadata/index.test.jsx
+++ b/src/app/components/Metadata/index.test.jsx
@@ -75,6 +75,28 @@ describe('Metadata', () => {
   );
 
   metadataSnapshotTest(
+    'News article with title value',
+    false,
+    'BBC News',
+    null,
+    'BBC News',
+    'https://www.bbc.com/news/articles/c0000000001o',
+    'https://www.bbc.com/news/image.png',
+    'BBC News',
+    'This is a description',
+    101010,
+    202020,
+    'en-GB',
+    'en_GB',
+    ['tagA', 'tagB'],
+    1514811600000,
+    1514811600000,
+    null,
+    '@BBCNews',
+    '@BBCNews',
+  );
+
+  metadataSnapshotTest(
     'News AMP article',
     true,
     'BBC News',

--- a/src/app/components/Metadata/index.test.jsx
+++ b/src/app/components/Metadata/index.test.jsx
@@ -75,7 +75,7 @@ describe('Metadata', () => {
   );
 
   metadataSnapshotTest(
-    'News article with title value',
+    'News article with null title value',
     false,
     'BBC News',
     null,

--- a/src/app/models/propTypes/promo/index.js
+++ b/src/app/models/propTypes/promo/index.js
@@ -3,7 +3,7 @@ import { number, shape, string } from 'prop-types';
 const promoPropTypes = {
   id: string.isRequired,
   headlines: shape({
-    seoHeadline: string.isRequired,
+    seoHeadline: string,
     promoHeadline: string,
   }),
   locators: shape({


### PR DESCRIPTION
Resolves #816

_This PR makes the seoHeadline optional due to it not being available in Ares, at current, for the alpha deadline. Changes the data schema, promo propTypes, and adds a snapshot test._

- [x] Tests added for new features
- [x] Test engineer approval

Check out locally and in one of the fixtures completely remove the `promo:seoHeadline` ensure that when rendering that fixture the title is ` - BBC News`