### PR TITLE
Fix JS bundles for IE11, stop bundles running IE 9-10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12917,11 +12917,6 @@
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
       "dev": true
     },
-    "mersenne-twister": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
-      "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o="
-    },
     "metaviewport-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
@@ -14467,14 +14462,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "polyfill-crypto.getrandomvalues": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/polyfill-crypto.getrandomvalues/-/polyfill-crypto.getrandomvalues-1.0.0.tgz",
-      "integrity": "sha1-XJVgKXbrthVbFjy2XXe57t47YaQ=",
-      "requires": {
-        "mersenne-twister": "^1.0.1"
-      }
     },
     "portfinder": {
       "version": "1.0.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -754,6 +754,13 @@
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        }
       }
     },
     "@babel/preset-env": {
@@ -1699,6 +1706,12 @@
         "webpack-hot-middleware": "^2.24.3"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
         "node-fetch": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
@@ -1741,6 +1754,14 @@
         "npmlog": "^4.1.2",
         "pretty-hrtime": "^1.0.3",
         "regenerator-runtime": "^0.12.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        }
       }
     },
     "@storybook/podda": {
@@ -1779,6 +1800,14 @@
         "regenerator-runtime": "^0.12.1",
         "semver": "^5.6.0",
         "webpack": "^4.23.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        }
       }
     },
     "@storybook/react-komposer": {
@@ -3714,6 +3743,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -11470,6 +11505,14 @@
         "core-js": "^2.5.7",
         "dotenv": "^6.0.0",
         "dotenv-expand": "^4.2.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        }
       }
     },
     "lcid": {
@@ -19735,6 +19778,14 @@
         "minimist": "^1.2.0",
         "request": "^2.88.0",
         "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        }
       }
     },
     "walker": {
@@ -20513,6 +20564,14 @@
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
         "validator": "^10.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12917,6 +12917,11 @@
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
       "dev": true
     },
+    "mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o="
+    },
     "metaviewport-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
