### PR TITLE
Remove react-universal-app and copy across

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,7 +193,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
       "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -201,8 +200,7 @@
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-          "dev": true
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -1085,8 +1083,7 @@
     "@types/node": {
       "version": "8.10.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
-      "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
-      "dev": true
+      "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA=="
     },
     "@types/rimraf": {
       "version": "0.0.28",
@@ -1667,7 +1664,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
       "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.10.0",
@@ -3495,8 +3491,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bowser": {
       "version": "1.9.4",
@@ -4041,6 +4036,60 @@
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
       "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "2.0.4",
@@ -5150,7 +5199,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0",
         "css-what": "2.1",
@@ -5195,8 +5243,7 @@
     "css-what": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
-      "dev": true
+      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
     },
     "cssesc": {
       "version": "0.1.0",
@@ -6114,6 +6161,11 @@
         "path-type": "^3.0.0"
       }
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -6184,7 +6236,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "~1.1.1",
         "entities": "~1.1.1"
@@ -6193,8 +6244,7 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -6212,8 +6262,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -6237,7 +6286,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -6477,13 +6525,86 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "env-variable": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+    },
+    "enzyme": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.8.0.tgz",
+      "integrity": "sha512-bfsWo5nHyZm1O1vnIsbwdfhU989jk+squU9NKvB+Puwo5j6/Wg9pN5CO0YJelm98Dao3NPjkDZk+vvgwpMwYxw==",
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-subset": "^0.1.1",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.6.0",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.1.2"
+      }
+    },
+    "enzyme-adapter-react-16": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.9.1.tgz",
+      "integrity": "sha512-Egzogv1y77DUxdnq/CyHxLHaNxmSSKDDSDNNB/EiAXCZVFXdFibaNy2uUuRQ1n24T2m6KH/1Rw16XDRq+1yVEg==",
+      "requires": {
+        "enzyme-adapter-utils": "^1.10.0",
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.7.0",
+        "react-test-renderer": "^16.0.0-0"
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.0.tgz",
+      "integrity": "sha512-VnIXJDYVTzKGbdW+lgK8MQmYHJquTQZiGzu/AseCZ7eHtOMAj4Rtvk8ZRopodkfPves0EXaHkXBDkVhPa3t0jA==",
+      "requires": {
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.6.2",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "object.fromentries": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+          "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.11.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1"
+          }
+        }
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz",
+      "integrity": "sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -6506,7 +6627,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -6520,7 +6640,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -8482,7 +8601,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -8885,7 +9003,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -9957,6 +10074,11 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -9974,8 +10096,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "1.0.10",
@@ -10007,8 +10128,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.2",
@@ -10134,6 +10254,11 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -10206,7 +10331,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -10234,6 +10358,16 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+    },
     "is-supported-regexp-flag": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
@@ -10253,7 +10387,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -12768,6 +12901,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -12777,8 +12915,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -12801,8 +12938,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -13399,6 +13535,11 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
       "dev": true
     },
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -13583,6 +13724,18 @@
             "y18n": "^3.2.0"
           }
         }
+      }
+    },
+    "nearley": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.4.3",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
       }
     },
     "needle": {
@@ -13866,7 +14019,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
       }
@@ -13950,6 +14102,16 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -13978,7 +14140,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -14030,7 +14191,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -14597,8 +14757,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pidtree": {
       "version": "0.3.0",
@@ -17043,11 +17202,33 @@
         "prop-types": "^15.5.8"
       }
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+    },
     "ramda": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
       "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
       "dev": true
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
     },
     "random-string": {
       "version": "0.2.0",
@@ -17155,14 +17336,14 @@
       }
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
+      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.1"
       }
     },
     "react-docgen": {
@@ -17181,14 +17362,14 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
+      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.1"
       }
     },
     "react-emotion": {
@@ -17309,9 +17490,12 @@
       }
     },
     "react-router-config": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-1.0.0-beta.4.tgz",
