### PR TITLE
Adding Cypress tests for Error Page

### DIFF
--- a/cypress/integration/errorPage.js
+++ b/cypress/integration/errorPage.js
@@ -1,18 +1,23 @@
+import config from '../support/config';
 import { getElement, renderedTitle } from '../support/bodyTestHelper';
 import { testResponseCode } from '../support/metaTestHelper';
 
 describe('Article Body Tests', () => {
   // eslint-disable-next-line no-undef
   before(() => {
-    cy.visit(`/news/articles/c9rpqyepmypo`, { failOnStatusCode: false });
+    cy.visit(`/news/articles/${config.assets.nonexistant}`, {
+      failOnStatusCode: false,
+    });
   });
 
   it('should return a 404 error code', () => {
-    testResponseCode(`/news/articles/c9rpqyepmypo`, 404);
+    testResponseCode(`/news/articles/${config.assets.nonexistant}`, 404);
   });
 
   it('should display a relevant error message on screen', () => {
-    cy.visit(`/news/articles/c9rpqyepmypo`, { failOnStatusCode: false });
+    cy.visit(`/news/articles/${config.assets.nonexistant}`, {
+      failOnStatusCode: false,
+    });
     getElement('h1 span').should('contain', '404');
     getElement('h1').should('contain', 'Page cannot be found');
   });

--- a/cypress/integration/errorPage.js
+++ b/cypress/integration/errorPage.js
@@ -5,17 +5,17 @@ import { testResponseCode } from '../support/metaTestHelper';
 describe('Article Body Tests', () => {
   // eslint-disable-next-line no-undef
   before(() => {
-    cy.visit(`/news/articles/${config.assets.nonexistant}`, {
+    cy.visit(`/news/articles/${config.assets.nonExistent}`, {
       failOnStatusCode: false,
     });
   });
 
   it('should return a 404 error code', () => {
-    testResponseCode(`/news/articles/${config.assets.nonexistant}`, 404);
+    testResponseCode(`/news/articles/${config.assets.nonExistent}`, 404);
   });
 
   it('should display a relevant error message on screen', () => {
-    cy.visit(`/news/articles/${config.assets.nonexistant}`, {
+    cy.visit(`/news/articles/${config.assets.nonExistent}`, {
       failOnStatusCode: false,
     });
     getElement('h1 span').should('contain', '404');

--- a/cypress/integration/errorPage.js
+++ b/cypress/integration/errorPage.js
@@ -1,0 +1,31 @@
+import { getElement, renderedTitle } from '../support/bodyTestHelper';
+import { testResponseCode } from '../support/metaTestHelper';
+
+describe('Article Body Tests', () => {
+  // eslint-disable-next-line no-undef
+  before(() => {
+    cy.visit(`/news/articles/c9rpqyepmypo`, { failOnStatusCode: false });
+  });
+
+  it('should return a 404 error code', () => {
+    testResponseCode(`/news/articles/c9rpqyepmypo`, 404);
+  });
+
+  it('should display a relevant error message on screen', () => {
+    cy.visit(`/news/articles/c9rpqyepmypo`, { failOnStatusCode: false });
+    getElement('h1 span').should('contain', '404');
+    getElement('h1').should('contain', 'Page cannot be found');
+  });
+
+  it('should have an inline link on the page that is linked to the home page', () => {
+    getElement('p')
+      .eq(1)
+      .within(() => {
+        getElement('a').should('have.attr', 'href', 'https://www.bbc.com/news');
+      });
+  });
+
+  it('should have a relevant error title in the head', () => {
+    renderedTitle('Page cannot be found - BBC News');
+  });
+});

--- a/cypress/support/config.js
+++ b/cypress/support/config.js
@@ -7,6 +7,7 @@ const config = {
       news: 'cxvxrj9yvppo',
       newsThreeSubheadlines: 'cpzk9lkk2p7o',
       persian: 'c5ml5n7w4m3o',
+      nonexistant: 'cxvxrj8tvppo',
     },
   },
   test: {
@@ -17,6 +18,7 @@ const config = {
       news: 'c85pqyj5m2ko',
       newsThreeSubheadlines: 'c9rpqy7pmypo',
       persian: 'cwv2xv848j5o',
+      nonexistant: 'cxvxrj8tvppo',
     },
   },
   local: {
@@ -27,6 +29,7 @@ const config = {
       news: 'c85pqyj5m2ko',
       newsThreeSubheadlines: 'c9rpqy7pmypo',
       persian: 'cwv2xv848j5o',
+      nonexistant: 'cxvxrj8tvppo',
     },
   },
 };

--- a/cypress/support/config.js
+++ b/cypress/support/config.js
@@ -7,7 +7,7 @@ const config = {
       news: 'cxvxrj9yvppo',
       newsThreeSubheadlines: 'cpzk9lkk2p7o',
       persian: 'c5ml5n7w4m3o',
-      nonexistant: 'cxvxrj8tvppo',
+      nonExistent: 'cxvxrj8tvppo',
     },
   },
   test: {
@@ -18,7 +18,7 @@ const config = {
       news: 'c85pqyj5m2ko',
       newsThreeSubheadlines: 'c9rpqy7pmypo',
       persian: 'cwv2xv848j5o',
-      nonexistant: 'cxvxrj8tvppo',
+      nonExistent: 'cxvxrj8tvppo',
     },
   },
   local: {
@@ -29,7 +29,7 @@ const config = {
       news: 'c85pqyj5m2ko',
       newsThreeSubheadlines: 'c9rpqy7pmypo',
       persian: 'cwv2xv848j5o',
-      nonexistant: 'cxvxrj8tvppo',
+      nonExistent: 'cxvxrj8tvppo',
     },
   },
 };


### PR DESCRIPTION
Resolves #1295

**Overall change:** Adding Cypress tests for the Error Page.

**Code changes:**

- _Adds Cypress tests to check several components on the newly added Error Page._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
