### PR TITLE
Add link to amphtml url

### DIFF
--- a/cypress/integration/ampSpec.js
+++ b/cypress/integration/ampSpec.js
@@ -1,6 +1,6 @@
 import config from '../support/config';
 import { getElement } from '../support/bodyTestHelper';
-import { testResponseCode } from '../support/metaTestHelper';
+import { testResponseCode, checkCanonicalURL } from '../support/metaTestHelper';
 
 describe('AMP Tests on a .amp page', () => {
   // eslint-disable-next-line no-undef
@@ -69,6 +69,11 @@ describe('AMP Tests on a .amp page', () => {
     figure.within(() => {
       getElement('amp-img').should('be.visible');
     });
+  });
+
+  it('should include the canonical URL', () => {
+    const defaultOrigin = 'https://www.bbc.co.uk';
+    checkCanonicalURL(`${defaultOrigin}/news/articles/${config.assets.news}`);
   });
 
   it('should not have an AMP attribute on the main article', () => {

--- a/cypress/integration/metaNewsSpec.js
+++ b/cypress/integration/metaNewsSpec.js
@@ -1,6 +1,7 @@
 import config from '../support/config';
 import { getElement, getSecondElement } from '../support/bodyTestHelper';
 import {
+  checkAmpHTML,
   checkCanonicalURL,
   facebookMeta,
   metadataAssertion,
@@ -81,7 +82,7 @@ describe('Article Meta Tests', () => {
     'BBC News',
     "Meghan's bouquet laid on tomb of unknown warrior",
     'article',
-    `https://www.bbc.com/news/articles/${config.assets.newsThreeSubheadlines}`,
+    `${config.baseUrl}/news/articles/${config.assets.newsThreeSubheadlines}`,
   );
 
   twitterMeta(
@@ -98,11 +99,15 @@ describe('Article Meta Tests', () => {
     metadataAssertion();
   });
 
-  it('should include the canonical URL', () => {
+  it('should include the canonical URL & ampHTML', () => {
+    const currentOrigin = window.location.origin;
     checkCanonicalURL(
-      `https://www.bbc.com/news/articles/${
+      `${currentOrigin}/news/articles/${config.assets.newsThreeSubheadlines}`,
+    );
+    checkAmpHTML(
+      `${currentOrigin}/news/articles/${
         config.assets.newsThreeSubheadlines
-      }`,
+      }.amp`,
     );
   });
 

--- a/cypress/integration/metaPersianSpec.js
+++ b/cypress/integration/metaPersianSpec.js
@@ -1,6 +1,7 @@
 import config from '../support/config';
 import describeForLocalOnly from '../support/describeForLocalOnly';
 import {
+  checkAmpHTML,
   checkCanonicalURL,
   facebookMeta,
   metadataAssertion,
@@ -44,7 +45,7 @@ describeForLocalOnly('Persian Article Meta Tests', () => {
     'BBC News فارسی',
     'پهپادی که برایتان قهوه می‌آورد',
     'article',
-    `https://www.bbc.com/persian/articles/${config.assets.persian}`,
+    `${config.baseUrl}/persian/articles/${config.assets.persian}`,
   );
 
   twitterMeta(
@@ -57,9 +58,13 @@ describeForLocalOnly('Persian Article Meta Tests', () => {
     'پهپادی که برایتان قهوه می‌آورد',
   );
 
-  it('should include the canonical URL', () => {
+  it('should include the canonical URL & ampHTML', () => {
+    const currentOrigin = window.location.origin;
     checkCanonicalURL(
-      `https://www.bbc.com/persian/articles/${config.assets.persian}`,
+      `${currentOrigin}/persian/articles/${config.assets.persian}`,
+    );
+    checkAmpHTML(
+      `${currentOrigin}/persian/articles/${config.assets.persian}.amp`,
     );
   });
 

--- a/cypress/support/metaTestHelper.js
+++ b/cypress/support/metaTestHelper.js
@@ -89,6 +89,11 @@ export const checkCanonicalURL = URL => {
   canonical.should('have.attr', 'href', URL);
 };
 
+export const checkAmpHTML = amphtml => {
+  const ampHtml = getElement('head link[rel="amphtml"]');
+  ampHtml.should('have.attr', 'href', amphtml);
+};
+
 export const retrieve404BodyResponse = (url, bodyResponse) => {
   cy.request({ url, failOnStatusCode: false })
     .its('body')

--- a/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Metadata/__snapshots__/index.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`Metadata News AMP article should render correctly 1`] = `
     BBC News
   </title>
   <link
-    href="https://www.bbc.com/news/articles/c0000000001o.amp"
+    href="https://www.bbc.com/news/articles/c0000000001o"
     rel="canonical"
   />
   <meta
@@ -99,7 +99,7 @@ exports[`Metadata News AMP article should render correctly 1`] = `
     name="og:type"
   />
   <meta
-    content="https://www.bbc.com/news/articles/c0000000001o.amp"
+    content="https://www.bbc.com/news/articles/c0000000001o"
     name="og:url"
   />
   <meta
@@ -175,6 +175,10 @@ exports[`Metadata News article should render correctly 1`] = `
   <link
     href="https://www.bbc.com/news/articles/c0000000001o"
     rel="canonical"
+  />
+  <link
+    href="https://www.bbc.com/news/articles/c0000000001o.amp"
+    rel="amphtml"
   />
   <meta
     content="BBC News"
@@ -311,7 +315,7 @@ exports[`Metadata Persian AMP article should render correctly 1`] = `
     BBC News فارسی
   </title>
   <link
-    href="https://www.bbc.com/persian/articles/cyddjz5058wo.amp"
+    href="https://www.bbc.com/persian/articles/cyddjz5058wo"
     rel="canonical"
   />
   <meta
@@ -374,7 +378,7 @@ exports[`Metadata Persian AMP article should render correctly 1`] = `
     name="og:type"
   />
   <meta
-    content="https://www.bbc.com/persian/articles/cyddjz5058wo.amp"
+    content="https://www.bbc.com/persian/articles/cyddjz5058wo"
     name="og:url"
   />
   <meta
@@ -450,6 +454,10 @@ exports[`Metadata Persian article should render correctly 1`] = `
   <link
     href="https://www.bbc.com/persian/articles/cyddjz5058wo"
     rel="canonical"
+  />
+  <link
+    href="https://www.bbc.com/persian/articles/cyddjz5058wo.amp"
+    rel="amphtml"
   />
   <meta
     content="BBC News فارسی"
@@ -587,6 +595,10 @@ exports[`Metadata articleSection is not null should render correctly 1`] = `
   <link
     href="https://www.bbc.com/news/articles/c0000000001o"
     rel="canonical"
+  />
+  <link
+    href="https://www.bbc.com/news/articles/c0000000001o.amp"
+    rel="amphtml"
   />
   <meta
     content="BBC News"

--- a/src/app/components/Metadata/index.jsx
+++ b/src/app/components/Metadata/index.jsx
@@ -2,8 +2,16 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { arrayOf, bool, string, number } from 'prop-types';
 
+const renderAmpHtml = (ampLink, isAmp) => {
+  if (isAmp) {
+    return null;
+  }
+  return <link rel="amphtml" href={ampLink} />;
+};
+
 const Metadata = ({
   isAmp,
+  ampLink,
   articleAuthor,
   articleSection,
   brandName,
@@ -44,6 +52,7 @@ const Metadata = ({
         {title} - {brandName}
       </title>
       <link rel="canonical" href={canonicalLink} />
+      {renderAmpHtml(ampLink, isAmp)}
       <meta name="article:author" content={articleAuthor} />
       <meta name="article:modified_time" content={timeLastPublished} />
       <meta name="article:published_time" content={timeFirstPublished} />
@@ -78,6 +87,7 @@ const Metadata = ({
 
 Metadata.propTypes = {
   isAmp: bool.isRequired,
+  ampLink: string.isRequired,
   articleAuthor: string.isRequired,
   articleSection: string,
   brandName: string.isRequired,

--- a/src/app/components/Metadata/index.test.jsx
+++ b/src/app/components/Metadata/index.test.jsx
@@ -5,6 +5,7 @@ import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 const metadataSnapshotTest = (
   testDescription,
   isAmp,
+  ampLink,
   articleAuthor,
   articleSection,
   brandName,
@@ -27,6 +28,7 @@ const metadataSnapshotTest = (
   describe(testDescription, () => {
     const metadataProps = {
       isAmp,
+      ampLink,
       articleAuthor,
       articleSection,
       brandName,
@@ -57,6 +59,7 @@ describe('Metadata', () => {
   metadataSnapshotTest(
     'News article',
     false,
+    'https://www.bbc.com/news/articles/c0000000001o.amp',
     'BBC News',
     null,
     'BBC News',
@@ -80,10 +83,11 @@ describe('Metadata', () => {
   metadataSnapshotTest(
     'News AMP article',
     true,
+    'https://www.bbc.com/news/articles/c0000000001o.amp',
     'BBC News',
     null,
     'BBC News',
-    'https://www.bbc.com/news/articles/c0000000001o.amp',
+    'https://www.bbc.com/news/articles/c0000000001o',
     'https://www.bbc.com/news/image.png',
     'BBC News',
     'This is a description',
@@ -103,6 +107,7 @@ describe('Metadata', () => {
   metadataSnapshotTest(
     'Persian article',
     false,
+    'https://www.bbc.com/persian/articles/cyddjz5058wo.amp',
     'BBC News فارسی',
     null,
     'BBC News فارسی',
@@ -126,10 +131,11 @@ describe('Metadata', () => {
   metadataSnapshotTest(
     'Persian AMP article',
     true,
+    'https://www.bbc.com/persian/articles/cyddjz5058wo.amp',
     'BBC News فارسی',
     null,
     'BBC News فارسی',
-    'https://www.bbc.com/persian/articles/cyddjz5058wo.amp',
+    'https://www.bbc.com/persian/articles/cyddjz5058wo',
     'https://www.bbc.com/persian/image.png',
     'BBC News فارسی',
     'This is a description',
@@ -149,6 +155,7 @@ describe('Metadata', () => {
   metadataSnapshotTest(
     'articleSection is not null',
     false,
+    'https://www.bbc.com/news/articles/c0000000001o.amp',
     'BBC News',
     'Politics',
     'BBC News',

--- a/src/app/containers/Article/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Article/__snapshots__/index.test.jsx.snap
@@ -83,7 +83,7 @@ exports[`ArticleContainer Component 200 status code should render correctly for 
             },
             "metadata": Object {
               "created": 1514808060000,
-              "createdBy": "",
+              "createdBy": "News",
               "firstPublished": 1514808060000,
               "id": "urn:bbc:ares::article:c0000000001o",
               "lastPublished": 1514811600000,
@@ -232,7 +232,7 @@ exports[`ArticleContainer Component 200 status code should render correctly for 
             },
             "metadata": Object {
               "created": 1514808060000,
-              "createdBy": "",
+              "createdBy": "Persian",
               "firstPublished": 1514808060000,
               "id": "urn:bbc:ares::article:cyddjz5058wo",
               "lastPublished": 1514811600000,

--- a/src/app/containers/Article/fixtureData.js
+++ b/src/app/containers/Article/fixtureData.js
@@ -2,6 +2,7 @@ import { blockContainingText, singleTextBlock } from '../../models/blocks';
 
 const articleDataBuilder = (
   id,
+  createdBy,
   passportLanguage,
   home,
   headlineText,
@@ -17,7 +18,7 @@ const articleDataBuilder = (
       optimoUrn: `urn:bbc:optimo:asset:${id}`,
     },
     type: 'article',
-    createdBy: '',
+    createdBy,
     created: 1514808060000,
     firstPublished: 1514808060000,
     lastPublished: 1514811600000,
@@ -83,6 +84,7 @@ const emptyThings = {
 
 export const articleDataNews = articleDataBuilder(
   'c0000000001o',
+  'News',
   'en-gb',
   'http://www.bbc.co.uk/ontologies/passport/home/News',
   'Article Headline',
@@ -95,6 +97,7 @@ export const articleDataNews = articleDataBuilder(
 
 export const articleDataPersian = articleDataBuilder(
   'cyddjz5058wo',
+  'Persian',
   'fa',
   'http://www.bbc.co.uk/ontologies/passport/home/Persian',
   'سرصفحه مقاله',

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`ArticleMain should render a news article correctly 1`] = `
     metadata={
       Object {
         "created": 1514808060000,
-        "createdBy": "",
+        "createdBy": "News",
         "firstPublished": 1514808060000,
         "id": "urn:bbc:ares::article:c0000000001o",
         "lastPublished": 1514811600000,
@@ -148,7 +148,7 @@ exports[`ArticleMain should render a persian article correctly 1`] = `
     metadata={
       Object {
         "created": 1514808060000,
-        "createdBy": "",
+        "createdBy": "Persian",
         "firstPublished": 1514808060000,
         "id": "urn:bbc:ares::article:cyddjz5058wo",
         "lastPublished": 1514811600000,

--- a/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`no data should render null 1`] = `null`;

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -28,7 +28,7 @@ const MetadataContainer = ({ metadata, promo }) => {
 
   return (
     <RequestContextConsumer>
-      {({ platform }) => (
+      {({ origin, platform }) => (
         <ServiceContextConsumer>
           {({
             service,
@@ -43,26 +43,25 @@ const MetadataContainer = ({ metadata, promo }) => {
             publishingPrinciples,
             noBylinesPolicy,
           }) => {
-            /* Canonical link generated from servicename and id */
-            const canonicalLink = `https://www.bbc.com/${service}/articles/${id}`;
+            const canonicalLink = `${origin}/${service}/articles/${id}`;
+            const ampLink = `${origin}/${service}/articles/${id}.amp`;
 
             return (
               <Fragment>
                 <LinkedData
-                  isAmp={platform === 'amp'}
-                  lang={metadata.passport.language}
-                  type={metadata.type}
-                  seoHeadline={promo.headlines.seoHeadline}
                   firstPublished={timeFirstPublished}
                   lastUpdated={timeLastPublished}
-                  optimoId={id}
-                  service={metadata.createdBy}
-                  publishingPrinciples={publishingPrinciples}
-                  noBylinesPolicy={noBylinesPolicy}
                   logoUrl={defaultImage}
+                  noBylinesPolicy={noBylinesPolicy}
+                  optimoId={id}
+                  publishingPrinciples={publishingPrinciples}
+                  seoHeadline={promo.headlines.seoHeadline}
+                  service={metadata.createdBy}
+                  type={metadata.type}
                 />
                 <Metadata
                   isAmp={platform === 'amp'}
+                  ampLink={ampLink}
                   articleAuthor={articleAuthor}
                   articleSection={metadata.passport.genre}
                   brandName={brandName}

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -1,194 +1,192 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import Helmet from 'react-helmet';
+import { mount } from 'enzyme';
 import MetadataContainer from './index';
+import LinkedData from '../../components/LinkedData';
+import Metadata from '../../components/Metadata';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
-import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
 import services from '../../lib/config/services/index';
 import { RequestContextProvider } from '../../contexts/RequestContext';
 
-const MetadataWithContextAsObject = (service, serviceFixtureData, platform) => {
-  const { metadata, promo } = serviceFixtureData;
-
-  renderer.create(
-    <ServiceContextProvider service={service}>
-      <RequestContextProvider platform={platform}>
-        <MetadataContainer
-          metadata={metadata}
-          promo={promo}
-          service={service}
-        />
+const Container = (service, bbcOrigin, platform, data) => {
+  const serviceConfig = services[service];
+  return (
+    <ServiceContextProvider {...serviceConfig}>
+      <RequestContextProvider bbcOrigin={bbcOrigin} platform={platform}>
+        <MetadataContainer {...data} />
       </RequestContextProvider>
-    </ServiceContextProvider>,
+    </ServiceContextProvider>
   );
-
-  return Helmet.peek();
 };
 
-describe('no data', () => {
-  shouldShallowMatchSnapshot(
-    'should render null',
-    <MetadataContainer metadata={{}} promo={{}} service="" />,
-  );
+const metadataProps = (
+  isAmp,
+  ampLink,
+  canonicalLink,
+  description,
+  lang,
+  metaTags,
+  title,
+  serviceConfig,
+) => ({
+  isAmp,
+  ampLink,
+  articleAuthor: serviceConfig.articleAuthor,
+  articleSection: null,
+  brandName: serviceConfig.brandName,
+  canonicalLink,
+  defaultImage: serviceConfig.defaultImage,
+  defaultImageAltText: serviceConfig.defaultImageAltText,
+  description,
+  facebookAdmin: 100004154058350,
+  facebookAppID: 1609039196070050,
+  lang,
+  locale: serviceConfig.locale,
+  metaTags,
+  themeColor: serviceConfig.themeColor,
+  timeFirstPublished: '2018-01-01T12:01:00.000Z',
+  timeLastPublished: '2018-01-01T13:00:00.000Z',
+  title,
+  twitterCreator: serviceConfig.twitterCreator,
+  twitterSite: serviceConfig.twitterSite,
+  type: 'article',
 });
 
-const metaTagsBuilder = (serviceConfig, description, seoTitle, id, things) => {
-  const metaTags = [
-    {
-      content: 'IE=edge',
-      'http-equiv': 'X-UA-Compatible',
-    },
-    {
-      charset: 'utf-8',
-    },
-    {
-      content: 'noodp,noydir',
-      name: 'robots',
-    },
-    {
-      content: '#B80000',
-      name: 'theme-color',
-    },
-    {
-      name: 'viewport',
-      content: 'width=device-width, initial-scale=1, minimum-scale=1',
-    },
-    {
-      name: 'article:author',
-      content: serviceConfig.articleAuthor,
-    },
-    {
-      name: 'article:modified_time',
-      content: '2018-01-01T13:00:00.000Z',
-    },
-    {
-      name: 'article:published_time',
-      content: '2018-01-01T12:01:00.000Z',
-    },
-    { name: 'description', content: description },
-    { name: 'fb:admins', content: 100004154058350 },
-    { name: 'fb:app_id', content: 1609039196070050 },
-    { name: 'og:description', content: description },
-    {
-      name: 'og:image',
-      content: serviceConfig.defaultImage,
-    },
-    { name: 'og:image:alt', content: serviceConfig.brandName },
-    { name: 'og:locale', content: serviceConfig.locale },
-    { name: 'og:site_name', content: serviceConfig.brandName },
-    { name: 'og:title', content: seoTitle },
-    { name: 'og:type', content: 'article' },
-    {
-      name: 'og:url',
-      content: `https://www.bbc.com/${serviceConfig.service}/articles/${id}`,
-    },
-    { name: 'twitter:card', content: 'summary_large_image' },
-    { name: 'twitter:creator', content: serviceConfig.twitterCreator },
-    { name: 'twitter:description', content: description },
-    { name: 'twitter:image:alt', content: serviceConfig.brandName },
-    {
-      name: 'twitter:image:src',
-      content: serviceConfig.defaultImage,
-    },
-    { name: 'twitter:site', content: serviceConfig.twitterSite },
-    { name: 'twitter:title', content: seoTitle },
-  ];
+const linkedDataProps = (createdBy, logoUrl, optimoId, seoHeadline) => ({
+  firstPublished: '2018-01-01T12:01:00.000Z',
+  lastUpdated: '2018-01-01T13:00:00.000Z',
+  logoUrl,
+  noBylinesPolicy: 'https://www.bbc.com/news/help-41670342#authorexpertise',
+  optimoId,
+  publishingPrinciples: 'https://www.bbc.com/news/help-41670342',
+  seoHeadline,
+  service: createdBy,
+  type: 'article',
+});
 
-  // if the a thing meta tag needs to be injected, inject it before the tag with the name 'description'
-  if (Array.isArray(things)) {
-    things.forEach(thing => {
-      const index = metaTags.findIndex(
-        metaTag => metaTag.name === 'description',
+const dotComOrigin = 'https://www.bbc.com';
+const dotCoDotUKOrigin = 'https://www.bbc.co.uk';
+
+describe('Metadata Container', () => {
+  describe('LinkedData and Metadata components called with correct props', () => {
+    it('should be correct for Canonical News & international origin', () => {
+      const Wrapper = mount(
+        Container('news', dotComOrigin, 'canonical', articleDataNews),
       );
-      metaTags.splice(index, 0, thing);
+
+      expect(Wrapper.containsMatchingElement(<MetadataContainer />)).toEqual(
+        true,
+      );
+      expect(Wrapper.find(Metadata).props()).toEqual(
+        metadataProps(
+          false,
+          'https://www.bbc.com/news/articles/c0000000001o.amp',
+          'https://www.bbc.com/news/articles/c0000000001o',
+          'Article summary.',
+          'en-gb',
+          ['Royal Wedding 2018', 'Queen Victoria'],
+          'Article Headline for SEO',
+          services.news,
+        ),
+      );
+      expect(Wrapper.find(LinkedData).props()).toEqual(
+        linkedDataProps(
+          'News',
+          'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+          'c0000000001o',
+          'Article Headline for SEO',
+        ),
+      );
     });
-  }
 
-  return metaTags;
-};
+    it('should be correct for AMP News & UK origin', () => {
+      const Wrapper = mount(
+        Container('news', dotCoDotUKOrigin, 'amp', articleDataNews),
+      );
 
-const articleMetadataBuilder = (
-  serviceName,
-  lang,
-  title,
-  description,
-  id,
-  seoTitle,
-  things,
-) => {
-  const serviceConfig = services[serviceName];
+      expect(Wrapper.containsMatchingElement(<MetadataContainer />)).toEqual(
+        true,
+      );
+      expect(Wrapper.find(Metadata).props()).toEqual(
+        metadataProps(
+          true,
+          'https://www.bbc.co.uk/news/articles/c0000000001o.amp',
+          'https://www.bbc.co.uk/news/articles/c0000000001o',
+          'Article summary.',
+          'en-gb',
+          ['Royal Wedding 2018', 'Queen Victoria'],
+          'Article Headline for SEO',
+          services.news,
+        ),
+      );
+      expect(Wrapper.find(LinkedData).props()).toEqual(
+        linkedDataProps(
+          'News',
+          'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+          'c0000000001o',
+          'Article Headline for SEO',
+        ),
+      );
+    });
 
-  return {
-    htmlAttributes: { lang },
-    linkTags: [
-      {
-        rel: 'canonical',
-        href: `https://www.bbc.com/${serviceConfig.service}/articles/${id}`,
-      },
-      { href: '/favicon.ico', rel: 'shortcut icon', type: 'image/x-icon' },
-    ],
-    metaTags: metaTagsBuilder(serviceConfig, description, seoTitle, id, things),
-    title: [seoTitle, ' - ', serviceConfig.brandName],
-  };
-};
+    it('should be correct for Persian News & international origin', () => {
+      const Wrapper = mount(
+        Container('persian', dotComOrigin, 'canonical', articleDataPersian),
+      );
 
-const doesMatch = (result, fixture) => {
-  Object.keys(fixture).forEach(key => {
-    expect(result[key]).toEqual(fixture[key]);
-  });
-};
+      expect(Wrapper.containsMatchingElement(<MetadataContainer />)).toEqual(
+        true,
+      );
+      expect(Wrapper.find(Metadata).props()).toEqual(
+        metadataProps(
+          false,
+          'https://www.bbc.com/persian/articles/cyddjz5058wo.amp',
+          'https://www.bbc.com/persian/articles/cyddjz5058wo',
+          'خلاصه مقاله',
+          'fa',
+          [],
+          'سرصفحه مقاله',
+          services.persian,
+        ),
+      );
+      expect(Wrapper.find(LinkedData).props()).toEqual(
+        linkedDataProps(
+          'Persian',
+          'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
+          'cyddjz5058wo',
+          'سرصفحه مقاله',
+        ),
+      );
+    });
 
-describe('Successfully passes data to the Metadata component via React context', () => {
-  it('should pass persian data to the Metadata component', () => {
-    const result = MetadataWithContextAsObject(
-      'persian',
-      articleDataPersian,
-      'canonical',
-    );
-    const expected = articleMetadataBuilder(
-      'persian',
-      'fa',
-      'سرصفحه مقاله',
-      'خلاصه مقاله',
-      'cyddjz5058wo',
-      'سرصفحه مقاله',
-      [],
-    );
+    it('should be correct for Persian News & UK origin', () => {
+      const Wrapper = mount(
+        Container('persian', dotCoDotUKOrigin, 'amp', articleDataPersian),
+      );
 
-    doesMatch(result, expected);
-  });
-
-  it('it should pass news data to the Metadata component', () => {
-    const result = MetadataWithContextAsObject(
-      'news',
-      articleDataNews,
-      'canonical',
-    );
-    const expected = articleMetadataBuilder(
-      'news',
-      'en-gb',
-      'Article Headline',
-      'Article summary.',
-      'c0000000001o',
-      'Article Headline for SEO',
-      [
-        {
-          name: 'article:tag',
-          content: 'Royal Wedding 2018',
-        },
-        {
-          name: 'article:tag',
-          content: 'Queen Victoria',
-        },
-      ],
-    );
-
-    doesMatch(result, expected);
-  });
-
-  it('should add amp to HTML attributes when platform is set to AMP', () => {
-    const result = MetadataWithContextAsObject('news', articleDataNews, 'amp');
-    expect(result.htmlAttributes.amp).not.toBe(undefined);
+      expect(Wrapper.containsMatchingElement(<MetadataContainer />)).toEqual(
+        true,
+      );
+      expect(Wrapper.find(Metadata).props()).toEqual(
+        metadataProps(
+          true,
+          'https://www.bbc.co.uk/persian/articles/cyddjz5058wo.amp',
+          'https://www.bbc.co.uk/persian/articles/cyddjz5058wo',
+          'خلاصه مقاله',
+          'fa',
+          [],
+          'سرصفحه مقاله',
+          services.persian,
+        ),
+      );
+      expect(Wrapper.find(LinkedData).props()).toEqual(
+        linkedDataProps(
+          'Persian',
+          'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
+          'cyddjz5058wo',
+          'سرصفحه مقاله',
+        ),
+      );
+    });
   });
 });


### PR DESCRIPTION
Resolves #1337 

**Overall change:** Adds amphtml link tag to head of document, for the canonical pages only.

**Code changes:**

- Adds amphtml link tag to component
- Canonical link & og:url meta content always of format `${bbcOrigin}/${service}/articles/${id}`
- AMP HTML link always of format `${bbcOrigin}/${service}/articles/${id}.amp`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
