### PR TITLE
Fix footer grid&margin bug

### DIFF
--- a/src/app/components/Footer/List/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Footer/List/__snapshots__/index.test.jsx.snap
@@ -28,7 +28,6 @@ exports[`FooterList should render correctly 1`] = `
 .c0 > li:first-child {
   border-bottom: 1px solid #FFFFFF;
   padding: 0.5rem 0;
-  margin-bottom: 0.5rem;
   grid-column: 1/-1;
 }
 
@@ -40,31 +39,40 @@ exports[`FooterList should render correctly 1`] = `
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(4,50%);
+    grid-template-rows: 3rem 2.5rem repeat(2,1fr);
+  }
+
+  .c0 li:nth-child(3n-1) {
+    margin-top: 8px;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c0 {
+    grid-column-gap: 1rem;
+    grid-template-rows: 3rem 2.5rem 1fr;
+  }
+
+  .c0 li:nth-child(2n) {
+    margin-top: 8px;
   }
 }
 
 @media (min-width:37.5em) and (max-width:62.9375em) {
   .c0 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 

--- a/src/app/components/Footer/List/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Footer/List/__snapshots__/index.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`FooterList should render correctly 1`] = `
 .c0 > li:first-child {
   border-bottom: 1px solid #FFFFFF;
   padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
   grid-column: 1/-1;
 }
 
@@ -39,40 +40,31 @@ exports[`FooterList should render correctly 1`] = `
   .c0 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: 3rem 2.5rem repeat(2,1fr);
