### PR TITLE
Bumping Cypress version as it's currently broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,9 +1098,9 @@
       "dev": true
     },
     "@types/sinon-chai": {
-      "version": "2.7.29",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.29.tgz",
-      "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.2.tgz",
+      "integrity": "sha512-5zSs2AslzyPZdOsbm2NRtuSNAI2aTWzNKOHa/GRecKo7a5efYD7qGcPxMZXQDayVXT2Vnd5waXxBvV31eCZqiA==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -5411,9 +5411,9 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "cypress": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.4.tgz",
-      "integrity": "sha512-8VJYtCAFqHXMnRDo4vdomR2CqfmhtReoplmbkXVspeKhKxU8WsZl0Nh5yeil8txxhq+YQwDrInItUqIm35Vw+g==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.5.tgz",
+      "integrity": "sha512-jzYGKJqU1CHoNocPndinf/vbG28SeU+hg+4qhousT/HDBMJxYgjecXOmSgBX/ga9/TakhqSrIrSP2r6gW/OLtg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -5427,7 +5427,7 @@
         "@types/minimatch": "3.0.3",
         "@types/mocha": "2.2.44",
         "@types/sinon": "7.0.0",
-        "@types/sinon-chai": "2.7.29",
+        "@types/sinon-chai": "3.2.2",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
         "chalk": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "chalk": "^2.4.1",
     "chrome-launcher": "^0.10.5",
     "core-js": "^2.6.0",
-    "cypress": "^3.1.1",
+    "cypress": "^3.1.5",
     "enzyme-to-json": "^3.3.5",
     "eslint": "^5.8.0",
     "eslint-config-airbnb": "^17.0.0",


### PR DESCRIPTION
**Overall change:** _Version bump for Cypress as it appears to longer be working._

**Code changes:**

- _Updating `Cypress` to `v3.11.5`._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
