### PR TITLE
Use dashes in env stamped file names to fix test coverage

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=http://localhost:7080
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets-local.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=http://localhost:7080
 APP_ENV=local

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 SIMORGH_BASE_URL=http://localhost:7080
 SIMORGH_PUBLIC_DIR=build/public
-SIMORGH_ASSETS_MANIFEST_PATH=build/assets.local.json
+SIMORGH_ASSETS_MANIFEST_PATH=build/assets-local.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=http://localhost:7080
 APP_ENV=local

--- a/.env.live
+++ b/.env.live
@@ -1,5 +1,5 @@
 SIMORGH_BASE_URL=https://www.bbc.com
 SIMORGH_PUBLIC_DIR=build/public
-SIMORGH_ASSETS_MANIFEST_PATH=build/assets.live.json
+SIMORGH_ASSETS_MANIFEST_PATH=build/assets-live.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.files.bbci.co.uk/include/articles/public
 APP_ENV=live

--- a/.env.live
+++ b/.env.live
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=https://www.bbc.com
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets-live.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.files.bbci.co.uk/include/articles/public
 APP_ENV=live

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 SIMORGH_BASE_URL=https://www.test.bbc.com
 SIMORGH_PUBLIC_DIR=build/public
-SIMORGH_ASSETS_MANIFEST_PATH=build/assets.test.json
+SIMORGH_ASSETS_MANIFEST_PATH=build/assets-test.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.test.files.bbci.co.uk/include/articles/public
 APP_ENV=test

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 SIMORGH_BASE_URL=https://www.test.bbc.com
-SIMORGH_PUBLIC_DIR=build/public
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets-test.json
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=https://news.test.files.bbci.co.uk/include/articles/public
 APP_ENV=test

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "snyk": "snyk test",
     "updateSnapshots": "npm run test:unit -- -u",
     "webpack:dev:client": "NODE_ENV=development webpack-dev-server --inline --hot --env.config='client'",
-    "webpack:dev:server": "wait-on ./build/assets.local.json && NODE_ENV=development webpack --env.config='server'"
+    "webpack:dev:server": "wait-on ./build/assets-local.json && NODE_ENV=development webpack --env.config='server'"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -170,8 +170,7 @@
     ],
     "testMatch": [
       "**/__tests__/**/*.js?(x)",
-      "**/?(*.)+(spec|test).js?(x)",
-      "!**/build/**/*.js"
+      "**/?(*.)+(spec|test).js?(x)"
     ]
   },
   "spec": {

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -60,7 +60,7 @@ module.exports = ({
       // this determines what scripts get put in the footer of the page
       new AssetsPlugin({
         path: resolvePath('build'),
-        filename: `assets.${APP_ENV}.json`,
+        filename: `assets-${APP_ENV}.json`,
       }),
       // copy static files otherwise untouched by Webpack, e.g. favicon
       new CopyWebpackPlugin([
@@ -112,7 +112,7 @@ module.exports = ({
         ServiceWorker: {
           events: true,
           minify: true,
-          output: `sw.${APP_ENV}.js`,
+          output: `sw-${APP_ENV}.js`,
         },
         updateStrategy: 'changed',
       }),


### PR DESCRIPTION
Resolves #1232

**Overall change:** Changes env stamped files from using the format `name.env.ext` to `name-env.ext

**Code changes:**

- Change asset files to use dashes
- Change sw files to use dashes
- Update .env files to reference new assets file names
- Change `npm run dev` to wait for the new file name

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