-  }
-
-  .c0 li:nth-child(3n-1) {
-    margin-top: 8px;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c0 {
-    grid-column-gap: 1rem;
-    grid-template-rows: 3rem 2.5rem 1fr;
-  }
-
-  .c0 li:nth-child(2n) {
-    margin-top: 8px;
+    grid-template-rows: repeat(4,auto);
   }
 }
 
 @media (min-width:37.5em) and (max-width:62.9375em) {
   .c0 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
 @media (min-width:80em) {
   .c0 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 

--- a/src/app/components/Footer/List/index.jsx
+++ b/src/app/components/Footer/List/index.jsx
@@ -25,30 +25,27 @@ const StyledList = styled.ul`
   @media (max-width: ${group2ScreenWidthMax}) {
     grid-column-gap: ${GEL_SPACING};
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: 3rem 2.5rem repeat(2, 1fr);
-    li:nth-child(3n-1) {
-      margin-top: 8px;
-    }
-  }
-  @media (min-width: ${group3ScreenWidthMin}) {
-    grid-column-gap: ${GEL_SPACING_DBL};
-    grid-template-rows: 3rem 2.5rem 1fr;
-    li:nth-child(2n) {
-      margin-top: 8px;
-    }
+    grid-template-rows: repeat(4, auto);
   }
   @media (min-width: ${group3ScreenWidthMin}) and (max-width: ${group3ScreenWidthMax}) {
+    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, auto);
   }
   @media (min-width: ${group4ScreenWidthMin}) and (max-width: ${group4ScreenWidthMax}) {
+    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(3, auto);
   }
   @media (min-width: ${group5ScreenWidthMin}) {
+    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(5, 1fr);
+    grid-template-rows: repeat(3, auto);
   }
   > li:first-child {
     border-bottom: 1px solid ${C_WHITE};
     padding: ${GEL_SPACING} 0;
+    margin-bottom: ${GEL_SPACING};
     grid-column: 1/-1;
     @supports not (display: grid) {
       width: 100%;

--- a/src/app/components/Footer/List/index.jsx
+++ b/src/app/components/Footer/List/index.jsx
@@ -25,27 +25,30 @@ const StyledList = styled.ul`
   @media (max-width: ${group2ScreenWidthMax}) {
     grid-column-gap: ${GEL_SPACING};
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(4, 50%);
+    grid-template-rows: 3rem 2.5rem repeat(2, 1fr);
+    li:nth-child(3n-1) {
+      margin-top: 8px;
+    }
+  }
+  @media (min-width: ${group3ScreenWidthMin}) {
+    grid-column-gap: ${GEL_SPACING_DBL};
+    grid-template-rows: 3rem 2.5rem 1fr;
+    li:nth-child(2n) {
+      margin-top: 8px;
+    }
   }
   @media (min-width: ${group3ScreenWidthMin}) and (max-width: ${group3ScreenWidthMax}) {
-    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(3, 33.333%);
   }
   @media (min-width: ${group4ScreenWidthMin}) and (max-width: ${group4ScreenWidthMax}) {
-    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: repeat(3, 33.333%);
   }
   @media (min-width: ${group5ScreenWidthMin}) {
-    grid-column-gap: ${GEL_SPACING_DBL};
     grid-template-columns: repeat(5, 1fr);
-    grid-template-rows: repeat(3, 33.333%);
   }
   > li:first-child {
     border-bottom: 1px solid ${C_WHITE};
     padding: ${GEL_SPACING} 0;
-    margin-bottom: ${GEL_SPACING};
     grid-column: 1/-1;
     @supports not (display: grid) {
       width: 100%;

--- a/src/app/components/Footer/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Footer/__snapshots__/index.test.jsx.snap
@@ -81,6 +81,7 @@ exports[`Footer should render correctly 1`] = `
 .c9 > li:first-child {
   border-bottom: 1px solid #FFFFFF;
   padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
   grid-column: 1/-1;
 }
 
@@ -146,40 +147,31 @@ exports[`Footer should render correctly 1`] = `
   .c9 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: 3rem 2.5rem repeat(2,1fr);
-  }
-
-  .c9 li:nth-child(3n-1) {
-    margin-top: 8px;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c9 {
-    grid-column-gap: 1rem;
-    grid-template-rows: 3rem 2.5rem 1fr;
-  }
-
-  .c9 li:nth-child(2n) {
-    margin-top: 8px;
+    grid-template-rows: repeat(4,auto);
   }
 }
 
 @media (min-width:37.5em) and (max-width:62.9375em) {
   .c9 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c9 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 
 @media (min-width:80em) {
   .c9 {
+    grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
+    grid-template-rows: repeat(3,auto);
   }
 }
 

--- a/src/app/components/Footer/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Footer/__snapshots__/index.test.jsx.snap
@@ -81,7 +81,6 @@ exports[`Footer should render correctly 1`] = `
 .c9 > li:first-child {
   border-bottom: 1px solid #FFFFFF;
   padding: 0.5rem 0;
-  margin-bottom: 0.5rem;
   grid-column: 1/-1;
 }
 
@@ -147,31 +146,40 @@ exports[`Footer should render correctly 1`] = `
   .c9 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
-    grid-template-rows: repeat(4,50%);
+    grid-template-rows: 3rem 2.5rem repeat(2,1fr);
+  }
+
+  .c9 li:nth-child(3n-1) {
+    margin-top: 8px;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c9 {
+    grid-column-gap: 1rem;
+    grid-template-rows: 3rem 2.5rem 1fr;
+  }
+
+  .c9 li:nth-child(2n) {
+    margin-top: 8px;
   }
 }
 
 @media (min-width:37.5em) and (max-width:62.9375em) {
   .c9 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c9 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 
 @media (min-width:80em) {
   .c9 {
-    grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
-    grid-template-rows: repeat(3,33.333%);
   }
 }
 


### PR DESCRIPTION
Resolves #693

UPDATED: The solution is much simpler than previously thought see https://github.com/BBC-News/simorgh/pull/823#issuecomment-432175431

There is an upcoming change to CSS grid and the way it handles margin's ([example](https://github.com/BBC-News/simorgh/issues/693#issuecomment-431058629)). This PR therefore removes the use of margin-bottom (to give border space between the first and second row) by setting the height of the first and second row of the footer list manually. This is required because now only grid-gaps can define the space between columns/rows and grid-gaps always affect all columns/rows.

NOTE: A cleaner solution may be to move the first link outside of the grid however this would require re-evaluation of the screen reader UX in terms of links being a single list (see blow).

![image](https://user-images.githubusercontent.com/7791726/47213944-68b34600-d394-11e8-9a96-7f4ce336c4b0.png)

- [x] Tests added for new features (snapshots)
- [ ] Test engineer approval

### Testing notes: ###
The bug was seen on Chrome Canary and Opera Developer therefore it should be tested against both of these to ensure the new changes work and also tested on Chrome and Firefox etc to ensure no regression has occurred. 

## Screenshot ##
![image](https://user-images.githubusercontent.com/7791726/47213527-35bc8280-d393-11e8-825f-5f8fe61d3992.png)
