### PR TITLE
[in progress] / [prototype] Apply oat color to article body

### DIFF
--- a/src/app/components/MainContent/index.jsx
+++ b/src/app/components/MainContent/index.jsx
@@ -10,7 +10,7 @@ import {
 
 export const StyledMainContent = styled.main``;
 
-export const StyleGridWrapper = styled.div`
+export const StyleGridWrapperStyled = styled.div`
   ${layoutGridWrapper};
 `;
 
@@ -25,13 +25,18 @@ export const GridItem = styled.div`
   }
 `;
 
-export const ConstrainedGridItem = ({ fullWidthBackgroundColor, children }) => (
-  <StyleGridWrapper style={{ backgroundColor: fullWidthBackgroundColor }}>
-    <GridItem>{children}</GridItem>
-  </StyleGridWrapper>
+export const GridItemFullWidth = styled.div`
+  grid-column: full;
+  background-color: red;
+`;
+
+export const StyleGridWrapper = ({ fullWidthBackgroundColor, children }) => (
+  <StyleGridWrapperStyled style={{ backgroundColor: fullWidthBackgroundColor }}>
+    {children}
+  </StyleGridWrapperStyled>
 );
 
-ConstrainedGridItem.propTypes = {
+StyleGridWrapper.propTypes = {
   children: node.isRequired,
   fullWidthBackgroundColor: string.isRequired,
 };

--- a/src/app/components/MainContent/index.jsx
+++ b/src/app/components/MainContent/index.jsx
@@ -8,7 +8,14 @@ import {
   group5ScreenWidthMin,
 } from '../../lib/constants/styles';
 
-export const StyledMainContent = styled.main`
+export const StyledMainContent = styled.main``;
+
+export const StyleGridWrapper = styled.div`
+  ${layoutGridWrapper};
+`;
+
+export const GridItem = styled.div`
+  ${layoutGridItem};
   margin: auto;
   @media (min-width: ${group4ScreenWidthMin}) and (max-width: ${group4ScreenWidthMax}) {
     max-width: 1008px;
@@ -18,20 +25,8 @@ export const StyledMainContent = styled.main`
   }
 `;
 
-const StyleGridWrapper = styled.div`
-  ${layoutGridWrapper};
-`;
-
-const GridItem = styled.div`
-  ${layoutGridItem};
-`;
-
-const MainContent = ({ children }) => (
-  <StyledMainContent role="main">
-    <StyleGridWrapper>
-      <GridItem>{children}</GridItem>
-    </StyleGridWrapper>
-  </StyledMainContent>
+export const MainContent = ({ children }) => (
+  <StyledMainContent role="main">{children}</StyledMainContent>
 );
 
 MainContent.propTypes = {

--- a/src/app/components/MainContent/index.jsx
+++ b/src/app/components/MainContent/index.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { node, string } from 'prop-types';
-import { layoutGridWrapper, layoutGridItem } from '../../lib/layoutGrid';
+import {
+  layoutGridWrapper,
+  layoutGridItem,
+  layoutGridItemFullWidth,
+} from '../../lib/layoutGrid';
 import {
   group4ScreenWidthMin,
   group4ScreenWidthMax,
@@ -26,8 +30,7 @@ export const GridItem = styled.div`
 `;
 
 export const GridItemFullWidth = styled.div`
