### PR TITLE
Add PlatformContext & remove passing of isAmp

### DIFF
--- a/src/app/components/PlatformContext/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/PlatformContext/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlatformContext should have a platform string for amp 1`] = `
+<span>
+  amp
+</span>
+`;
+
+exports[`PlatformContext should have a platform string for canonical 1`] = `
+<span>
+  canonical
+</span>
+`;
+
+exports[`PlatformContext should have a platform string for default 1`] = `
+<span>
+  default
+</span>
+`;

--- a/src/app/components/PlatformContext/index.jsx
+++ b/src/app/components/PlatformContext/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { node, string, func } from 'prop-types';
+
+const PlatformContext = React.createContext('default');
+
+export const PlatformContextProvider = ({ children, platform }) => (
+  <PlatformContext.Provider value={platform}>
+    {children}
+  </PlatformContext.Provider>
+);
+
+export const PlatformContextConsumer = ({ children }) => (
+  <PlatformContext.Consumer>{children}</PlatformContext.Consumer>
+);
+
+PlatformContextProvider.propTypes = {
+  children: node.isRequired,
+  platform: string.isRequired,
+};
+
+PlatformContextConsumer.propTypes = {
+  children: func.isRequired,
+};

--- a/src/app/components/PlatformContext/index.test.jsx
+++ b/src/app/components/PlatformContext/index.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { PlatformContextProvider, PlatformContextConsumer } from './index';
+
+describe('PlatformContext', () => {
+  const testPlatformStringWithPlatformContext = platformString => {
+    shouldMatchSnapshot(
+      `should have a platform string for ${platformString}`,
+      <PlatformContextProvider platform={platformString}>
+        <PlatformContextConsumer>
+          {platform => <span>{platform}</span>}
+        </PlatformContextConsumer>
+      </PlatformContextProvider>,
+    );
+  };
+
+  testPlatformStringWithPlatformContext('default');
+  testPlatformStringWithPlatformContext('canonical');
+  testPlatformStringWithPlatformContext('amp');
+});

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -7,122 +7,125 @@ exports[`ArticleContainer Component should render Persian article correctly 1`] 
   <ServiceContextProvider
     service="persian"
   >
-    <Header />
-    <MetadataContainer
-      isAmp={false}
-      metadata={
-        Object {
-          "created": 1514808060000,
-          "createdBy": "",
-          "firstPublished": 1514808060000,
-          "id": "urn:bbc:ares::article:cwv2xv848j5o",
-          "lastPublished": 1514811600000,
-          "lastUpdated": 1514811600000,
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
-          },
-          "passport": Object {
-            "category": "news",
-            "genre": null,
-            "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
-            "language": "fa",
-          },
-          "tags": Object {
-            "about": null,
-            "mentions": null,
-          },
-          "type": "article",
-        }
-      }
-      promo={
-        Object {
-          "headlines": Object {
-            "promoHeadline": "سرصفحه مقاله برای ارتقاء",
-            "seoHeadline": "سرصفحه مقاله",
-          },
-          "id": "urn:bbc:ares::article:cwv2xv848j5o",
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
-          },
-          "summary": "خلاصه مقاله",
-          "timestamp": 1514811600000,
-        }
-      }
-      service="persian"
-    />
-    <main
-      role="main"
+    <PlatformContextProvider
+      platform="canonical"
     >
-      <Wrapper>
-        <GridItemConstrained>
-          <Blocks
-            blocks={
-              Array [
-                Object {
-                  "model": Object {
-                    "blocks": Array [
-                      Object {
-                        "model": Object {
-                          "blocks": Array [
-                            Object {
-                              "model": Object {
-                                "text": "سرصفحه مقاله",
+      <Header />
+      <MetadataContainer
+        metadata={
+          Object {
+            "created": 1514808060000,
+            "createdBy": "",
+            "firstPublished": 1514808060000,
+            "id": "urn:bbc:ares::article:cwv2xv848j5o",
+            "lastPublished": 1514811600000,
+            "lastUpdated": 1514811600000,
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
+            },
+            "passport": Object {
+              "category": "news",
+              "genre": null,
+              "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
+              "language": "fa",
+            },
+            "tags": Object {
+              "about": null,
+              "mentions": null,
+            },
+            "type": "article",
+          }
+        }
+        promo={
+          Object {
+            "headlines": Object {
+              "promoHeadline": "سرصفحه مقاله برای ارتقاء",
+              "seoHeadline": "سرصفحه مقاله",
+            },
+            "id": "urn:bbc:ares::article:cwv2xv848j5o",
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
+            },
+            "summary": "خلاصه مقاله",
+            "timestamp": 1514811600000,
+          }
+        }
+        service="persian"
+      />
+      <main
+        role="main"
+      >
+        <Wrapper>
+          <GridItemConstrained>
+            <Blocks
+              blocks={
+                Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "blocks": Array [
+                              Object {
+                                "model": Object {
+                                  "text": "سرصفحه مقاله",
+                                },
+                                "type": "paragraph",
                               },
-                              "type": "paragraph",
-                            },
-                          ],
+                            ],
+                          },
+                          "type": "text",
                         },
-                        "type": "text",
-                      },
-                    ],
+                      ],
+                    },
+                    "type": "headline",
                   },
-                  "type": "headline",
-                },
-              ]
-            }
-            componentsToRender={
-              Object {
-                "headline": [Function],
+                ]
               }
-            }
-          />
-          <Timestamp
-            timestamp={1514811600000}
-          />
-        </GridItemConstrained>
-      </Wrapper>
-      <OatWrapper>
-        <GridItemConstrained>
-          <Blocks
-            blocks={
-              Array [
+              componentsToRender={
                 Object {
-                  "model": Object {
-                    "blocks": Array [
-                      Object {
-                        "model": Object {
-                          "text": "یک پاراگراف.",
-                        },
-                        "type": "paragraph",
-                      },
-                    ],
-                  },
-                  "type": "text",
-                },
-              ]
-            }
-            componentsToRender={
-              Object {
-                "image": [Function],
-                "subheadline": [Function],
-                "text": [Function],
+                  "headline": [Function],
+                }
               }
-            }
-          />
-        </GridItemConstrained>
-      </OatWrapper>
-    </main>
-    <FooterContainer />
+            />
+            <Timestamp
+              timestamp={1514811600000}
+            />
+          </GridItemConstrained>
+        </Wrapper>
+        <OatWrapper>
+          <GridItemConstrained>
+            <Blocks
+              blocks={
+                Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "text": "یک پاراگراف.",
+                          },
+                          "type": "paragraph",
+                        },
+                      ],
+                    },
+                    "type": "text",
+                  },
+                ]
+              }
+              componentsToRender={
+                Object {
+                  "image": [Function],
+                  "subheadline": [Function],
+                  "text": [Function],
+                }
+              }
+            />
+          </GridItemConstrained>
+        </OatWrapper>
+      </main>
+      <FooterContainer />
+    </PlatformContextProvider>
   </ServiceContextProvider>
 </React.Fragment>
 `;
