### PR TITLE
 Add Ligsalz8 story data 

### DIFF
--- a/data/prod/news/articles/c5jje4ejkqvo.json
+++ b/data/prod/news/articles/c5jje4ejkqvo.json
@@ -1,0 +1,1004 @@
+{
+  "content": {
+    "model": {
+      "blocks": [
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "The Germans solving rising rents with people power"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "The Germans solving rising rents with people power"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 549,
+                  "locator": "e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 976
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "The residents of Ligsalz8 believe they have found the answer to the expensive cost of renting in Munich"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "The residents of Ligsalz8 believe they have found the answer to the expensive cost of renting in Munich"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "group of residents"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "group of residents"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Rents in Munich's trendy Westend district have soared in recent years. \nThe former working-class neighbourhood, home to the city's oldest \nbrewery, the Augustiner, has been smartened up and gentrified. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Rents in Munich's trendy Westend district have soared in recent years. \nThe former working-class neighbourhood, home to the city's oldest \nbrewery, the Augustiner, has been smartened up and gentrified. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Anger at rising rents has grown, with 10,000 people taking to the streets in protest in Munich last September."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Anger at rising rents has grown, with 10,000 people taking to the streets in protest in Munich last September."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "But in one building, known as Ligsalz8, rents have remained the same for 10 years - and are set to stay that way."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "But in one building, known as Ligsalz8, rents have remained the same for 10 years - and are set to stay that way."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"In 2008, we started with rents of €7.88 per square metre and in 2018 it\n is still the same,\" York Runte, one of the tenants, told me. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"In 2008, we started with rents of €7.88 per square metre and in 2018 it\n is still the same,\" York Runte, one of the tenants, told me. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "And in Munich, that's cheap."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "And in Munich, that's cheap."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "Ligsalz8",
+                  "height": 624,
+                  "locator": "6e7c/test/05bb8ab0-50aa-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 624
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "Ligsalz8's colourful decor stands out, complete with a slogan demanding an end to migrant deportations to Afghanistan\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "Ligsalz8's colourful decor stands out, complete with a slogan demanding an end to migrant deportations to Afghanistan\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "a painted house with some vines"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "a painted house with some vines"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"Average rent around here is €13 per square metre, but now if you are a new tenant, you have to pay more than €17,\" said York."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"Average rent around here is €13 per square metre, but now if you are a new tenant, you have to pay more than €17,\" said York."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "How Ligsalz8 keeps its prices low"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "How Ligsalz8 keeps its prices low"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "It's a communal property, neither owned by private landlords nor by the state."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "It's a communal property, neither owned by private landlords nor by the state."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ligsalz8\n is part of a rental housing syndicate, the Mietshäuser Syndikat, which \naims to keep rents affordable and out of the hands of speculators."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ligsalz8\n is part of a rental housing syndicate, the Mietshäuser Syndikat, which \naims to keep rents affordable and out of the hands of speculators."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "There are rent controls in Munich and prices are lower than in the UK, but rents are still creeping up"
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "There are rent controls in Munich and prices are lower than in the UK, but rents are still creeping up"
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ligsalz8 is involved in more than 100 projects throughout Germany, \nand has links to similar setups in the Netherlands and Austria. Aware of\n how high living costs are in the UK, the organisers are keen to spread \nthe idea even further."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ligsalz8 is involved in more than 100 projects throughout Germany, \nand has links to similar setups in the Netherlands and Austria. Aware of\n how high living costs are in the UK, the organisers are keen to spread \nthe idea even further."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We thought, what can we do to make sure that these flats never get privatised again?\" said York."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We thought, what can we do to make sure that these flats never get privatised again?\" said York."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "How they buy their buildings"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "How they buy their buildings"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Groups of tenants create housing associations, which join with the \nsyndicate to form private limited companies. Those companies then buy - \nand own - the buildings. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Groups of tenants create housing associations, which join with the \nsyndicate to form private limited companies. Those companies then buy - \nand own - the buildings. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "They are financed by direct microcredits\n in the form of tiny loans and crowdfunding, as well as \"standard\" bank \nloans and support from the syndicate."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "They are financed by direct microcredits\n in the form of tiny loans and crowdfunding, as well as \"standard\" bank \nloans and support from the syndicate."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "The rents stay the same, even after the loans are paid off. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "The rents stay the same, even after the loans are paid off. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "It's not a co-operative. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "It's not a co-operative. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Tenants would need their own capital for that, York told me, and there is the \ndanger that with a majority vote, the rental flats could be put on the \nmarket again.  "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Tenants would need their own capital for that, York told me, and there is the \ndanger that with a majority vote, the rental flats could be put on the \nmarket again.  "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "Yorke Runte",
+                  "height": 351,
+                  "locator": "5d3e/test/aeeb4f30-50aa-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 624
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "York Runte is keen on the shared ownership model\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "York Runte is keen on the shared ownership model\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": " York Runte is keen on the shared ownership model "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": " York Runte is keen on the shared ownership model "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Instead, the tenants administer the buildings themselves and make the\n key decisions on upkeep, renovation and rents, but the syndicate has \nthe right to veto any proposal to re-sell the property. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Instead, the tenants administer the buildings themselves and make the\n key decisions on upkeep, renovation and rents, but the syndicate has \nthe right to veto any proposal to re-sell the property. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We are not start-ups, we are very solid and stable and pay off the interest on \nour loans on time,\" another tenant, Ralf Homann, said."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We are not start-ups, we are very solid and stable and pay off the interest on \nour loans on time,\" another tenant, Ralf Homann, said."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "For residents like Ramona Pielenhofer, a young freelance designer, the model provides security."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "For residents like Ramona Pielenhofer, a young freelance designer, the model provides security."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"In Munich it is particularly hard to find affordable places to live. But \ncompared with other flatshares I have lived in, Ligsalz8 is cheap,\" she \ntold me. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"In Munich it is particularly hard to find affordable places to live. But \ncompared with other flatshares I have lived in, Ligsalz8 is cheap,\" she \ntold me. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 351,
+                  "locator": "4a9f/test/1ed00610-50ab-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 211
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "Tenants share a common area to socialise in - which for many is an advantage\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "Tenants share a common area to socialise in - which for many is an advantage\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "residents"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "residents"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"And that makes many things much simpler for me, including my \ndecision to go freelance. I became self-employed three years ago and \nit's a real relief to be able to live here."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"And that makes many things much simpler for me, including my \ndecision to go freelance. I became self-employed three years ago and \nit's a real relief to be able to live here."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"It is also really nice to be in the centre of the city. I can cycle to work and take \nadvantage of the shops and bars and restaurants.\""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"It is also really nice to be in the centre of the city. I can cycle to work and take \nadvantage of the shops and bars and restaurants.\""
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ramona says her fellow tenants are like \"a kind of family\"."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ramona says her fellow tenants are like \"a kind of family\"."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We are all very different, we have different jobs, we are of different \nages including a 20-month-old baby. But this building brings us \ntogether. We feel responsible for the house. I like it very much.\""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We are all very different, we have different jobs, we are of different \nages including a 20-month-old baby. But this building brings us \ntogether. We feel responsible for the house. I like it very much.\""
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 100,
+                  "locator": "94fa/test/d6af1960-50ab-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 100
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "This is a minimum size image of 100px x 100px. "
+                                  },
+                                  "type": "fragment"
+                                },
+                                {
+                                  "model": {
+                                    "attributes": ["italic"],
+                                    "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "This is a minimum size image of 100px x 100px. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut"
+                            },
+                            "type": "paragraph"
+                          },
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": ["italic"],
+                                    "text": " "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": " "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "small image"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "small image"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": ""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": ""
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "analyticsLabels": {},
+    "blockTypes": [
+      "headline",
+      "text",
+      "paragraph",
+      "fragment",
+      "image",
+      "rawImage",
+      "caption",
+      "altText"
+    ],
+    "createdBy": "News",
+    "firstPublished": 1553703216863.0,
+    "id": "urn:bbc:ares::article:c5jje4ejkqvo",
+    "language": "en-gb",
+    "lastPublished": 1553703633751.0,
+    "lastUpdated": 1553703637912.0,
+    "locators": {
+      "canonicalUrl": "https://www.bbc.com/news/articles/c5jje4ejkqvo",
+      "optimoUrn": "urn:bbc:optimo:asset:c5jje4ejkqvo"
+    },
+    "options": {},
+    "passport": {
+      "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+      "language": "en-gb"
+    },
+    "tags": {},
+    "type": "article",
+    "version": "v1.0.6"
+  },
+  "promo": {
+    "headlines": {
+      "seoHeadline": "The Germans solving rising rents with people power"
+    },
+    "id": "urn:bbc:ares::article:c5jje4ejkqvo",
+    "locators": {
+      "canonicalUrl": "https://www.bbc.com/news/articles/c5jje4ejkqvo",
+      "optimoUrn": "urn:bbc:optimo:asset:c5jje4ejkqvo"
+    },
+    "summary": "",
+    "timestamp": 1553703633751.0,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "site": {
+      "name": "News",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/news"
+    }
+  }
+}

