### PR TITLE
Remove unnecessary copyright wording from footer

### DIFF
--- a/cypress/integration/footerSpec.js
+++ b/cypress/integration/footerSpec.js
@@ -54,7 +54,7 @@ describe('Footer Tests', () => {
     const footerCopyrightArea = getElement('footer p');
     footerCopyrightArea.should(
       'contain',
-      'Copyright © 2018 BBC. The BBC is not responsible for the content of external sites. ',
+      '© 2018 BBC. The BBC is not responsible for the content of external sites. ',
     );
   });
   it('should contain a link in the copyright text', () => {

--- a/src/app/containers/Footer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Footer/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FooterContainer should render correctly 1`] = `
 <Footer
-  copyrightText="Copyright © 2018 BBC. The BBC is not responsible for the content of external sites. "
+  copyrightText="© 2018 BBC. The BBC is not responsible for the content of external sites. "
   externalLink={
     Object {
       "href": "https://www.bbc.co.uk/help/web/links/",

--- a/src/app/containers/Footer/index.jsx
+++ b/src/app/containers/Footer/index.jsx
@@ -38,7 +38,7 @@ const links = [
 ];
 
 const currentYear = new Date().getFullYear();
-const copyrightText = `Copyright \u00A9 ${currentYear} BBC. The BBC is not responsible for the content of external sites. `;
+const copyrightText = `\u00A9 ${currentYear} BBC. The BBC is not responsible for the content of external sites. `;
 
 const FooterContainer = () => (
   <Footer


### PR DESCRIPTION
Resolves #861 

Removes unnecessary copyright text from Footer component. Updates snapshot tests.

- [x] Tests updated for new features
- [ ] Test engineer approval