### PR TITLE
Change article wrapper widths

### DIFF
--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -38,8 +38,6 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -103,7 +101,7 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -76,13 +76,13 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -76,13 +76,13 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -38,6 +38,8 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -84,22 +86,10 @@ exports[`ErrorMain should correctly render for an error 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -112,8 +102,8 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -145,35 +135,35 @@ exports[`ErrorMain should correctly render for an error 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -36,7 +36,6 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -86,21 +85,18 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -147,32 +143,24 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -87,7 +87,7 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -135,9 +135,21 @@ exports[`ErrorMain should correctly render for an error 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -145,7 +157,7 @@ exports[`ErrorMain should correctly render for an error 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -153,7 +165,7 @@ exports[`ErrorMain should correctly render for an error 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -161,7 +173,7 @@ exports[`ErrorMain should correctly render for an error 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 

--- a/src/app/components/ErrorPage/index.jsx
+++ b/src/app/components/ErrorPage/index.jsx
@@ -8,7 +8,7 @@ import Paragraph from '@bbc/psammead-paragraph';
 import { C_POSTBOX } from '@bbc/psammead-styles/colours';
 import { GEL_PARAGON } from '@bbc/gel-foundations/typography';
 import { FF_NEWS_SANS_REG } from '@bbc/psammead-styles/fonts';
-import { GhostWrapper, GridItemConstrained } from '../../lib/styledGrid';
+import { GhostWrapper, GridItemConstrainedMedium } from '../../lib/styledGrid';
 
 const StatusCode = styled.span`
   ${GEL_PARAGON}
@@ -23,7 +23,7 @@ const ShortHeadline = styled(Headline)`
   padding: 2.5rem 0 2.5rem 0;
 `;
 
-const LongGridItemConstrained = styled(GridItemConstrained)`
+const LongGridItemConstrainedMedium = styled(GridItemConstrainedMedium)`
   padding-bottom: 4rem;
 `;
 
@@ -39,7 +39,7 @@ const ErrorPage = ({
 }) => (
   <main role="main">
     <GhostWrapper>
-      <LongGridItemConstrained>
+      <LongGridItemConstrainedMedium>
         <ShortHeadline>
           <StatusCode>{statusCode}</StatusCode>
           {title}
@@ -59,7 +59,7 @@ const ErrorPage = ({
           </InlineLink>
           {callToActionLast}
         </Paragraph>
-      </LongGridItemConstrained>
+      </LongGridItemConstrainedMedium>
     </GhostWrapper>
   </main>
 );

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -112,45 +112,47 @@ exports[`ArticleMain should render a news article correctly 1`] = `
             }
           }
         />
+      </ForwardRef>
+      <ForwardRef>
         <TimestampContainer
           timestamp={1514811600000}
         />
-        <Blocks
-          blocks={
-            Array [
-              Object {
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "model": Object {
-                              "attributes": Array [],
-                              "text": "A paragraph.",
-                            },
-                            "type": "fragment",
-                          },
-                        ],
-                        "text": "A paragraph.",
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                },
-                "type": "text",
-              },
-            ]
-          }
-          componentsToRender={
-            Object {
-              "image": [Function],
-              "subheadline": [Function],
-              "text": [Function],
-            }
-          }
-        />
       </ForwardRef>
+      <Blocks
+        blocks={
+          Array [
+            Object {
+              "model": Object {
+                "blocks": Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "attributes": Array [],
+                            "text": "A paragraph.",
+                          },
+                          "type": "fragment",
+                        },
+                      ],
+                      "text": "A paragraph.",
+                    },
+                    "type": "paragraph",
+                  },
+                ],
+              },
+              "type": "text",
+            },
+          ]
+        }
+        componentsToRender={
+          Object {
+            "image": [Function],
+            "subheadline": [Function],
+            "text": [Function],
+          }
+        }
+      />
     </ForwardRef>
   </main>
 </React.Fragment>
@@ -243,45 +245,47 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
             }
           }
         />
+      </ForwardRef>
+      <ForwardRef>
         <TimestampContainer
           timestamp={1514811600000}
         />
-        <Blocks
-          blocks={
-            Array [
-              Object {
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "model": Object {
-                              "attributes": Array [],
-                              "text": "یک پاراگراف.",
-                            },
-                            "type": "fragment",
-                          },
-                        ],
-                        "text": "یک پاراگراف.",
-                      },
-                      "type": "paragraph",
-                    },
-                  ],
-                },
-                "type": "text",
-              },
-            ]
-          }
-          componentsToRender={
-            Object {
-              "image": [Function],
-              "subheadline": [Function],
-              "text": [Function],
-            }
-          }
-        />
       </ForwardRef>
+      <Blocks
+        blocks={
+          Array [
+            Object {
+              "model": Object {
+                "blocks": Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "attributes": Array [],
+                            "text": "یک پاراگراف.",
+                          },
+                          "type": "fragment",
+                        },
+                      ],
+                      "text": "یک پاراگراف.",
+                    },
+                    "type": "paragraph",
+                  },
+                ],
+              },
+              "type": "text",
+            },
+          ]
+        }
+        componentsToRender={
+          Object {
+            "image": [Function],
+            "subheadline": [Function],
+            "text": [Function],
+          }
+        }
+      />
     </ForwardRef>
   </main>
 </React.Fragment>

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -71,48 +71,46 @@ exports[`ArticleMain should render a news article correctly 1`] = `
     role="main"
   >
     <ForwardRef>
-      <ForwardRef>
-        <Blocks
-          blocks={
-            Array [
-              Object {
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "model": Object {
-                              "blocks": Array [
-                                Object {
-                                  "model": Object {
-                                    "attributes": Array [],
-                                    "text": "Article Headline",
-                                  },
-                                  "type": "fragment",
-                                },
-                              ],
-                              "text": "Article Headline",
-                            },
-                            "type": "paragraph",
-                          },
-                        ],
-                      },
-                      "type": "text",
-                    },
-                  ],
-                },
-                "type": "headline",
-              },
-            ]
-          }
-          componentsToRender={
+      <Blocks
+        blocks={
+          Array [
             Object {
-              "headline": [Function],
-            }
+              "model": Object {
+                "blocks": Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "blocks": Array [
+                              Object {
+                                "model": Object {
+                                  "attributes": Array [],
+                                  "text": "Article Headline",
+                                },
+                                "type": "fragment",
+                              },
+                            ],
+                            "text": "Article Headline",
+                          },
+                          "type": "paragraph",
+                        },
+                      ],
+                    },
+                    "type": "text",
+                  },
+                ],
+              },
+              "type": "headline",
+            },
+          ]
+        }
+        componentsToRender={
+          Object {
+            "headline": [Function],
           }
-        />
-      </ForwardRef>
+        }
+      />
       <ForwardRef>
         <TimestampContainer
           timestamp={1514811600000}
