### PR TITLE
Route service worker per env

### DIFF
--- a/cypress/integration/statusSpec.js
+++ b/cypress/integration/statusSpec.js
@@ -1,7 +1,17 @@
-import { testNonHTMLResponseCode } from '../support/metaTestHelper';
+import {
+  testNonHTMLResponseCode,
+  testContentType,
+} from '../support/metaTestHelper';
 
 describe('Simorgh Status', () => {
   it('should return 200', () => {
     testNonHTMLResponseCode('/status', 200);
+  });
+
+  it('should have the content type set to Javascript', () => {
+    testContentType(
+      '/news/articles/sw.js',
+      'application/javascript; charset=UTF-8',
+    );
   });
 });

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -6,6 +6,12 @@ export const testNonHTMLResponseCode = (path, responseCode) => {
   });
 };
 
+export const testContentType = (path, contentType) => {
+  cy.request(path).then(({ headers }) => {
+    expect(headers).to.have.property('content-type', contentType);
+  });
+};
+
 export const retrieveMetaDataContent = (metaDataTag, content) => {
   const metaElement = getElement(metaDataTag);
   metaElement.should('have.attr', 'content', content);

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -10,7 +10,7 @@ const ampRegex = '.amp';
 
 export const articleRegexPath = `/:service(${serviceRegex})/articles/:id(${idRegex}):amp(${ampRegex})?`;
 
-export const swRegexPath = `/:service(${serviceRegex})/articles/sw.js?`;
+export const swRegexPath = `/:service(${serviceRegex})/articles/sw.js`;
 
 const routes = [
   {

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -10,6 +10,8 @@ const ampRegex = '.amp';
 
 export const articleRegexPath = `/:service(${serviceRegex})/articles/:id(${idRegex}):amp(${ampRegex})?`;
 
+export const swRegexPath = `/:service(${serviceRegex})/articles/sw.js?`;
+
 const routes = [
   {
     path: articleRegexPath,

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -68,7 +68,7 @@ server
     res.sendStatus(200);
   })
   .get(swRegexPath, (req, res, next) => {
-    const swPath = `${__dirname}/public/sw.${process.env.APP_ENV}.js`;
+    const swPath = `${__dirname}/public/sw-${process.env.APP_ENV}.js`;
     res.sendFile(swPath, {}, error => {
       if (error) {
         console.log(error); // eslint-disable-line no-console

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -67,12 +67,12 @@ server
   .get('/status', (req, res) => {
     res.sendStatus(200);
   })
-  .get(swRegexPath, (req, res, next) => {
+  .get(swRegexPath, (req, res) => {
     const swPath = `${__dirname}/public/sw-${process.env.APP_ENV}.js`;
     res.sendFile(swPath, {}, error => {
       if (error) {
         console.log(error); // eslint-disable-line no-console
-        next(error);
+        res.status(404).send('Unable to find service worker.');
       }
     });
   })

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -72,7 +72,7 @@ server
     res.sendFile(swPath, {}, error => {
       if (error) {
         console.log(error); // eslint-disable-line no-console
-        res.status(404).send('Unable to find service worker.');
+        res.status(500).send('Unable to find service worker.');
       }
     });
   })

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -67,6 +67,15 @@ server
   .get('/status', (req, res) => {
     res.sendStatus(200);
   })
+  .get('/sw.js', (req, res, next) => {
+    const swPath = `${__dirname}/public/sw.${process.env.APP_ENV}.js`;
+    res.sendFile(swPath, {}, err => {
+      if (err) {
+        console.log(`Err fetching service worker at ${swPath}`, err);
+        next(err);
+      }
+    });
+  })
   .get('/*', async ({ url }, res) => {
     try {
       const sheet = new ServerStyleSheet();

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -11,7 +11,7 @@ import path from 'path';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
-import routes, { articleRegexPath } from '../app/routes';
+import routes, { articleRegexPath, swRegexPath } from '../app/routes';
 import { getStyleTag } from './styles';
 import getAssetsArray from './assets';
 import getEnv from './env';
@@ -67,7 +67,7 @@ server
   .get('/status', (req, res) => {
     res.sendStatus(200);
   })
-  .get('/sw.js', (req, res, next) => {
+  .get(swRegexPath, (req, res, next) => {
     const swPath = `${__dirname}/public/sw.${process.env.APP_ENV}.js`;
     res.sendFile(swPath, {}, err => {
       if (err) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -69,10 +69,10 @@ server
   })
   .get(swRegexPath, (req, res, next) => {
     const swPath = `${__dirname}/public/sw.${process.env.APP_ENV}.js`;
-    res.sendFile(swPath, {}, err => {
-      if (err) {
-        console.log(`Err fetching service worker at ${swPath}`, err);
-        next(err);
+    res.sendFile(swPath, {}, error => {
+      if (error) {
+        console.log(error); // eslint-disable-line no-console
+        next(error);
       }
     });
   })

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -19,6 +19,9 @@ module.exports = ({ resolvePath, START_DEV_SERVER }) => {
       }),
     ],
     watch: true,
+    node: {
+      __dirname: false,
+    },
   };
 
   if (START_DEV_SERVER) {

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -20,6 +20,10 @@ module.exports = ({ resolvePath, START_DEV_SERVER }) => {
     ],
     watch: true,
     node: {
+      /**
+       * Override webpacks default handling of __dirname
+       * which replaces it with '/'.
+       */
       __dirname: false,
     },
   };


### PR DESCRIPTION
Resolves #1210

### REQUIRES https://github.com/bbc/simorgh/pull/1233 FIRST

**Overall change:** Routes the built service worker files `sw-local.js`, `sw-test.js` and `sw-live.js` to `sw.js` based on the `APP_ENV`

**Code changes:**

- Adds route for `/SERVICE/articles/sw.js` using the express [sendFile method](https://expressjs.com/en/api.html#res.sendFile)

**E2E tests required**
- Check service worker route works for both services
- Check the header content type is 'Javascript'
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.

### REQUIRES https://github.com/bbc/simorgh/pull/1233 FIRST
