### PR TITLE
Fix bug when passing props from validateProperty

### DIFF
--- a/src/app/dataValidator/helpers/validators/validateNode.js
+++ b/src/app/dataValidator/helpers/validators/validateNode.js
@@ -56,7 +56,7 @@ const validateNode = (schemaNode, dataNode, schemaName, parentSchemaName) => {
   }
 
   if (schemaNode.items) {
-    handleSchemaItems(schemaNode.items, dataNode, schemaName, parentSchemaName);
+    handleSchemaItems(schemaNode.items, dataNode, parentSchemaName);
   }
 };
 
@@ -74,13 +74,7 @@ const validateProperties = (
 
       log(`\nValidating Property '${property}' in '${parentSchemaName}'`);
 
-      validateProperty(
-        propertySchema,
-        dataNode,
-        property,
-        schemaName,
-        parentSchemaName,
-      );
+      validateProperty(propertySchema, dataNode, property, parentSchemaName);
     } else {
       log(`\nOptional Property '${property}' not in '${schemaName}'`);
     }
@@ -91,12 +85,11 @@ const validateProperty = (
   propertySchema,
   dataNode,
   property,
-  schemaName,
   parentSchemaName,
 ) => {
   if (referencesSchemaDefinition(propertySchema)) {
     recursivelyCallValidateBlock(
-      dataNode,
+      dataNode[property],
       getSchemaRefName(propertySchema),
       parentSchemaName,
     );
@@ -104,25 +97,18 @@ const validateProperty = (
     recursivelyCallValidateNode(
       propertySchema,
       dataNode[property],
-      schemaName,
+      property,
       `${parentSchemaName}:${property}`,
     );
   }
 };
 
-const handleSchemaItems = (
-  referencedItems,
-  dataNode,
-  schemaName,
-  parentSchemaName,
-) => {
+const handleSchemaItems = (referencedItems, dataNode, parentSchemaName) => {
   // if the value is null and not an array EG: article:promo:tags:about
   if (dataNode) {
     // oneOf declaration require $ref inside
     if (referencedItems.oneOf) {
-      const dataNodeArray = dataNode[schemaName];
-
-      dataNodeArray.forEach(dataItem => {
+      dataNode.forEach(dataItem => {
         validateOneOf(referencedItems.oneOf, dataItem, parentSchemaName);
 
         recursivelyCallValidateBlock(

--- a/src/app/dataValidator/helpers/validators/validateNode.test.js
+++ b/src/app/dataValidator/helpers/validators/validateNode.test.js
@@ -131,38 +131,37 @@ describe('Validate block', () => {
     const validateBlockSpy = jest.spyOn(validateNode, 'validateBlock');
 
     const articleContent = data.content;
-    const articleModel = articleContent.model;
-    const articleBlocks = articleModel.blocks;
+    const articleBlocks = articleContent.model.blocks;
     const headlineBlock = articleBlocks[0];
-    const headlineModel = headlineBlock.model;
-    const textBlock = headlineModel.blocks[0];
-    const textModel = textBlock.model;
-    const paragraphBlock = textModel.blocks[0];
-    const paragraphModel = paragraphBlock.model;
-    const fragmentBlock = paragraphModel.blocks[0];
+    const headlineBlocks = headlineBlock.model.blocks;
+    const textBlock = headlineBlocks[0];
+    const textBlocks = textBlock.model.blocks;
+    const paragraphBlock = textBlocks[0];
+    const paragraphBlocks = paragraphBlock.model.blocks;
+    const fragmentBlock = paragraphBlocks[0];
     const textBlock2 = articleBlocks[1];
-    const textModel2 = textBlock2.model;
-    const paragraphBlock2 = textModel2.blocks[0];
-    const paragraphModel2 = paragraphBlock2.model;
-    const fragmentBlock2 = paragraphModel2.blocks[0];
+    const textBlocks2 = textBlock2.model.blocks;
+    const paragraphBlock2 = textBlocks2[0];
+    const paragraphBlocks2 = paragraphBlock2.model.blocks;
+    const fragmentBlock2 = paragraphBlocks2[0];
 
     validateNode.validateBlock(data, 'article');
 
     // prettier-ignore
     expect(validateBlockSpy.mock.calls).toEqual([
       [data,            'article'],
-      [articleModel,    'blocks',     ':article:content:model'],
+      [articleBlocks,   'blocks',     ':article:content:model'],
       [headlineBlock,   'headline',   ':article:content:model:blocks'],
-      [headlineModel,   'blocks',     ':article:content:model:blocks:headline:model'],
+      [headlineBlocks,   'blocks',     ':article:content:model:blocks:headline:model'],
       [textBlock,       'text',       ':article:content:model:blocks:headline:model:blocks'],
-      [textModel,       'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model'],
+      [textBlocks,       'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model'],
       [paragraphBlock,  'paragraph',  ':article:content:model:blocks:headline:model:blocks:text:model:blocks'],
-      [paragraphModel,  'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model'],
+      [paragraphBlocks,  'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model'],
       [fragmentBlock,   'fragment',   ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model:blocks'],
       [textBlock2,      'text',       ':article:content:model:blocks'],
-      [textModel2,      'blocks',     ':article:content:model:blocks:text:model'],
+      [textBlocks2,      'blocks',     ':article:content:model:blocks:text:model'],
       [paragraphBlock2, 'paragraph',  ':article:content:model:blocks:text:model:blocks'],
-      [paragraphModel2, 'blocks',     ':article:content:model:blocks:text:model:blocks:paragraph:model'],
+      [paragraphBlocks2, 'blocks',     ':article:content:model:blocks:text:model:blocks:paragraph:model'],
       [fragmentBlock2,   'fragment',   ':article:content:model:blocks:text:model:blocks:paragraph:model:blocks'],
     ]);
     // The prettier ignore finishes here - https://prettier.io/docs/en/ignore.html

--- a/src/app/dataValidator/helpers/validators/validateNode.test.js
+++ b/src/app/dataValidator/helpers/validators/validateNode.test.js
@@ -149,20 +149,20 @@ describe('Validate block', () => {
 
     // prettier-ignore
     expect(validateBlockSpy.mock.calls).toEqual([
-      [data,            'article'],
-      [articleBlocks,   'blocks',     ':article:content:model'],
-      [headlineBlock,   'headline',   ':article:content:model:blocks'],
-      [headlineBlocks,   'blocks',     ':article:content:model:blocks:headline:model'],
-      [textBlock,       'text',       ':article:content:model:blocks:headline:model:blocks'],
-      [textBlocks,       'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model'],
-      [paragraphBlock,  'paragraph',  ':article:content:model:blocks:headline:model:blocks:text:model:blocks'],
-      [paragraphBlocks,  'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model'],
-      [fragmentBlock,   'fragment',   ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model:blocks'],
-      [textBlock2,      'text',       ':article:content:model:blocks'],
-      [textBlocks2,      'blocks',     ':article:content:model:blocks:text:model'],
-      [paragraphBlock2, 'paragraph',  ':article:content:model:blocks:text:model:blocks'],
-      [paragraphBlocks2, 'blocks',     ':article:content:model:blocks:text:model:blocks:paragraph:model'],
-      [fragmentBlock2,   'fragment',   ':article:content:model:blocks:text:model:blocks:paragraph:model:blocks'],
+      [data,              'article'],
+      [articleBlocks,     'blocks',     ':article:content:model'],
+      [headlineBlock,     'headline',   ':article:content:model:blocks'],
+      [headlineBlocks,    'blocks',     ':article:content:model:blocks:headline:model'],
+      [textBlock,         'text',       ':article:content:model:blocks:headline:model:blocks'],
+      [textBlocks,        'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model'],
+      [paragraphBlock,    'paragraph',  ':article:content:model:blocks:headline:model:blocks:text:model:blocks'],
+      [paragraphBlocks,   'blocks',     ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model'],
+      [fragmentBlock,     'fragment',   ':article:content:model:blocks:headline:model:blocks:text:model:blocks:paragraph:model:blocks'],
+      [textBlock2,        'text',       ':article:content:model:blocks'],
+      [textBlocks2,       'blocks',     ':article:content:model:blocks:text:model'],
+      [paragraphBlock2,   'paragraph',  ':article:content:model:blocks:text:model:blocks'],
+      [paragraphBlocks2,  'blocks',     ':article:content:model:blocks:text:model:blocks:paragraph:model'],
+      [fragmentBlock2,    'fragment',   ':article:content:model:blocks:text:model:blocks:paragraph:model:blocks'],
     ]);
     // The prettier ignore finishes here - https://prettier.io/docs/en/ignore.html
   });


### PR DESCRIPTION
Resolves #1006

- This bug was not seen as it only occurs when calling an array, hence the removal of the const `dataNodeArray`
- Inside of the `validateProperty` function there are two onward function calls which were incorrectly passing the `schemaName` where
they should be passing the `property` to the functions `recursivelyCallValidateBlock` and `recursivelyCallValidateNode`

- [x] Tests added for new features
- [ ] Test engineer approval