@@ -204,48 +202,46 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
     role="main"
   >
     <ForwardRef>
-      <ForwardRef>
-        <Blocks
-          blocks={
-            Array [
-              Object {
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "model": Object {
-                              "blocks": Array [
-                                Object {
-                                  "model": Object {
-                                    "attributes": Array [],
-                                    "text": "سرصفحه مقاله",
-                                  },
-                                  "type": "fragment",
-                                },
-                              ],
-                              "text": "سرصفحه مقاله",
-                            },
-                            "type": "paragraph",
-                          },
-                        ],
-                      },
-                      "type": "text",
-                    },
-                  ],
-                },
-                "type": "headline",
-              },
-            ]
-          }
-          componentsToRender={
+      <Blocks
+        blocks={
+          Array [
             Object {
-              "headline": [Function],
-            }
+              "model": Object {
+                "blocks": Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "blocks": Array [
+                              Object {
+                                "model": Object {
+                                  "attributes": Array [],
+                                  "text": "سرصفحه مقاله",
+                                },
+                                "type": "fragment",
+                              },
+                            ],
+                            "text": "سرصفحه مقاله",
+                          },
+                          "type": "paragraph",
+                        },
+                      ],
+                    },
+                    "type": "text",
+                  },
+                ],
+              },
+              "type": "headline",
+            },
+          ]
+        }
+        componentsToRender={
+          Object {
+            "headline": [Function],
           }
-        />
-      </ForwardRef>
+        }
+      />
       <ForwardRef>
         <TimestampContainer
           timestamp={1514811600000}

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -58,11 +58,11 @@ const ArticleMain = ({ articleData }) => {
             </GridItemConstrainedLargeWithMargin>
             <GridItemConstrainedMedium>
               <Timestamp timestamp={metadata.lastPublished} />
-              <Blocks
-                blocks={mainBlocks}
-                componentsToRender={componentsToRenderMain}
-              />
             </GridItemConstrainedMedium>
+            <Blocks
+              blocks={mainBlocks}
+              componentsToRender={componentsToRenderMain}
+            />
           </GhostWrapper>
         </main>
       </Fragment>

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -7,7 +7,11 @@ import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
 import Timestamp from '../Timestamp';
-import { GhostWrapper, GridItemConstrainedMedium } from '../../lib/styledGrid';
+import {
+  GhostWrapper,
+  GridItemConstrainedMedium,
+  GridItemConstrainedLargeWithMargin,
+} from '../../lib/styledGrid';
 
 const componentsToRenderHeadline = {
   headline: headings,
@@ -46,11 +50,13 @@ const ArticleMain = ({ articleData }) => {
         <MetadataContainer metadata={metadata} promo={promo} />
         <main role="main">
           <GhostWrapper>
-            <GridItemConstrainedMedium>
+            <GridItemConstrainedLargeWithMargin>
               <Blocks
                 blocks={headlineBlocks}
                 componentsToRender={componentsToRenderHeadline}
               />
+            </GridItemConstrainedLargeWithMargin>
+            <GridItemConstrainedMedium>
               <Timestamp timestamp={metadata.lastPublished} />
               <Blocks
                 blocks={mainBlocks}

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -10,7 +10,6 @@ import Timestamp from '../Timestamp';
 import {
   GhostWrapper,
   GridItemConstrainedMedium,
-  GridItemConstrainedLargeWithMargin,
 } from '../../lib/styledGrid';
 
 const componentsToRenderHeadline = {
@@ -50,12 +49,10 @@ const ArticleMain = ({ articleData }) => {
         <MetadataContainer metadata={metadata} promo={promo} />
         <main role="main">
           <GhostWrapper>
-            <GridItemConstrainedLargeWithMargin>
-              <Blocks
-                blocks={headlineBlocks}
-                componentsToRender={componentsToRenderHeadline}
-              />
-            </GridItemConstrainedLargeWithMargin>
+            <Blocks
+              blocks={headlineBlocks}
+              componentsToRender={componentsToRenderHeadline}
+            />
             <GridItemConstrainedMedium>
               <Timestamp timestamp={metadata.lastPublished} />
             </GridItemConstrainedMedium>

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -7,10 +7,7 @@ import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
 import Timestamp from '../Timestamp';
-import {
-  GhostWrapper,
-  GridItemConstrainedMedium,
-} from '../../lib/styledGrid';
+import { GhostWrapper, GridItemConstrainedMedium } from '../../lib/styledGrid';
 
 const componentsToRenderHeadline = {
   headline: headings,

--- a/src/app/containers/ArticleMain/index.jsx
+++ b/src/app/containers/ArticleMain/index.jsx
@@ -7,7 +7,7 @@ import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
 import Timestamp from '../Timestamp';
-import { GhostWrapper, GridItemConstrained } from '../../lib/styledGrid';
+import { GhostWrapper, GridItemConstrainedMedium } from '../../lib/styledGrid';
 
 const componentsToRenderHeadline = {
   headline: headings,
@@ -46,7 +46,7 @@ const ArticleMain = ({ articleData }) => {
         <MetadataContainer metadata={metadata} promo={promo} />
         <main role="main">
           <GhostWrapper>
-            <GridItemConstrained>
+            <GridItemConstrainedMedium>
               <Blocks
                 blocks={headlineBlocks}
                 componentsToRender={componentsToRenderHeadline}
@@ -56,7 +56,7 @@ const ArticleMain = ({ articleData }) => {
                 blocks={mainBlocks}
                 componentsToRender={componentsToRenderMain}
               />
-            </GridItemConstrained>
+            </GridItemConstrainedMedium>
           </GhostWrapper>
         </main>
       </Fragment>

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -38,6 +38,8 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -84,22 +86,10 @@ exports[`ErrorMain should correctly render for 404 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -112,8 +102,8 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -145,35 +135,35 @@ exports[`ErrorMain should correctly render for 404 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 
@@ -273,6 +263,8 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -319,22 +311,10 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -347,8 +327,8 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -380,35 +360,35 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 
@@ -508,6 +488,8 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -554,22 +536,10 @@ exports[`ErrorMain should correctly render for 500 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -582,8 +552,8 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -615,35 +585,35 @@ exports[`ErrorMain should correctly render for 500 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 
@@ -738,6 +708,8 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -784,22 +756,10 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -812,8 +772,8 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -845,35 +805,35 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 
@@ -968,6 +928,8 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -1014,22 +976,10 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
   }
 }
 
-@media (max-width:25em) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25em) and (max-width:62.9375em) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: repeat(6,1fr);
+    grid-template-columns: 0 repeat(6,1fr) 0;
   }
 }
 
@@ -1042,8 +992,8 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.9rem))[10] 1fr;
-    grid-template-columns: 1fr repeat(10,minmax(0,6.9rem)) 1fr;
+    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
+    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
   }
 }
 
@@ -1075,35 +1025,35 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
   }
 }
 