-      "integrity": "sha512-4jWfQK+PNAYeMU7dZ5h/dNDTReVjm41p761+XP+II360Jz5TfzHiuP27tAasIQ+JcGWwX2l2dCWG8jEmcS5SBA=="
+      "version": "4.4.0-beta.6",
+      "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-4.4.0-beta.6.tgz",
+      "integrity": "sha512-qxqqJ4LDok3UNRpJEs2NwCOBxugvKA71I4N5mk/qeZwo3EiUnqsX7YVyDIiGcTvzKx+h8qVTUyJeCqOe0fFMGw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
     },
     "react-router-dom": {
       "version": "4.3.1",
@@ -17358,15 +17542,21 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
-      "integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
-      "dev": true,
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.1.tgz",
+      "integrity": "sha512-Bd21TN3+YVl6GZwav6O0T6m5UwGfOj+2+xZH5VH93ToD6M5uclN/c+R1DGX49ueG413KZPUx7Kw3sOYz2aJgfg==",
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "scheduler": "^0.12.0"
+        "react-is": "^16.8.1",
+        "scheduler": "^0.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
+          "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+        }
       }
     },
     "react-transition-group": {
@@ -17413,6 +17603,13 @@
       "requires": {
         "react-router-config": "^1.0.0-beta.4",
         "react-router-dom": "^4.3.1"
+      },
+      "dependencies": {
+        "react-router-config": {
+          "version": "1.0.0-beta.4",
+          "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-1.0.0-beta.4.tgz",
+          "integrity": "sha512-4jWfQK+PNAYeMU7dZ5h/dNDTReVjm41p761+XP+II360Jz5TfzHiuP27tAasIQ+JcGWwX2l2dCWG8jEmcS5SBA=="
+        }
       }
     },
     "read-pkg": {
@@ -17972,6 +18169,15 @@
       "integrity": "sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ==",
       "dev": true
     },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "requires": {
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -18089,9 +18295,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
+      "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -19477,6 +19683,16 @@
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
         "function-bind": "^1.0.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17596,22 +17596,6 @@
         }
       }
     },
-    "react-universal-app": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-universal-app/-/react-universal-app-1.0.0.tgz",
-      "integrity": "sha512-KbT9xclbNJS4Cn3lFOKXPEaGbYInUtRpfk1LV6sl05PwzfFuHE5KCSQcQYiGgF5Kjt7/6p7wmfq4218Xw0b3tg==",
-      "requires": {
-        "react-router-config": "^1.0.0-beta.4",
-        "react-router-dom": "^4.3.1"
-      },
-      "dependencies": {
-        "react-router-config": {
-          "version": "1.0.0-beta.4",
-          "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-1.0.0-beta.4.tgz",
-          "integrity": "sha512-4jWfQK+PNAYeMU7dZ5h/dNDTReVjm41p761+XP+II360Jz5TfzHiuP27tAasIQ+JcGWwX2l2dCWG8jEmcS5SBA=="
-        }
-      }
-    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
     "compression-webpack-plugin": "^2.0.0",
     "copy-webpack-plugin": "^4.6.0",
     "dotenv": "^6.2.0",
+    "enzyme": "^3.8.0",
+    "enzyme-adapter-react-16": "^1.9.1",
     "es6-promise": "^4.2.5",
     "express": "^4.16.4",
     "express-static-gzip": "^1.1.3",
@@ -111,6 +113,7 @@
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-helmet": "^5.2.0",
+    "react-router-config": "^4.4.0-beta.6",
     "react-router-dom": "^4.3.1",
     "react-universal-app": "^1.0.0",
     "speculate": "^1.7.4",
@@ -133,6 +136,7 @@
     "chrome-launcher": "^0.10.5",
     "core-js": "^2.6.0",
     "cypress": "^3.1.1",
+    "enzyme-to-json": "^3.3.5",
     "eslint": "^5.8.0",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-config-prettier": "^3.3.0",
