### PR TITLE
Ensure <title> test expectation matches seoHeadline value

### DIFF
--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -85,9 +85,10 @@ describe('Article Body Tests', () => {
   });
 
   it('should render a title', () => {
-    renderedTitle(
-      "Meghan's bouquet laid on tomb of unknown warrior – BBC News",
-    );
+    cy.window().then(win => {
+      const { seoHeadline } = win.SIMORGH_DATA.data.promo.headlines;
+      renderedTitle(`${seoHeadline} – BBC News`);
+    });
   });
 
   it('should have an inline link with focus styling', () => {


### PR DESCRIPTION
Resolves #950 

_Changes the `<title>` Cypress test is no longer a static string but instead matches the `promo.headlines.seoHeadline` value appended with ` - BBC News`_

- ~[ ] Tests added for new features~
- [x] Test engineer approval - Spoke with James prior to the PR as he had already made these changes in a local PR