-@media (max-width:37.5em) {
+@media (max-width:25em) {
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
 }
 
-@media (min-width:37.5em) and (max-width:62.9375em) {
+@media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
     -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 4;
-    -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
   }
 }
 

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -87,7 +87,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -135,9 +135,21 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -145,7 +157,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -153,7 +165,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -161,7 +173,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 
@@ -310,7 +322,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -358,9 +370,21 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -368,7 +392,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -376,7 +400,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -384,7 +408,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 
@@ -533,7 +557,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -581,9 +605,21 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -591,7 +627,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -599,7 +635,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -607,7 +643,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 
@@ -751,7 +787,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -799,9 +835,21 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -809,7 +857,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -817,7 +865,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -825,7 +873,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 
@@ -969,7 +1017,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 @media (max-width:62.9375em) {
   .c0 {
     -ms-grid-columns: (1fr)[6];
-    grid-template-columns: 0 repeat(6,1fr) 0;
+    grid-template-columns: repeat(6,1fr);
   }
 }
 
@@ -1017,9 +1065,21 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (max-width:25em) {
   .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25em) and (max-width:62.9375em) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25em) {
+  .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / span 6;
   }
 }
 
@@ -1027,7 +1087,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
   .c1 {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / span 5;
   }
 }
 
@@ -1035,7 +1095,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
   .c1 {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
 }
 
@@ -1043,7 +1103,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
   .c1 {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 }
 

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -36,7 +36,6 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -86,21 +85,18 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -147,32 +143,24 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }
@@ -271,7 +259,6 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -321,21 +308,18 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -382,32 +366,24 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }
@@ -506,7 +482,6 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -556,21 +531,18 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -617,32 +589,24 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }
@@ -736,7 +700,6 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -786,21 +749,18 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -847,32 +807,24 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }
@@ -966,7 +918,6 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 }
 
 .c0 {
-  display: -ms-grid;
   display: grid;
   background: #FDFDFD;
 }
