### PR TITLE
Adding Cypress tests for AMP metadata

### DIFF
--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -5,6 +5,7 @@ import {
   facebookMeta,
   metadataAssertion,
   openGraphMeta,
+  retrieveAMPMetadata,
   retrieveMetaDataContent,
   twitterMeta,
 } from '../support/metaTestHelper';
@@ -99,5 +100,13 @@ describe('Article Meta Tests', () => {
         config.assets.newsThreeSubheadlines
       }`,
     );
+  });
+
+  it('should include metadata in the head on AMP pages', () => {
+    cy.window().then(win => {
+      const windowData = win.SIMORGH_DATA.data;
+      cy.visit(`/news/articles/${config.assets.newsThreeSubheadlines}.amp`);
+      retrieveAMPMetadata(windowData);
+    });
   });
 });

--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -4,8 +4,8 @@ import {
   checkCanonicalURL,
   facebookMeta,
   metadataAssertion,
+  metadataAssertionAMP,
   openGraphMeta,
-  retrieveAMPMetadata,
   retrieveMetaDataContent,
   twitterMeta,
 } from '../support/metaTestHelper';
@@ -103,10 +103,8 @@ describe('Article Meta Tests', () => {
   });
 
   it('should include metadata in the head on AMP pages', () => {
-    cy.window().then(win => {
-      const windowData = win.SIMORGH_DATA.data;
-      cy.visit(`/news/articles/${config.assets.newsThreeSubheadlines}.amp`);
-      retrieveAMPMetadata(windowData);
-    });
+    metadataAssertionAMP(
+      `/news/articles/${config.assets.newsThreeSubheadlines}.amp`,
+    );
   });
 });

--- a/cypress/integration/metaPersianSpec.js
+++ b/cypress/integration/metaPersianSpec.js
@@ -2,6 +2,8 @@ import config from '../support/config';
 import {
   checkCanonicalURL,
   facebookMeta,
+  metadataAssertion,
+  metadataAssertionAMP,
   openGraphMeta,
   retrieveMetaDataContent,
   twitterMeta,
@@ -54,5 +56,13 @@ describe('Persian Article Meta Tests', () => {
     checkCanonicalURL(
       `https://www.bbc.com/persian/articles/${config.assets.persian}`,
     );
+  });
+
+  it('should include metadata that matches the JSON data', () => {
+    metadataAssertion();
+  });
+
+  it('should include metadata in the head on AMP pages', () => {
+    metadataAssertionAMP(`/persian/articles/${config.assets.persian}.amp`);
   });
 });

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -81,13 +81,13 @@ export const retrieve404BodyResponse = (url, bodyResponse) => {
     .should('include', bodyResponse);
 };
 
