### PR TITLE
Fix scripts in document

### DIFF
--- a/src/app/components/Document/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Document/__snapshots__/index.test.jsx.snap
@@ -44,6 +44,10 @@ exports[`Document should render correctly 1`] = `
     <style>
       html { color: red; }
     </style>
+    <script
+      async={true}
+      href="www.test.com/script.js"
+    />
   </head>
   <body>
     <div

--- a/src/app/components/Document/index.jsx
+++ b/src/app/components/Document/index.jsx
@@ -9,6 +9,7 @@ const Document = ({ assets, app, data, styleTags, helmet }) => {
   const meta = helmet.meta.toComponent();
   const title = helmet.title.toComponent();
   const links = helmet.link.toComponent();
+  const helmetScripts = helmet.script.toComponent();
   const serialisedData = JSON.stringify(data);
   const scripts = assets.map(asset => (
     <script key={asset} type="text/javascript" src={asset} defer />
@@ -28,6 +29,7 @@ const Document = ({ assets, app, data, styleTags, helmet }) => {
         {title}
         {links}
         {styleTags}
+        {helmetScripts}
       </head>
       <body>
         {/* eslint-disable react/no-danger */

--- a/src/app/components/Document/index.test.jsx
+++ b/src/app/components/Document/index.test.jsx
@@ -27,6 +27,9 @@ describe('Document', () => {
       />,
     ),
     title: mockHelmetToComponent(<title>Test title</title>),
+    script: mockHelmetToComponent(
+      <script async href="www.test.com/script.js" />,
+    ),
   };
   const styleTags = <style>{'html { color: red; }'}</style>;
 


### PR DESCRIPTION
Resolves #833

_Injects the helmet scripts into the Document for the server-side render. If we did not inject the client-side React app, the script element would never be added to the DOM. i.e. on AMP. AMP should not add the client-side JS, but currently does so.._

- [x] Tests added for new features
- [ ] Test engineer approval
