### PR TITLE
bump buffer to 20s each way to prevent test flakiness

### DIFF
--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -11,7 +11,7 @@ export const assertCookieValue = (cookieName, value) => {
 };
 
 export const assertCookieExpiryDate = (cookieName, timestamp) => {
-  const testBuffer = 20;
+  const testBuffer = 60;
   cy.getCookie(cookieName).then(c => {
     expect(c.expiry).to.be.within(timestamp - testBuffer, timestamp);
   });

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -11,9 +11,12 @@ export const assertCookieValue = (cookieName, value) => {
 };
 
 export const assertCookieExpiryDate = (cookieName, timestamp) => {
-  const testBuffer = 60;
+  const testBuffer = 20;
   cy.getCookie(cookieName).then(c => {
-    expect(c.expiry).to.be.within(timestamp - testBuffer, timestamp);
+    expect(c.expiry).to.be.within(
+      timestamp - testBuffer,
+      timestamp + testBuffer,
+    );
   });
 };
 


### PR DESCRIPTION
Resolves N/A

**Overall change:** Increases buffer time for cookie expiry date checks, so that slow-running tests (due to poor CPU on box, slow network etc) don't fail.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
