### PR TITLE
add Merging process section to readme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,3 +4,5 @@ _PR changes summary to go here._
 
 - [ ] Tests added for new features
 - [ ] Test engineer approval
+
+When merging a PR there is a manual process as defined in [this documentation](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,4 @@ _PR changes summary to go here._
 
 - [ ] Tests added for new features
 - [ ] Test engineer approval
-
-When merging a PR there is a manual process as defined in [this documentation](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md).
+- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,7 @@ To run these on your forked version follow these steps.
 - To setup CodeClimate you need to login to the 'quality' option on [https://codeclimate.com/](https://codeclimate.com/) and obtain a code coverage [CC_TEST_REPORTER_ID](https://docs.codeclimate.com/docs/finding-your-test-coverage-token), this then needs to be added as an environment variable in TravisCI (see the TravisCI settings page).
 - Now create a branch and start committing and pushing to it!
 - You should see Travis CI and codecoverage now running against your branch and PRs within your fork. :white_check_mark:
+
+### Merging a Pull Request
+
+There is a [guide](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) for BBC staff which documents the manual process that should be followed before merging a PR. Please note: The guide links through to our CI endpoints and therefore is hosted in a private repository.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ To avoid indexing by search engines during our early development, there is a `no
 
 Every run of `npm run build` will update the bundle analysis files in the repo. To view a breakdown of the bundle size, open the generated html report in a browser `./reports/webpackBundleReport.html` This is generated via `webpack-bundle-analyzer`. The data is also available as json `./reports/webpackBundleReport.json`.
 
-## Merging process
-
-Please read the documentation for merging PR's in which is hosted [here](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md)
-
 ## Tests
 
 ### Linting and unit tests

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ To avoid indexing by search engines during our early development, there is a `no
 
 Every run of `npm run build` will update the bundle analysis files in the repo. To view a breakdown of the bundle size, open the generated html report in a browser `./reports/webpackBundleReport.html` This is generated via `webpack-bundle-analyzer`. The data is also available as json `./reports/webpackBundleReport.json`.
 
+## Merging process
+
+Please read the documentation for merging PR's in which is hosted [here](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md)
+
 ## Tests
 
 ### Linting and unit tests


### PR DESCRIPTION
Resolves #952 

_Adds a "Merging process" section to the readme which links to the documentation added in https://github.com/bbc/simorgh-infrastructure/pull/164_

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
