### PR TITLE
[POC] Context translations

### DIFF
--- a/src/app/components/Figure/Copyright/index.jsx
+++ b/src/app/components/Figure/Copyright/index.jsx
@@ -9,6 +9,7 @@ import {
 } from '../../../lib/constants/styles';
 import { T_MINION } from '../../../lib/constants/typography';
 import VisuallyHiddenText from '../../VisuallyHiddenText';
+import { ServiceContextConsumer } from '../../ServiceContext';
 
 const StyledCopyright = styled.p.attrs({
   role: 'text',
@@ -25,16 +26,16 @@ const StyledCopyright = styled.p.attrs({
   margin: 0;
 `;
 
-const Copyright = ({ children }) => {
-  const attributionText = `Image source, `;
-
-  return (
-    <StyledCopyright>
-      <VisuallyHiddenText>{attributionText}</VisuallyHiddenText>
-      {children}
-    </StyledCopyright>
-  );
-};
+const Copyright = ({ children }) => (
+  <ServiceContextConsumer>
+    {({ translations }) => (
+      <StyledCopyright>
+        <VisuallyHiddenText>{translations.attributionText}</VisuallyHiddenText>
+        {children}
+      </StyledCopyright>
+    )}
+  </ServiceContextConsumer>
+);
 
 Copyright.propTypes = {
   children: string.isRequired,

--- a/src/app/components/Figure/fixtureData.jsx
+++ b/src/app/components/Figure/fixtureData.jsx
@@ -13,6 +13,9 @@ const copyrightText = 'Getty Images';
 
 const serviceContextStubNews = {
   imageCaptionOffscreenText: 'Image caption, ',
+  translations: {
+    attributionText: 'Image source, ',
+  },
 };
 
 const generateFixtureData = (caption, copyright) => (

--- a/src/app/lib/config/services/index.js
+++ b/src/app/lib/config/services/index.js
@@ -5,12 +5,14 @@
 
 import news from './news';
 import persian from './persian';
+import translations from '../translations/en-gb';
 
 export default {
   default: {
     brandName: 'Default Brand Name',
     imageCaptionOffscreenText: 'Default image caption prefix, ',
     service: 'default',
+    translations,
   },
   news,
   persian,

--- a/src/app/lib/config/services/news.js
+++ b/src/app/lib/config/services/news.js
@@ -1,3 +1,5 @@
+import translations from '../translations/en-gb';
+
 const news = {
   brandName: 'BBC News',
   serviceName: 'News',
@@ -9,6 +11,7 @@ const news = {
   locale: 'en_GB',
   twitterCreator: '@BBCNews',
   twitterSite: '@BBCNews',
+  translations,
 };
 
 export default news;

--- a/src/app/lib/config/services/news.js
+++ b/src/app/lib/config/services/news.js
@@ -1,4 +1,4 @@
-import translations from '../translations/en-gb';
+import enGbTranslations from '../translations/en-gb';
 
 const news = {
   brandName: 'BBC News',
@@ -11,7 +11,7 @@ const news = {
   locale: 'en_GB',
   twitterCreator: '@BBCNews',
   twitterSite: '@BBCNews',
-  translations,
+  translations: enGbTranslations,
 };
 
 export default news;

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -1,4 +1,5 @@
-import translations from '../translations/fa';
+import faTranslations from '../translations/fa';
+import enGbTranslations from '../translations/en-gb';
 
 const persian = {
   brandName: 'BBC News فارسی',
@@ -10,7 +11,7 @@ const persian = {
   locale: 'fa',
   twitterCreator: '@bbcpersian',
   twitterSite: '@bbcpersian',
-  translations,
+  translations: { ...enGbTranslations, ...faTranslations },
 };
 
 export default persian;

--- a/src/app/lib/config/translations/en-gb.js
+++ b/src/app/lib/config/translations/en-gb.js
@@ -1,6 +1,4 @@
-import translations from '../translations/fa';
-
-const persian = {
+const enGb = {
   brandName: 'BBC News فارسی',
   serviceName: 'Persian',
   service: 'persian',
@@ -10,7 +8,6 @@ const persian = {
   locale: 'fa',
   twitterCreator: '@bbcpersian',
   twitterSite: '@bbcpersian',
-  translations,
 };
 
-export default persian;
+export default enGb;

--- a/src/app/lib/config/translations/en-gb.js
+++ b/src/app/lib/config/translations/en-gb.js
@@ -9,6 +9,7 @@ const enGb = {
   loading: 'loading',
   share_post_on: 'Share post on',
   read_more_on_links: 'Read more on',
+  attributionText: 'Image source, ',
 };
 
 export default enGb;

--- a/src/app/lib/config/translations/en-gb.js
+++ b/src/app/lib/config/translations/en-gb.js
@@ -1,13 +1,14 @@
 const enGb = {
-  brandName: 'BBC News فارسی',
-  serviceName: 'Persian',
-  service: 'persian',
-  articleAuthor: 'https://www.facebook.com/bbcnews',
-  defaultImage: 'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
-  defaultImageAltText: 'BBC News فارسی',
-  locale: 'fa',
-  twitterCreator: '@bbcpersian',
-  twitterSite: '@bbcpersian',
+  show_more: 'show more',
+  back_to_top: 'go back to the top',
+  live: 'live',
+  breaking: 'Breaking',
+  share: 'share',
+  report: 'report',
+  duration: 'duration',
+  loading: 'loading',
+  share_post_on: 'Share post on',
+  read_more_on_links: 'Read more on',
 };
 
 export default enGb;

--- a/src/app/lib/config/translations/fa.js
+++ b/src/app/lib/config/translations/fa.js
@@ -7,6 +7,7 @@ const fa = {
   loading: 'بارگذاری',
   share_post_on: 'همرسانی در ::',
   read_more_on_links: 'لینک های دیگر ::',
+  attributionText: 'من نمیفهمم ایرانی, ',
 };
 
 export default fa;

--- a/src/app/lib/config/translations/fa.js
+++ b/src/app/lib/config/translations/fa.js
@@ -1,13 +1,12 @@
 const fa = {
-  brandName: 'BBC News فارسی',
-  serviceName: 'Persian',
-  service: 'persian',
-  articleAuthor: 'https://www.facebook.com/bbcnews',
-  defaultImage: 'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
-  defaultImageAltText: 'BBC News فارسی',
-  locale: 'fa',
-  twitterCreator: '@bbcpersian',
-  twitterSite: '@bbcpersian',
+  show_more: 'نمایش همه',
+  back_to_top: 'بازگشت به بالا',
+  breaking: 'خبر فوری:',
+  share: 'اشتراک گذاری ::',
+  auto_updates: 'این صفحه به طورخودکار به روز می‌شود',
+  loading: 'بارگذاری',
+  share_post_on: 'همرسانی در ::',
+  read_more_on_links: 'لینک های دیگر ::',
 };
 
 export default fa;

--- a/src/app/lib/config/translations/fa.js
+++ b/src/app/lib/config/translations/fa.js
@@ -1,6 +1,4 @@
-import translations from '../translations/fa';
-
-const persian = {
+const fa = {
   brandName: 'BBC News فارسی',
   serviceName: 'Persian',
   service: 'persian',
@@ -10,7 +8,6 @@ const persian = {
   locale: 'fa',
   twitterCreator: '@bbcpersian',
   twitterSite: '@bbcpersian',
-  translations,
 };
 
-export default persian;
+export default fa;


### PR DESCRIPTION
Adds translations to the service context.

They're added to the service configs like 
```translations: { ...enGbTranslations, ...faTranslations }``` 
meaning that if a translation does not exist it falls back to a default language if desired. This is nice IMO as it means we could do
```translations: { ...enGbTranslations, ...arTranslations, ...faTranslations }```
if a non-english language would a better fallback if it is available.