@@ -1016,21 +967,18 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (max-width:62.9375em) {
   .c0 {
-    -ms-grid-columns: (1fr)[6];
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,6.75rem))[8] 1fr;
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
   }
 }
 
 @media (min-width:80em) {
   .c0 {
-    -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
@@ -1077,32 +1025,24 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (max-width:25em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:25em) and (max-width:62.9375em) {
   .c1 {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
 }
 
 @media (min-width:63em) and (max-width:80em) {
   .c1 {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
 }
 
 @media (min-width:80em) {
   .c1 {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 }

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -76,13 +76,13 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 
@@ -301,13 +301,13 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 
@@ -526,13 +526,13 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 
@@ -746,13 +746,13 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 
@@ -966,13 +966,13 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0 0.5rem;
+    grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 0 1rem;
+    grid-column-gap: 1rem;
   }
 }
 

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -76,13 +76,13 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 
@@ -301,13 +301,13 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 
@@ -526,13 +526,13 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 
@@ -746,13 +746,13 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 
@@ -966,13 +966,13 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 
 @media (max-width:37.4375em) {
   .c0 {
-    grid-gap: 0.5rem;
+    grid-gap: 0 0.5rem;
   }
 }
 
 @media (min-width:37.5em) {
   .c0 {
-    grid-gap: 1rem;
+    grid-gap: 0 1rem;
   }
 }
 

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -38,8 +38,6 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -103,7 +101,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 
@@ -263,8 +261,6 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -328,7 +324,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 
@@ -488,8 +484,6 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -553,7 +547,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 
@@ -708,8 +702,6 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -773,7 +765,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 
@@ -928,8 +920,6 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 .c0 {
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: 80em;
   background: #FDFDFD;
 }
 
@@ -993,7 +983,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
 @media (min-width:80em) {
   .c0 {
     -ms-grid-columns: 1fr (minmax(0,2.95rem))[20] 1fr;
-    grid-template-columns: 0 repeat(20,minmax(0,2.95rem)) 0;
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
   }
 }
 

--- a/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Headings with headline data should render correctly 1`] = `
-<ForwardRef
-  text="This is a headline!"
->
-  This is a headline!
+<ForwardRef>
+  <ForwardRef
+    text="This is a headline!"
+  >
+    This is a headline!
+  </ForwardRef>
 </ForwardRef>
 `;
 
 exports[`Headings with subheadline data should render correctly 1`] = `
-<ForwardRef
-  text="This is a subheadline"
->
-  This is a subheadline
+<ForwardRef>
+  <ForwardRef
+    text="This is a subheadline"
+  >
+    This is a subheadline
+  </ForwardRef>
 </ForwardRef>
 `;

--- a/src/app/containers/Headings/index.jsx
+++ b/src/app/containers/Headings/index.jsx
@@ -4,14 +4,24 @@ import { Headline, SubHeading } from '@bbc/psammead-headings';
 import { extractText } from '../../helpers/blockHandlers';
 import { textDefaultPropTypes } from '../../models/propTypes';
 import { headlineModelPropTypes } from '../../models/propTypes/headline';
+import {
+  GridItemConstrainedMedium,
+  GridItemConstrainedLargeWithMargin,
+} from '../../lib/styledGrid';
 
 const Headings = {
   headline: Headline,
   subheadline: SubHeading,
 };
 
+const GridConstrains = {
+  headline: GridItemConstrainedLargeWithMargin,
+  subheadline: GridItemConstrainedMedium,
+};
+
 const HeadingsContainer = ({ blocks, type }) => {
   const Heading = Headings[type];
+  const GridConstrain = GridConstrains[type];
 
   const { text } = extractText(blocks);
 
@@ -19,7 +29,11 @@ const HeadingsContainer = ({ blocks, type }) => {
     return null;
   }
 
-  return <Heading text={text}>{text}</Heading>;
+  return (
+    <GridConstrain>
+      <Heading text={text}>{text}</Heading>
+    </GridConstrain>
+  );
 };
 
 HeadingsContainer.propTypes = {

--- a/src/app/containers/Headings/index.jsx
+++ b/src/app/containers/Headings/index.jsx
@@ -6,7 +6,7 @@ import { textDefaultPropTypes } from '../../models/propTypes';
 import { headlineModelPropTypes } from '../../models/propTypes/headline';
 import {
   GridItemConstrainedMedium,
-  GridItemConstrainedLargeWithMargin,
+  GridItemConstrainedLarge,
 } from '../../lib/styledGrid';
 
 const Headings = {
@@ -15,7 +15,7 @@ const Headings = {
 };
 
 const GridConstrains = {
-  headline: GridItemConstrainedLargeWithMargin,
+  headline: GridItemConstrainedLarge,
   subheadline: GridItemConstrainedMedium,
 };
 

--- a/src/app/containers/Headings/index.jsx
+++ b/src/app/containers/Headings/index.jsx
@@ -14,14 +14,14 @@ const Headings = {
   subheadline: SubHeading,
 };
 
-const GridConstrains = {
+const GridConstraints = {
   headline: GridItemConstrainedLarge,
   subheadline: GridItemConstrainedMedium,
 };
 
 const HeadingsContainer = ({ blocks, type }) => {
   const Heading = Headings[type];
-  const GridConstrain = GridConstrains[type];
+  const GridConstrain = GridConstraints[type];
 
   const { text } = extractText(blocks);
 

--- a/src/app/containers/Image/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Image/__snapshots__/index.test.jsx.snap
@@ -1,103 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Image with data should render an image with alt text 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={null}
-  copyright={null}
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={null}
+    copyright={null}
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;
 
 exports[`Image with data should render an image with alt text and caption 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={
-    Object {
-      "model": Object {
-        "blocks": Array [
-          Object {
-            "model": Object {
-              "blocks": Array [
-                Object {
-                  "model": Object {
-                    "blocks": Array [
-                      Object {
-                        "model": Object {
-                          "attributes": Array [],
-                          "text": "Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme",
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={
+      Object {
+        "model": Object {
+          "blocks": Array [
+            Object {
+              "model": Object {
+                "blocks": Array [
+                  Object {
+                    "model": Object {
+                      "blocks": Array [
+                        Object {
+                          "model": Object {
+                            "attributes": Array [],
+                            "text": "Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme",
+                          },
+                          "type": "fragment",
                         },
-                        "type": "fragment",
-                      },
-                    ],
-                    "text": "Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme",
+                      ],
+                      "text": "Study by the Home Office about the Syrian Vulnerable Persons Resettlement Scheme",
+                    },
+                    "type": "paragraph",
                   },
-                  "type": "paragraph",
-                },
-              ],
+                ],
+              },
+              "type": "text",
             },
-            "type": "text",
-          },
-        ],
-      },
-      "type": "caption",
+          ],
+        },
+        "type": "caption",
+      }
     }
-  }
-  copyright={null}
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+    copyright={null}
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;
 
 exports[`Image with data should render an image with alt text and offscreen copyright 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={null}
-  copyright="Getty images"
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={null}
+    copyright="Getty images"
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/cpsprodpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;
 
 exports[`Image with data should render an image with other originCode - this would be a broken image 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={null}
-  copyright="Getty images"
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/other/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={null}
+    copyright="Getty images"
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/other/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;
 
 exports[`Image with data should render an image with the default originCode \`cpsdevpb\` - empty string 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={null}
-  copyright="Getty images"
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/cpsdevpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={null}
+    copyright="Getty images"
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/cpsdevpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;
 
 exports[`Image with data should render an image with the default originCode \`cpsdevpb\` - null 1`] = `
-<FigureContainer
-  alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
-  captionBlock={null}
-  copyright="Getty images"
-  height={420}
-  ratio={65.625}
-  src="https://ichef.bbci.co.uk/news/640/cpsdevpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
-  width={640}
-/>
+<ForwardRef>
+  <FigureContainer
+    alt="Map of the UK displaying Syrian refugees and asylum seekers per 10000 population. Ranges from 0 to 17."
+    captionBlock={null}
+    copyright="Getty images"
+    height={420}
+    ratio={65.625}
+    src="https://ichef.bbci.co.uk/news/640/cpsdevpb/439A/production/_100960371_syrians_and_asylum_v2-nc.png"
+    width={640}
+  />
+</ForwardRef>
 `;

--- a/src/app/containers/Image/index.jsx
+++ b/src/app/containers/Image/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { filterForBlockType } from '../../helpers/blockHandlers';
 import { imageModelPropTypes } from '../../models/propTypes/image';
 import Figure from '../Figure';
-import { GridItemConstrainedLarge } from '../../lib/styledGrid';
+import { GridItemConstrainedLargeNoMargin } from '../../lib/styledGrid';
 
 const DEFAULT_IMAGE_RES = 640;
 
@@ -55,7 +55,7 @@ const ImageContainer = ({ blocks }) => {
   // https://github.com/bbc/simorgh/issues/1369
   // https://github.com/bbc/simorgh/issues/1319
   return (
-    <GridItemConstrainedLarge>
+    <GridItemConstrainedLargeNoMargin>
       <Figure
         alt={altText}
         captionBlock={captionBlock}
@@ -65,7 +65,7 @@ const ImageContainer = ({ blocks }) => {
         src={rawImageSrc}
         width={width}
       />
-    </GridItemConstrainedLarge>
+    </GridItemConstrainedLargeNoMargin>
   );
 };
 

--- a/src/app/containers/Image/index.jsx
+++ b/src/app/containers/Image/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { filterForBlockType } from '../../helpers/blockHandlers';
 import { imageModelPropTypes } from '../../models/propTypes/image';
 import Figure from '../Figure';
+import { GridItemConstrainedLarge } from '../../lib/styledGrid';
 
 const DEFAULT_IMAGE_RES = 640;
 
@@ -51,15 +52,17 @@ const ImageContainer = ({ blocks }) => {
   const rawImageSrc = getRawImageSrc(originCode, locator);
 
   return (
-    <Figure
-      alt={altText}
-      captionBlock={captionBlock}
-      copyright={copyright}
-      height={height}
-      ratio={ratio}
-      src={rawImageSrc}
-      width={width}
-    />
+    <GridItemConstrainedLarge>
+      <Figure
+        alt={altText}
+        captionBlock={captionBlock}
+        copyright={copyright}
+        height={height}
+        ratio={ratio}
+        src={rawImageSrc}
+        width={width}
+      />
+    </GridItemConstrainedLarge>
   );
 };
 

--- a/src/app/containers/Image/index.jsx
+++ b/src/app/containers/Image/index.jsx
@@ -51,6 +51,9 @@ const ImageContainer = ({ blocks }) => {
   const ratio = (height / width) * 100;
   const rawImageSrc = getRawImageSrc(originCode, locator);
 
+  // This grid contain will be refactored in
+  // https://github.com/bbc/simorgh/issues/1369
+  // https://github.com/bbc/simorgh/issues/1319
   return (
     <GridItemConstrainedLarge>
       <Figure

--- a/src/app/containers/Paragraph/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Paragraph/__snapshots__/index.test.jsx.snap
@@ -2,59 +2,61 @@
 
 exports[`ParagraphContainer should render correctly 1`] = `
 <ForwardRef>
-  <Blocks
-    blocks={
-      Array [
-        Object {
-          "model": Object {
-            "attributes": Array [
-              "bold",
-            ],
-            "text": "This is some text.",
+  <ForwardRef>
+    <Blocks
+      blocks={
+        Array [
+          Object {
+            "model": Object {
+              "attributes": Array [
+                "bold",
+              ],
+              "text": "This is some text.",
+            },
+            "type": "fragment",
           },
-          "type": "fragment",
-        },
-        Object {
-          "model": Object {
-            "blocks": Array [
-              Object {
-                "model": Object {
-                  "attributes": Array [],
-                  "text": "Some text",
+          Object {
+            "model": Object {
+              "blocks": Array [
+                Object {
+                  "model": Object {
+                    "attributes": Array [],
+                    "text": "Some text",
+                  },
+                  "type": "fragment",
                 },
-                "type": "fragment",
-              },
-              Object {
-                "model": Object {
-                  "attributes": Array [
-                    "bold",
-                  ],
-                  "text": " for the ",
+                Object {
+                  "model": Object {
+                    "attributes": Array [
+                      "bold",
+                    ],
+                    "text": " for the ",
+                  },
+                  "type": "fragment",
                 },
-                "type": "fragment",
-              },
-              Object {
-                "model": Object {
-                  "attributes": Array [
-                    "italic",
-                  ],
-                  "text": " link!",
+                Object {
+                  "model": Object {
+                    "attributes": Array [
+                      "italic",
+                    ],
+                    "text": " link!",
+                  },
+                  "type": "fragment",
                 },
-                "type": "fragment",
-              },
-            ],
-            "locator": "/bbc-test",
+              ],
+              "locator": "/bbc-test",
+            },
+            "type": "urlLink",
           },
-          "type": "urlLink",
-        },
-      ]
-    }
-    componentsToRender={
-      Object {
-        "fragment": [Function],
-        "urlLink": [Function],
+        ]
       }
-    }
-  />
+      componentsToRender={
+        Object {
+          "fragment": [Function],
+          "urlLink": [Function],
+        }
+      }
+    />
+  </ForwardRef>
 </ForwardRef>
 `;

--- a/src/app/containers/Paragraph/index.jsx
+++ b/src/app/containers/Paragraph/index.jsx
@@ -4,13 +4,16 @@ import Blocks from '../Blocks';
 import fragment from '../Fragment';
 import InlineLink from '../InlineLink';
 import { paragraphModelPropTypes } from '../../models/propTypes/paragraph';
+import { GridItemConstrainedMedium } from '../../lib/styledGrid';
 
 const componentsToRender = { fragment, urlLink: InlineLink };
 
 const ParagraphContainer = ({ blocks }) => (
-  <Paragraph>
-    <Blocks blocks={blocks} componentsToRender={componentsToRender} />
-  </Paragraph>
+  <GridItemConstrainedMedium>
+    <Paragraph>
+      <Blocks blocks={blocks} componentsToRender={componentsToRender} />
+    </Paragraph>
+  </GridItemConstrainedMedium>
 );
 
 ParagraphContainer.propTypes = paragraphModelPropTypes;

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -49,7 +49,7 @@ export const layoutGridWrapper = css`
     grid-column-gap: ${GEL_GUTTER_BELOW_600PX};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    grid-gap: 0 ${GEL_GUTTER_ABOVE_600PX};
+    grid-column-gap: ${GEL_GUTTER_ABOVE_600PX};
   }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: (1fr)[6]; // prettier-ignore

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -46,10 +46,10 @@ export const layoutGridWrapper = css`
   max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    grid-gap: ${GEL_GUTTER_BELOW_600PX};
+    grid-gap: 0 ${GEL_GUTTER_BELOW_600PX};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    grid-gap: ${GEL_GUTTER_ABOVE_600PX};
+    grid-gap: 0 ${GEL_GUTTER_ABOVE_600PX};
   }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: (1fr)[6]; // prettier-ignore

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -69,17 +69,17 @@ export const layoutGridItemLargeNoMargin = css`
   @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
     -ms-grid-column-span: 6;
-    grid-column: 3 / -3;
+    grid-column: 3 / span 6;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 6;
     -ms-grid-column-span: 12;
-    grid-column: 6 / -6;
+    grid-column: 6 / span 12;
   }
 `;
 
@@ -94,22 +94,22 @@ export const layoutGridItemMedium = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 1 / -1;
+    grid-column: 1 / span 5;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
     -ms-grid-column-span: 5;
-    grid-column: 3 / -4;
+    grid-column: 3 / span 5;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 6;
     -ms-grid-column-span: 10;
-    grid-column: 6 / -8;
+    grid-column: 6 / span 10;
   }
 `;
 
@@ -119,27 +119,27 @@ export const layoutGridItemSmall = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 4;
-    grid-column: 1 / -3;
+    grid-column: 1 / span 4;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 1 / -2;
+    grid-column: 1 / span 5;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
     -ms-grid-column-span: 4;
-    grid-column: 3 / -5;
+    grid-column: 3 / span 4;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 6;
     -ms-grid-column-span: 8;
-    grid-column: 5 / -10;
+    grid-column: 6 / span 8;
   }
 `;
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -69,7 +69,7 @@ export const layoutGridItemLarge = css`
   @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 1 / -1;
+    grid-column: 2 / -2;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
@@ -83,12 +83,12 @@ export const layoutGridItemLarge = css`
   }
 `;
 
-export const layoutGridItemLargeWithMargin = css`
+export const layoutGridItemLargeNoMargin = css`
   ${layoutGridItemLarge}
   @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / -1;
   }
 `;
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -21,11 +21,13 @@ const group4ColWidth = `6.75rem`;
 const group5ColWidth = `2.95rem`;
 /* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 47.2px = 2.95rem single column width */
 
-export const layoutWrapperWithoutGrid = css`
+// WHY
+  
+export const gelGridMargin = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     padding: 0 ${GEL_MARGIN_BELOW_400PX};
   }
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     padding: 0 ${GEL_MARGIN_ABOVE_400PX};
   }
 `;
@@ -42,8 +44,6 @@ export const layoutWrapperWithoutGrid = css`
 export const layoutGridWrapper = css`
   display: -ms-grid;
   display: grid;
-  margin: 0 auto;
-  max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     grid-column-gap: ${GEL_GUTTER_BELOW_600PX};
@@ -53,7 +53,7 @@ export const layoutGridWrapper = css`
   }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: (1fr)[6]; // prettier-ignore
-    grid-template-columns: 0 repeat(6, 1fr) 0;
+    grid-template-columns: repeat(6, 1fr);
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: 1fr (minmax(0, ${group4ColWidth}))[8] 1fr; // prettier-ignore
@@ -61,15 +61,15 @@ export const layoutGridWrapper = css`
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     -ms-grid-columns: 1fr (minmax(0, ${group5ColWidth}))[20] 1fr; // prettier-ignore
-    grid-template-columns: 0 repeat(20, minmax(0, ${group5ColWidth})) 0;
+    grid-template-columns: 1fr repeat(20, minmax(0, ${group5ColWidth})) 1fr;
   }
 `;
 
-export const layoutGridItemLarge = css`
+export const layoutGridItemLargeNoMargin = css`
   @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / -1;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
@@ -83,25 +83,23 @@ export const layoutGridItemLarge = css`
   }
 `;
 
-export const layoutGridItemLargeNoMargin = css`
-  ${layoutGridItemLarge}
-  @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+export const layoutGridItemLarge = css`
+  ${layoutGridItemLargeNoMargin}
+  ${gelGridMargin}
+`;
+
+export const layoutGridItemMedium = css`
+  ${gelGridMargin}
+
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
     grid-column: 1 / -1;
   }
-`;
-
-export const layoutGridItemMedium = css`
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
-  }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / -1;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
@@ -116,20 +114,22 @@ export const layoutGridItemMedium = css`
 `;
 
 export const layoutGridItemSmall = css`
+  ${gelGridMargin}
+
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 2 / -2;
+    grid-column: 1 / -1;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 4;
-    grid-column: 2 / -4;
+    grid-column: 1 / -3;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 5;
-    grid-column: 2 / -3;
+    grid-column: 1 / -2;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
@@ -139,7 +139,7 @@ export const layoutGridItemSmall = css`
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 6;
     -ms-grid-column-span: 8;
-    grid-column: 6 / -10;
+    grid-column: 5 / -10;
   }
 `;
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -19,7 +19,7 @@ const group4ColWidth = `6.75rem`;
 /* (1008px - (2*16px margins + 7*16px gutters) / 8 columns = 108px = 6.75rem single column width */
 
 const group5ColWidth = `2.95rem`;
-/* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 110.4px = 2.95rem single column width */
+/* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 47.2px = 2.95rem single column width */
 
 export const layoutWrapperWithoutGrid = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -83,6 +83,15 @@ export const layoutGridItemLarge = css`
   }
 `;
 
+export const layoutGridItemLargeWithMargin = css`
+  ${layoutGridItemLarge}
+  @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
+    grid-column: 2 / -2;
+  }
+`;
+
 export const layoutGridItemMedium = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -34,7 +34,7 @@ export const gelGridMargin = css`
   0-599px: 8px gutter
   600+: 16px gutter
 
-  0-399px: 8px margin  
+  0-399px: 8px margin
   400-1007px: 16px margin
   1008+: no explicit margin, since we use 16px gutters as margin
 */

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -46,7 +46,7 @@ export const layoutGridWrapper = css`
   max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    grid-gap: 0 ${GEL_GUTTER_BELOW_600PX};
+    grid-column-gap: ${GEL_GUTTER_BELOW_600PX};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     grid-gap: 0 ${GEL_GUTTER_ABOVE_600PX};

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -22,7 +22,7 @@ const group5ColWidth = `2.95rem`;
 /* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 47.2px = 2.95rem single column width */
 
 // WHY
-  
+
 export const gelGridMargin = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     padding: 0 ${GEL_MARGIN_BELOW_400PX};

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -18,8 +18,8 @@ import {
 const group4ColWidth = `6.75rem`;
 /* (1008px - (2*16px margins + 7*16px gutters) / 8 columns = 108px = 6.75rem single column width */
 
-const group5ColWidth = `6.9rem`;
-/* (1280px - (2*16px margins + 9*16px gutters)  / 10 columns = 110.4px = 6.9rem single column width */
+const group5ColWidth = `2.95rem`;
+/* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 110.4px = 2.95rem single column width */
 
 export const layoutWrapperWithoutGrid = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
@@ -42,42 +42,34 @@ export const layoutWrapperWithoutGrid = css`
 export const layoutGridWrapper = css`
   display: -ms-grid;
   display: grid;
+  margin: 0 auto;
+  max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
+
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     grid-gap: ${GEL_GUTTER_BELOW_600PX};
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     grid-gap: ${GEL_GUTTER_ABOVE_600PX};
   }
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    padding: 0 ${GEL_MARGIN_BELOW_400PX};
-  }
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    padding: 0 ${GEL_MARGIN_ABOVE_400PX};
-  }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: (1fr)[6]; // prettier-ignore
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: 0 repeat(6, 1fr) 0;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-columns: 1fr (minmax(0, ${group4ColWidth}))[8] 1fr; // prettier-ignore
     grid-template-columns: 1fr repeat(8, minmax(0, ${group4ColWidth})) 1fr;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-columns: 1fr (minmax(0, ${group5ColWidth}))[10] 1fr; // prettier-ignore
-    grid-template-columns: 1fr repeat(10, minmax(0, ${group5ColWidth})) 1fr;
+    -ms-grid-columns: 1fr (minmax(0, ${group5ColWidth}))[20] 1fr; // prettier-ignore
+    grid-template-columns: 0 repeat(20, minmax(0, ${group5ColWidth})) 0;
   }
 `;
 
-export const layoutGridItemConstrained = css`
-  @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+export const layoutGridItemLarge = css`
+  @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     -ms-grid-column: 1;
     -ms-grid-column-span: 6;
     grid-column: 1 / -1;
-  }
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 2;
-    -ms-grid-column-span: 4;
-    grid-column: 2 / -2;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     -ms-grid-column: 3;
@@ -85,9 +77,60 @@ export const layoutGridItemConstrained = css`
     grid-column: 3 / -3;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 4;
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 12;
+    grid-column: 6 / -6;
+  }
+`;
+
+export const layoutGridItemMedium = css`
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 1;
     -ms-grid-column-span: 6;
-    grid-column: 4 / -4;
+    grid-column: 2 / -2;
+  }
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
+  }
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 5;
+    grid-column: 3 / -4;
+  }
+  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 10;
+    grid-column: 6 / -8;
+  }
+`;
+
+export const layoutGridItemSmall = css`
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 6;
+    grid-column: 2 / -2;
+  }
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 4;
+    grid-column: 2 / -4;
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 5;
+    grid-column: 2 / -3;
+  }
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
+    -ms-grid-column: 3;
+    -ms-grid-column-span: 4;
+    grid-column: 3 / -5;
+  }
+  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
+    -ms-grid-column: 6;
+    -ms-grid-column-span: 8;
+    grid-column: 6 / -10;
   }
 `;
 

--- a/src/app/lib/layoutGrid.js
+++ b/src/app/lib/layoutGrid.js
@@ -21,8 +21,6 @@ const group4ColWidth = `6.75rem`;
 const group5ColWidth = `2.95rem`;
 /* (1280px - (2*16px margins + 19*16px gutters)  / 20 columns = 47.2px = 2.95rem single column width */
 
-// WHY
-
 export const gelGridMargin = css`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     padding: 0 ${GEL_MARGIN_BELOW_400PX};