@@ -132,147 +135,150 @@ exports[`ArticleContainer Component should render correctly 1`] = `
   <ServiceContextProvider
     service="news"
   >
-    <Header />
-    <MetadataContainer
-      isAmp={false}
-      metadata={
-        Object {
-          "created": 1514808060000,
-          "createdBy": "",
-          "firstPublished": 1514808060000,
-          "id": "urn:bbc:ares::article:c0000000001o",
-          "lastPublished": 1514811600000,
-          "lastUpdated": 1514811600000,
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
-          },
-          "passport": Object {
-            "category": "news",
-            "genre": null,
-            "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
-            "language": "en-gb",
-          },
-          "tags": Object {
-            "about": Array [
-              Object {
-                "curationType": Array [
-                  "vivo-stream",
-                ],
-                "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
-                "thingLabel": "Royal Wedding 2018",
-                "thingType": Array [
-                  "Thing",
-                  "Event",
-                ],
-                "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
-                "topicId": "cpwpy79d6dxt",
-                "topicName": "Royal Wedding 2018",
-              },
-            ],
-            "mentions": Array [
-              Object {
-                "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
-                "thingLabel": "Queen Victoria",
-                "thingType": Array [
-                  "Person",
-                  "Thing",
-                ],
-                "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
-              },
-            ],
-          },
-          "type": "article",
-        }
-      }
-      promo={
-        Object {
-          "headlines": Object {
-            "promoHeadline": "Article Headline for Promo",
-            "seoHeadline": "Article Headline for SEO",
-          },
-          "id": "urn:bbc:ares::article:c0000000001o",
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
-          },
-          "summary": "Article summary.",
-          "timestamp": 1514811600000,
-        }
-      }
-      service="news"
-    />
-    <main
-      role="main"
+    <PlatformContextProvider
+      platform="canonical"
     >
-      <Wrapper>
-        <GridItemConstrained>
-          <Blocks
-            blocks={
-              Array [
+      <Header />
+      <MetadataContainer
+        metadata={
+          Object {
+            "created": 1514808060000,
+            "createdBy": "",
+            "firstPublished": 1514808060000,
+            "id": "urn:bbc:ares::article:c0000000001o",
+            "lastPublished": 1514811600000,
+            "lastUpdated": 1514811600000,
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+            },
+            "passport": Object {
+              "category": "news",
+              "genre": null,
+              "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+              "language": "en-gb",
+            },
+            "tags": Object {
+              "about": Array [
                 Object {
-                  "model": Object {
-                    "blocks": Array [
-                      Object {
-                        "model": Object {
-                          "blocks": Array [
-                            Object {
-                              "model": Object {
-                                "text": "Article Headline",
+                  "curationType": Array [
+                    "vivo-stream",
+                  ],
+                  "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
+                  "thingLabel": "Royal Wedding 2018",
+                  "thingType": Array [
+                    "Thing",
+                    "Event",
+                  ],
+                  "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
+                  "topicId": "cpwpy79d6dxt",
+                  "topicName": "Royal Wedding 2018",
+                },
+              ],
+              "mentions": Array [
+                Object {
+                  "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
+                  "thingLabel": "Queen Victoria",
+                  "thingType": Array [
+                    "Person",
+                    "Thing",
+                  ],
+                  "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
+                },
+              ],
+            },
+            "type": "article",
+          }
+        }
+        promo={
+          Object {
+            "headlines": Object {
+              "promoHeadline": "Article Headline for Promo",
+              "seoHeadline": "Article Headline for SEO",
+            },
+            "id": "urn:bbc:ares::article:c0000000001o",
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+            },
+            "summary": "Article summary.",
+            "timestamp": 1514811600000,
+          }
+        }
+        service="news"
+      />
+      <main
+        role="main"
+      >
+        <Wrapper>
+          <GridItemConstrained>
+            <Blocks
+              blocks={
+                Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "blocks": Array [
+                              Object {
+                                "model": Object {
+                                  "text": "Article Headline",
+                                },
+                                "type": "paragraph",
                               },
-                              "type": "paragraph",
-                            },
-                          ],
+                            ],
+                          },
+                          "type": "text",
                         },
-                        "type": "text",
-                      },
-                    ],
+                      ],
+                    },
+                    "type": "headline",
                   },
-                  "type": "headline",
-                },
-              ]
-            }
-            componentsToRender={
-              Object {
-                "headline": [Function],
+                ]
               }
-            }
-          />
-          <Timestamp
-            timestamp={1514811600000}
-          />
-        </GridItemConstrained>
-      </Wrapper>
-      <OatWrapper>
-        <GridItemConstrained>
-          <Blocks
-            blocks={
-              Array [
+              componentsToRender={
                 Object {
-                  "model": Object {
-                    "blocks": Array [
-                      Object {
-                        "model": Object {
-                          "text": "A paragraph.",
-                        },
-                        "type": "paragraph",
-                      },
-                    ],
-                  },
-                  "type": "text",
-                },
-              ]
-            }
-            componentsToRender={
-              Object {
-                "image": [Function],
-                "subheadline": [Function],
-                "text": [Function],
+                  "headline": [Function],
+                }
               }
-            }
-          />
-        </GridItemConstrained>
-      </OatWrapper>
-    </main>
-    <FooterContainer />
+            />
+            <Timestamp
+              timestamp={1514811600000}
+            />
+          </GridItemConstrained>
+        </Wrapper>
+        <OatWrapper>
+          <GridItemConstrained>
+            <Blocks
+              blocks={
+                Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "text": "A paragraph.",
+                          },
+                          "type": "paragraph",
+                        },
+                      ],
+                    },
+                    "type": "text",
+                  },
+                ]
+              }
+              componentsToRender={
+                Object {
+                  "image": [Function],
+                  "subheadline": [Function],
+                  "text": [Function],
+                }
+              }
+            />
+          </GridItemConstrained>
+        </OatWrapper>
+      </main>
+      <FooterContainer />
+    </PlatformContextProvider>
   </ServiceContextProvider>
 </React.Fragment>
 `;

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -16,6 +16,7 @@ import {
   layoutGridItemConstrained,
 } from '../../lib/layoutGrid';
 import { C_OAT_LHT } from '../../lib/constants/styles';
