### PR TITLE
add react/no-danger eslint disable line

### DIFF
--- a/src/server/styles.jsx
+++ b/src/server/styles.jsx
@@ -18,6 +18,7 @@ export const getStyleTag = (sheet, isAmp = false) => {
   }, '');
 
   return (
+    // eslint-disable-next-line react/no-danger
     <style amp-custom="" dangerouslySetInnerHTML={{ __html: inlineCss }} />
   );
 };


### PR DESCRIPTION
Resolves #1014

_Disables the eslint check for dangerouslySetInnerHTML in `src/server/styles.jsx` [this line](https://github.com/BBC-News/simorgh/blob/d5c76c52c2db9e66681f908f8e155a047d22a054/src/server/styles.jsx#L22)_

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
