### PR TITLE
removes array casting, fixes #976

### DIFF
--- a/src/server/styles.jsx
+++ b/src/server/styles.jsx
@@ -4,10 +4,7 @@ export const getStyleTag = (sheet, isAmp = false) => {
   const styleTags = sheet.getStyleElement();
   if (!isAmp) return styleTags;
 
-  // `getStyleElement()` doesn't always return an array (in our tests)
-  const styleTagsArray = Array.isArray(styleTags) ? styleTags : [styleTags];
-
-  const inlineCss = styleTagsArray.reduce((inlineStyles, currentStylesheet) => {
+  const inlineCss = styleTags.reduce((inlineStyles, currentStylesheet) => {
     if (currentStylesheet && currentStylesheet.props) {
       return `${inlineStyles}${
         // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
Upgrade to styled-components v4 means we don't need to cast our getStyleElement() call to an array anymore. It consistently returns an array.

Resolves #976

- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
