### PR TITLE
Logging dependencies in Application

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,11 +176,16 @@
   },
   "spec": {
     "executable": [
-      "./bake-scripts/01-env-variables.sh"
+      "./bake-scripts/*"
     ],
     "post": [
       "mkdir -p /etc/bake-scripts/",
       "cp -R -af /usr/lib/simorgh/bake-scripts/* /etc/bake-scripts"
+    ],
+    "prune": false,
+    "requires": [
+      "td-agent",
+      "cloudteam-td-agent-setup"
     ]
   }
 }


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh-infrastructure/issues/30

**Overall change:** 
Adds dependencies to our application for uploading our logs to S3. This is a prerequisite for https://github.com/bbc/simorgh-infrastructure/pull/233

**Code changes:**

- Ensure all bake scripts are run 
- Requires td-agent and cloudteam-td-agent-setup
- Turn off automatic npm pruning at the spec generation stage. (https://github.com/bbc/speculate/blob/master/README.md#pruning-dependencies) If we want to do pruning, I think we should explicitly run `npm prune --production` in our Jenkinsfile at the application build stage. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
