### PR TITLE
Change mode to CORS for fetch GET request

### DIFF
--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -8,7 +8,7 @@ const getInitialData = async ({ match }) => {
       process.env.RAZZLE_BASE_PATH
     }/${service}/articles/${id}.json`;
 
-    const response = await fetch(url);
+    const response = await fetch(url, { mode: 'cors' });
 
     const data = await response.json();
     const isAmp = !!amp;


### PR DESCRIPTION
Resolves #877

- Updates fetch request to have mode CORS. 
This is needed for when we have localhost pointing to the TEST environment, or LIVE environment. 
This PR should only be merged after this other PR the Frameworks + Tools team are working on is completed and deployed to TEST.  I will add a comment below when that work has been done. https://github.com/bbc/mozart-routing/pull/676


Test instructions:
```
cd simorgh
git checkout fetch-cors-fix
RAZZLE_BASE_PATH=https://www.test.bbc.com npm run dev
```
Visit http://localhost:7080/news/articles/c85pqyj5m2ko & click on the inline link. You should see the page load without errors 
 

- [ ] Tests added for new features
- [ ] Test engineer approval