@@ -36,13 +34,12 @@ export const gelGridMargin = css`
   0-599px: 8px gutter
   600+: 16px gutter
 
-  0-399px: 8px margin
+  0-399px: 8px margin  
   400-1007px: 16px margin
   1008+: no explicit margin, since we use 16px gutters as margin
 */
 
 export const layoutGridWrapper = css`
-  display: -ms-grid;
   display: grid;
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
@@ -52,33 +49,24 @@ export const layoutGridWrapper = css`
     grid-column-gap: ${GEL_GUTTER_ABOVE_600PX};
   }
   @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    -ms-grid-columns: (1fr)[6]; // prettier-ignore
     grid-template-columns: repeat(6, 1fr);
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    -ms-grid-columns: 1fr (minmax(0, ${group4ColWidth}))[8] 1fr; // prettier-ignore
     grid-template-columns: 1fr repeat(8, minmax(0, ${group4ColWidth})) 1fr;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-columns: 1fr (minmax(0, ${group5ColWidth}))[20] 1fr; // prettier-ignore
     grid-template-columns: 1fr repeat(20, minmax(0, ${group5ColWidth})) 1fr;
   }
 `;
 
 export const layoutGridItemLargeNoMargin = css`
   @media (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 6;
     grid-column: 3 / span 6;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 12;
     grid-column: 6 / span 12;
   }
 `;
