### PR TITLE
Removing CSS tests from Cypress

### DIFF
--- a/cypress/integration/footerSpec.js
+++ b/cypress/integration/footerSpec.js
@@ -1,10 +1,8 @@
 import config from '../support/config';
 import {
-  checkLinkStyling,
   checkFooterLinks,
   getElement,
   shouldContainText,
-  shouldContainStyles,
 } from '../support/bodyTestHelper';
 
 describe('Footer Tests', () => {
@@ -13,21 +11,10 @@ describe('Footer Tests', () => {
     cy.visit(`/news/articles/${config.assets.newsThreeSubheadlines}`);
   });
   it('should render the BBC News branding', () => {
-    const headerBranding = getElement('footer div').eq(0);
-    shouldContainStyles(headerBranding, 'height', '80px');
-    shouldContainStyles(headerBranding, 'background-color', 'rgb(184, 0, 0)');
+    const newsBrandingLink = getElement('footer a').eq(0);
+    shouldContainText(newsBrandingLink, 'BBC News');
   });
-  it('should have a focused state', () => {
-    const anchorElement = getElement('footer a').eq(0);
-    shouldContainText(anchorElement, 'BBC News');
 
-    anchorElement.focus();
-    shouldContainStyles(
-      getElement('footer a span'),
-      'border-bottom',
-      '4px solid rgb(255, 255, 255)',
-    );
-  });
   it('should have working links', () => {
     getElement('footer ul').within(() => {
       checkFooterLinks('0', '/news/help-41670342');
@@ -39,17 +26,7 @@ describe('Footer Tests', () => {
       checkFooterLinks('6', '/contact/');
     });
   });
-  it('should have styling', () => {
-    getElement('footer ul').within(() => {
-      checkLinkStyling(0);
-      checkLinkStyling(1);
-      checkLinkStyling(2);
-      checkLinkStyling(3);
-      checkLinkStyling(4);
-      checkLinkStyling(5);
-      checkLinkStyling(6);
-    });
-  });
+
   it('should contain copyright text', () => {
     const footerCopyrightArea = getElement('footer p');
     footerCopyrightArea.should(
@@ -63,21 +40,5 @@ describe('Footer Tests', () => {
       .children('a')
       .should('have.attr', 'href')
       .and('contain', '/help/web/links');
-  });
-  it('should contain a link in the copyright text, which have hover and focus states', () => {
-    const link = getElement('footer p a');
-    link.focus();
-    const linkSpan = link.get('footer p a span');
-    shouldContainStyles(
-      linkSpan,
-      'border-bottom',
-      '2px solid rgb(255, 255, 255)',
-    );
-    link.invoke('mouseover');
-    shouldContainStyles(
-      linkSpan,
-      'border-bottom',
-      '2px solid rgb(255, 255, 255)',
-    );
   });
 });

--- a/cypress/integration/headerSpec.js
+++ b/cypress/integration/headerSpec.js
@@ -1,9 +1,5 @@
 import config from '../support/config';
-import {
-  getElement,
-  shouldContainText,
-  shouldContainStyles,
-} from '../support/bodyTestHelper';
+import { getElement, shouldContainText } from '../support/bodyTestHelper';
 
 describe('Header Tests', () => {
   // eslint-disable-next-line no-undef
@@ -12,20 +8,7 @@ describe('Header Tests', () => {
   });
 
   it('should render the BBC News branding', () => {
-    const headerBranding = getElement('header div');
-    shouldContainStyles(headerBranding, 'height', '80px');
-    shouldContainStyles(headerBranding, 'background-color', 'rgb(184, 0, 0)');
-  });
-
-  it('should have a focused state', () => {
-    const anchorElement = getElement('header a');
-    shouldContainText(anchorElement, 'BBC News');
-
-    anchorElement.focus();
-    shouldContainStyles(
-      getElement('header a span'),
-      'border-bottom',
-      '4px solid rgb(255, 255, 255)',
-    );
+    const newsBrandingLink = getElement('header a');
+    shouldContainText(newsBrandingLink, 'BBC News');
   });
 });

--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -7,7 +7,6 @@ import {
   getElement,
   placeholderImageLoaded,
   renderedTitle,
-  shouldContainStyles,
   visibleImageNoCaption,
   visibleImageWithCaption,
   shouldContainText,
@@ -63,21 +62,8 @@ describe('Article Body Tests', () => {
     });
   });
 
-  it('should have an inline link with focus styling', () => {
-    const firstInlineLink = getElement('main a');
-
-    firstInlineLink.focus();
-    shouldContainStyles(
-      firstInlineLink,
-      'background-color',
-      'rgb(15, 85, 108)',
-    );
-    shouldContainStyles(firstInlineLink, 'color', 'rgb(245, 243, 241)');
-    shouldContainStyles(
-      firstInlineLink,
-      'border-bottom',
-      '1px solid rgb(245, 243, 241)',
-    );
+  it('should have an inline link', () => {
+    getElement('main a');
   });
 
   // it('should have a working first inline link', () => {

--- a/cypress/support/bodyTestHelper.js
+++ b/cypress/support/bodyTestHelper.js
@@ -14,13 +14,6 @@ export const shouldContainStyles = (element, css, styling) => {
   });
 };
 
-export const checkElementStyles = (elementString, text, color, fontFamily) => {
-  const el = getElement(elementString);
-  shouldContainText(el, text);
-  shouldContainStyles(el, 'color', color);
-  shouldContainStyles(el, 'font-family', fontFamily);
-};
-
 export const getBlockData = (blockType, win) => {
   let blockData;
   const { blocks } = win.SIMORGH_DATA.data.content.model;
@@ -37,12 +30,9 @@ export const firstHeadlineDataWindow = () => {
   cy.window().then(win => {
     const headlineData = getBlockData('headline', win);
     const { text } = headlineData.model.blocks[0].model.blocks[0].model;
-    checkElementStyles(
-      'h1',
-      text,
-      'rgb(34, 34, 34)',
-      'ReithSerifNewsMedium, Helvetica, Arial, sans-serif',
-    );
+    const headline = getElement('h1');
+
+    shouldContainText(headline, text);
   });
 };
 
@@ -50,13 +40,9 @@ export const firstSubheadlineDataWindow = () => {
   cy.window().then(win => {
     const subheadingData = getBlockData('subheadline', win);
     const { text } = subheadingData.model.blocks[0].model.blocks[0].model;
+    const subheading = getElement('h2');
 
-    checkElementStyles(
-      'h2',
-      text,
-      'rgb(64, 64, 64)',
-      'ReithSansNewsRegular, Helvetica, Arial, sans-serif',
-    );
+    shouldContainText(subheading, text);
   });
 };
 
@@ -75,13 +61,8 @@ export const copyrightDataWindow = () => {
     const copyrightData = getBlockData('image', win);
     const { copyrightHolder } = copyrightData.model.blocks[0].model;
     const copyrightLabel = getElement('figure p').eq(0);
-    copyrightLabel.should('contain', copyrightHolder);
-    shouldContainStyles(
-      copyrightLabel,
-      'background-color',
-      'rgba(34, 34, 34, 0.75)',
-    );
-    shouldContainStyles(copyrightLabel, 'color', 'rgb(255, 255, 255)');
+
+    shouldContainText(copyrightLabel, copyrightHolder);
   });
 };
 
@@ -92,28 +73,11 @@ export const checkFooterLinks = (position, url) => {
     .and('contain', url);
 };
 
-export const checkLinkStyling = position => {
-  const link = cy.get('a').eq(position);
-  shouldContainStyles(link, 'color', 'rgb(255, 255, 255)');
-  link.focus();
-  const linkSpan = link.get('span').eq(position);
-  shouldContainStyles(
-    linkSpan,
-    'border-bottom',
-    '2px solid rgb(255, 255, 255)',
-  );
-  link.invoke('mouseover');
-  shouldContainStyles(
-    linkSpan,
-    'border-bottom',
-    '2px solid rgb(255, 255, 255)',
-  );
-};
-
 export const clickInlineLinkAndTestPageHasHTML = (link, url) => {
   getElement(link).click();
   cy.url().should('contain', url);
   const anchorElement = getElement('header a');
+
   shouldContainText(anchorElement, 'BBC News');
 };
 
@@ -122,11 +86,6 @@ export const renderedTitle = title => {
 };
 
 export const placeholderImageLoaded = placeholderImage => {
-  shouldContainStyles(
-    placeholderImage,
-    'background-color',
-    'rgb(236, 234, 231)',
-  );
   shouldContainStyles(
     placeholderImage,
     'background-image',

--- a/cypress/support/bodyTestHelper.js
+++ b/cypress/support/bodyTestHelper.js
@@ -14,6 +14,10 @@ export const shouldContainStyles = (element, css, styling) => {
   });
 };
 
+export const shouldMatchReturnedData = (data, element) => {
+  getElement(element).should('contain', data);
+};
+
 export const getBlockData = (blockType, win) => {
   let blockData;
   const { blocks } = win.SIMORGH_DATA.data.content.model;
@@ -30,9 +34,8 @@ export const firstHeadlineDataWindow = () => {
   cy.window().then(win => {
     const headlineData = getBlockData('headline', win);
     const { text } = headlineData.model.blocks[0].model.blocks[0].model;
-    const headline = getElement('h1');
 
-    shouldContainText(headline, text);
+    shouldMatchReturnedData(text, 'h1');
   });
 };
 
@@ -40,9 +43,8 @@ export const firstSubheadlineDataWindow = () => {
   cy.window().then(win => {
     const subheadingData = getBlockData('subheadline', win);
     const { text } = subheadingData.model.blocks[0].model.blocks[0].model;
-    const subheading = getElement('h2');
 
-    shouldContainText(subheading, text);
+    shouldMatchReturnedData(text, 'h2');
   });
 };
 


### PR DESCRIPTION
Resolves #1326 

**Overall change:** _Removing CSS tests from Cypress._

**Code changes:**

- _Removing the CSS tests from Cypress, which are duplicated in the Snapshot suite._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
