### PR TITLE
Ensure Infrastructure deployment set to run to live env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,10 @@ pipeline {
       steps {
         build(
           job: 'simorgh-infrastructure/latest',
-          parameters: [[$class: 'StringParameterValue', name: 'BRANCH', value: env.BRANCH_NAME]],
+          parameters: [
+            [$class: 'StringParameterValue', name: 'BRANCH', value: env.BRANCH_NAME],
+            [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: 'live'],
+          ],
           propagate: true,
           wait: true
         )


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh-infrastructure/issues/248

**Overall change:** Ensure infrastructure job is run with the parameter ENVIRONMENT set to 'live'. This is because it is currently using the default value of 'test'. 

This is needed as a precursor to the Infrastructure PR here https://github.com/bbc/simorgh-infrastructure/pull/273

**Code changes:**

- Ensure infrastructure job is run with the parameter ENVIRONMENT set to 'live'


**Test notes**
Once merged, this deployment should build to Live and run E2Es against the Live env. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~Tests added for new features~
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
