### PR TITLE
Add tick box to prompt people to assign PR/issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@ Resolves #NUMBER
 
 _PR changes summary to go here._
 
+- [ ] I have assigned myself to this PR and the corresponding issues
 - [ ] Tests added for new features
 - [ ] Test engineer approval
 - [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.


### PR DESCRIPTION
When using the github [projects board](https://github.com/orgs/bbc-news/projects/1) it can be confusing who is working on an issue/PR as the creator of the item is displayed. This can become misleading when person X created an issue and person Y picked up the issue. Therefore adding a tick box to prompt people to assign themselves.

- ~[ ] Tests added for new features~
- [ ] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
