### PR TITLE
Only use fixture data route if on local env

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -94,7 +94,7 @@ if (process.env.APP_ENV === 'local') {
 }
 
 /*
- * Test and Live env routes
+ * Application env routes
  */
 
 server


### PR DESCRIPTION
**Overall change:** Only use fixture data route if on local env

**Code changes:**

- Only use fixture data route if on local env

**Testing notes:**
Building using test env and the live env should result in the application not serving up `/articles/:id.json`. The application should continue to work since it fetches from the relevant endpoint instead: `https://www.(test.)bbc.co.uk/news/articles/:id.json`

`npm run build:test && npm run start`  & http://localhost:7080/news/articles/cn7769kpk9mo.json should 404. Same for the live env. 

However, the local dev setup `npm run dev` should have the json endpoint working.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
