### PR TITLE
Handle 404, 500 & 502 status codes

### DIFF
--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -16,7 +16,6 @@ describe('AMP Tests on a .amp page', () => {
 
   it('should error gracefully', () => {
     testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
-    testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
     testNonHTMLResponseCode('/news/lol/c85pqyj5m2ko.amp', 404);
     testNonHTMLResponseCode('/cake/articles/c85pqyj5m2ko.amp', 404);
   });

--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -1,8 +1,5 @@
 import { getElement } from '../support/bodyTestHelper';
-import {
-  testNonHTMLResponseCode,
-  retrieve404BodyResponse,
-} from '../support/metaTestHelper';
+import { testNonHTMLResponseCode } from '../support/metaTestHelper';
 
 describe('AMP Tests on a .amp page', () => {
   // eslint-disable-next-line no-undef
@@ -18,18 +15,10 @@ describe('AMP Tests on a .amp page', () => {
   });
 
   it('should error gracefully', () => {
-    retrieve404BodyResponse(
-      '/news/articles/c85pqyj5m2ko.cake',
-      'No route was found for /news/articles/c85pqyj5m2ko.cake.',
-    );
-    retrieve404BodyResponse(
-      '/news/lol/c85pqyj5m2ko.amp',
-      'No route was found for /news/lol/c85pqyj5m2ko.amp.',
-    );
-    retrieve404BodyResponse(
-      '/cake/articles/c85pqyj5m2ko.amp',
-      'No route was found for /cake/articles/c85pqyj5m2ko.amp.',
-    );
+    testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
+    testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
+    testNonHTMLResponseCode('/news/lol/c85pqyj5m2ko.amp', 404);
+    testNonHTMLResponseCode('/cake/articles/c85pqyj5m2ko.amp', 404);
   });
 
   it('should have AMP attribute', () => {

--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -1,5 +1,5 @@
 import { getElement } from '../support/bodyTestHelper';
-import { testNonHTMLResponseCode } from '../support/metaTestHelper';
+import { testResponseCode } from '../support/metaTestHelper';
 
 describe('AMP Tests on a .amp page', () => {
   // eslint-disable-next-line no-undef
@@ -10,14 +10,14 @@ describe('AMP Tests on a .amp page', () => {
 
   describe('AMP Status', () => {
     it('should return a 200 response', () => {
-      testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.amp', 200);
+      testResponseCode('/news/articles/c85pqyj5m2ko.amp', 200);
     });
   });
 
   it('should error gracefully', () => {
-    testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
-    testNonHTMLResponseCode('/news/lol/c85pqyj5m2ko.amp', 404);
-    testNonHTMLResponseCode('/cake/articles/c85pqyj5m2ko.amp', 404);
+    testResponseCode('/news/articles/c85pqyj5m2ko.cake', 404);
+    testResponseCode('/news/lol/c85pqyj5m2ko.amp', 404);
+    testResponseCode('/cake/articles/c85pqyj5m2ko.amp', 404);
   });
 
   it('should have AMP attribute', () => {

--- a/cypress/integration/dataSpec.js
+++ b/cypress/integration/dataSpec.js
@@ -1,7 +1,7 @@
-import { testNonHTMLResponseCode } from '../support/metaTestHelper';
+import { testResponseCode } from '../support/metaTestHelper';
 
 describe('Static Articles data', () => {
   it('should return a 200 status code', () => {
-    testNonHTMLResponseCode('/news/articles/c85pqyj5m2ko.json', 200);
+    testResponseCode('/news/articles/c85pqyj5m2ko.json', 200);
   });
 });

--- a/cypress/integration/statusSpec.js
+++ b/cypress/integration/statusSpec.js
@@ -1,11 +1,8 @@
-import {
-  testNonHTMLResponseCode,
-  testContentType,
-} from '../support/metaTestHelper';
+import { testResponseCode, testContentType } from '../support/metaTestHelper';
 
 describe('Simorgh Status', () => {
   it('should return 200', () => {
-    testNonHTMLResponseCode('/status', 200);
+    testResponseCode('/status', 200);
   });
 
   it('should have the content type set to Javascript', () => {

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -1,7 +1,7 @@
 import { getElement } from './bodyTestHelper';
 
 export const testNonHTMLResponseCode = (path, responseCode) => {
-  cy.request(path).then(({ status }) => {
+  cy.request({ url: path, failOnStatusCode: false }).then(({ status }) => {
     expect(status).to.eq(responseCode);
   });
 };

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -1,6 +1,6 @@
 import { getElement } from './bodyTestHelper';
 
-export const testNonHTMLResponseCode = (path, responseCode) => {
+export const testResponseCode = (path, responseCode) => {
   cy.request({ url: path, failOnStatusCode: false }).then(({ status }) => {
     expect(status).to.eq(responseCode);
   });

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -1,155 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleContainer Component no data should render correctly 1`] = `null`;
-
-exports[`ArticleContainer Component should render Persian article correctly 1`] = `
-<React.Fragment>
-  <GlobalStyleComponent />
-  <ServiceContextProvider
-    service="persian"
-  >
-    <PlatformContextProvider
-      platform="canonical"
-    >
-      <HeaderContainer />
-      <MetadataContainer
-        metadata={
-          Object {
-            "created": 1514808060000,
-            "createdBy": "",
-            "firstPublished": 1514808060000,
-            "id": "urn:bbc:ares::article:cwv2xv848j5o",
-            "lastPublished": 1514811600000,
-            "lastUpdated": 1514815200000,
-            "locators": Object {
-              "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
-            },
-            "passport": Object {
-              "category": "news",
-              "genre": null,
-              "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
-              "language": "fa",
-            },
-            "tags": Object {
-              "about": null,
-              "mentions": null,
-            },
-            "type": "article",
-          }
-        }
-        promo={
-          Object {
-            "headlines": Object {
-              "promoHeadline": "سرصفحه مقاله برای ارتقاء",
-              "seoHeadline": "سرصفحه مقاله",
-            },
-            "id": "urn:bbc:ares::article:cwv2xv848j5o",
-            "locators": Object {
-              "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
-            },
-            "summary": "خلاصه مقاله",
-            "timestamp": 1514811600000,
-          }
-        }
-        service="persian"
-      />
-      <main
-        role="main"
-      >
-        <ForwardRef>
-          <ForwardRef>
-            <Blocks
-              blocks={
-                Array [
-                  Object {
-                    "model": Object {
-                      "blocks": Array [
-                        Object {
-                          "model": Object {
-                            "blocks": Array [
-                              Object {
-                                "model": Object {
-                                  "blocks": Array [
-                                    Object {
-                                      "model": Object {
-                                        "attributes": Array [],
-                                        "text": "سرصفحه مقاله",
-                                      },
-                                      "type": "fragment",
-                                    },
-                                  ],
-                                  "text": "سرصفحه مقاله",
-                                },
-                                "type": "paragraph",
-                              },
-                            ],
-                          },
-                          "type": "text",
-                        },
-                      ],
-                    },
-                    "type": "headline",
-                  },
-                ]
-              }
-              componentsToRender={
-                Object {
-                  "headline": [Function],
-                }
-              }
-            />
-            <TimestampContainer
-              timestamp={1514811600000}
-            />
-          </ForwardRef>
-        </ForwardRef>
-        <ForwardRef>
-          <ForwardRef>
-            <Blocks
-              blocks={
-                Array [
-                  Object {
-                    "model": Object {
-                      "blocks": Array [
-                        Object {
-                          "model": Object {
-                            "blocks": Array [
-                              Object {
-                                "model": Object {
-                                  "attributes": Array [],
-                                  "text": "یک پاراگراف.",
-                                },
-                                "type": "fragment",
-                              },
-                            ],
-                            "text": "یک پاراگراف.",
-                          },
-                          "type": "paragraph",
-                        },
-                      ],
-                    },
-                    "type": "text",
-                  },
-                ]
-              }
-              componentsToRender={
-                Object {
-                  "image": [Function],
-                  "subheadline": [Function],
-                  "text": [Function],
-                }
-              }
-            />
-          </ForwardRef>
-        </ForwardRef>
-      </main>
-      <FooterContainer />
-    </PlatformContextProvider>
-  </ServiceContextProvider>
-</React.Fragment>
-`;
-
-exports[`ArticleContainer Component should render correctly 1`] = `
+exports[`ArticleContainer Component 200 status code should render correctly 1`] = `
 <React.Fragment>
   <GlobalStyleComponent />
   <ServiceContextProvider
@@ -159,80 +10,12 @@ exports[`ArticleContainer Component should render correctly 1`] = `
       platform="canonical"
     >
       <HeaderContainer />
-      <MetadataContainer
-        metadata={
+      <ArticleMain
+        articleData={
           Object {
-            "created": 1514808060000,
-            "createdBy": "",
-            "firstPublished": 1514808060000,
-            "id": "urn:bbc:ares::article:c0000000001o",
-            "lastPublished": 1514811600000,
-            "lastUpdated": 1514815200000,
-            "locators": Object {
-              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
-            },
-            "passport": Object {
-              "category": "news",
-              "genre": null,
-              "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
-              "language": "en-gb",
-            },
-            "tags": Object {
-              "about": Array [
-                Object {
-                  "curationType": Array [
-                    "vivo-stream",
-                  ],
-                  "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
-                  "thingLabel": "Royal Wedding 2018",
-                  "thingType": Array [
-                    "Thing",
-                    "Event",
-                  ],
-                  "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
-                  "topicId": "cpwpy79d6dxt",
-                  "topicName": "Royal Wedding 2018",
-                },
-              ],
-              "mentions": Array [
-                Object {
-                  "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
-                  "thingLabel": "Queen Victoria",
-                  "thingType": Array [
-                    "Person",
-                    "Thing",
-                  ],
-                  "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
-                },
-              ],
-            },
-            "type": "article",
-          }
-        }
-        promo={
-          Object {
-            "headlines": Object {
-              "promoHeadline": "Article Headline for Promo",
-              "seoHeadline": "Article Headline for SEO",
-            },
-            "id": "urn:bbc:ares::article:c0000000001o",
-            "locators": Object {
-              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
-            },
-            "summary": "Article summary.",
-            "timestamp": 1514811600000,
-          }
-        }
-        service="news"
-      />
-      <main
-        role="main"
-      >
-        <ForwardRef>
-          <ForwardRef>
-            <Blocks
-              blocks={
-                Array [
+            "content": Object {
+              "model": Object {
+                "blocks": Array [
                   Object {
                     "model": Object {
                       "blocks": Array [
@@ -262,24 +45,6 @@ exports[`ArticleContainer Component should render correctly 1`] = `
                     },
                     "type": "headline",
                   },
-                ]
-              }
-              componentsToRender={
-                Object {
-                  "headline": [Function],
-                }
-              }
-            />
-            <TimestampContainer
-              timestamp={1514811600000}
-            />
-          </ForwardRef>
-        </ForwardRef>
-        <ForwardRef>
-          <ForwardRef>
-            <Blocks
-              blocks={
-                Array [
                   Object {
                     "model": Object {
                       "blocks": Array [
@@ -302,23 +67,95 @@ exports[`ArticleContainer Component should render correctly 1`] = `
                     },
                     "type": "text",
                   },
-                ]
-              }
-              componentsToRender={
-                Object {
-                  "image": [Function],
-                  "subheadline": [Function],
-                  "text": [Function],
-                }
-              }
-            />
-          </ForwardRef>
-        </ForwardRef>
-      </main>
+                ],
+              },
+            },
+            "metadata": Object {
+              "created": 1514808060000,
+              "createdBy": "",
+              "firstPublished": 1514808060000,
+              "id": "urn:bbc:ares::article:c0000000001o",
+              "lastPublished": 1514811600000,
+              "lastUpdated": 1514815200000,
+              "locators": Object {
+                "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+              },
+              "passport": Object {
+                "category": "news",
+                "genre": null,
+                "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+                "language": "en-gb",
+              },
+              "tags": Object {
+                "about": Array [
+                  Object {
+                    "curationType": Array [
+                      "vivo-stream",
+                    ],
+                    "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
+                    "thingLabel": "Royal Wedding 2018",
+                    "thingType": Array [
+                      "Thing",
+                      "Event",
+                    ],
+                    "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
+                    "topicId": "cpwpy79d6dxt",
+                    "topicName": "Royal Wedding 2018",
+                  },
+                ],
+                "mentions": Array [
+                  Object {
+                    "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
+                    "thingLabel": "Queen Victoria",
+                    "thingType": Array [
+                      "Person",
+                      "Thing",
+                    ],
+                    "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
+                  },
+                ],
+              },
+              "type": "article",
+            },
+            "promo": Object {
+              "headlines": Object {
+                "promoHeadline": "Article Headline for Promo",
+                "seoHeadline": "Article Headline for SEO",
+              },
+              "id": "urn:bbc:ares::article:c0000000001o",
+              "locators": Object {
+                "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+              },
+              "summary": "Article summary.",
+              "timestamp": 1514811600000,
+            },
+          }
+        }
+        service="news"
+      />
       <FooterContainer />
     </PlatformContextProvider>
   </ServiceContextProvider>
 </React.Fragment>
 `;
 
-exports[`ArticleContainer Component should render null if no headline block 1`] = `null`;
+exports[`ArticleContainer Component no data should render correctly 1`] = `null`;
+
+exports[`ArticleContainer Component non-200 status code should render correctly 1`] = `
+<React.Fragment>
+  <GlobalStyleComponent />
+  <ServiceContextProvider
+    service="news"
+  >
+    <PlatformContextProvider
+      platform="canonical"
+    >
+      <HeaderContainer />
+      <ErrorMain
+        status={451}
+      />
+      <FooterContainer />
+    </PlatformContextProvider>
+  </ServiceContextProvider>
+</React.Fragment>
+`;

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -131,7 +131,6 @@ exports[`ArticleContainer Component 200 status code should render correctly 1`] 
             },
           }
         }
-        service="news"
       />
       <FooterContainer />
     </PlatformContextProvider>

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -31,7 +31,7 @@ const ArticleContainer = ({ loading, error, data }) => {
           <PlatformContextProvider platform={isAmp ? 'amp' : 'canonical'}>
             <HeaderContainer />
             {status === 200 ? (
-              <ArticleMain service={service} articleData={articleData} />
+              <ArticleMain articleData={articleData} />
             ) : (
               <ErrorMain status={status} />
             )}

--- a/src/app/containers/Article/index.jsx
+++ b/src/app/containers/Article/index.jsx
@@ -1,57 +1,13 @@
 import React, { Fragment } from 'react';
 import { bool, string, shape } from 'prop-types';
-import styled from 'styled-components';
-import { C_OAT_LHT } from '@bbc/psammead-styles/colours';
-import MetadataContainer from '../Metadata';
 import HeaderContainer from '../Header';
 import FooterContainer from '../Footer';
-import headings from '../Headings';
-import text from '../Text';
-import image from '../Image';
-import Blocks from '../Blocks';
 import articlePropTypes from '../../models/propTypes/article';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
-import Timestamp from '../Timestamp';
-import {
-  layoutGridWrapper,
-  layoutGridItemConstrained,
-} from '../../lib/layoutGrid';
 import { PlatformContextProvider } from '../../contexts/PlatformContext';
 import GlobalStyle from '../../lib/globalStyles';
-
-const Wrapper = styled.div`
-  ${layoutGridWrapper};
-`;
-
-const OatWrapper = styled(Wrapper)`
-  background: ${C_OAT_LHT};
-`;
-
-const GridItemConstrained = styled.div`
-  ${layoutGridItemConstrained};
-`;
-
-const componentsToRenderHeadline = {
-  headline: headings,
-};
-
-const componentsToRenderMain = {
-  subheadline: headings,
-  text,
-  image,
-};
-
-const splitBlocksByHeadline = ({ model }) => {
-  const { blocks } = model;
-
-  const headlineIndexPlusOne =
-    blocks.findIndex(({ type }) => type === 'headline') + 1;
-
-  const headlineBlocks = blocks.slice(0, headlineIndexPlusOne);
-  const mainBlocks = blocks.slice(headlineIndexPlusOne, blocks.length);
-
-  return { headlineBlocks, mainBlocks };
-};
+import ArticleMain from '../ArticleMain';
+import ErrorMain from '../ErrorMain';
 
 /*
   [1] This handles async data fetching, and a 'loading state', which we should look to handle more intelligently.
@@ -60,53 +16,24 @@ const ArticleContainer = ({ loading, error, data }) => {
   if (loading) return 'Loading...'; /* [1] */
   if (error) return 'Something went wrong :(';
   if (data) {
-    const { isAmp, data: articleData, service } = data;
-    const { content, metadata, promo } = articleData;
+    const { isAmp, data: articleData, service, status } = data;
 
-    const { headlineBlocks, mainBlocks } = splitBlocksByHeadline(content);
-
-    /*
-     * headlineBlocks length check is temporary
-     * Simorgh will respond with 400 to lack of headline block in issue
-     * https://github.com/bbc/simorgh/issues/836
-     */
-    if (headlineBlocks.length > 0) {
-      return (
-        <Fragment>
-          <GlobalStyle />
-          <ServiceContextProvider service={service}>
-            <PlatformContextProvider platform={isAmp ? 'amp' : 'canonical'}>
-              <HeaderContainer />
-              <MetadataContainer
-                metadata={metadata}
-                promo={promo}
-                service={service}
-              />
-              <main role="main">
-                <Wrapper>
-                  <GridItemConstrained>
-                    <Blocks
-                      blocks={headlineBlocks}
-                      componentsToRender={componentsToRenderHeadline}
-                    />
-                    <Timestamp timestamp={metadata.lastPublished} />
-                  </GridItemConstrained>
-                </Wrapper>
-                <OatWrapper>
-                  <GridItemConstrained>
-                    <Blocks
-                      blocks={mainBlocks}
-                      componentsToRender={componentsToRenderMain}
-                    />
-                  </GridItemConstrained>
-                </OatWrapper>
-              </main>
-              <FooterContainer />
-            </PlatformContextProvider>
-          </ServiceContextProvider>
-        </Fragment>
-      );
-    }
+    return (
+      <Fragment>
+        <GlobalStyle />
+        <ServiceContextProvider service={service}>
+          <PlatformContextProvider platform={isAmp ? 'amp' : 'canonical'}>
+            <HeaderContainer />
+            {status === 200 ? (
+              <ArticleMain service={service} articleData={articleData} />
+            ) : (
+              <ErrorMain status={status} />
+            )}
+            <FooterContainer />
+          </PlatformContextProvider>
+        </ServiceContextProvider>
+      </Fragment>
+    );
   }
 
   return null;

--- a/src/app/containers/Article/index.test.jsx
+++ b/src/app/containers/Article/index.test.jsx
@@ -1,39 +1,40 @@
 import React from 'react';
 import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 import ArticleContainer from './index';
-import { articleDataNews, articleDataPersian } from './fixtureData';
+import { articleDataNews } from './fixtureData';
 
 // explicitly ignore console.log errors for Article/index:getInitialProps() error logging
 global.console.log = jest.fn();
 
 describe('ArticleContainer', () => {
-  const newsData = { data: articleDataNews, isAmp: false, service: 'news' };
-
-  // temporary: will be removed with https://github.com/bbc/simorgh/issues/836
-  const newsDataNoHeadline = JSON.parse(JSON.stringify(newsData));
-  newsDataNoHeadline.data.content.model.blocks.shift();
-
-  const persianData = {
-    data: articleDataPersian,
+  const goodData = {
+    data: articleDataNews,
     isAmp: false,
-    service: 'persian',
+    service: 'news',
+    status: 200,
+  };
+
+  const badData = {
+    data: undefined,
+    isAmp: false,
+    service: 'news',
+    status: 451,
   };
 
   describe('Component', () => {
-    shouldShallowMatchSnapshot(
-      'should render correctly',
-      <ArticleContainer data={newsData} />,
-    );
+    describe('200 status code', () => {
+      shouldShallowMatchSnapshot(
+        'should render correctly',
+        <ArticleContainer data={goodData} />,
+      );
+    });
 
-    shouldShallowMatchSnapshot(
-      'should render Persian article correctly',
-      <ArticleContainer data={persianData} />,
-    );
-
-    shouldShallowMatchSnapshot(
-      'should render null if no headline block',
-      <ArticleContainer data={newsDataNoHeadline} />,
-    );
+    describe('non-200 status code', () => {
+      shouldShallowMatchSnapshot(
+        'should render correctly',
+        <ArticleContainer data={badData} />,
+      );
+    });
 
     describe('no data', () => {
       shouldShallowMatchSnapshot(

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -1,467 +1,300 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleMain should render a news article correctly 1`] = `
-.c2 {
-  color: #222222;
-  font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
-  margin: 0;
-  padding: 2rem 0 1rem 0;
-  font-size: 1.75em;
-  line-height: 2rem;
-}
-
-.c5 {
-  color: #404040;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-  margin: 0;
-  font-size: 0.9375em;
-  line-height: 1.25rem;
-}
-
-.c0 {
-  display: -ms-grid;
-  display: grid;
-}
-
-.c4 {
-  display: -ms-grid;
-  display: grid;
-  background: #F5F3F1;
-}
-
-.c3 {
-  font-size: 0.875em;
-  line-height: 1rem;
-  color: #5A5A5A;
-  display: block;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c2 {
-    font-size: 2em;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c2 {
-    font-size: 2.75em;
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:20em) {
-  .c5 {
-    font-size: 1em;
-    line-height: 1.375rem;
-  }
-}
-
-@media (max-width:37.4375em) {
-  .c0 {
-    grid-gap: 0.5rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c0 {
-    grid-gap: 1rem;
-  }
-}
-
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
-@media (max-width:62.9375em) {
-  .c0 {
-    -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
-    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
-  }
-}
-
-@media (min-width:80em) {
-  .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
-  }
-}
-
-@media (max-width:37.4375em) {
-  .c4 {
-    grid-gap: 0.5rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c4 {
-    grid-gap: 1rem;
-  }
-}
-
-@media (max-width:25em) {
-  .c4 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c4 {
-    padding: 0 1rem;
-  }
-}
-
-@media (max-width:62.9375em) {
-  .c4 {
-    -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c4 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
-    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
-  }
-}
-
-@media (min-width:80em) {
-  .c4 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
-  }
-}
-
-@media (max-width:37.5em) {
-  .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
-  }
-}
-
-@media (min-width:37.5em) and (max-width:62.9375em) {
-  .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
-  }
-}
-
-@media (min-width:80em) {
-  .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
-  }
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c3 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c3 {
-    font-size: 0.8125em;
-  }
-}
-
-<main
-  role="main"
->
-  <div
-    className="c0"
+<React.Fragment>
+  <MetadataContainer
+    metadata={
+      Object {
+        "created": 1514808060000,
+        "createdBy": "",
+        "firstPublished": 1514808060000,
+        "id": "urn:bbc:ares::article:c0000000001o",
+        "lastPublished": 1514811600000,
+        "lastUpdated": 1514815200000,
+        "locators": Object {
+          "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+        },
+        "passport": Object {
+          "category": "news",
+          "genre": null,
+          "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+          "language": "en-gb",
+        },
+        "tags": Object {
+          "about": Array [
+            Object {
+              "curationType": Array [
+                "vivo-stream",
+              ],
+              "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
+              "thingLabel": "Royal Wedding 2018",
+              "thingType": Array [
+                "Thing",
+                "Event",
+              ],
+              "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
+              "topicId": "cpwpy79d6dxt",
+              "topicName": "Royal Wedding 2018",
+            },
+          ],
+          "mentions": Array [
+            Object {
+              "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
+              "thingLabel": "Queen Victoria",
+              "thingType": Array [
+                "Person",
+                "Thing",
+              ],
+              "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
+            },
+          ],
+        },
+        "type": "article",
+      }
+    }
+    promo={
+      Object {
+        "headlines": Object {
+          "promoHeadline": "Article Headline for Promo",
+          "seoHeadline": "Article Headline for SEO",
+        },
+        "id": "urn:bbc:ares::article:c0000000001o",
+        "locators": Object {
+          "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+        },
+        "summary": "Article summary.",
+        "timestamp": 1514811600000,
+      }
+    }
+    service="news"
+  />
+  <main
+    role="main"
   >
-    <div
-      className="c1"
-    >
-      <h1
-        className="c2"
-      >
-        Article Headline
-      </h1>
-      <time
-        className="c3"
-        dateTime="2018-01-01"
-      >
-        1 January 2018
-      </time>
-    </div>
-  </div>
-  <div
-    className="c4"
-  >
-    <div
-      className="c1"
-    >
-      <p
-        className="c5"
-      >
-        A paragraph.
-      </p>
-    </div>
-  </div>
-</main>
+    <ForwardRef>
+      <ForwardRef>
+        <Blocks
+          blocks={
+            Array [
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "attributes": Array [],
+                                    "text": "Article Headline",
+                                  },
+                                  "type": "fragment",
+                                },
+                              ],
+                              "text": "Article Headline",
+                            },
+                            "type": "paragraph",
+                          },
+                        ],
+                      },
+                      "type": "text",
+                    },
+                  ],
+                },
+                "type": "headline",
+              },
+            ]
+          }
+          componentsToRender={
+            Object {
+              "headline": [Function],
+            }
+          }
+        />
+        <TimestampContainer
+          timestamp={1514811600000}
+        />
+      </ForwardRef>
+    </ForwardRef>
+    <ForwardRef>
+      <ForwardRef>
+        <Blocks
+          blocks={
+            Array [
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "attributes": Array [],
+                              "text": "A paragraph.",
+                            },
+                            "type": "fragment",
+                          },
+                        ],
+                        "text": "A paragraph.",
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                },
+                "type": "text",
+              },
+            ]
+          }
+          componentsToRender={
+            Object {
+              "image": [Function],
+              "subheadline": [Function],
+              "text": [Function],
+            }
+          }
+        />
+      </ForwardRef>
+    </ForwardRef>
+  </main>
+</React.Fragment>
 `;
 
 exports[`ArticleMain should render a persian article correctly 1`] = `
-.c2 {
-  color: #222222;
-  font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
-  margin: 0;
-  padding: 2rem 0 1rem 0;
-  font-size: 1.75em;
-  line-height: 2rem;
-}
-
-.c5 {
-  color: #404040;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-  margin: 0;
-  font-size: 0.9375em;
-  line-height: 1.25rem;
-}
-
-.c0 {
-  display: -ms-grid;
-  display: grid;
-}
-
-.c4 {
-  display: -ms-grid;
-  display: grid;
-  background: #F5F3F1;
-}
-
-.c3 {
-  font-size: 0.875em;
-  line-height: 1rem;
-  color: #5A5A5A;
-  display: block;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c2 {
-    font-size: 2em;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c2 {
-    font-size: 2.75em;
-    line-height: 3rem;
-  }
-}
-
-@media (min-width:20em) {
-  .c5 {
-    font-size: 1em;
-    line-height: 1.375rem;
-  }
-}
-
-@media (max-width:37.4375em) {
-  .c0 {
-    grid-gap: 0.5rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c0 {
-    grid-gap: 1rem;
-  }
-}
-
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
-@media (max-width:62.9375em) {
-  .c0 {
-    -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
-    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
-  }
-}
-
-@media (min-width:80em) {
-  .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
-  }
-}
-
-@media (max-width:37.4375em) {
-  .c4 {
-    grid-gap: 0.5rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c4 {
-    grid-gap: 1rem;
-  }
-}
-
-@media (max-width:25em) {
-  .c4 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c4 {
-    padding: 0 1rem;
-  }
-}
-
-@media (max-width:62.9375em) {
-  .c4 {
-    -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c4 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
-    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
-  }
-}
-
-@media (min-width:80em) {
-  .c4 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
-  }
-}
-
-@media (max-width:37.5em) {
-  .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
-  }
-}
-
-@media (min-width:37.5em) and (max-width:62.9375em) {
-  .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
-  }
-}
-
-@media (min-width:63em) and (max-width:80em) {
-  .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
-  }
-}
-
-@media (min-width:80em) {
-  .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
-  }
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c3 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c3 {
-    font-size: 0.8125em;
-  }
-}
-
-<main
-  role="main"
->
-  <div
-    className="c0"
+<React.Fragment>
+  <MetadataContainer
+    metadata={
+      Object {
+        "created": 1514808060000,
+        "createdBy": "",
+        "firstPublished": 1514808060000,
+        "id": "urn:bbc:ares::article:cwv2xv848j5o",
+        "lastPublished": 1514811600000,
+        "lastUpdated": 1514815200000,
+        "locators": Object {
+          "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
+        },
+        "passport": Object {
+          "category": "news",
+          "genre": null,
+          "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
+          "language": "fa",
+        },
+        "tags": Object {
+          "about": null,
+          "mentions": null,
+        },
+        "type": "article",
+      }
+    }
+    promo={
+      Object {
+        "headlines": Object {
+          "promoHeadline": "سرصفحه مقاله برای ارتقاء",
+          "seoHeadline": "سرصفحه مقاله",
+        },
+        "id": "urn:bbc:ares::article:cwv2xv848j5o",
+        "locators": Object {
+          "optimoUrn": "urn:bbc:optimo:asset:cwv2xv848j5o",
+        },
+        "summary": "خلاصه مقاله",
+        "timestamp": 1514811600000,
+      }
+    }
+    service="persian"
+  />
+  <main
+    role="main"
   >
-    <div
-      className="c1"
-    >
-      <h1
-        className="c2"
-      >
-        سرصفحه مقاله
-      </h1>
-      <time
-        className="c3"
-        dateTime="2018-01-01"
-      >
-        1 January 2018
-      </time>
-    </div>
-  </div>
-  <div
-    className="c4"
-  >
-    <div
-      className="c1"
-    >
-      <p
-        className="c5"
-      >
-        یک پاراگراف.
-      </p>
-    </div>
-  </div>
-</main>
+    <ForwardRef>
+      <ForwardRef>
+        <Blocks
+          blocks={
+            Array [
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "attributes": Array [],
+                                    "text": "سرصفحه مقاله",
+                                  },
+                                  "type": "fragment",
+                                },
+                              ],
+                              "text": "سرصفحه مقاله",
+                            },
+                            "type": "paragraph",
+                          },
+                        ],
+                      },
+                      "type": "text",
+                    },
+                  ],
+                },
+                "type": "headline",
+              },
+            ]
+          }
+          componentsToRender={
+            Object {
+              "headline": [Function],
+            }
+          }
+        />
+        <TimestampContainer
+          timestamp={1514811600000}
+        />
+      </ForwardRef>
+    </ForwardRef>
+    <ForwardRef>
+      <ForwardRef>
+        <Blocks
+          blocks={
+            Array [
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "attributes": Array [],
+                              "text": "یک پاراگراف.",
+                            },
+                            "type": "fragment",
+                          },
+                        ],
+                        "text": "یک پاراگراف.",
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                },
+                "type": "text",
+              },
+            ]
+          }
+          componentsToRender={
+            Object {
+              "image": [Function],
+              "subheadline": [Function],
+              "text": [Function],
+            }
+          }
+        />
+      </ForwardRef>
+    </ForwardRef>
+  </main>
+</React.Fragment>
 `;
 
 exports[`ArticleMain should render null if no headline block 1`] = `null`;

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,237 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArticleMain should render a news article correctly 1`] = `null`;
+
+exports[`ArticleMain should render a news article correctly 2`] = `
+.c2 {
+  color: #222222;
+  font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 2rem 0 1rem 0;
+  font-size: 1.75em;
+  line-height: 2rem;
+}
+
+.c5 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-size: 0.9375em;
+  line-height: 1.25rem;
+}
+
+.c3 {
+  font-size: 0.875em;
+  line-height: 1rem;
+  color: #5A5A5A;
+  display: block;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+}
+
+.c0 {
+  display: -ms-grid;
+  display: grid;
+}
+
+.c4 {
+  display: -ms-grid;
+  display: grid;
+  background: #F5F3F1;
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c2 {
+    font-size: 2em;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c2 {
+    font-size: 2.75em;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:20em) {
+  .c5 {
+    font-size: 1em;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c3 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c3 {
+    font-size: 0.8125em;
+  }
+}
+
+@media (max-width:37.4375em) {
+  .c0 {
+    grid-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c0 {
+    grid-gap: 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:62.9375em) {
+  .c0 {
+    -ms-grid-columns: (1fr)[6];
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+  }
+}
+
+@media (min-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
+    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+  }
+}
+
+@media (max-width:37.4375em) {
+  .c4 {
+    grid-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c4 {
+    grid-gap: 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c4 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c4 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:62.9375em) {
+  .c4 {
+    -ms-grid-columns: (1fr)[6];
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c4 {
+    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+  }
+}
+
+@media (min-width:80em) {
+  .c4 {
+    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
+    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+  }
+}
+
+@media (max-width:37.5em) {
+  .c1 {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width:37.5em) and (max-width:62.9375em) {
+  .c1 {
+    -ms-grid-column: 2;
+    -ms-grid-column-span: 4;
+    grid-column: 2 / -2;
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c1 {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 6;
+    grid-column: 3 / -3;
+  }
+}
+
+@media (min-width:80em) {
+  .c1 {
+    -ms-grid-column: 4;
+    -ms-grid-column-span: 6;
+    grid-column: 4 / -4;
+  }
+}
+
+<main
+  role="main"
+>
+  <div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <h1
+        className="c2"
+      >
+        سرصفحه مقاله
+      </h1>
+      <time
+        className="c3"
+        dateTime="2018-01-01"
+      >
+        1 January 2018
+      </time>
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
+    <div
+      className="c1"
+    >
+      <p
+        className="c5"
+      >
+        یک پاراگراف.
+      </p>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`ArticleMain should render null if no headline block 1`] = `null`;

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -19,15 +19,6 @@ exports[`ArticleMain should render a news article correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c3 {
-  font-size: 0.875em;
-  line-height: 1rem;
-  color: #5A5A5A;
-  display: block;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-}
-
 .c0 {
   display: -ms-grid;
   display: grid;
@@ -37,6 +28,15 @@ exports[`ArticleMain should render a news article correctly 1`] = `
   display: -ms-grid;
   display: grid;
   background: #F5F3F1;
+}
+
+.c3 {
+  font-size: 0.875em;
+  line-height: 1rem;
+  color: #5A5A5A;
+  display: block;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
 }
 
 @media (min-width:20em) and (max-width:37.4375em) {
@@ -57,18 +57,6 @@ exports[`ArticleMain should render a news article correctly 1`] = `
   .c5 {
     font-size: 1em;
     line-height: 1.375rem;
-  }
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c3 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c3 {
-    font-size: 0.8125em;
   }
 }
 
@@ -191,6 +179,18 @@ exports[`ArticleMain should render a news article correctly 1`] = `
     -ms-grid-column: 4;
     -ms-grid-column-span: 6;
     grid-column: 4 / -4;
+  }
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c3 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c3 {
+    font-size: 0.8125em;
   }
 }
 
@@ -251,15 +251,6 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
   line-height: 1.25rem;
 }
 
-.c3 {
-  font-size: 0.875em;
-  line-height: 1rem;
-  color: #5A5A5A;
-  display: block;
-  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
-  padding-bottom: 1rem;
-}
-
 .c0 {
   display: -ms-grid;
   display: grid;
@@ -269,6 +260,15 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
   display: -ms-grid;
   display: grid;
   background: #F5F3F1;
+}
+
+.c3 {
+  font-size: 0.875em;
+  line-height: 1rem;
+  color: #5A5A5A;
+  display: block;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
 }
 
 @media (min-width:20em) and (max-width:37.4375em) {
@@ -289,18 +289,6 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
   .c5 {
     font-size: 1em;
     line-height: 1.375rem;
-  }
-}
-
-@media (min-width:20em) and (max-width:37.4375em) {
-  .c3 {
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5em) {
-  .c3 {
-    font-size: 0.8125em;
   }
 }
 
@@ -423,6 +411,18 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
     -ms-grid-column: 4;
     -ms-grid-column-span: 6;
     grid-column: 4 / -4;
+  }
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c3 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c3 {
+    font-size: 0.8125em;
   }
 }
 

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -66,7 +66,6 @@ exports[`ArticleMain should render a news article correctly 1`] = `
         "timestamp": 1514811600000,
       }
     }
-    service="news"
   />
   <main
     role="main"
@@ -202,7 +201,6 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
         "timestamp": 1514811600000,
       }
     }
-    service="persian"
   />
   <main
     role="main"

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -1,8 +1,238 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleMain should render a news article correctly 1`] = `null`;
+exports[`ArticleMain should render a news article correctly 1`] = `
+.c2 {
+  color: #222222;
+  font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 2rem 0 1rem 0;
+  font-size: 1.75em;
+  line-height: 2rem;
+}
 
-exports[`ArticleMain should render a news article correctly 2`] = `
+.c5 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-size: 0.9375em;
+  line-height: 1.25rem;
+}
+
+.c3 {
+  font-size: 0.875em;
+  line-height: 1rem;
+  color: #5A5A5A;
+  display: block;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+}
+
+.c0 {
+  display: -ms-grid;
+  display: grid;
+}
+
+.c4 {
+  display: -ms-grid;
+  display: grid;
+  background: #F5F3F1;
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c2 {
+    font-size: 2em;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c2 {
+    font-size: 2.75em;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:20em) {
+  .c5 {
+    font-size: 1em;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c3 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c3 {
+    font-size: 0.8125em;
+  }
+}
+
+@media (max-width:37.4375em) {
+  .c0 {
+    grid-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c0 {
+    grid-gap: 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:62.9375em) {
+  .c0 {
+    -ms-grid-columns: (1fr)[6];
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+  }
+}
+
+@media (min-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
+    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+  }
+}
+
+@media (max-width:37.4375em) {
+  .c4 {
+    grid-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c4 {
+    grid-gap: 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c4 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c4 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:62.9375em) {
+  .c4 {
+    -ms-grid-columns: (1fr)[6];
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c4 {
+    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+  }
+}
+
+@media (min-width:80em) {
+  .c4 {
+    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
+    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+  }
+}
+
+@media (max-width:37.5em) {
+  .c1 {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width:37.5em) and (max-width:62.9375em) {
+  .c1 {
+    -ms-grid-column: 2;
+    -ms-grid-column-span: 4;
+    grid-column: 2 / -2;
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c1 {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 6;
+    grid-column: 3 / -3;
+  }
+}
+
+@media (min-width:80em) {
+  .c1 {
+    -ms-grid-column: 4;
+    -ms-grid-column-span: 6;
+    grid-column: 4 / -4;
+  }
+}
+
+<main
+  role="main"
+>
+  <div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <h1
+        className="c2"
+      >
+        Article Headline
+      </h1>
+      <time
+        className="c3"
+        dateTime="2018-01-01"
+      >
+        1 January 2018
+      </time>
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
+    <div
+      className="c1"
+    >
+      <p
+        className="c5"
+      >
+        A paragraph.
+      </p>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`ArticleMain should render a persian article correctly 1`] = `
 .c2 {
   color: #222222;
   font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -1,7 +1,8 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { string, object } from 'prop-types';
+import { string, shape } from 'prop-types';
 import { C_OAT_LHT } from '@bbc/psammead-styles/colours';
+import { articleDataPropTypes } from '../../models/propTypes/article';
 import MetadataContainer from '../Metadata';
 import headings from '../Headings';
 import text from '../Text';
@@ -92,7 +93,7 @@ const ArticleMain = ({ service, articleData }) => {
 
 ArticleMain.propTypes = {
   service: string.isRequired,
-  articleData: object.isRequired, // eslint-disable-line
+  articleData: shape(articleDataPropTypes).isRequired,
 };
 
 export default ArticleMain;

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { string, shape } from 'prop-types';
+import { shape } from 'prop-types';
 import { articleDataPropTypes } from '../../models/propTypes/article';
 import MetadataContainer from '../Metadata';
 import headings from '../Headings';
@@ -31,7 +31,7 @@ const splitBlocksByHeadline = ({ model }) => {
   return { headlineBlocks, mainBlocks };
 };
 
-const ArticleMain = ({ service, articleData }) => {
+const ArticleMain = ({ articleData }) => {
   const { content, metadata, promo } = articleData;
   const { headlineBlocks, mainBlocks } = splitBlocksByHeadline(content);
 
@@ -43,11 +43,7 @@ const ArticleMain = ({ service, articleData }) => {
   if (headlineBlocks.length > 0) {
     return (
       <Fragment>
-        <MetadataContainer
-          metadata={metadata}
-          promo={promo}
-          service={service}
-        />
+        <MetadataContainer metadata={metadata} promo={promo} />
         <main role="main">
           <Wrapper>
             <GridItemConstrained>
@@ -75,7 +71,6 @@ const ArticleMain = ({ service, articleData }) => {
 };
 
 ArticleMain.propTypes = {
-  service: string.isRequired,
   articleData: shape(articleDataPropTypes).isRequired,
 };
 

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -1,0 +1,98 @@
+import React, { Fragment } from 'react';
+import styled from 'styled-components';
+import { string, object } from 'prop-types';
+import { C_OAT_LHT } from '@bbc/psammead-styles/colours';
+import MetadataContainer from '../Metadata';
+import headings from '../Headings';
+import text from '../Text';
+import image from '../Image';
+import Blocks from '../Blocks';
+import Timestamp from '../Timestamp';
+import {
+  layoutGridWrapper,
+  layoutGridItemConstrained,
+} from '../../lib/layoutGrid';
+
+const Wrapper = styled.div`
+  ${layoutGridWrapper};
+`;
+
+const OatWrapper = styled(Wrapper)`
+  background: ${C_OAT_LHT};
+`;
+
+const GridItemConstrained = styled.div`
+  ${layoutGridItemConstrained};
+`;
+
+const componentsToRenderHeadline = {
+  headline: headings,
+};
+
+const componentsToRenderMain = {
+  subheadline: headings,
+  text,
+  image,
+};
+
+const splitBlocksByHeadline = ({ model }) => {
+  const { blocks } = model;
+
+  const headlineIndexPlusOne =
+    blocks.findIndex(({ type }) => type === 'headline') + 1;
+
+  const headlineBlocks = blocks.slice(0, headlineIndexPlusOne);
+  const mainBlocks = blocks.slice(headlineIndexPlusOne, blocks.length);
+
+  return { headlineBlocks, mainBlocks };
+};
+
+const ArticleMain = ({ service, articleData }) => {
+  const { content, metadata, promo } = articleData;
+  const { headlineBlocks, mainBlocks } = splitBlocksByHeadline(content);
+
+  /*
+   * headlineBlocks length check is temporary
+   * Simorgh will respond with 400 to lack of headline block in issue
+   * https://github.com/bbc/simorgh/issues/836
+   */
+  if (headlineBlocks.length > 0) {
+    return (
+      <Fragment>
+        <MetadataContainer
+          metadata={metadata}
+          promo={promo}
+          service={service}
+        />
+        <main role="main">
+          <Wrapper>
+            <GridItemConstrained>
+              <Blocks
+                blocks={headlineBlocks}
+                componentsToRender={componentsToRenderHeadline}
+              />
+              <Timestamp timestamp={metadata.lastPublished} />
+            </GridItemConstrained>
+          </Wrapper>
+          <OatWrapper>
+            <GridItemConstrained>
+              <Blocks
+                blocks={mainBlocks}
+                componentsToRender={componentsToRenderMain}
+              />
+            </GridItemConstrained>
+          </OatWrapper>
+        </main>
+      </Fragment>
+    );
+  }
+
+  return null;
+};
+
+ArticleMain.propTypes = {
+  service: string.isRequired,
+  articleData: object.isRequired, // eslint-disable-line
+};
+
+export default ArticleMain;

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -1,7 +1,5 @@
 import React, { Fragment } from 'react';
-import styled from 'styled-components';
 import { string, shape } from 'prop-types';
-import { C_OAT_LHT } from '@bbc/psammead-styles/colours';
 import { articleDataPropTypes } from '../../models/propTypes/article';
 import MetadataContainer from '../Metadata';
 import headings from '../Headings';
@@ -9,22 +7,7 @@ import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
 import Timestamp from '../Timestamp';
-import {
-  layoutGridWrapper,
-  layoutGridItemConstrained,
-} from '../../lib/layoutGrid';
-
-const Wrapper = styled.div`
-  ${layoutGridWrapper};
-`;
-
-const OatWrapper = styled(Wrapper)`
-  background: ${C_OAT_LHT};
-`;
-
-const GridItemConstrained = styled.div`
-  ${layoutGridItemConstrained};
-`;
+import { Wrapper, OatWrapper, GridItemConstrained } from '../../lib/styledGrid';
 
 const componentsToRenderHeadline = {
   headline: headings,

--- a/src/app/containers/ArticleMain/index.test.jsx
+++ b/src/app/containers/ArticleMain/index.test.jsx
@@ -4,7 +4,7 @@ import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
 import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
 
 // temporary: will be removed with https://github.com/bbc/simorgh/issues/836
-const articleDataNewsNoHeadline = articleDataNews;
+const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
 articleDataNewsNoHeadline.content.model.blocks.shift();
 
 describe('ArticleMain', () => {
@@ -14,7 +14,7 @@ describe('ArticleMain', () => {
   );
 
   shouldMatchSnapshot(
-    'should render a news article correctly',
+    'should render a persian article correctly',
     <ArticleMain service="persian" articleData={articleDataPersian} />,
   );
 

--- a/src/app/containers/ArticleMain/index.test.jsx
+++ b/src/app/containers/ArticleMain/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ArticleMain from '.';
-import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
 
 // temporary: will be removed with https://github.com/bbc/simorgh/issues/836
@@ -8,17 +8,17 @@ const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
 articleDataNewsNoHeadline.content.model.blocks.shift();
 
 describe('ArticleMain', () => {
-  shouldMatchSnapshot(
+  shouldShallowMatchSnapshot(
     'should render a news article correctly',
     <ArticleMain service="news" articleData={articleDataNews} />,
   );
 
-  shouldMatchSnapshot(
+  shouldShallowMatchSnapshot(
     'should render a persian article correctly',
     <ArticleMain service="persian" articleData={articleDataPersian} />,
   );
 
-  shouldMatchSnapshot(
+  shouldShallowMatchSnapshot(
     'should render null if no headline block',
     <ArticleMain service="news" articleData={articleDataNewsNoHeadline} />,
   );

--- a/src/app/containers/ArticleMain/index.test.jsx
+++ b/src/app/containers/ArticleMain/index.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ArticleMain from '.';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
+
+// temporary: will be removed with https://github.com/bbc/simorgh/issues/836
+const articleDataNewsNoHeadline = articleDataNews;
+articleDataNewsNoHeadline.content.model.blocks.shift();
+
+describe('ArticleMain', () => {
+  shouldMatchSnapshot(
+    'should render a news article correctly',
+    <ArticleMain service="news" articleData={articleDataNews} />,
+  );
+
+  shouldMatchSnapshot(
+    'should render a news article correctly',
+    <ArticleMain service="persian" articleData={articleDataPersian} />,
+  );
+
+  shouldMatchSnapshot(
+    'should render null if no headline block',
+    <ArticleMain service="news" articleData={articleDataNewsNoHeadline} />,
+  );
+});

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorMain should correctly render 1`] = `
+.c2 {
+  color: #222222;
+  font-family: ReithSerifNewsMedium,Helvetica,Arial,sans-serif;
+  margin: 0;
+  padding: 2rem 0 1rem 0;
+  font-size: 1.75em;
+  line-height: 2rem;
+}
+
+.c3 {
+  color: #404040;
+  font-family: ReithSansNewsRegular,Helvetica,Arial,sans-serif;
+  padding-bottom: 1rem;
+  margin: 0;
+  font-size: 0.9375em;
+  line-height: 1.25rem;
+}
+
+.c0 {
+  display: -ms-grid;
+  display: grid;
+}
+
+@media (min-width:20em) and (max-width:37.4375em) {
+  .c2 {
+    font-size: 2em;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c2 {
+    font-size: 2.75em;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:20em) {
+  .c3 {
+    font-size: 1em;
+    line-height: 1.375rem;
+  }
+}
+
+@media (max-width:37.4375em) {
+  .c0 {
+    grid-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5em) {
+  .c0 {
+    grid-gap: 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:62.9375em) {
+  .c0 {
+    -ms-grid-columns: (1fr)[6];
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+  }
+}
+
+@media (min-width:80em) {
+  .c0 {
+    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
+    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+  }
+}
+
+@media (max-width:37.5em) {
+  .c1 {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width:37.5em) and (max-width:62.9375em) {
+  .c1 {
+    -ms-grid-column: 2;
+    -ms-grid-column-span: 4;
+    grid-column: 2 / -2;
+  }
+}
+
+@media (min-width:63em) and (max-width:80em) {
+  .c1 {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 6;
+    grid-column: 3 / -3;
+  }
+}
+
+@media (min-width:80em) {
+  .c1 {
+    -ms-grid-column: 4;
+    -ms-grid-column-span: 6;
+    grid-column: 4 / -4;
+  }
+}
+
+<main
+  role="main"
+>
+  <div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <h1
+        className="c2"
+      >
+        Oops: something went wrong!
+      </h1>
+      <p
+        className="c3"
+      >
+        Response code: 
+        451
+      </p>
+    </div>
+  </div>
+</main>
+`;

--- a/src/app/containers/ErrorMain/index.jsx
+++ b/src/app/containers/ErrorMain/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { number } from 'prop-types';
+import styled from 'styled-components';
+import { Headline } from '@bbc/psammead-headings';
+import Paragraph from '@bbc/psammead-paragraph';
+import {
+  layoutGridWrapper,
+  layoutGridItemConstrained,
+} from '../../lib/layoutGrid';
+
+const Wrapper = styled.div`
+  ${layoutGridWrapper};
+`;
+
+const GridItemConstrained = styled.div`
+  ${layoutGridItemConstrained};
+`;
+
+const ErrorMain = ({ status }) => (
+  <main role="main">
+    <Wrapper>
+      <GridItemConstrained>
+        <Headline>Oops: something went wrong!</Headline>
+        <Paragraph>Response code: {status}</Paragraph>
+      </GridItemConstrained>
+    </Wrapper>
+  </main>
+);
+
+ErrorMain.propTypes = {
+  status: number.isRequired,
+};
+
+export default ErrorMain;

--- a/src/app/containers/ErrorMain/index.jsx
+++ b/src/app/containers/ErrorMain/index.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
 import { number } from 'prop-types';
-import styled from 'styled-components';
 import { Headline } from '@bbc/psammead-headings';
 import Paragraph from '@bbc/psammead-paragraph';
-import {
-  layoutGridWrapper,
-  layoutGridItemConstrained,
-} from '../../lib/layoutGrid';
-
-const Wrapper = styled.div`
-  ${layoutGridWrapper};
-`;
-
-const GridItemConstrained = styled.div`
-  ${layoutGridItemConstrained};
-`;
+import { Wrapper, GridItemConstrained } from '../../lib/styledGrid';
 
 const ErrorMain = ({ status }) => (
   <main role="main">

--- a/src/app/containers/ErrorMain/index.test.jsx
+++ b/src/app/containers/ErrorMain/index.test.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
+import ErrorMain from './index';
+
+describe('ErrorMain', () => {
+  shouldMatchSnapshot('should correctly render', <ErrorMain status={451} />);
+});

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, shape } from 'prop-types';
+import { shape } from 'prop-types';
 import { ServiceContextConsumer } from '../../contexts/ServiceContext';
 import { PlatformContextConsumer } from '../../contexts/PlatformContext';
 import Metadata from '../../components/Metadata';
@@ -14,7 +14,7 @@ const allTags = tags => {
   return aboutTags.concat(mentionTags);
 };
 
-const MetadataContainer = ({ metadata, promo, service }) => {
+const MetadataContainer = ({ metadata, promo }) => {
   const { id: aresArticleId } = metadata;
 
   if (!aresArticleId) {
@@ -22,8 +22,6 @@ const MetadataContainer = ({ metadata, promo, service }) => {
   }
 
   const id = aresArticleId.split(':').pop();
-  /* Canonical link generated from servicename and id */
-  const canonicalLink = `https://www.bbc.com/${service}/articles/${id}`;
   const timeFirstPublished = new Date(metadata.firstPublished).toISOString();
   const timeLastPublished = new Date(metadata.lastPublished).toISOString();
 
@@ -32,6 +30,7 @@ const MetadataContainer = ({ metadata, promo, service }) => {
       {platform => (
         <ServiceContextConsumer>
           {({
+            service,
             brandName,
             articleAuthor,
             defaultImage,
@@ -39,29 +38,34 @@ const MetadataContainer = ({ metadata, promo, service }) => {
             locale,
             twitterCreator,
             twitterSite,
-          }) => (
-            <Metadata
-              isAmp={platform === 'amp'}
-              articleAuthor={articleAuthor}
-              articleSection={metadata.passport.genre}
-              brandName={brandName}
-              canonicalLink={canonicalLink}
-              defaultImage={defaultImage}
-              defaultImageAltText={defaultImageAltText}
-              description={promo.summary}
-              facebookAdmin={100004154058350}
-              facebookAppID={1609039196070050}
-              lang={metadata.passport.language}
-              locale={locale}
-              metaTags={allTags(metadata.tags)}
-              timeFirstPublished={timeFirstPublished}
-              timeLastPublished={timeLastPublished}
-              title={promo.headlines.seoHeadline}
-              twitterCreator={twitterCreator}
-              twitterSite={twitterSite}
-              type={metadata.type}
-            />
-          )}
+          }) => {
+            /* Canonical link generated from servicename and id */
+            const canonicalLink = `https://www.bbc.com/${service}/articles/${id}`;
+
+            return (
+              <Metadata
+                isAmp={platform === 'amp'}
+                articleAuthor={articleAuthor}
+                articleSection={metadata.passport.genre}
+                brandName={brandName}
+                canonicalLink={canonicalLink}
+                defaultImage={defaultImage}
+                defaultImageAltText={defaultImageAltText}
+                description={promo.summary}
+                facebookAdmin={100004154058350}
+                facebookAppID={1609039196070050}
+                lang={metadata.passport.language}
+                locale={locale}
+                metaTags={allTags(metadata.tags)}
+                timeFirstPublished={timeFirstPublished}
+                timeLastPublished={timeLastPublished}
+                title={promo.headlines.seoHeadline}
+                twitterCreator={twitterCreator}
+                twitterSite={twitterSite}
+                type={metadata.type}
+              />
+            );
+          }}
         </ServiceContextConsumer>
       )}
     </PlatformContextConsumer>
@@ -71,7 +75,6 @@ const MetadataContainer = ({ metadata, promo, service }) => {
 MetadataContainer.propTypes = {
   metadata: shape(metadataPropTypes).isRequired,
   promo: shape(promoPropTypes).isRequired,
-  service: string.isRequired,
 };
 
 export default MetadataContainer;

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { C_OAT_LHT } from '@bbc/psammead-styles/colours';
+import { layoutGridWrapper, layoutGridItemConstrained } from './layoutGrid';
+
+export const Wrapper = styled.div`
+  ${layoutGridWrapper};
+`;
+
+export const OatWrapper = styled(Wrapper)`
+  background: ${C_OAT_LHT};
+`;
+
+export const GridItemConstrained = styled.div`
+  ${layoutGridItemConstrained};
+`;

--- a/src/app/models/propTypes/article/index.js
+++ b/src/app/models/propTypes/article/index.js
@@ -3,15 +3,17 @@ import metadataPropTypes from '../metadata';
 import promoPropTypes from '../promo';
 import mainContentPropTypes from '../mainContent';
 
+export const articleDataPropTypes = {
+  metadata: shape(metadataPropTypes).isRequired,
+  content: shape({
+    model: shape(mainContentPropTypes),
+  }).isRequired,
+  promo: shape(promoPropTypes).isRequired,
+};
+
 const articlePropTypes = {
   isAmp: bool,
-  data: shape({
-    metadata: shape(metadataPropTypes).isRequired,
-    content: shape({
-      model: shape(mainContentPropTypes),
-    }).isRequired,
-    promo: shape(promoPropTypes).isRequired,
-  }),
+  data: shape(articleDataPropTypes),
   service: string,
 };
 

--- a/src/app/models/propTypes/article/index.js
+++ b/src/app/models/propTypes/article/index.js
@@ -1,4 +1,4 @@
-import { bool, shape, string } from 'prop-types';
+import { bool, shape, string, number } from 'prop-types';
 import metadataPropTypes from '../metadata';
 import promoPropTypes from '../promo';
 import mainContentPropTypes from '../mainContent';
@@ -15,6 +15,7 @@ const articlePropTypes = {
   isAmp: bool,
   data: shape(articleDataPropTypes),
   service: string,
+  status: number,
 };
 
 export default articlePropTypes;

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -1,27 +1,39 @@
 import 'isomorphic-fetch';
 
+const upstreamStatusCodesToPropagate = [200, 404, 502];
+
 const getInitialData = async ({ match }) => {
+  const { id, service, amp } = match.params;
+  const isAmp = !!amp;
+  const url = `${process.env.SIMORGH_BASE_URL}/${service}/articles/${id}.json`;
+
+  let data;
+  let status;
+
   try {
-    const { id, service, amp } = match.params;
-
-    const url = `${
-      process.env.SIMORGH_BASE_URL
-    }/${service}/articles/${id}.json`;
-
     const response = await fetch(url);
 
-    const data = await response.json();
-    const isAmp = !!amp;
-
-    return {
-      isAmp,
-      data,
-      service,
-    };
+    status = response.status; // eslint-disable-line prefer-destructuring
+    if (status === 200) {
+      data = await response.json();
+    } else if (!upstreamStatusCodesToPropagate.includes(status)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Unexpected upstream response (HTTP status code ${status}) when requesting ${url}`,
+      );
+      status = 502;
+    }
   } catch (error) {
     console.log(error); // eslint-disable-line no-console
-    return {};
+    status = 502;
   }
+
+  return {
+    isAmp,
+    data,
+    service,
+    status,
+  };
 };
 
 export default getInitialData;

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 
-const upstreamStatusCodesToPropagate = [200, 404, 502];
+const upstreamStatusCodesToPropagate = [200, 404];
 
 const getInitialData = async ({ match }) => {
   const { id, service, amp } = match.params;

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -14,6 +14,7 @@ const getInitialData = async ({ match }) => {
     const response = await fetch(url);
 
     status = response.status; // eslint-disable-line prefer-destructuring
+
     if (status === 200) {
       data = await response.json();
     } else if (!upstreamStatusCodesToPropagate.includes(status)) {

--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -24,10 +24,10 @@ describe('getInitialData', () => {
   const mockFetchInvalidJSON = () =>
     fetch.mockResponseOnce('Some Invalid: { JSON');
 
-  const mockFetchNotFound = () =>
+  const mockFetchNotFoundStatus = () =>
     fetch.mockResponseOnce(JSON.stringify({}), { status: 404 });
 
-  const mockFetchTeapot = () =>
+  const mockFetchTeapotStatus = () =>
     fetch.mockResponseOnce(JSON.stringify({}), { status: 418 });
 
   const callGetInitialData = async (
@@ -121,7 +121,7 @@ describe('getInitialData', () => {
     it('should return the status code as 404', async () => {
       const response = await callGetInitialData(
         defaultContext,
-        mockFetchNotFound,
+        mockFetchNotFoundStatus,
       );
 
       expect(response).toEqual({
@@ -139,7 +139,7 @@ describe('getInitialData', () => {
 
       const response = await callGetInitialData(
         defaultContext,
-        mockFetchTeapot,
+        mockFetchTeapotStatus,
       );
 
       expect(global.console.warn).toBeCalledWith(

--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -21,6 +21,15 @@ describe('getInitialData', () => {
   const mockFetchFailure = () =>
     fetch.mockReject(JSON.stringify({ error: true }));
 
+  const mockFetchInvalidJSON = () =>
+    fetch.mockResponseOnce('Some Invalid: { JSON');
+
+  const mockFetchNotFound = () =>
+    fetch.mockResponseOnce(JSON.stringify({}), { status: 404 });
+
+  const mockFetchTeapot = () =>
+    fetch.mockResponseOnce(JSON.stringify({}), { status: 418 });
+
   const callGetInitialData = async (
     context = defaultContext,
     mockFetch = mockFetchSuccess,
@@ -40,6 +49,7 @@ describe('getInitialData', () => {
       isAmp: false,
       data: mockSuccessfulResponse,
       service: 'news',
+      status: 200,
     });
   });
 
@@ -59,6 +69,7 @@ describe('getInitialData', () => {
       isAmp: true,
       data: mockSuccessfulResponse,
       service: 'news',
+      status: 200,
     });
   });
 
@@ -77,8 +88,72 @@ describe('getInitialData', () => {
 
   describe('Rejected fetch', () => {
     it('should return an empty object', async () => {
-      const response = await callGetInitialData({}, mockFetchFailure);
-      expect(response).toEqual({});
+      const response = await callGetInitialData(
+        defaultContext,
+        mockFetchFailure,
+      );
+      expect(response).toEqual({
+        data: undefined,
+        isAmp: false,
+        service: 'news',
+        status: 502,
+      });
+    });
+  });
+
+  describe('Ares returns 200 status code, but invalid JSON', () => {
+    it('should return a 502 error code', async () => {
+      const response = await callGetInitialData(
+        defaultContext,
+        mockFetchInvalidJSON,
+      );
+
+      expect(response).toEqual({
+        data: undefined,
+        isAmp: false,
+        service: 'news',
+        status: 502,
+      });
+    });
+  });
+
+  describe('Ares returns a 404 status code', () => {
+    it('should return the status code as 404', async () => {
+      const response = await callGetInitialData(
+        defaultContext,
+        mockFetchNotFound,
+      );
+
+      expect(response).toEqual({
+        data: undefined,
+        isAmp: false,
+        service: 'news',
+        status: 404,
+      });
+    });
+  });
+
+  describe('Ares returns a non-200, non-404 status code', () => {
+    it('should log, and return the status code as 502', async () => {
+      global.console.warn = jest.fn();
+
+      const response = await callGetInitialData(
+        defaultContext,
+        mockFetchTeapot,
+      );
+
+      expect(global.console.warn).toBeCalledWith(
+        `Unexpected upstream response (HTTP status code 418) when requesting ${
+          process.env.SIMORGH_BASE_URL
+        }/news/articles/c0000000001o.json`,
+      );
+
+      expect(response).toEqual({
+        data: undefined,
+        isAmp: false,
+        service: 'news',
+        status: 502,
+      });
     });
   });
 });

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -10,6 +10,8 @@ const ampRegex = '.amp';
 
 export const articleRegexPath = `/:service(${serviceRegex})/articles/:id(${idRegex}):amp(${ampRegex})?`;
 
+export const articleDataRegexPath = `${articleRegexPath}.json`;
+
 export const swRegexPath = `/:service(${serviceRegex})/articles/sw.js`;
 
 const routes = [

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -108,7 +108,7 @@ server
         .status(status)
         .send(`<!doctype html>${await renderArticle(url, data)}`);
     } catch ({ message }) {
-      // Internal server error
+      // Return an internal server error for any uncaught errors
       res.status(500).send(message);
     }
   });

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -11,7 +11,11 @@ import path from 'path';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
-import routes, { articleRegexPath, swRegexPath } from '../app/routes';
+import routes, {
+  articleRegexPath,
+  articleDataRegexPath,
+  swRegexPath,
+} from '../app/routes';
 import { getStyleTag } from './styles';
 import getAssetsArray from './assets';
 
@@ -22,8 +26,6 @@ const assets = getAssetsArray();
 const publicDirectory = 'build/public';
 const dataFolderToRender =
   process.env.NODE_ENV === 'production' ? 'data/prod' : 'data/test';
-
-const articleDataRegexPath = `${articleRegexPath}.json`;
 
 const renderArticle = async (url, data) => {
   const sheet = new ServerStyleSheet();
@@ -97,7 +99,7 @@ server
       }
     });
   })
-  .get('/*', async ({ url }, res) => {
+  .get(articleRegexPath, async ({ url }, res) => {
     try {
       const data = await loadInitialData(url, routes);
       const { status } = data;

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -68,46 +68,80 @@ describe('Server', () => {
   });
 
   describe('/*', () => {
+    const successDataResponse = {
+      isAmp: false,
+      data: { some: 'data' },
+      service: 'someService',
+      status: 200,
+    };
+
+    const notFoundDataResponse = {
+      isAmp: false,
+      data: { some: 'data' },
+      service: 'someService',
+      status: 404,
+    };
+
     describe('Successful render', () => {
-      beforeEach(() => {
-        loadInitialData.mockImplementationOnce(() =>
-          Promise.resolve({ some: 'data' }),
-        );
+      describe('200 status code', () => {
+        beforeEach(() => {
+          loadInitialData.mockImplementationOnce(() =>
+            Promise.resolve(successDataResponse),
+          );
+        });
+
+        it('should respond with rendered data', async () => {
+          const { text, status } = await makeRequest('/some/route');
+
+          expect(status).toBe(200);
+
+          expect(reactDomServer.renderToString).toHaveBeenCalledWith(
+            <h1>Mock app</h1>,
+          );
+
+          expect(reactDomServer.renderToStaticMarkup).toHaveBeenCalledWith(
+            <Document
+              app="<h1>Mock app</h1>"
+              assets={['one.js']}
+              data={successDataResponse}
+              helmet={{ head: 'tags' }}
+              styleTags={<style />}
+            />,
+          );
+
+          expect(text).toEqual(
+            '<!doctype html><html><body><h1>Mock app</h1></body></html>',
+          );
+        });
       });
 
-      it('should respond with rendered data', async () => {
-        const { text } = await makeRequest('/some/route');
+      describe('404 status code', () => {
+        beforeEach(() => {
+          loadInitialData.mockImplementationOnce(() =>
+            Promise.resolve(notFoundDataResponse),
+          );
+        });
 
-        expect(reactDomServer.renderToString).toHaveBeenCalledWith(
-          <h1>Mock app</h1>,
-        );
-
-        expect(reactDomServer.renderToStaticMarkup).toHaveBeenCalledWith(
-          <Document
-            app="<h1>Mock app</h1>"
-            assets={['one.js']}
-            data={{ some: 'data' }}
-            helmet={{ head: 'tags' }}
-            styleTags={<style />}
-          />,
-        );
-
-        expect(text).toEqual(
-          '<!doctype html><html><body><h1>Mock app</h1></body></html>',
-        );
+        it('should respond with a rendered 404', async () => {
+          const { status, text } = await makeRequest('/some/route');
+          expect(status).toBe(404);
+          expect(text).toEqual(
+            '<!doctype html><html><body><h1>Mock app</h1></body></html>',
+          );
+        });
       });
     });
 
-    describe('Error', () => {
+    describe('Unknown error within universal-react-app or its dependencies', () => {
       beforeEach(() => {
         loadInitialData.mockImplementationOnce(() =>
           Promise.reject(Error('Error!')),
         );
       });
 
-      it('should respond with a 404', async () => {
+      it('should respond with a 500', async () => {
         const { status, text } = await makeRequest('/');
-        expect(status).toEqual(404);
+        expect(status).toEqual(500);
         expect(text).toEqual('Error!');
       });
     });

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -67,7 +67,7 @@ describe('Server', () => {
     });
   });
 
-  describe('/*', () => {
+  describe('/{service}/articles/{optimoID}', () => {
     const successDataResponse = {
       isAmp: false,
       data: { some: 'data' },
@@ -91,7 +91,9 @@ describe('Server', () => {
         });
 
         it('should respond with rendered data', async () => {
-          const { text, status } = await makeRequest('/some/route');
+          const { text, status } = await makeRequest(
+            '/news/articles/c0000000001o',
+          );
 
           expect(status).toBe(200);
 
@@ -123,7 +125,9 @@ describe('Server', () => {
         });
 
         it('should respond with a rendered 404', async () => {
-          const { status, text } = await makeRequest('/some/route');
+          const { status, text } = await makeRequest(
+            '/news/articles/c0000000001o',
+          );
           expect(status).toBe(404);
           expect(text).toEqual(
             '<!doctype html><html><body><h1>Mock app</h1></body></html>',
@@ -140,10 +144,20 @@ describe('Server', () => {
       });
 
       it('should respond with a 500', async () => {
-        const { status, text } = await makeRequest('/');
+        const { status, text } = await makeRequest(
+          '/news/articles/c0000000001o',
+        );
         expect(status).toEqual(500);
         expect(text).toEqual('Error!');
       });
+    });
+  });
+
+  describe('/someInvalidPath', () => {
+    it('should respond 404', async () => {
+      const { status } = await makeRequest('/blah');
+
+      expect(status).toBe(404);
     });
   });
 });


### PR DESCRIPTION
Resolves #1214

**Overall change:** Ensures Simorgh responds with suitable error codes, as defined by the following rules:
- If the data source 404s, Simorgh 404s
- If the data source responds with any non-200, non-404 status code, Simorgh 502s
- If the data source 200s, but responds with invalid JSON, Simorgh 502s
- If Simorgh throws an unhandled error, Simorgh 500s

**Code changes:**

- Changes `getInitialData` to return a status code, & ensure it only ever returns one of `200`, `404` or `502`. If the data source returns anything else, it will be logged & `getInitialData` will instead return `502`. The solution I ended up with here feels less intimidating than an entirely new layer handling the mapping, but perhaps this could be re-evaluated.
- Refactors `ArticleContainer`, to provide a consistent page skeleton & avoid any assumptions that the article data will always be present. This helps set us up for error & loading pages, which will require a large amount of shared page furniture that was previously entangled in logic.
- The business logic that previously lived in `ArticleContainer` now lives in the `ArticleMain` container. `ArticleContainer` now only branches on the `status` it receives from `getInitialData`, choosing different `main` containers to switch in.
- This PR introduces `ErrorMain` & passes it `status`, providing a basis for the error page work coming up. Currently, it looks like this:
![screenshot 2019-02-06 at 16 06 17](https://user-images.githubusercontent.com/11646957/52354903-330c9880-2a29-11e9-92da-81d67604f355.png)
- Finally, `server/index.jsx` now responds with the status code determined by `getInitialData`. As described above, it feels a little strange for our data fetcher to also determine _our_ status code, but without it there would need to be something more complex, that still allows for a solution that works across both server & client.

Small refactors: 
- moves `articleDataRegexPath` so all our path regexes live in `routes.js`
- renames the Cypress test helper `testNonHtmlResponseCode` to `testResponseCode`
- changes MetadataContainer to utilise ServiceContextProvider when creating canonical links, removing the need for a `service` prop in both ArticleMain & MetadataContainer

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.