@@ -14462,6 +14467,14 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "polyfill-crypto.getrandomvalues": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/polyfill-crypto.getrandomvalues/-/polyfill-crypto.getrandomvalues-1.0.0.tgz",
+      "integrity": "sha1-XJVgKXbrthVbFjy2XXe57t47YaQ=",
+      "requires": {
+        "mersenne-twister": "^1.0.1"
+      }
     },
     "portfinder": {
       "version": "1.0.20",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "compression": "^1.7.3",
     "compression-webpack-plugin": "^2.0.0",
     "copy-webpack-plugin": "^4.6.0",
+    "core-js": "^2.6.5",
     "dotenv": "^6.2.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "morgan": "^1.9.1",
     "nanoid": "^2.0.0",
     "path-to-regexp": "^2.4.0",
+    "polyfill-crypto.getrandomvalues": "^1.0.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "morgan": "^1.9.1",
     "nanoid": "^2.0.0",
     "path-to-regexp": "^2.4.0",
-    "polyfill-crypto.getrandomvalues": "^1.0.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
-/* eslint-disable react/jsx-filename-extension  */
+import 'core-js/es6/set'; // polyfill for >IE11
+import 'core-js/es6/map'; // polyfill for >IE11
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { ClientApp } from './app/containers/App';
@@ -7,7 +8,7 @@ import routes from './app/routes';
 const data = window.SIMORGH_DATA || {};
 const root = document.getElementById('root');
 
-hydrate(<ClientApp data={data} routes={routes} />, root);
+hydrate(<ClientApp data={data} routes={routes} />, root); // eslint-disable-line react/jsx-filename-extension
 
 if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
   navigator.serviceWorker.register(`/${data.service}/articles/sw.js`);

--- a/src/client.js
+++ b/src/client.js
@@ -1,9 +1,20 @@
-import 'core-js/es6/set'; // polyfill for >IE11
-import 'core-js/es6/map'; // polyfill for >IE11
+// polyfills for >IE11
+// import polyfillCryptoGetRandomValues from 'polyfill-crypto.getrandomvalues';
+import getRandomValuesPolyfill from 'nanoid/non-secure';
+
+import 'core-js/es6/set';
+import 'core-js/es6/map';
+import 'core-js/es6/symbol';
+
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { ClientApp } from './app/containers/App';
 import routes from './app/routes';
+
+window.crypto = { getRandomValues: getRandomValuesPolyfill };
+self.crypto = { getRandomValues: getRandomValuesPolyfill };
+global.crypto = { getRandomValues: getRandomValuesPolyfill };
+crypto = { getRandomValues: getRandomValuesPolyfill };
 
 const data = window.SIMORGH_DATA || {};
 const root = document.getElementById('root');

--- a/src/client.js
+++ b/src/client.js
@@ -1,30 +1,5 @@
-// polyfills for >IE11
-// import polyfillCryptoGetRandomValues from 'polyfill-crypto.getrandomvalues';
-import getRandomValuesPolyfill from 'nanoid/non-secure';
+import hydrateClient from './client/hydrate';
 
-import 'core-js/es6/set';
-import 'core-js/es6/map';
-import 'core-js/es6/symbol';
-
-import React from 'react';
-import { hydrate } from 'react-dom';
-import { ClientApp } from './app/containers/App';
-import routes from './app/routes';
-
-window.crypto = { getRandomValues: getRandomValuesPolyfill };
-self.crypto = { getRandomValues: getRandomValuesPolyfill };
-global.crypto = { getRandomValues: getRandomValuesPolyfill };
-crypto = { getRandomValues: getRandomValuesPolyfill };
-
-const data = window.SIMORGH_DATA || {};
-const root = document.getElementById('root');
-
-hydrate(<ClientApp data={data} routes={routes} />, root); // eslint-disable-line react/jsx-filename-extension
-
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-  navigator.serviceWorker.register(`/${data.service}/articles/sw.js`);
-}
-
-if (module.hot) {
-  module.hot.accept();
+if (window.crypto || window.msCrypto) {
+  hydrateClient();
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 import hydrateClient from './client/hydrate';
+import cutsTheMustard from './client/cutsTheMustard';
 
-if (window.crypto || window.msCrypto) {
+if (cutsTheMustard) {
   hydrateClient();
 }

--- a/src/client/cutsTheMustard.js
+++ b/src/client/cutsTheMustard.js
@@ -1,0 +1,9 @@
+/*
+ * cutsTheMustard is a method for checking that the current client can support the client-side hydration logic.
+ * Current checks are:
+ * - window.crypto || window.msCrypto: Mitigates against "undefined window.crypto.getRandomValues" https://caniuse.com/#feat=getrandomvalues
+ */
+
+const cutsTheMustard = () => window.crypto || window.msCrypto;
+
+export default cutsTheMustard;

--- a/src/client/hydrate.js
+++ b/src/client/hydrate.js
@@ -1,0 +1,26 @@
+// polyfills for IE11
+import 'core-js/es6/set';
+import 'core-js/es6/map';
+import 'core-js/es6/symbol';
+
+import React from 'react';
+import { hydrate } from 'react-dom';
+import { ClientApp } from '../app/containers/App';
+import routes from '../app/routes';
+
+const hydrateClient = () => {
+  const data = window.SIMORGH_DATA || {};
+  const root = document.getElementById('root');
+
+  hydrate(<ClientApp data={data} routes={routes} />, root); // eslint-disable-line react/jsx-filename-extension
+
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    navigator.serviceWorker.register(`/${data.service}/articles/sw.js`);
+  }
+
+  if (module.hot) {
+    module.hot.accept();
+  }
+};
+
+export default hydrateClient;

--- a/src/client/hydrate.test.jsx
+++ b/src/client/hydrate.test.jsx
@@ -14,7 +14,7 @@ jest.mock('../app/routes', () => ({
   default: [],
 }));
 
-window.crypto = () => {};
+window.crypto = () => {}; // depended on by the cuts-the-mustard check
 const mockRootElement = <div />;
 document.getElementById = jest.fn().mockReturnValue(mockRootElement);
 

--- a/src/client/hydrate.test.jsx
+++ b/src/client/hydrate.test.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import * as reactDom from 'react-dom';
-import { ClientApp } from './app/containers/App';
-import routes from './app/routes';
+import { ClientApp } from '../app/containers/App';
+import routes from '../app/routes';
+import hydrateClient from './hydrate';
 
 jest.mock('react-dom');
 
 jest.mock('react-router-dom');
 
-jest.mock('./app/containers/App');
+jest.mock('../app/containers/App');
 
-jest.mock('./app/routes', () => ({
+jest.mock('../app/routes', () => ({
   default: [],
 }));
 
+window.crypto = () => {};
 const mockRootElement = <div />;
 document.getElementById = jest.fn().mockReturnValue(mockRootElement);
 
@@ -42,7 +44,7 @@ describe('Client', () => {
       });
 
       it('should be installed', async () => {
-        await import('./client');
+        hydrateClient();
 
         expect(navigator.serviceWorker.register).toHaveBeenCalledWith(
           '/foobar/articles/sw.js',
@@ -56,7 +58,7 @@ describe('Client', () => {
       });
 
       it('should not be installed', async () => {
-        await import('./client');
+        hydrateClient();
 
         expect(navigator.serviceWorker.register).not.toHaveBeenCalled();
       });
@@ -64,7 +66,7 @@ describe('Client', () => {
   });
 
   it('should hydrate client once routes are ready', async () => {
-    await import('./client');
+    hydrateClient();
 
     expect(reactDom.hydrate).toHaveBeenCalledWith(
       <ClientApp routes={routes} data={window.SIMORGH_DATA} />,


### PR DESCRIPTION
Resolves #1444

**Overall change:** _Removes the console.log error from IE11 and now Client Side Renders. Stops the Client side render being hydrated on browsers that don't support `window.crypto` or `window.msCrypto`_

**Code changes:**

- _Makes `core-js` a direct dependency (already is a child dep of babel)_
- _Imports the polyfills for `set`, `map` and `symbol` in client.js which are needed for IE11 to client side render_
- _Moves the client hydration logic into a new file and then wraps the calling of the file in a check for `window.crypto` or `window.msCrypto` which stops browser who don't support this from having a blank page when the client side render fails. [More info]()_
- _Tidies an eslint disable comment_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