@@ -92,23 +80,15 @@ export const layoutGridItemMedium = css`
   ${gelGridMargin}
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 5;
     grid-column: 3 / span 5;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 10;
     grid-column: 6 / span 10;
   }
 `;
@@ -117,28 +97,18 @@ export const layoutGridItemSmall = css`
   ${gelGridMargin}
 
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 6;
     grid-column: 1 / span 6;
   }
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 4;
     grid-column: 1 / span 4;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 1;
-    -ms-grid-column-span: 5;
     grid-column: 1 / span 5;
   }
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    -ms-grid-column: 3;
-    -ms-grid-column-span: 4;
     grid-column: 3 / span 4;
   }
   @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    -ms-grid-column: 6;
-    -ms-grid-column-span: 8;
     grid-column: 6 / span 8;
   }
 `;

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -12,14 +12,14 @@ export const GhostWrapper = styled.div`
   background: ${C_GHOST};
 `;
 
-export const GridItemConstrainedMediumSmall = styled.div`
+export const GridItemConstrainedSmall = styled.div`
   ${layoutGridItemSmall};
 `;
 
-export const GridItemConstrainedMediumMedium = styled.div`
+export const GridItemConstrainedMedium = styled.div`
   ${layoutGridItemMedium};
 `;
 
-export const GridItemConstrainedMediumLarge = styled.div`
+export const GridItemConstrainedLarge = styled.div`
   ${layoutGridItemLarge};
 `;

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -5,6 +5,7 @@ import {
   layoutGridItemSmall,
   layoutGridItemMedium,
   layoutGridItemLarge,
+  layoutGridItemLargeWithMargin
 } from './layoutGrid';
 
 export const GhostWrapper = styled.div`
