### PR TITLE
Adding a Cypress test for the amp-img

### DIFF
--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -49,6 +49,14 @@ describe('AMP Tests on a .amp page', () => {
       .should('be', 2); // 1 for amp.js + 1 that Cypress injects into the head
   });
 
+  it('should contain an amp-img', () => {
+    const figure = getElement('figure').eq(0);
+    figure.should('be.visible');
+    figure.within(() => {
+      getElement('amp-img');
+    });
+  });
+
   it('should not have an AMP attribute on the main article', () => {
     cy.visit('/news/articles/c85pqyj5m2ko');
     getElement('html').should('not.have.attr', 'amp');

--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -53,7 +53,7 @@ describe('AMP Tests on a .amp page', () => {
     const figure = getElement('figure').eq(0);
     figure.should('be.visible');
     figure.within(() => {
-      getElement('amp-img');
+      getElement('amp-img').should('be.visible');
     });
   });
 


### PR DESCRIPTION
Resolves #953 

_This adds a Cypress test to make sure that the image that is rendered on the page is an `amp-img`._

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
