### PR TITLE
Remove SIMORGH_PUBLIC_DIR as it does not vary

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=http://localhost:7080
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets.local.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=http://localhost:7080
 APP_ENV=local

--- a/.env.live
+++ b/.env.live
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=https://www.bbc.com
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets.live.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.files.bbci.co.uk/include/articles/public
 APP_ENV=live

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=https://www.test.bbc.com
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets.test.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.test.files.bbci.co.uk/include/articles/public
 APP_ENV=test

--- a/src/clientEnvVars.test.js
+++ b/src/clientEnvVars.test.js
@@ -26,7 +26,6 @@ describe('webpack client config', () => {
     const dotenvConfigMock = {
       parsed: {
         SIMORGH_BASE_URL: 'https://www.bbc.com',
-        SIMORGH_PUBLIC_DIR: 'build/public',
         SIMORGH_ASSETS_MANIFEST_PATH: 'build/assets.json',
         CI: 'false',
         NOT_SIMORGH_PREFIXED: 'foobar',
@@ -35,7 +34,6 @@ describe('webpack client config', () => {
     const result = getClientEnvVars(dotenvConfigMock);
     const expected = {
       SIMORGH_BASE_URL: '"https://www.bbc.com"',
-      SIMORGH_PUBLIC_DIR: '"build/public"',
       SIMORGH_ASSETS_MANIFEST_PATH: '"build/assets.json"',
     };
 

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -22,7 +22,7 @@ getEnv();
 
 const assets = getAssetsArray();
 
-const publicDirectory = process.env.SIMORGH_PUBLIC_DIR;
+const publicDirectory = 'build/public';
 const dataFolderToRender =
   process.env.NODE_ENV === 'production' ? 'data/prod' : 'data/test';
 


### PR DESCRIPTION
Resolves #1222 

**Overall change:** _Changes a variable to be statically hardcoded._

**Code changes:** _Removes a variable that was in all cases set to `build/public` and hardcodes the value, rather than using a variable that only has one value across all envs_

- Removes SIMORGH_PUBLIC_DIR from `.env` `.env.test` and `.env.live`
- Remove reference to `SIMORGH_PUBLIC_DIR`` in the `clientEnvVar.test.jsx`
- Hardcoding the value in `server/index.jsx`

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- [ ] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