@@ -22,4 +23,8 @@ export const GridItemConstrainedMedium = styled.div`
 
 export const GridItemConstrainedLarge = styled.div`
   ${layoutGridItemLarge};
+`;
+
+export const GridItemConstrainedLargeWithMargin = styled.div`
+  ${layoutGridItemLargeWithMargin};
 `;

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -5,7 +5,7 @@ import {
   layoutGridItemSmall,
   layoutGridItemMedium,
   layoutGridItemLarge,
-  layoutGridItemLargeWithMargin,
+  layoutGridItemLargeNoMargin,
 } from './layoutGrid';
 
 export const GhostWrapper = styled.div`
@@ -25,6 +25,6 @@ export const GridItemConstrainedLarge = styled.div`
   ${layoutGridItemLarge};
 `;
 
-export const GridItemConstrainedLargeWithMargin = styled.div`
-  ${layoutGridItemLargeWithMargin};
+export const GridItemConstrainedLargeNoMargin = styled.div`
+  ${layoutGridItemLargeNoMargin};
 `;

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -5,7 +5,7 @@ import {
   layoutGridItemSmall,
   layoutGridItemMedium,
   layoutGridItemLarge,
-  layoutGridItemLargeWithMargin
+  layoutGridItemLargeWithMargin,
 } from './layoutGrid';
 
 export const GhostWrapper = styled.div`

