### PR TITLE
Add ServerApp context prop for StaticRouter, reducing log noise

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -98,7 +98,7 @@ server
 
       const app = renderToString(
         sheet.collectStyles(
-          <ServerApp location={url} routes={routes} data={data} />,
+          <ServerApp location={url} routes={routes} data={data} context={{}} />,
         ),
       );
 


### PR DESCRIPTION
Resolves #847.

Opened to reduce logging noise. Currently, on first run & request, there is an unnecessary console log, originating from StaticRouter being passed `undefined` instead of an empty object. 

<img width="703" alt="screen shot 2018-10-25 at 17 39 36" src="https://user-images.githubusercontent.com/11646957/47516543-9d843900-d87d-11e8-9d06-eb97a5896669.png">

[`react-universal-app` expects us to pass this as a prop when using the ServerApp component](https://github.com/jtart/react-universal-app/blob/f9721d4d5e23c981ba874c43a5608e278dfcb32c/examples/basic/src/server.js#L26).

- [ ] Tests added for new features
- [ ] Test engineer approval
