### PR TITLE
Whitelist Jest vulnerability

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,0 +1,11 @@
+{
+  "low": true,
+  //
+  // Whitelist Jest issue 786 due to there being no available fix for v23
+  // https://github.com/facebook/jest/issues/7917
+  // Version 24 has a fix however support for Babel 6 was also dropped.
+  // This whitelist is temporary until we have time to move to Babel 7
+  //
+  "advisories": "786",
+  "whitelist": "jest"
+}

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,11 +1,5 @@
 {
   "low": true,
-  //
-  // Whitelist Jest issue 786 due to there being no available fix for v23
-  // https://github.com/facebook/jest/issues/7917
-  // Version 24 has a fix however support for Babel 6 was also dropped.
-  // This whitelist is temporary until we have time to move to Babel 7
-  //
   "advisories": "786",
   "whitelist": "jest"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simorgh",
   "scripts": {
     "amp:validate": "wait-on http://localhost:7080/news/articles/c9rpqy7pmypo.amp && amphtml-validator http://localhost:7080/news/articles/c9rpqy7pmypo.amp",
-    "audit:ci": "audit-ci -low",
+    "audit:ci": "audit-ci --config audit-ci.json",
     "bbcA11y": "bbc-a11y",
     "build:ci": "export NODE_ENV=production && rm -rf build && npm run build:test && npm run build:live",
     "build": "rm -rf build && cp envConfig/local.env .env && NODE_ENV=production webpack",


### PR DESCRIPTION
**Overall change:** Whitelist jest vulnerability

**Code changes:**

- Adds audit-ci whitelist for jest vulnerability https://www.npmjs.com/advisories/786

Jest has a fix for this issue in v24 however in v24 they drop Babel 6 support. Because of this we cant move immediately as using Babel 7 is a larger piece of work. When we move to babel 7, this can be reverted

We also reasoned that this vulnerability is a lower priority as Jest is only a dev-dependency -- as such, it will not affect the client payload.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