--- a/src/app/lib/styledGrid.js
+++ b/src/app/lib/styledGrid.js
@@ -1,12 +1,25 @@
 import styled from 'styled-components';
 import { C_GHOST } from '@bbc/psammead-styles/colours';
-import { layoutGridWrapper, layoutGridItemConstrained } from './layoutGrid';
+import {
+  layoutGridWrapper,
+  layoutGridItemSmall,
+  layoutGridItemMedium,
+  layoutGridItemLarge,
+} from './layoutGrid';
 
 export const GhostWrapper = styled.div`
   ${layoutGridWrapper};
   background: ${C_GHOST};
 `;
 
-export const GridItemConstrained = styled.div`
-  ${layoutGridItemConstrained};
+export const GridItemConstrainedMediumSmall = styled.div`
+  ${layoutGridItemSmall};
+`;
+
+export const GridItemConstrainedMediumMedium = styled.div`
+  ${layoutGridItemMedium};
+`;
+
+export const GridItemConstrainedMediumLarge = styled.div`
+  ${layoutGridItemLarge};
 `;


### PR DESCRIPTION
Resolves #1318

**Overall change:** Updates grid spec for new UX designs

**Code changes:**

- Adds 20 used columns on 1280px
- Uses a 0 width column instead of padding to allow full width content with no margin
- Moves grid constraint to the container of the component instead of the whole article

**New Grid constrained divs**
Note: These column numbers dont include the two used for margins

 -`GridItemConstrainedLarge`
Example use:  Headlines which span full width but **DONT** touch the sides of the screen

 | Breakpoints | Width |
 | ------------ | ------ |
  | <= Group 1 | spans all columns **excluding** margin |
  | Group 2 | spans all columns **excluding** margin |
  |  Group 3  | spans all columns **excluding** margin |
  | Group 4 | spans columns 2-7 out of 8 |
  | >=Group 5  | spans columns 5 - 16 out of 20 |

-`GridItemConstrainedLargeNoMargin`
Example use: Images which touch the sides of the screen

| Breakpoints | Width |
| ------------ | ------ |
 | <= Group 1 | spans all columns **including** margin |
 | Group 2 | spans all columns **including** margin |
 |  Group 3  | spans all columns **including** margin |
 | Group 4 | spans columns 2-7 out of 8 |
 | >=Group 5  | spans columns 5 - 16 out of 20 |

- `GridItemConstrainedMedium`
Example use: Paragraph blocks

| Breakpoints | Width |
| ------------ | ------ |
 | <= Group 1 | spans all columns excluding margins |
 |  Group 2  | spans columns 1-5 out of 6 |
 | Group 3 | spans columns 1-5 out of 6 |
 | Group 4 | spans columns 2-6 out of 8 |
 | >=Group 5  | spans columns  5 - 14 out of 20 |

- `GridItemConstrainedSmall`
Example use: Portrait images and captions of small images.

| Breakpoints | Width |
| ------------ | ------ |
 | <= Group 1 | spans all columns excluding margins |
 |  Group 2  | spans columns 1-4 out of 6 |
 |  Group 3  | spans columns 1-5 out of 6  |
 | Group 4 | spans columns 2-5 out of 8 |
 | >=Group 5  | spans columns 5 - 12 out of 20 |

![image](https://user-images.githubusercontent.com/11341355/53740682-a8368680-3e8c-11e9-908d-6cd1346cb7a0.png)

![image](https://user-images.githubusercontent.com/11341355/53740758-ce5c2680-3e8c-11e9-8fd9-8bcac3c7afca.png)


### THIS REMOVES THE IE GRID FALLBACK
There is no auto-placement behaviour in IE implementation. This means that you have to position everything rather than use the auto-placement ability of grid.

If you don’t position items they will stack up in the first cell of the grid. That means that you have to set position explicitly for every single grid item or it will reside in first cell.

We will have to use the IE9 fallback implementation for 10 and 11 too.

Having ms-grid caused the following look
![image](https://user-images.githubusercontent.com/11341355/53896706-6e9c8180-402c-11e9-993a-0a1885002702.png)


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [x] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