@@ -175,6 +179,9 @@
     "testMatch": [
       "**/__tests__/**/*.js?(x)",
       "**/?(*.)+(spec|test).js?(x)"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
     ]
   },
   "spec": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "react-helmet": "^5.2.0",
     "react-router-config": "^4.4.0-beta.6",
     "react-router-dom": "^4.3.1",
-    "react-universal-app": "^1.0.0",
     "speculate": "^1.7.4",
     "styled-components": "^4.1.3",
     "styled-normalize": "^8.0.3",

--- a/src/app/containers/App/App.jsx
+++ b/src/app/containers/App/App.jsx
@@ -1,0 +1,68 @@
+/* eslint-disable */
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import { Component } from 'react';
+import { renderRoutes } from 'react-router-config';
+import { withRouter } from 'react-router-dom';
+
+import loadInitialData from '../../routes/loadInitialData';
+
+export class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: this.props.initialData,
+      loading: false,
+      error: null,
+      loadInitialDataPromise: null,
+    };  
+  }
+
+  async componentDidUpdate({ location: prevLocation }) {
+    if (this.props.location.pathname !== prevLocation.pathname) {
+      const initialData = loadInitialData(
+        this.props.location.pathname,
+        this.props.routes,
+      );
+
+      this.setState({
+        data: null,
+        loading: true,
+        error: null,
+        loadInitialDataPromise: initialData,
+      });
+    }
+
+    if (this.state.loading) {
+      try {
+        const data = await this.state.loadInitialDataPromise;
+        this.setState({
+          data,
+          loading: false,
+          error: null,
+          loadInitialDataPromise: null,
+        });
+      } catch (error) {
+        this.setState({
+          data: null,
+          loading: false,
+          error,
+          loadInitialDataPromise: null,
+        });
+      }
+    }
+  }
+
+  render() {
+    return renderRoutes(this.props.routes, {
+      data: this.state.data,
+      loading: this.state.loading,
+      error: this.state.error,
+    });
+  }
+}
+
+export default withRouter(App);

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -1,0 +1,137 @@
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import React from 'react';
+import * as reactRouterConfig from 'react-router-config';
+import { App } from './App';
+import * as loadInitialData from '../../routes/loadInitialData';
+
+describe('App', () => {
+  let wrapper;
+  let setStateSpy;
+  let loadInitialDataSpy;
+  const initialData = { data: 'Some initial data' };
+
+  reactRouterConfig.renderRoutes = jest
+    .fn()
+    .mockReturnValue(<h1>{initialData.data}</h1>);
+
+  beforeAll(() => {
+    // eslint-disable-next-line no-undef
+    wrapper = shallow(
+      <App
+        location={{ pathname: 'pathnameOne' }}
+        routes={[]}
+        initialData={initialData}
+      />,
+    );
+    setStateSpy = jest.spyOn(wrapper.instance(), 'setState');
+    loadInitialDataSpy = jest.spyOn(loadInitialData, 'default');
+  });
+
+  it('should return rendered routes', () => {
+    expect.assertions(4);
+    expect(loadInitialDataSpy).not.toHaveBeenCalled();
+    expect(reactRouterConfig.renderRoutes).toHaveBeenCalledTimes(1);
+    expect(reactRouterConfig.renderRoutes).toHaveBeenCalledWith([], {
+      data: initialData,
+      error: null,
+      loading: false,
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('componentDidUpdate', () => {
+    describe('same location', () => {
+      it('should not call set state with new data', () => {
+        wrapper.setProps({ location: { pathname: 'pathnameOne' } });
+
+        expect.assertions(2);
+        expect(loadInitialDataSpy).not.toHaveBeenCalled();
+        expect(setStateSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('different location', () => {
+      describe('rejected loadInitialData', () => {
+        it('should set state to the error', async () => {
+          const error = 'Error!';
+
+          loadInitialData.default = jest
+            .fn()
+            .mockImplementation(() => Promise.reject(error));
+
+          wrapper.setProps({ location: { pathname: 'pathnameThree' } });
+
+          await loadInitialData.default;
+
+          expect.assertions(3);
+
+          // why is state being called 3 times?
+          expect(setStateSpy).toHaveBeenNthCalledWith(1, {
+            data: null,
+            error: null,
+            loadInitialDataPromise: expect.any(Promise),
+            loading: true,
+          });
+
+          expect(setStateSpy).toHaveBeenNthCalledWith(2, {
+            data: null,
+            error,
+            loadInitialDataPromise: null,
+            loading: false,
+          });
+
+          expect(setStateSpy).toHaveBeenNthCalledWith(2, {
+            data: null,
+            error,
+            loadInitialDataPromise: null,
+            loading: false,
+          });
+        });
+      });
+
+      describe('successful fetch of route, match, and initial props', () => {
+        it('should call set state with new data', async () => {
+          const pathname = 'pathnameFour';
+          const data = 'Really cool data';
+
+          loadInitialData.default = jest
+            .fn()
+            .mockImplementation(async () => data);
+
+          wrapper.setProps({ location: { pathname } });
+
+          await loadInitialData.default;
+
+          expect.assertions(4);
+
+          expect(loadInitialData.default).toHaveBeenCalledWith(pathname, []);
+
+          // why is state being called 3 times?
+          expect(setStateSpy).toHaveBeenNthCalledWith(4, {
+            data: null,
+            error: null,
+            loadInitialDataPromise: expect.any(Promise),
+            loading: true,
+          });
+
+          expect(setStateSpy).toHaveBeenNthCalledWith(5, {
+            data,
+            error: null,
+            loadInitialDataPromise: null,
+            loading: false,
+          });
+
+          expect(setStateSpy).toHaveBeenNthCalledWith(6, {
+            data,
+            error: null,
+            loadInitialDataPromise: null,
+            loading: false,
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/app/containers/App/__snapshots__/App.test.jsx.snap
+++ b/src/app/containers/App/__snapshots__/App.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App should return rendered routes 1`] = `
+<h1>
+  Some initial data
+</h1>
+`;

--- a/src/app/containers/App/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/App/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClientApp should render correctly 1`] = `
+<BrowserRouter
+  data="someData!"
+  routes={
+    Array [
+      "someRoute",
+    ]
+  }
+>
+  <withRouter(App)
+    initialData="someData!"
+    routes={
+      Array [
+        "someRoute",
+      ]
+    }
+  />
+</BrowserRouter>
+`;
+
+exports[`ServerApp no passed routerContext should render correctly 1`] = `
+<StaticRouter
+  basename=""
+  context={Object {}}
+  data="somePassedData"
+  location="someUrl"
+  routes={
+    Array [
+      "someRoute",
+    ]
+  }
+>
+  <withRouter(App)
+    initialData="somePassedData"
+    routes={
+      Array [
+        "someRoute",
+      ]
+    }
+  />
+</StaticRouter>
+`;
+
+exports[`ServerApp should render correctly 1`] = `
+<StaticRouter
+  basename=""
+  context={
+    Object {
+      "context": "someRouterContext",
+    }
+  }
+  data="somePassedData"
+  location="someUrl"
+  routes={
+    Array [
+      "someRoute",
+    ]
+  }
+>
+  <withRouter(App)
+    initialData="somePassedData"
+    routes={
+      Array [
+        "someRoute",
+      ]
+    }
+  />
+</StaticRouter>
+`;

--- a/src/app/containers/App/index.jsx
+++ b/src/app/containers/App/index.jsx
@@ -1,0 +1,20 @@
+/* eslint-disable */
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import React from 'react';
+import { StaticRouter, BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+export const ClientApp = props => (
+  <BrowserRouter {...props}>
+    <App initialData={props.data} routes={props.routes} />
+  </BrowserRouter>
+);
+
+export const ServerApp = props => (
+  <StaticRouter {...props}>
+    <App initialData={props.data} routes={props.routes} />
+  </StaticRouter>
+);

--- a/src/app/containers/App/index.test.jsx
+++ b/src/app/containers/App/index.test.jsx
@@ -1,0 +1,38 @@
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import React from 'react';
+import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
+import { ClientApp, ServerApp } from '.';
+
+describe('ClientApp', () => {
+  shouldShallowMatchSnapshot(
+    'should render correctly',
+    <ClientApp data="someData!" routes={['someRoute']} />,
+  );
+});
+
+describe('ServerApp', () => {
+  describe('no passed routerContext', () => {
+    shouldShallowMatchSnapshot(
+      'should render correctly',
+      <ServerApp
+        location="someUrl"
+        routes={['someRoute']}
+        data="somePassedData"
+        context={{}}
+      />,
+    );
+  });
+
+  shouldShallowMatchSnapshot(
+    'should render correctly',
+    <ServerApp
+      location="someUrl"
+      routes={['someRoute']}
+      data="somePassedData"
+      context={{ context: 'someRouterContext' }}
+    />,
+  );
+});

--- a/src/app/helpers/tests/jest-setup.js
+++ b/src/app/helpers/tests/jest-setup.js
@@ -1,7 +1,13 @@
+import Enzyme, { shallow, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import fetch from 'jest-fetch-mock'; // eslint-disable-line import/no-extraneous-dependencies
 import path from 'path';
 
+Enzyme.configure({ adapter: new Adapter() });
+
 global.fetch = fetch;
+global.shallow = shallow;
+global.mount = mount;
 
 process.env.SIMORGH_ASSETS_MANIFEST_PATH = path.resolve(
   __dirname,

--- a/src/app/routes/loadInitialData/__snapshots__/index.test.js.snap
+++ b/src/app/routes/loadInitialData/__snapshots__/index.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadInitialData no matched route should return an empty object 1`] = `[Error: No route was found for url.]`;

--- a/src/app/routes/loadInitialData/index.js
+++ b/src/app/routes/loadInitialData/index.js
@@ -1,0 +1,23 @@
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import { matchRoutes } from 'react-router-config';
+
+const loadInitialData = async (url, routes) => {
+  const matchedRoutes = matchRoutes(routes, url);
+
+  if (matchedRoutes.length <= 0) {
+    throw new Error(`No route was found for ${url}.`);
+  }
+
+  const { route, match } = matchedRoutes[0];
+
+  if (!route.getInitialData) {
+    return {};
+  }
+
+  return route.getInitialData({ match });
+};
+
+export default loadInitialData;

--- a/src/app/routes/loadInitialData/index.test.js
+++ b/src/app/routes/loadInitialData/index.test.js
@@ -1,0 +1,80 @@
+/*
+ * © Jordan Tart https://github.com/jtart
+ * https://github.com/jtart/react-universal-app
+ */
+import * as reactRouterConfig from 'react-router-config';
+import loadInitialData from '.';
+
+describe('loadInitialData', () => {
+  const data = 'Some data!';
+  const match = { match: true };
+
+  describe('no matched route', () => {
+    it('should return an empty object', async () => {
+      reactRouterConfig.matchRoutes = jest.fn().mockReturnValue([]);
+
+      try {
+        await loadInitialData('url', []);
+      } catch (error) {
+        expect(error).toMatchSnapshot();
+      }
+    });
+  });
+
+  describe('no getInitialData function on route', () => {
+    it('should return an empty object', async () => {
+      reactRouterConfig.matchRoutes = jest
+        .fn()
+        .mockReturnValue([
+          { route: { route: 'data' }, match: { match: true } },
+        ]);
+
+      const initialData = await loadInitialData('url', ['url']);
+
+      expect(initialData).toEqual({});
+    });
+  });
+
+  describe('getInitialData function on route', () => {
+    it('should call getInitialData with passed ctx and return value', async () => {
+      const route = {
+        getInitialData: jest
+          .fn()
+          .mockImplementation(() => Promise.resolve(data)),
+      };
+
+      reactRouterConfig.matchRoutes = jest
+        .fn()
+        .mockReturnValue([{ route, match }]);
+
+      const initialData = await loadInitialData('url', ['url']);
+
+      expect(route.getInitialData).toHaveBeenCalledTimes(1);
+      expect(route.getInitialData).toHaveBeenCalledWith({ match });
+      expect(initialData).toEqual(data);
+    });
+
+    describe('error on getInitialData call', () => {
+      it('should throw an error', async () => {
+        const error = 'Error!';
+        const route = {
+          getInitialData: jest
+            .fn()
+            .mockImplementation(() => Promise.reject(error)),
+        };
+
+        reactRouterConfig.matchRoutes = jest
+          .fn()
+          .mockReturnValue([{ route, match }]);
+
+        try {
+          await loadInitialData(route, {});
+        } catch (err) {
+          expect(err).toEqual(error);
+        }
+
+        expect(route.getInitialData).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/client.js
+++ b/src/client.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import 'babel-polyfill';
 import { hydrate } from 'react-dom';
-import { ClientApp } from 'react-universal-app';
 import * as OfflinePluginRuntime from 'offline-plugin/runtime';
+import { ClientApp } from './app/containers/App';
 import routes from './app/routes';
 
 if (process.env.NODE_ENV === 'production') {

--- a/src/client.test.jsx
+++ b/src/client.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import OfflinePluginRuntime from 'offline-plugin/runtime';
-import { ClientApp } from 'react-universal-app';
 import * as reactDom from 'react-dom';
+import { ClientApp } from './app/containers/App';
 import routes from './app/routes';
 
 jest.mock('offline-plugin/runtime', () => ({
@@ -13,7 +13,7 @@ jest.mock('react-dom');
 
 jest.mock('react-router-dom');
 
-jest.mock('react-universal-app');
+jest.mock('./app/containers/App');
 
 jest.mock('./app/routes', () => ({
   default: [],

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import express from 'express';
-import { ServerApp, loadInitialData } from 'react-universal-app';
 import { renderToString, renderToStaticMarkup } from 'react-dom/server';
 import { ServerStyleSheet } from 'styled-components';
 import { Helmet } from 'react-helmet';
@@ -11,6 +10,8 @@ import path from 'path';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
+import { ServerApp } from '../app/containers/App';
+import loadInitialData from '../app/routes/loadInitialData';
 import routes, {
   articleRegexPath,
   articleDataRegexPath,

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import request from 'supertest';
 import * as reactDomServer from 'react-dom/server';
 import * as styledComponents from 'styled-components';
-import { loadInitialData } from 'react-universal-app';
 import dotenv from 'dotenv';
+import loadInitialData from '../app/routes/loadInitialData';
 import Document from '../app/components/Document';
 
 // mimic the logic in `src/index.js` which imports the `server/index.jsx`
@@ -33,10 +33,7 @@ jest.mock('react-helmet', () => ({
   },
 }));
 
-jest.mock('react-universal-app', () => ({
-  loadInitialData: jest.fn(),
-  ServerApp: jest.fn().mockImplementation(() => <h1>Mock app</h1>),
-}));
+jest.mock('../app/routes/loadInitialData');
 
 styledComponents.ServerStyleSheet = jest.fn().mockImplementation(() => ({
   collectStyles: jest.fn().mockReturnValue(<h1>Mock app</h1>),


### PR DESCRIPTION
Resolves #1219 

**Overall change:** Move the `react-universal-app` code base over to simorgh, giving credit

This is direct move across with only a few changes to appease eslint. This will be refactored in a future PR.

**Code changes:**

- Copy the code across
- Add enzyme temporarily to be refactored out at a later date 
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [x] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
