### PR TITLE
fixes hot module reloading

### DIFF
--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -29,11 +29,14 @@ module.exports = ({ resolvePath, IS_CI, IS_PROD, START_DEV_SERVER }) => {
     },
     output: {
       path: resolvePath('build/public'),
-      filename: 'static/js/[name].[hash:8].js',
+      // need unhashed client bundle when running dev server: https://github.com/jaredpalmer/razzle/tree/master/packages/create-razzle-app/templates/default#how-razzle-works-the-secret-sauce
+      filename: START_DEV_SERVER
+        ? 'static/js/[name].js'
+        : 'static/js/[name].[hash:8].js',
       // need full URL for dev server & HMR: https://github.com/webpack/docs/wiki/webpack-dev-server#combining-with-an-existing-server
-      publicPath: IS_PROD
-        ? `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_PATH}/`
-        : `http://localhost:${webpackDevServerPort}/`,
+      publicPath: START_DEV_SERVER
+        ? `http://localhost:${webpackDevServerPort}/`
+        : `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_PATH}/`,
     },
     optimization: {
       // specify min/max file sizes for each JS chunk for optimal performance


### PR DESCRIPTION
Server bundle always had previous version of assets manifest, and as bundles are hashed it would therefore load an older version of the content. But in dev server mode now we don't make the hash part of the output filename, so the file is always loaded 'fresh' and HMR works again

Resolves #1167

**Overall change:** Webpack config change for `npm run dev` mode ONLY - should make no difference to production.

**Code changes:**

- Change hashing strategy based on value of `START_DEV_SERVER` in webpack config.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
