### PR TITLE
Bump assets-webpack-plugin to avoid snyk vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,14 +1894,13 @@
       "dev": true
     },
     "assets-webpack-plugin": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/assets-webpack-plugin/-/assets-webpack-plugin-3.9.7.tgz",
-      "integrity": "sha512-yxo4MlSb++B88qQFE27Wf56ykGaDHZeKcSbrstSFOOwOxv33gWXtM49+yfYPSErlXPAMT5lVy3YPIhWlIFjYQw==",
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/assets-webpack-plugin/-/assets-webpack-plugin-3.9.8.tgz",
+      "integrity": "sha512-j8U/Cq0/ipCGdYsuDOlzFp7+4R39ka2SP+IyvFGUDJqSNh0uV+p/myRgNs8pr5YRJtJEaRNaMMFj0K0k5n4NCw==",
       "requires": {
         "camelcase": "^5.0.0",
         "escape-string-regexp": "^1.0.3",
-        "lodash.assign": "^4.2.0",
-        "lodash.merge": "^4.6.1",
+        "lodash": "^4.17.10",
         "mkdirp": "^0.5.1"
       }
     },
@@ -13090,7 +13089,8 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -13182,11 +13182,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@bbc/psammead-sitewide-links": "^0.1.4",
     "@bbc/psammead-styles": "^0.2.0",
     "@bbc/psammead-visually-hidden-text": "^0.1.7",
-    "assets-webpack-plugin": "^3.9.7",
+    "assets-webpack-plugin": "^3.9.8",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-dynamic-import-node": "^2.2.0",


### PR DESCRIPTION
Resolves #1359

**Overall change:** Fixes the low vulnerability `lodash.merge` https://snyk.io/vuln/SNYK-JS-LODASHMERGE-173732

**Code changes:**

- Bumps assets-webpack-plugin to version that fixes vulnerability https://github.com/ztoben/assets-webpack-plugin/issues/167

**Test instructions:**

On `latest`, do `npm install`, then `git checkout -b new-branch-name`, edit a README or something, and try committing (`git commit -a -m "testing #1365"`). Now try pushing: `git push origin new-branch-name` - it should fail for the reason in #1359.

`git checkout SnykLodashMergeBump`, `npm install` and try `git push origin SnykLodashMergeBump` - it should push without issues, as the vulnerability has been fixed.

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- [x] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
