### PR TITLE
Fix for IE 11 Grid Layout - Body Content

### DIFF
--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -40,6 +40,7 @@ export const layoutWrapperWithoutGrid = css`
 */
 
 export const layoutGridWrapper = css`
+  display: -ms-grid;
   display: grid;
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     grid-gap: ${GEL_GUTTER_BELOW_600PX};
@@ -54,27 +55,38 @@ export const layoutGridWrapper = css`
     padding: 0 ${GEL_MARGIN_ABOVE_400PX};
   }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    -ms-grid-columns: (1fr)[6]; // prettier-ignore
     grid-template-columns: repeat(6, 1fr);
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+    -ms-grid-columns: 1fr (minmax(0, ${group4ColWidth}))[8] 1fr; // prettier-ignore
     grid-template-columns: 1fr repeat(8, minmax(0, ${group4ColWidth})) 1fr;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+    -ms-grid-columns: 1fr (minmax(0, ${group5ColWidth}))[10] 1fr; // prettier-ignore
     grid-template-columns: 1fr repeat(10, minmax(0, ${group5ColWidth})) 1fr;
   }
 `;
 
 export const layoutGridItemConstrained = css`
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
     grid-column: 1 / -1;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 2;
+    -ms-grid-column-span: 4;
     grid-column: 2 / -2;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 6;
     grid-column: 3 / -3;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 4;
+    -ms-grid-column-span: 6;
     grid-column: 4 / -4;
   }
 `;


### PR DESCRIPTION
Part of #821

This PR was opened as a result of investigating for a fix being needed for user testing pilot with a prototype next week. 

- Add IE 11 grid syntax
- Adding pretter-ignore command to ensure we have no spaces between parentheses in the IE repeat syntax: ()[]

**Before PR**
The content spans the width of the viewport, which is incorrect.
<img width="1421" alt="screen shot of article on Windows 7 - IE 11 - 1400px" src="https://user-images.githubusercontent.com/3028997/51034277-303f9480-159e-11e9-9ecd-ce3f1c203878.png">

**After PR**
The content respects the grid layout: 
1440px
<img width="1440" alt="screen shot of article on Windows 7 - IE 11 - 1400px" src="https://user-images.githubusercontent.com/3028997/51034217-e5be1800-159d-11e9-98fc-0e6b728c7098.png">

1010px
<img width="1073" alt="screen shot of article on Windows 7 - IE 11 - 1010px" src="https://user-images.githubusercontent.com/3028997/51034216-e5be1800-159d-11e9-8925-9b9321c92cb6.png">

650px
<img width="650" alt="screen shot of article on Windows 7 - IE 11 - 650px" src="https://user-images.githubusercontent.com/3028997/51034214-e5be1800-159d-11e9-886c-01a7252b0026.png">

400px
<img width="400" alt="screen shot of article on Windows 7 - IE 11 - 400px" src="https://user-images.githubusercontent.com/3028997/51034213-e5258180-159d-11e9-9e93-b578cdc8845f.png">

Resources used:
https://medium.com/@elad/supporting-css-grid-in-internet-explorer-b38669e75d66
https://css-tricks.com/css-grid-in-ie-debunking-common-ie-grid-misconceptions/

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
