### PR TITLE
Adding Cypress tests to test the canonical URL

### DIFF
--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -1,6 +1,7 @@
 import config from '../support/config';
 import { getElement, getSecondElement } from '../support/bodyTestHelper';
 import {
+  checkCanonicalURL,
   facebookMeta,
   openGraphMeta,
   retrieveMetaDataContent,
@@ -92,11 +93,9 @@ describe('Article Meta Tests', () => {
     '@BBCNews',
     "Meghan's bouquet laid on tomb of unknown warrior",
   );
+
   it('should include the canonical URL', () => {
-    const canonical = getElement('head link[rel="canonical"]');
-    canonical.should(
-      'have.attr',
-      'href',
+    checkCanonicalURL(
       `https://www.bbc.com/news/articles/${
         config.assets.newsThreeSubheadlines
       }`,

--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -92,4 +92,14 @@ describe('Article Meta Tests', () => {
     '@BBCNews',
     "Meghan's bouquet laid on tomb of unknown warrior",
   );
+  it('should include the canonical URL', () => {
+    const canonical = getElement('head link[rel="canonical"]');
+    canonical.should(
+      'have.attr',
+      'href',
+      `https://www.bbc.com/news/articles/${
+        config.assets.newsThreeSubheadlines
+      }`,
+    );
+  });
 });

--- a/cypress/integration/metaPersianSpec.js
+++ b/cypress/integration/metaPersianSpec.js
@@ -1,4 +1,5 @@
 import config from '../support/config';
+import { getElement } from '../support/bodyTestHelper';
 import {
   facebookMeta,
   openGraphMeta,
@@ -48,4 +49,13 @@ describe('Persian Article Meta Tests', () => {
     '@bbcpersian',
     'پهپادی که برایتان قهوه می‌آورد',
   );
+
+  it('should include the canonical URL', () => {
+    const canonical = getElement('head link[rel="canonical"]');
+    canonical.should(
+      'have.attr',
+      'href',
+      `https://www.bbc.com/persian/articles/${config.assets.persian}`,
+    );
+  });
 });

--- a/cypress/integration/metaPersianSpec.js
+++ b/cypress/integration/metaPersianSpec.js
@@ -1,6 +1,6 @@
 import config from '../support/config';
-import { getElement } from '../support/bodyTestHelper';
 import {
+  checkCanonicalURL,
   facebookMeta,
   openGraphMeta,
   retrieveMetaDataContent,
@@ -51,10 +51,7 @@ describe('Persian Article Meta Tests', () => {
   );
 
   it('should include the canonical URL', () => {
-    const canonical = getElement('head link[rel="canonical"]');
-    canonical.should(
-      'have.attr',
-      'href',
+    checkCanonicalURL(
       `https://www.bbc.com/persian/articles/${config.assets.persian}`,
     );
   });

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -74,6 +74,11 @@ export const twitterMeta = (
   });
 };
 
+export const checkCanonicalURL = URL => {
+  const canonical = getElement('head link[rel="canonical"]');
+  canonical.should('have.attr', 'href', URL);
+};
+
 export const retrieve404BodyResponse = (url, bodyResponse) => {
   cy.request({ url, failOnStatusCode: false })
     .its('body')


### PR DESCRIPTION
Resolves #1331  

**Overall change:** _Adding a Cypress test, which checks the canonical URL returns as expected._

**Code changes:**

- _Added a Cypress test for both News and Persian, which checks the canonical URL returns as expected._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
