### PR TITLE
Updates the testing note section in the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,9 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Testing notes**
-Will Cypress tests be required or are unit tests sufficient?
+[Tester to complete]
+
+Dev insight: Will Cypress tests be required or are unit tests sufficient? Will there be any potential regression? etc
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Test see the testing notes as confirmation from their point of view on what is likely to need testing. Currently dev's see this section in the issue and detail notes from their point of view, this means the "testing notes" have different meanings to different disciplines. Therefore I'm clarifying that the notes shouldn't be confirmed and completed by testers and dev can give insight into how the issue is likely to affect the application, which should help the tester in defining the testing notes.

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
