### PR TITLE
Temporarily comment out end-to-end tests that are externally blocked

### DIFF
--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -1,7 +1,6 @@
 import { getElement, getSecondElement } from '../support/bodyTestHelper';
 import {
   facebookMeta,
-  metaDataDescription,
   openGraphMeta,
   retrieveMetaDataContent,
   twitterMeta,
@@ -67,11 +66,11 @@ describe('Article Meta Tests', () => {
     'https://www.facebook.com/bbcnews',
   );
 
-  it('should have description meta data', () => {
-    metaDataDescription(
-      'Meghan follows the royal bridal tradition started by the Queen Mother in 1923.',
-    );
-  });
+  // it('should have description meta data', () => {
+  //   metaDataDescription(
+  //     'Meghan follows the royal bridal tradition started by the Queen Mother in 1923.',
+  //   );
+  // });
 
   openGraphMeta(
     'Meghan follows the royal bridal tradition started by the Queen Mother in 1923.',

--- a/cypress/integration/metaPersianSpec.js
+++ b/cypress/integration/metaPersianSpec.js
@@ -1,6 +1,5 @@
 import {
   facebookMeta,
-  metaDataDescription,
   openGraphMeta,
   retrieveMetaDataContent,
   twitterMeta,
@@ -23,11 +22,11 @@ describe('Persian Article Meta Tests', () => {
     'https://www.facebook.com/bbcnews',
   );
 
-  it('should have description meta data', () => {
-    metaDataDescription(
-      'شاید خیلی طول نکشد که زمانی برسد که وقتی خسته هستید و مثلا هوس فنجان قهوه‌ای را کردید، پهپادی را ببینید که با قهوه سراغتان می‌آید.',
-    );
-  });
+  // it('should have description meta data', () => {
+  //   metaDataDescription(
+  //     'شاید خیلی طول نکشد که زمانی برسد که وقتی خسته هستید و مثلا هوس فنجان قهوه‌ای را کردید، پهپادی را ببینید که با قهوه سراغتان می‌آید.',
+  //   );
+  // });
 
   openGraphMeta(
     'شاید خیلی طول نکشد که زمانی برسد که وقتی خسته هستید و مثلا هوس فنجان قهوه‌ای را کردید، پهپادی را ببینید که با قهوه سراغتان می‌آید.',

--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -3,7 +3,6 @@ import {
   checkElementStyles,
   getElement,
   placeholderImageLoaded,
-  renderedTitle,
   shouldContainText,
   shouldContainStyles,
   visibleImageNoCaption,
@@ -70,11 +69,11 @@ describe('Article Body Tests', () => {
     shouldContainStyles(copyrightLabel, 'color', 'rgb(255, 255, 255)');
   });
 
-  it('should render a title', () => {
-    renderedTitle(
-      "Meghan's bouquet laid on tomb of unknown warrior – BBC News",
-    );
-  });
+  // it('should render a title', () => {
+  //   renderedTitle(
+  //     "Meghan's bouquet laid on tomb of unknown warrior – BBC News",
+  //   );
+  // });
 
   it('should have an inline link with focus styling', () => {
     const firstInlineLink = getElement('main a');

--- a/cypress/integration/persianBodySpec.js
+++ b/cypress/integration/persianBodySpec.js
@@ -2,7 +2,6 @@ import {
   checkElementStyles,
   getElement,
   placeholderImageLoaded,
-  renderedTitle,
   shouldContainText,
   visibleImageNoCaption,
   visibleImageWithCaption,
@@ -44,7 +43,7 @@ describe('Article Body Tests', () => {
     visibleImageWithCaption(getElement('figure').eq(2));
   });
 
-  it('should render a title', () => {
-    renderedTitle('پهپادی که برایتان قهوه می‌آورد – BBC News فارسی');
-  });
+  // it('should render a title', () => {
+  //   renderedTitle('پهپادی که برایتان قهوه می‌آورد – BBC News فارسی');
+  // });
 });

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -24,22 +24,23 @@ export const metaDataDescription = description => {
 };
 
 export const openGraphMeta = (
-  description,
+  description, // eslint-disable-line no-unused-vars
   imageUrl,
   altText,
   locale,
   siteName,
-  title,
+  title, // eslint-disable-line no-unused-vars
   type,
   url,
 ) => {
   it('should have OpenGraph meta data', () => {
-    retrieveMetaDataContent('head meta[name="og:description"]', description);
+    // retrieveMetaDataContent('head meta[name="og:description"]', description); // !!! Remove eslint-disabling comment above when un-commenting this test.
     retrieveMetaDataContent('head meta[name="og:image"]', imageUrl);
     retrieveMetaDataContent('head meta[name="og:image:alt"]', altText);
     retrieveMetaDataContent('head meta[name="og:locale"]', locale);
     retrieveMetaDataContent('head meta[name="og:site_name"]', siteName);
-    retrieveMetaDataContent('head meta[name="og:title"]', title);
+    // retrieveMetaDataContent('head meta[name="og:title"]', title); // !!! Remove eslint-disabling comment above when un-commenting this test.
+
     retrieveMetaDataContent('head meta[name="og:type"]', type);
     retrieveMetaDataContent('head meta[name="og:url"]', url);
   });
@@ -48,23 +49,23 @@ export const openGraphMeta = (
 export const twitterMeta = (
   card,
   creator,
-  description,
+  description, // eslint-disable-line no-unused-vars
   imageAlt,
   imageSrc,
   site,
-  title,
+  title, // eslint-disable-line no-unused-vars
 ) => {
   it('should have Twitter meta data', () => {
     retrieveMetaDataContent('head meta[name="twitter:card"]', card);
     retrieveMetaDataContent('head meta[name="twitter:creator"]', creator);
-    retrieveMetaDataContent(
-      'head meta[name="twitter:description"]',
-      description,
-    );
+    // retrieveMetaDataContent(
+    //   'head meta[name="twitter:description"]',
+    //   description,
+    // ); // !!! Remove eslint-disabling comment above when un-commenting this test.
     retrieveMetaDataContent('head meta[name="twitter:image:alt"]', imageAlt);
     retrieveMetaDataContent('head meta[name="twitter:image:src"]', imageSrc);
     retrieveMetaDataContent('head meta[name="twitter:site"]', site);
-    retrieveMetaDataContent('head meta[name="twitter:title"]', title);
+    // retrieveMetaDataContent('head meta[name="twitter:title"]', title); // !!! Remove eslint-disabling comment above when un-commenting this test.
   });
 };
 

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -40,7 +40,6 @@ export const openGraphMeta = (
     retrieveMetaDataContent('head meta[name="og:locale"]', locale);
     retrieveMetaDataContent('head meta[name="og:site_name"]', siteName);
     // retrieveMetaDataContent('head meta[name="og:title"]', title); // !!! Remove eslint-disabling comment above when un-commenting this test.
-
     retrieveMetaDataContent('head meta[name="og:type"]', type);
     retrieveMetaDataContent('head meta[name="og:url"]', url);
   });


### PR DESCRIPTION
Resolves #838.

Temporarily comments out Cypress test assertions for pieces of metadata that are not currently supported by our data provider. These will be un-commented in #820 and #842, which we expect to be played soon. I will try & ensure notes have been added to each of these issues have been added that capture exactly which tests should be un-commented.

- [ ] Tests added for new features
- [ ] Test engineer approval