### PR TITLE
Clean up missed console logs

### DIFF
--- a/src/app/helpers/tests/loggerMock.js
+++ b/src/app/helpers/tests/loggerMock.js
@@ -1,0 +1,16 @@
+import nodeLogger from '../logger.node';
+
+const mocks = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  verbose: jest.fn(),
+  debug: jest.fn(),
+  silly: jest.fn(),
+};
+
+jest.mock('../logger.node', () => jest.fn());
+
+nodeLogger.mockImplementation(() => mocks);
+
+export default mocks;

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -21,8 +21,7 @@ const getInitialData = async ({ match }) => {
     if (status === 200) {
       data = await response.json();
     } else if (!upstreamStatusCodesToPropagate.includes(status)) {
-      // eslint-disable-next-line no-console
-      console.warn(
+      logger.warn(
         `Unexpected upstream response (HTTP status code ${status}) when requesting ${url}`,
       );
       status = 502;

--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -1,10 +1,5 @@
-import nodeLogger from '../../helpers/logger.node';
-
-const mockLogWarn = jest.fn();
-jest.mock('../../helpers/logger.node', () => jest.fn());
-nodeLogger.mockImplementation(() => ({ warn: mockLogWarn, error: jest.fn() }));
-
-const getInitialData = require('./index').default;
+import loggerMock from '../../helpers/tests/loggerMock'; // Must be imported before getInitialData
+import getInitialData from './index';
 
 describe('getInitialData', () => {
   const defaultIdParam = 'c0000000001o';
@@ -146,7 +141,7 @@ describe('getInitialData', () => {
         mockFetchTeapotStatus,
       );
 
-      expect(mockLogWarn).toBeCalledWith(
+      expect(loggerMock.warn).toBeCalledWith(
         `Unexpected upstream response (HTTP status code 418) when requesting ${
           process.env.SIMORGH_BASE_URL
         }/news/articles/c0000000001o.json`,

--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -1,4 +1,10 @@
-import getInitialData from './index';
+import nodeLogger from '../../helpers/logger.node';
+
+const mockLogWarn = jest.fn();
+jest.mock('../../helpers/logger.node', () => jest.fn());
+nodeLogger.mockImplementation(() => ({ warn: mockLogWarn, error: jest.fn() }));
+
+const getInitialData = require('./index').default;
 
 describe('getInitialData', () => {
   const defaultIdParam = 'c0000000001o';
@@ -135,14 +141,12 @@ describe('getInitialData', () => {
 
   describe('Ares returns a non-200, non-404 status code', () => {
     it('should log, and return the status code as 502', async () => {
-      global.console.warn = jest.fn();
-
       const response = await callGetInitialData(
         defaultContext,
         mockFetchTeapotStatus,
       );
 
-      expect(global.console.warn).toBeCalledWith(
+      expect(mockLogWarn).toBeCalledWith(
         `Unexpected upstream response (HTTP status code 418) when requesting ${
           process.env.SIMORGH_BASE_URL
         }/news/articles/c0000000001o.json`,

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -82,7 +82,7 @@ server
     const swPath = `${__dirname}/public/sw.js`;
     res.sendFile(swPath, {}, error => {
       if (error) {
-        console.log(error); // eslint-disable-line no-console
+        logger.error(error);
         res.status(500).send('Unable to find service worker.');
       }
     });


### PR DESCRIPTION
Resolves #1259

**Overall change:** Uses logger instead of console log where it was missed

**Code changes:**

- Replaces console log with logger within simorgh
- Adds a testing helper for asserting logger was called

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
