### PR TITLE
Fixes wait-on in amp:validate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simorgh",
   "main": "index.js",
   "scripts": {
-    "amp:validate": "wait-on http://localhost:7080/ && (amphtml-validator http://localhost:7080/news/articles/c9rpqy7pmypo.amp || true)",
+    "amp:validate": "wait-on http://localhost:7080/news/articles/c9rpqy7pmypo.amp && (amphtml-validator http://localhost:7080/news/articles/c9rpqy7pmypo.amp || true)",
     "bbcA11y": "bbc-a11y",
     "build": "razzle build",
     "cypress": "cypress run",


### PR DESCRIPTION
Resolves #1109 

The `wait-on` in the `amp:validate` script hangs because we no longer serve anything on `/index.html`.

If running `curl http://localhost:7080` against latest, you will see the following output:
`No route was found for /index.html.`

Currently Simorgh has no need for an root-level route, so instead of adding one, this PR changes `amp:validate` to wait for the same article path as it tests.

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.