+import { PlatformContextProvider } from '../../components/PlatformContext';
 
 const Wrapper = styled.div`
   ${layoutGridWrapper};
@@ -72,33 +73,34 @@ const ArticleContainer = ({ loading, error, data }) => {
       return (
         <Fragment>
           <ServiceContextProvider service={service}>
-            <Header />
-            <MetadataContainer
-              isAmp={isAmp}
-              metadata={metadata}
-              promo={promo}
-              service={service}
-            />
-            <main role="main">
-              <Wrapper>
-                <GridItemConstrained>
-                  <Blocks
-                    blocks={headlineBlocks}
-                    componentsToRender={componentsToRenderHeadline}
-                  />
-                  <Timestamp timestamp={metadata.lastUpdated} />
-                </GridItemConstrained>
-              </Wrapper>
-              <OatWrapper>
-                <GridItemConstrained>
-                  <Blocks
-                    blocks={mainBlocks}
-                    componentsToRender={componentsToRenderMain}
-                  />
-                </GridItemConstrained>
-              </OatWrapper>
-            </main>
-            <Footer />
+            <PlatformContextProvider platform={isAmp ? 'amp' : 'canonical'}>
+              <Header />
+              <MetadataContainer
+                metadata={metadata}
+                promo={promo}
+                service={service}
+              />
+              <main role="main">
+                <Wrapper>
+                  <GridItemConstrained>
+                    <Blocks
+                      blocks={headlineBlocks}
+                      componentsToRender={componentsToRenderHeadline}
+                    />
+                    <Timestamp timestamp={metadata.lastUpdated} />
+                  </GridItemConstrained>
+                </Wrapper>
+                <OatWrapper>
+                  <GridItemConstrained>
+                    <Blocks
+                      blocks={mainBlocks}
+                      componentsToRender={componentsToRenderMain}
+                    />
+                  </GridItemConstrained>
+                </OatWrapper>
+              </main>
+              <Footer />
+            </PlatformContextProvider>
           </ServiceContextProvider>
         </Fragment>
       );

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { bool, string, shape } from 'prop-types';
+import { string, shape } from 'prop-types';
 import { ServiceContextConsumer } from '../../components/ServiceContext';
+import { PlatformContextConsumer } from '../../components/PlatformContext';
 import Metadata from '../../components/Metadata';
 import metadataPropTypes from '../../models/propTypes/metadata';
 import promoPropTypes from '../../models/propTypes/promo';
@@ -13,7 +14,7 @@ const allTags = tags => {
   return aboutTags.concat(mentionTags);
 };
 
-const MetadataContainer = ({ isAmp, metadata, promo, service }) => {
+const MetadataContainer = ({ metadata, promo, service }) => {
   const { id: aresArticleId } = metadata;
 
   if (!aresArticleId) {
@@ -27,44 +28,47 @@ const MetadataContainer = ({ isAmp, metadata, promo, service }) => {
   const timeLastUpdated = new Date(metadata.lastUpdated).toISOString();
 
   return (
-    <ServiceContextConsumer>
-      {({
-        brandName,
-        articleAuthor,
-        defaultImage,
-        defaultImageAltText,
-        locale,
-        twitterCreator,
-        twitterSite,
-      }) => (
-        <Metadata
-          isAmp={isAmp}
-          articleAuthor={articleAuthor}
-          articleSection={metadata.passport.genre}
-          brandName={brandName}
-          canonicalLink={canonicalLink}
-          defaultImage={defaultImage}
-          defaultImageAltText={defaultImageAltText}
-          description={promo.summary}
-          facebookAdmin={100004154058350}
-          facebookAppID={1609039196070050}
-          lang={metadata.passport.language}
-          locale={locale}
-          metaTags={allTags(metadata.tags)}
-          timeFirstPublished={timeFirstPublished}
-          timeLastUpdated={timeLastUpdated}
-          title={promo.headlines.seoHeadline}
-          twitterCreator={twitterCreator}
-          twitterSite={twitterSite}
-          type={metadata.type}
-        />
+    <PlatformContextConsumer>
+      {platform => (
+        <ServiceContextConsumer>
+          {({
+            brandName,
+            articleAuthor,
+            defaultImage,
+            defaultImageAltText,
+            locale,
+            twitterCreator,
+            twitterSite,
+          }) => (
+            <Metadata
+              isAmp={platform === 'amp'}
+              articleAuthor={articleAuthor}
+              articleSection={metadata.passport.genre}
+              brandName={brandName}
+              canonicalLink={canonicalLink}
+              defaultImage={defaultImage}
+              defaultImageAltText={defaultImageAltText}
+              description={promo.summary}
+              facebookAdmin={100004154058350}
+              facebookAppID={1609039196070050}
+              lang={metadata.passport.language}
+              locale={locale}
+              metaTags={allTags(metadata.tags)}
+              timeFirstPublished={timeFirstPublished}
+              timeLastUpdated={timeLastUpdated}
+              title={promo.headlines.seoHeadline}
+              twitterCreator={twitterCreator}
+              twitterSite={twitterSite}
+              type={metadata.type}
+            />
+          )}
+        </ServiceContextConsumer>
       )}
-    </ServiceContextConsumer>
+    </PlatformContextConsumer>
   );
 };
 
 MetadataContainer.propTypes = {
-  isAmp: bool.isRequired,
   metadata: shape(metadataPropTypes).isRequired,
   promo: shape(promoPropTypes).isRequired,
   service: string.isRequired,

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -8,12 +8,12 @@ import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 import services from '../../lib/config/services/index';
 import { PlatformContextProvider } from '../../components/PlatformContext';
 
-const MetadataWithContextAsObject = (service, serviceFixtureData) => {
+const MetadataWithContextAsObject = (service, serviceFixtureData, platform) => {
   const { metadata, promo } = serviceFixtureData;
 
   renderer.create(
     <ServiceContextProvider service={service}>
-      <PlatformContextProvider platform="canonical">
+      <PlatformContextProvider platform={platform}>
         <MetadataContainer
           metadata={metadata}
           promo={promo}
@@ -125,7 +125,11 @@ const doesMatch = (result, fixture) => {
 
 describe('Successfully passes data to the Metadata component via React context', () => {
   it('should pass persian data to the Metadata component', () => {
-    const result = MetadataWithContextAsObject('persian', articleDataPersian);
+    const result = MetadataWithContextAsObject(
+      'persian',
+      articleDataPersian,
+      'canonical',
+    );
     const expected = articleMetadataBuilder(
       'persian',
       'fa',
@@ -140,7 +144,11 @@ describe('Successfully passes data to the Metadata component via React context',
   });
 
   it('it should pass news data to the Metadata component', () => {
-    const result = MetadataWithContextAsObject('news', articleDataNews);
+    const result = MetadataWithContextAsObject(
+      'news',
+      articleDataNews,
+      'canonical',
+    );
     const expected = articleMetadataBuilder(
       'news',
       'en-gb',
@@ -161,5 +169,10 @@ describe('Successfully passes data to the Metadata component via React context',
     );
 
     doesMatch(result, expected);
+  });
+
+  it('should add amp to HTML attributes when platform is set to AMP', () => {
+    const result = MetadataWithContextAsObject('news', articleDataNews, 'amp');
+    expect(result.htmlAttributes.amp).not.toBe(undefined);
   });
 });

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -6,18 +6,20 @@ import { ServiceContextProvider } from '../../components/ServiceContext';
 import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
 import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 import services from '../../lib/config/services/index';
+import { PlatformContextProvider } from '../../components/PlatformContext';
 
 const MetadataWithContextAsObject = (service, serviceFixtureData) => {
   const { metadata, promo } = serviceFixtureData;
 
   renderer.create(
     <ServiceContextProvider service={service}>
-      <MetadataContainer
-        isAmp={false}
-        metadata={metadata}
-        promo={promo}
-        service={service}
-      />
+      <PlatformContextProvider platform="canonical">
+        <MetadataContainer
+          metadata={metadata}
+          promo={promo}
+          service={service}
+        />
+      </PlatformContextProvider>
     </ServiceContextProvider>,
   );
 
@@ -27,7 +29,7 @@ const MetadataWithContextAsObject = (service, serviceFixtureData) => {
 describe('no data', () => {
   shouldShallowMatchSnapshot(
     'should render null',
-    <MetadataContainer isAmp={false} metadata={{}} promo={{}} service="" />,
+    <MetadataContainer metadata={{}} promo={{}} service="" />,
   );
 });
 


### PR DESCRIPTION
Resolves #927 

* Creates PlatformContext, which currently only takes a String. Expected values are "canonical" or "amp", & currently we default to "default" in a similar way to ServiceContext, to ensure failures are very obvious.
* Wraps ArticleContainer in PlatformContextProvider.
* Uses PlatformContextConsumer in the Metadata container.

- [x] Tests added for new features
- [ ] Test engineer approval