--- a/data/test/news/articles/c0000000025o.json
+++ b/data/test/news/articles/c0000000025o.json
@@ -1,0 +1,995 @@
+{
+  "metadata": {
+    "analyticsLabels": {},
+    "blockTypes": [
+      "headline",
+      "text",
+      "paragraph",
+      "fragment",
+      "image",
+      "rawImage",
+      "caption",
+      "altText"
+    ],
+    "createdBy": "News",
+    "firstPublished": 1553703216863.0,
+    "id": "urn:bbc:ares::article:c0000000025o",
+    "language": "en-gb",
+    "lastPublished": 1553703633751.0,
+    "lastUpdated": 1553703637912.0,
+    "locators": {
+      "canonicalUrl": "https://www.bbc.com/news/articles/c0000000025o",
+      "optimoUrn": "urn:bbc:optimo:asset:c0000000025o"
+    },
+    "options": {},
+    "passport": {
+      "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+      "language": "en-gb"
+    },
+    "tags": {},
+    "type": "article",
+    "version": "v1.0.6"
+  },
+  "content": {
+    "model": {
+      "blocks": [
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "The Germans solving rising rents with people power"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "The Germans solving rising rents with people power"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 549,
+                  "locator": "e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 976
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "The residents of Ligsalz8 believe they have found the answer to the expensive cost of renting in Munich"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "The residents of Ligsalz8 believe they have found the answer to the expensive cost of renting in Munich"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "group of residents"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "group of residents"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Rents in Munich's trendy Westend district have soared in recent years. \nThe former working-class neighbourhood, home to the city's oldest \nbrewery, the Augustiner, has been smartened up and gentrified. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Rents in Munich's trendy Westend district have soared in recent years. \nThe former working-class neighbourhood, home to the city's oldest \nbrewery, the Augustiner, has been smartened up and gentrified. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Anger at rising rents has grown, with 10,000 people taking to the streets in protest in Munich last September."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Anger at rising rents has grown, with 10,000 people taking to the streets in protest in Munich last September."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "But in one building, known as Ligsalz8, rents have remained the same for 10 years - and are set to stay that way."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "But in one building, known as Ligsalz8, rents have remained the same for 10 years - and are set to stay that way."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"In 2008, we started with rents of €7.88 per square metre and in 2018 it\n is still the same,\" York Runte, one of the tenants, told me. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"In 2008, we started with rents of €7.88 per square metre and in 2018 it\n is still the same,\" York Runte, one of the tenants, told me. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "And in Munich, that's cheap."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "And in Munich, that's cheap."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "Ligsalz8",
+                  "height": 624,
+                  "locator": "6e7c/test/05bb8ab0-50aa-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 624
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "Ligsalz8's colourful decor stands out, complete with a slogan demanding an end to migrant deportations to Afghanistan\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "Ligsalz8's colourful decor stands out, complete with a slogan demanding an end to migrant deportations to Afghanistan\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "a painted house with some vines"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "a painted house with some vines"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"Average rent around here is €13 per square metre, but now if you are a new tenant, you have to pay more than €17,\" said York."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"Average rent around here is €13 per square metre, but now if you are a new tenant, you have to pay more than €17,\" said York."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "How Ligsalz8 keeps its prices low"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "How Ligsalz8 keeps its prices low"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "It's a communal property, neither owned by private landlords nor by the state."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "It's a communal property, neither owned by private landlords nor by the state."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ligsalz8\n is part of a rental housing syndicate, the Mietshäuser Syndikat, which \naims to keep rents affordable and out of the hands of speculators."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ligsalz8\n is part of a rental housing syndicate, the Mietshäuser Syndikat, which \naims to keep rents affordable and out of the hands of speculators."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "There are rent controls in Munich and prices are lower than in the UK, but rents are still creeping up"
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "There are rent controls in Munich and prices are lower than in the UK, but rents are still creeping up"
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ligsalz8 is involved in more than 100 projects throughout Germany, \nand has links to similar setups in the Netherlands and Austria. Aware of\n how high living costs are in the UK, the organisers are keen to spread \nthe idea even further."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ligsalz8 is involved in more than 100 projects throughout Germany, \nand has links to similar setups in the Netherlands and Austria. Aware of\n how high living costs are in the UK, the organisers are keen to spread \nthe idea even further."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We thought, what can we do to make sure that these flats never get privatised again?\" said York."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We thought, what can we do to make sure that these flats never get privatised again?\" said York."
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "attributes": [],
+                              "text": "How they buy their buildings"
+                            },
+                            "type": "fragment"
+                          }
+                        ],
+                        "text": "How they buy their buildings"
+                      },
+                      "type": "paragraph"
+                    }
+                  ]
+                },
+                "type": "text"
+              }
+            ]
+          },
+          "type": "headline"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Groups of tenants create housing associations, which join with the \nsyndicate to form private limited companies. Those companies then buy - \nand own - the buildings. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Groups of tenants create housing associations, which join with the \nsyndicate to form private limited companies. Those companies then buy - \nand own - the buildings. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "They are financed by direct microcredits\n in the form of tiny loans and crowdfunding, as well as \"standard\" bank \nloans and support from the syndicate."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "They are financed by direct microcredits\n in the form of tiny loans and crowdfunding, as well as \"standard\" bank \nloans and support from the syndicate."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "The rents stay the same, even after the loans are paid off. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "The rents stay the same, even after the loans are paid off. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "It's not a co-operative. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "It's not a co-operative. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Tenants would need their own capital for that, York told me, and there is the \ndanger that with a majority vote, the rental flats could be put on the \nmarket again.  "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Tenants would need their own capital for that, York told me, and there is the \ndanger that with a majority vote, the rental flats could be put on the \nmarket again.  "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "Yorke Runte",
+                  "height": 351,
+                  "locator": "5d3e/test/aeeb4f30-50aa-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 624
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "York Runte is keen on the shared ownership model\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "York Runte is keen on the shared ownership model\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": " York Runte is keen on the shared ownership model "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": " York Runte is keen on the shared ownership model "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Instead, the tenants administer the buildings themselves and make the\n key decisions on upkeep, renovation and rents, but the syndicate has \nthe right to veto any proposal to re-sell the property. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Instead, the tenants administer the buildings themselves and make the\n key decisions on upkeep, renovation and rents, but the syndicate has \nthe right to veto any proposal to re-sell the property. "
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We are not start-ups, we are very solid and stable and pay off the interest on \nour loans on time,\" another tenant, Ralf Homann, said."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We are not start-ups, we are very solid and stable and pay off the interest on \nour loans on time,\" another tenant, Ralf Homann, said."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "For residents like Ramona Pielenhofer, a young freelance designer, the model provides security."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "For residents like Ramona Pielenhofer, a young freelance designer, the model provides security."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"In Munich it is particularly hard to find affordable places to live. But \ncompared with other flatshares I have lived in, Ligsalz8 is cheap,\" she \ntold me. "
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"In Munich it is particularly hard to find affordable places to live. But \ncompared with other flatshares I have lived in, Ligsalz8 is cheap,\" she \ntold me. "
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 351,
+                  "locator": "4a9f/test/1ed00610-50ab-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 211
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "Tenants share a common area to socialise in - which for many is an advantage\n                "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "Tenants share a common area to socialise in - which for many is an advantage\n                "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "residents"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "residents"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"And that makes many things much simpler for me, including my \ndecision to go freelance. I became self-employed three years ago and \nit's a real relief to be able to live here."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"And that makes many things much simpler for me, including my \ndecision to go freelance. I became self-employed three years ago and \nit's a real relief to be able to live here."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"It is also really nice to be in the centre of the city. I can cycle to work and take \nadvantage of the shops and bars and restaurants.\""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"It is also really nice to be in the centre of the city. I can cycle to work and take \nadvantage of the shops and bars and restaurants.\""
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "Ramona says her fellow tenants are like \"a kind of family\"."
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "Ramona says her fellow tenants are like \"a kind of family\"."
+                },
+                "type": "paragraph"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": "\"We are all very different, we have different jobs, we are of different \nages including a 20-month-old baby. But this building brings us \ntogether. We feel responsible for the house. I like it very much.\""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": "\"We are all very different, we have different jobs, we are of different \nages including a 20-month-old baby. But this building brings us \ntogether. We feel responsible for the house. I like it very much.\""
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "copyrightHolder": "@twitterhandle",
+                  "height": 100,
+                  "locator": "94fa/test/d6af1960-50ab-11e9-8100-2defb9ff0749.jpg",
+                  "originCode": "cpsdevpb",
+                  "width": 100
+                },
+                "type": "rawImage"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "This is a minimum size image of 100px x 100px. "
+                                  },
+                                  "type": "fragment"
+                                },
+                                {
+                                  "model": {
+                                    "attributes": ["italic"],
+                                    "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "This is a minimum size image of 100px x 100px. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut"
+                            },
+                            "type": "paragraph"
+                          },
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": ["italic"],
+                                    "text": " "
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": " "
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "caption"
+              },
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "blocks": [
+                          {
+                            "model": {
+                              "blocks": [
+                                {
+                                  "model": {
+                                    "attributes": [],
+                                    "text": "small image"
+                                  },
+                                  "type": "fragment"
+                                }
+                              ],
+                              "text": "small image"
+                            },
+                            "type": "paragraph"
+                          }
+                        ]
+                      },
+                      "type": "text"
+                    }
+                  ]
+                },
+                "type": "altText"
+              }
+            ]
+          },
+          "type": "image"
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "model": {
+                  "blocks": [
+                    {
+                      "model": {
+                        "attributes": [],
+                        "text": ""
+                      },
+                      "type": "fragment"
+                    }
+                  ],
+                  "text": ""
+                },
+                "type": "paragraph"
+              }
+            ]
+          },
+          "type": "text"
+        }
+      ]
+    }
+  },
+  "promo": {
+    "headlines": {
+      "seoHeadline": "The Germans solving rising rents with people power"
+    },
+    "id": "urn:bbc:ares::article:c0000000025o",
+    "locators": {
+      "canonicalUrl": "https://www.bbc.com/news/articles/c0000000025o",
+      "optimoUrn": "urn:bbc:optimo:asset:c0000000025o"
+    },
+    "summary": "",
+    "timestamp": 1553703633751.0,
+    "type": "cps"
+  }
+}