-export const retrieveData = (
-  description,
-  title,
-  type,
-  firstPublished,
-  lastPublished,
-) => {
+export const retrieveData = data => {
+  const description = data.promo.summary;
+  const title = data.promo.headlines.seoHeadline;
+  const { type } = data.metadata;
+  const firstPublished = new Date(data.metadata.firstPublished).toISOString();
+  const lastPublished = new Date(data.metadata.lastPublished).toISOString();
+
   retrieveMetaDataContent('head meta[name="description"]', description);
   retrieveMetaDataContent('head meta[name="og:title"]', title);
   retrieveMetaDataContent('head meta[name="og:type"]', type);
@@ -100,39 +100,19 @@ export const retrieveData = (
     lastPublished,
   );
 };
-
 export const metadataAssertion = () => {
   cy.window().then(win => {
     const windowData = win.SIMORGH_DATA.data;
-    const description = windowData.promo.summary;
     const { language } = windowData.metadata.passport;
-    const title = windowData.promo.headlines.seoHeadline;
-    const { type } = windowData.metadata;
-    const firstPublished = new Date(
-      windowData.metadata.firstPublished,
-    ).toISOString();
-    const lastPublished = new Date(
-      windowData.metadata.lastPublished,
-    ).toISOString();
-    retrieveData(description, title, type, firstPublished, lastPublished);
+    retrieveData(windowData);
     getElement('html').should('contain', language);
   });
-};
-
-export const retrieveAMPMetadata = data => {
-  const description = data.promo.summary;
-  // const { language } = data.metadata.passport;
-  const title = data.promo.headlines.seoHeadline;
-  const { type } = data.metadata;
-  const firstPublished = new Date(data.metadata.firstPublished).toISOString();
-  const lastPublished = new Date(data.metadata.lastPublished).toISOString();
-  retrieveData(description, title, type, firstPublished, lastPublished);
 };
 
 export const metadataAssertionAMP = service => {
   cy.window().then(win => {
     const windowData = win.SIMORGH_DATA.data;
     cy.visit(service);
-    retrieveAMPMetadata(windowData);
+    retrieveData(windowData);
   });
 };

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -81,9 +81,10 @@ export const retrieve404BodyResponse = (url, bodyResponse) => {
     .should('include', bodyResponse);
 };
 
-export const retrieveData = data => {
+export const checkDataMatchesMetadata = data => {
   const description = data.promo.summary;
   const title = data.promo.headlines.seoHeadline;
+  const { language } = data.metadata.passport;
   const { type } = data.metadata;
   const firstPublished = new Date(data.metadata.firstPublished).toISOString();
   const lastPublished = new Date(data.metadata.lastPublished).toISOString();
@@ -99,20 +100,27 @@ export const retrieveData = data => {
     'head meta[name="article:modified_time"]',
     lastPublished,
   );
+  getElement('html').should('have.attr', 'lang', language);
 };
 export const metadataAssertion = () => {
   cy.window().then(win => {
     const windowData = win.SIMORGH_DATA.data;
-    const { language } = windowData.metadata.passport;
-    retrieveData(windowData);
-    getElement('html').should('contain', language);
+    checkDataMatchesMetadata(windowData);
   });
 };
 
-export const metadataAssertionAMP = service => {
+// This will only work if you visit the matching canonical
+// url prior to running this.
+
+export const metadataAssertionAMP = AMPURL => {
   cy.window().then(win => {
     const windowData = win.SIMORGH_DATA.data;
-    cy.visit(service);
-    retrieveData(windowData);
+    cy.visit(AMPURL);
+    checkDataMatchesMetadata(windowData);
   });
 };
+
+// AMP overrides the Window data in window.SIMORGH_DATA. In order to get
+// around this we visit the canonical page first to retrieve
+// window.SIMORGH_DATA and use this to compare against the metadata
+// served in the head of an AMP page.

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -81,6 +81,26 @@ export const retrieve404BodyResponse = (url, bodyResponse) => {
     .should('include', bodyResponse);
 };
 
+export const retrieveData = (
+  description,
+  title,
+  type,
+  firstPublished,
+  lastPublished,
+) => {
+  retrieveMetaDataContent('head meta[name="description"]', description);
+  retrieveMetaDataContent('head meta[name="og:title"]', title);
+  retrieveMetaDataContent('head meta[name="og:type"]', type);
+  retrieveMetaDataContent(
+    'head meta[name="article:published_time"]',
+    firstPublished,
+  );
+  retrieveMetaDataContent(
+    'head meta[name="article:modified_time"]',
+    lastPublished,
+  );
+};
+
 export const metadataAssertion = () => {
   cy.window().then(win => {
     const windowData = win.SIMORGH_DATA.data;
@@ -94,18 +114,17 @@ export const metadataAssertion = () => {
     const lastPublished = new Date(
       windowData.metadata.lastPublished,
     ).toISOString();
-
-    retrieveMetaDataContent('head meta[name="description"]', description);
-    retrieveMetaDataContent('head meta[name="og:title"]', title);
-    retrieveMetaDataContent('head meta[name="og:type"]', type);
-    retrieveMetaDataContent(
-      'head meta[name="article:published_time"]',
-      firstPublished,
-    );
-    retrieveMetaDataContent(
-      'head meta[name="article:modified_time"]',
-      lastPublished,
-    );
+    retrieveData(description, title, type, firstPublished, lastPublished);
     getElement('html').should('contain', language);
   });
+};
+
+export const retrieveAMPMetadata = data => {
+  const description = data.promo.summary;
+  // const { language } = data.metadata.passport;
+  const title = data.promo.headlines.seoHeadline;
+  const { type } = data.metadata;
+  const firstPublished = new Date(data.metadata.firstPublished).toISOString();
+  const lastPublished = new Date(data.metadata.lastPublished).toISOString();
+  retrieveData(description, title, type, firstPublished, lastPublished);
 };

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -128,3 +128,11 @@ export const retrieveAMPMetadata = data => {
   const lastPublished = new Date(data.metadata.lastPublished).toISOString();
   retrieveData(description, title, type, firstPublished, lastPublished);
 };
+
+export const metadataAssertionAMP = service => {
+  cy.window().then(win => {
+    const windowData = win.SIMORGH_DATA.data;
+    cy.visit(service);
+    retrieveAMPMetadata(windowData);
+  });
+};


### PR DESCRIPTION
Resolves #1375 

**Overall change:** _Adding Cypress tests for AMP metadata._

**Code changes:**

- _Adding Cypress tests, which check the metadata on AMP pages._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