-  grid-column: full;
-  background-color: red;
+  ${layoutGridItemFullWidth};
 `;
 
 export const StyleGridWrapper = ({ fullWidthBackgroundColor, children }) => (

--- a/src/app/components/MainContent/index.jsx
+++ b/src/app/components/MainContent/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { node } from 'prop-types';
+import { node, string } from 'prop-types';
 import { layoutGridWrapper, layoutGridItem } from '../../lib/layoutGrid';
 import {
   group4ScreenWidthMin,
@@ -24,6 +24,17 @@ export const GridItem = styled.div`
     max-width: 1280px;
   }
 `;
+
+export const ConstrainedGridItem = ({ fullWidthBackgroundColor, children }) => (
+  <StyleGridWrapper style={{ backgroundColor: fullWidthBackgroundColor }}>
+    <GridItem>{children}</GridItem>
+  </StyleGridWrapper>
+);
+
+ConstrainedGridItem.propTypes = {
+  children: node.isRequired,
+  fullWidthBackgroundColor: string.isRequired,
+};
 
 export const MainContent = ({ children }) => (
   <StyledMainContent role="main">{children}</StyledMainContent>

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -7,11 +7,7 @@ import headings from '../Headings';
 import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
-import {
-  MainContent,
-  StyleGridWrapper,
-  GridItem,
-} from '../../components/MainContent';
+import { MainContent, ConstrainedGridItem } from '../../components/MainContent';
 import articlePropTypes from '../../models/propTypes/article';
 import { ServiceContextProvider } from '../../components/ServiceContext';
 
@@ -66,22 +62,18 @@ const ArticleContainer = ({ loading, error, data }) => {
               service={service}
             />
             <MainContent>
-              <StyleGridWrapper style={{ backgroundColor: 'white' }}>
-                <GridItem>
-                  <Blocks
-                    blocks={headlineBlocks}
-                    componentsToRender={componentsToRenderHeadline}
-                  />
-                </GridItem>
-              </StyleGridWrapper>
-              <StyleGridWrapper style={{ backgroundColor: '#f5f3f1' }}>
-                <GridItem>
-                  <Blocks
-                    blocks={mainBlocks}
-                    componentsToRender={componentsToRenderMain}
-                  />
-                </GridItem>
-              </StyleGridWrapper>
+              <ConstrainedGridItem fullWidthBackgroundColor="white">
+                <Blocks
+                  blocks={headlineBlocks}
+                  componentsToRender={componentsToRenderHeadline}
+                />
+              </ConstrainedGridItem>
+              <ConstrainedGridItem fullWidthBackgroundColor="#f5f3f1">
+                <Blocks
+                  blocks={mainBlocks}
+                  componentsToRender={componentsToRenderMain}
+                />
+              </ConstrainedGridItem>
             </MainContent>
             <Footer />
           </ServiceContextProvider>

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -7,7 +7,7 @@ import headings from '../Headings';
 import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
-import { MainContent, ConstrainedGridItem } from '../../components/MainContent';
+import { MainContent, StyleGridWrapper } from '../../components/MainContent';
 import articlePropTypes from '../../models/propTypes/article';
 import { ServiceContextProvider } from '../../components/ServiceContext';
 
@@ -62,18 +62,18 @@ const ArticleContainer = ({ loading, error, data }) => {
               service={service}
             />
             <MainContent>
-              <ConstrainedGridItem fullWidthBackgroundColor="white">
+              <StyleGridWrapper fullWidthBackgroundColor="white">
                 <Blocks
                   blocks={headlineBlocks}
                   componentsToRender={componentsToRenderHeadline}
                 />
-              </ConstrainedGridItem>
-              <ConstrainedGridItem fullWidthBackgroundColor="#f5f3f1">
+              </StyleGridWrapper>
+              <StyleGridWrapper fullWidthBackgroundColor="#f5f3f1">
                 <Blocks
                   blocks={mainBlocks}
                   componentsToRender={componentsToRenderMain}
                 />
-              </ConstrainedGridItem>
+              </StyleGridWrapper>
             </MainContent>
             <Footer />
           </ServiceContextProvider>

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -7,7 +7,11 @@ import headings from '../Headings';
 import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
-import MainContent from '../../components/MainContent';
+import {
+  MainContent,
+  StyleGridWrapper,
+  GridItem,
+} from '../../components/MainContent';
 import articlePropTypes from '../../models/propTypes/article';
 import { ServiceContextProvider } from '../../components/ServiceContext';
 
@@ -62,14 +66,22 @@ const ArticleContainer = ({ loading, error, data }) => {
               service={service}
             />
             <MainContent>
-              <Blocks
-                blocks={headlineBlocks}
-                componentsToRender={componentsToRenderHeadline}
-              />
-              <Blocks
-                blocks={mainBlocks}
-                componentsToRender={componentsToRenderMain}
-              />
+              <StyleGridWrapper style={{ backgroundColor: 'white' }}>
+                <GridItem>
+                  <Blocks
+                    blocks={headlineBlocks}
+                    componentsToRender={componentsToRenderHeadline}
+                  />
+                </GridItem>
+              </StyleGridWrapper>
+              <StyleGridWrapper style={{ backgroundColor: '#f5f3f1' }}>
+                <GridItem>
+                  <Blocks
+                    blocks={mainBlocks}
+                    componentsToRender={componentsToRenderMain}
+                  />
+                </GridItem>
+              </StyleGridWrapper>
             </MainContent>
             <Footer />
           </ServiceContextProvider>

--- a/src/app/containers/Blocks/index.jsx
+++ b/src/app/containers/Blocks/index.jsx
@@ -17,6 +17,7 @@ const Blocks = ({ blocks, componentsToRender }) =>
 
     const Block = componentsToRender[type] || BlockString;
 
+    // @TODO - have a better conditional
     if (type === 'image') {
       return (
         <GridItemFullWidth>

--- a/src/app/containers/Blocks/index.jsx
+++ b/src/app/containers/Blocks/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { objectOf, arrayOf, func, shape, string, any } from 'prop-types';
 import nanoid from 'nanoid';
+import { GridItem, GridItemFullWidth } from '../../components/MainContent';
 
 // Inlined as this is a temporary component
 const BlockString = props => {
@@ -16,13 +17,27 @@ const Blocks = ({ blocks, componentsToRender }) =>
 
     const Block = componentsToRender[type] || BlockString;
 
+    if (type === 'image') {
+      return (
+        <GridItemFullWidth>
+          <Block
+            key={nanoid()}
+            type={type}
+            typeOfPreviousBlock={typeOfPreviousBlock}
+            {...model}
+          />
+        </GridItemFullWidth>
+      );
+    }
     return (
-      <Block
-        key={nanoid()}
-        type={type}
-        typeOfPreviousBlock={typeOfPreviousBlock}
-        {...model}
-      />
+      <GridItem>
+        <Block
+          key={nanoid()}
+          type={type}
+          typeOfPreviousBlock={typeOfPreviousBlock}
+          {...model}
+        />
+      </GridItem>
     );
   });
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -21,13 +21,13 @@ export const layoutGridWrapper = css`
     padding: 0 ${GEL_SPACING_DBL}; /* On grid wrapper */
   }
   @media (max-width: ${group3ScreenWidthMax}) {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: [full-start] repeat(6, 1fr) [full-end];
   }
   @media (min-width: ${group4ScreenWidthMin}) and (max-width: ${group4ScreenWidthMax}) {
-    grid-template-columns: repeat(8, 1fr);
+    grid-template-columns: [full-start] repeat(8, 1fr) [full-end];
   }
   @media (min-width: ${group5ScreenWidthMin}) {
-    grid-template-columns: repeat(10, 1fr);
+    grid-template-columns: [full-start] repeat(10, 1fr) [full-end];
   }
 `;
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -21,13 +21,13 @@ export const layoutGridWrapper = css`
     padding: 0 ${GEL_SPACING_DBL}; /* On grid wrapper */
   }
   @media (max-width: ${group3ScreenWidthMax}) {
-    grid-template-columns: [full-start] repeat(6, 1fr) [full-end];
+    grid-template-columns: repeat(6, 1fr);
   }
   @media (min-width: ${group4ScreenWidthMin}) and (max-width: ${group4ScreenWidthMax}) {
-    grid-template-columns: [full-start] repeat(8, 1fr) [full-end];
+    grid-template-columns: repeat(8, 1fr);
   }
   @media (min-width: ${group5ScreenWidthMin}) {
-    grid-template-columns: [full-start] repeat(10, 1fr) [full-end];
+    grid-template-columns: repeat(10, 1fr);
   }
 `;
 


### PR DESCRIPTION
Resolves #417 

A possible solution for applying oat color to article body, without applying any new CSS. I was looking at the grid overrides and media queries in #824 (with Sareh and Ben), it seems to me to be quite a complex solution that might be better handled by just nesting more HTML.

This solution also works with full-bleed blocks ([currently hard-coded to all images](https://github.com/BBC-News/simorgh/compare/oaty#diff-5fae61fd1dbf5f5e4b81bf6a693381b2R20)).

<img width="476" alt="screen shot 2018-10-29 at 17 03 39" src="https://user-images.githubusercontent.com/5111927/47666912-9ec6a600-db9c-11e8-96dc-276a088b65ce.png">

No hard feelings if you want to close this 😇it's been a useful learning exercise for me!

- [ ] Tests added for new features
- [ ] Test engineer approval