--- a/data/test/news/articles/c5jje4ejkqvo.json
+++ b/data/test/news/articles/c5jje4ejkqvo.json
@@ -13,13 +13,13 @@
     ],
     "createdBy": "News",
     "firstPublished": 1553703216863.0,
-    "id": "urn:bbc:ares::article:c0000000025o",
+    "id": "urn:bbc:ares::article:c5jje4ejkqvo",
     "language": "en-gb",
     "lastPublished": 1553703633751.0,
     "lastUpdated": 1553703637912.0,
     "locators": {
-      "canonicalUrl": "https://www.bbc.com/news/articles/c0000000025o",
-      "optimoUrn": "urn:bbc:optimo:asset:c0000000025o"
+      "canonicalUrl": "https://www.bbc.com/news/articles/c5jje4ejkqvo",
+      "optimoUrn": "urn:bbc:optimo:asset:c5jje4ejkqvo"
     },
     "options": {},
     "passport": {
@@ -983,10 +983,10 @@
     "headlines": {
       "seoHeadline": "The Germans solving rising rents with people power"
     },
-    "id": "urn:bbc:ares::article:c0000000025o",
+    "id": "urn:bbc:ares::article:c5jje4ejkqvo",
     "locators": {
-      "canonicalUrl": "https://www.bbc.com/news/articles/c0000000025o",
-      "optimoUrn": "urn:bbc:optimo:asset:c0000000025o"
+      "canonicalUrl": "https://www.bbc.com/news/articles/c5jje4ejkqvo",
+      "optimoUrn": "urn:bbc:optimo:asset:c5jje4ejkqvo"
     },
     "summary": "",
     "timestamp": 1553703633751.0,

--- a/src/app/dataValidator/helpers/dataLoader/asyncValidateDir.test.js
+++ b/src/app/dataValidator/helpers/dataLoader/asyncValidateDir.test.js
@@ -33,7 +33,7 @@ describe('asyncValidateDir helper', () => {
   it('should call readScenario for every file in the /data directory', async () => {
     const readScenarioSpy = jest.spyOn(readScenario, 'readScenario');
 
-    await expectMethodToBeCalledTimes(53, readScenarioSpy);
+    await expectMethodToBeCalledTimes(49, readScenarioSpy);
   });
 
   it('should call fileToValidate for only the valid json file in the /data directory', async () => {

--- a/src/app/dataValidator/helpers/dataLoader/asyncValidateDir.test.js
+++ b/src/app/dataValidator/helpers/dataLoader/asyncValidateDir.test.js
@@ -33,19 +33,19 @@ describe('asyncValidateDir helper', () => {
   it('should call readScenario for every file in the /data directory', async () => {
     const readScenarioSpy = jest.spyOn(readScenario, 'readScenario');
 
-    await expectMethodToBeCalledTimes(47, readScenarioSpy);
+    await expectMethodToBeCalledTimes(53, readScenarioSpy);
   });
 
   it('should call fileToValidate for only the valid json file in the /data directory', async () => {
     fileToValidateSpy = jest.spyOn(readScenario, 'fileToValidate');
 
-    await expectMethodToBeCalledTimes(34, fileToValidateSpy);
+    await expectMethodToBeCalledTimes(36, fileToValidateSpy);
   });
 
   it('should call fileToValidate for only the files in /data/prod/news', async () => {
     fileToValidateSpy = jest.spyOn(readScenario, 'fileToValidate');
 
-    await expectMethodToBeCalledTimes(5, fileToValidateSpy, './data/prod/news');
+    await expectMethodToBeCalledTimes(6, fileToValidateSpy, './data/prod/news');
   });
 
   it('should return a promise', () => {


### PR DESCRIPTION
Doesn't resolve a ticket, I did this work as part of #1506

**Overall change:**
Data is added for the article that is used in the [designs on Zeplin](https://app.zeplin.io/project/5baa564c05c2eba0d2b89568).
The article can be [found on test](https://www.test.bbc.co.uk/news/articles/c5jje4ejkqvo). 
This should be helpful when testing whether things we have implemented match the designs.

**Code changes:**

- A `test` version of the data is added under `c5jje4ejkqvo`
- A `prod` version of the data is added under `c5jje4ejkqvo`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
