### PR TITLE
Re-enabling inline link Cypress test

### DIFF
--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -1,5 +1,5 @@
 import {
-  // clickInlineLinkAndTestPageHasHTML,
+  clickInlineLinkAndTestPageHasHTML,
   checkElementStyles,
   getElement,
   placeholderImageLoaded,
@@ -108,12 +108,7 @@ describe('Article Body Tests', () => {
     );
   });
 
-  /*
-    The following test is commented out due to it breaking the E2E tests once we are integrated with Mozart and Ares.
-    The issue https://github.com/BBC-News/simorgh/issues/930 has further details.
-  */
-
-  // it('should have a working first inline link', () => {
-  //   clickInlineLinkAndTestPageHasHTML('main a', '/news/articles/c85pqyj5m2ko');
-  // });
+  it('should have a working first inline link', () => {
+    clickInlineLinkAndTestPageHasHTML('main a', '/news/articles/c85pqyj5m2ko');
+  });
 });


### PR DESCRIPTION
Resolves #932 

_Now that the inline links are working again, we're re-enabling the Cypress test. This PR re-enables the test._

