### PR TITLE
Timestamp bug fix

### DIFF
--- a/.storybook/cypress/integration/index.js
+++ b/.storybook/cypress/integration/index.js
@@ -13,7 +13,7 @@ describe('Storybook Article', () => {
   });
 
   it('each story render panel should not be blank', () => {
-    cy.get('ul>li>a').each($a => {
+    cy.get('div[role="menuitem"]').each($a => {
       cy.wrap($a).click({ force: true });
       cy.get('#storybook-preview-iframe').then($iframe => {
         // .sb-show-main is the class of the storybook display panel

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,3 @@
 Cypress.Screenshot.defaults({
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: true,
 });

--- a/data/prod/news/articles/c5ll353v7y9o.json
+++ b/data/prod/news/articles/c5ll353v7y9o.json
@@ -753,11 +753,11 @@
       "caption"
     ],
     "createdBy": "News",
-    "firstPublished": 1549451854630,
+    "firstPublished": 1539188371344,
     "id": "urn:bbc:ares::article:c5ll353v7y9o",
     "language": "en-gb",
-    "lastPublished": 1549451854630,
-    "lastUpdated": 1550157568186,
+    "lastPublished": 1544541368761,
+    "lastUpdated": 1553207108515,
     "locators": {
       "optimoUrn": "urn:bbc:optimo:asset:c5ll353v7y9o"
     },
@@ -779,7 +779,7 @@
       "optimoUrn": "urn:bbc:optimo:asset:c5ll353v7y9o"
     },
     "summary": "",
-    "timestamp": 1549451854630,
+    "timestamp": 1544541368761,
     "type": "cps"
   },
   "relatedContent": {

--- a/data/prod/news/articles/c5ll353v7y9o.json
+++ b/data/prod/news/articles/c5ll353v7y9o.json
@@ -753,11 +753,11 @@
       "caption"
     ],
     "createdBy": "News",
-    "firstPublished": 1539188371344,
+    "firstPublished": 1549451854630,
     "id": "urn:bbc:ares::article:c5ll353v7y9o",
     "language": "en-gb",
-    "lastPublished": 1544541368761,
-    "lastUpdated": 1553207108515,
+    "lastPublished": 1549451854630,
+    "lastUpdated": 1550157568186,
     "locators": {
       "optimoUrn": "urn:bbc:optimo:asset:c5ll353v7y9o"
     },
@@ -779,7 +779,7 @@
       "optimoUrn": "urn:bbc:optimo:asset:c5ll353v7y9o"
     },
     "summary": "",
-    "timestamp": 1544541368761,
+    "timestamp": 1549451854630,
     "type": "cps"
   },
   "relatedContent": {

--- a/data/test/news/articles/cl55zn0w0l4o.json
+++ b/data/test/news/articles/cl55zn0w0l4o.json
@@ -793,8 +793,8 @@
     "firstPublished": 1539188371344,
     "id": "urn:bbc:ares::article:cl55zn0w0l4o",
     "language": "en-gb",
-    "lastPublished": 1544541368761,
-    "lastUpdated": 1553207108515,
+    "lastPublished": 1539188371344,
+    "lastUpdated": 1552558371324,
     "locators": {
       "canonicalUrl": "https://www.bbc.com/news/articles/cl55zn0w0l4o",
       "optimoUrn": "urn:bbc:optimo:asset:cl55zn0w0l4o"
@@ -888,7 +888,7 @@
       "optimoUrn": "urn:bbc:optimo:asset:cl55zn0w0l4o"
     },
     "summary": "",
-    "timestamp": 1544541368761,
+    "timestamp": 1539188371344,
     "type": "cps"
   },
   "relatedContent": {

--- a/data/test/news/articles/cl55zn0w0l4o.json
+++ b/data/test/news/articles/cl55zn0w0l4o.json
@@ -793,8 +793,8 @@
     "firstPublished": 1539188371344,
     "id": "urn:bbc:ares::article:cl55zn0w0l4o",
     "language": "en-gb",
-    "lastPublished": 1539188371344,
-    "lastUpdated": 1552558371324,
+    "lastPublished": 1544541368761,
+    "lastUpdated": 1553207108515,
     "locators": {
       "canonicalUrl": "https://www.bbc.com/news/articles/cl55zn0w0l4o",
       "optimoUrn": "urn:bbc:optimo:asset:cl55zn0w0l4o"
@@ -888,7 +888,7 @@
       "optimoUrn": "urn:bbc:optimo:asset:cl55zn0w0l4o"
     },
     "summary": "",
-    "timestamp": 1539188371344,
+    "timestamp": 1544541368761,
     "type": "cps"
   },
   "relatedContent": {

--- a/src/app/containers/Timestamp/index.jsx
+++ b/src/app/containers/Timestamp/index.jsx
@@ -47,47 +47,50 @@ const timestampWithPrefixUpdated = (datetime, updateTime) => (
   </Timestamp>
 );
 
-const defaultTimestamp = published => (
-  <Timestamp datetime={formatUnixTimestamp(new Date(published), longNumeric)}>
-    {formatUnixTimestamp(new Date(published), shortAlphaNumeric)}
+const defaultTimestamp = firstPublished => (
+  <Timestamp
+    datetime={formatUnixTimestamp(new Date(firstPublished), longNumeric)}
+  >
+    {formatUnixTimestamp(new Date(firstPublished), shortAlphaNumeric)}
   </Timestamp>
 );
 
-const hasBeenUpdated = (updated, published) => updated !== published;
+const hasBeenlastPublished = (lastPublished, firstPublished) =>
+  lastPublished !== firstPublished;
 
-const updatedTimestamp = (updated, published) => {
-  if (!hasBeenUpdated(updated, published)) {
+const updatedTimestamp = (lastPublished, firstPublished) => {
+  if (!hasBeenlastPublished(lastPublished, firstPublished)) {
     return null;
   }
 
   // return absolute or relative secondary timestamp depending on <= 10 hours
   return timestampWithPrefixUpdated(
-    formatUnixTimestamp(updated, longNumeric),
-    isTenHoursAgoOrLess(updated)
-      ? formatUnixTimestamp(updated, shortAlphaNumeric)
-      : relativeTime(updated),
+    formatUnixTimestamp(lastPublished, longNumeric),
+    isTenHoursAgoOrLess(lastPublished)
+      ? formatUnixTimestamp(lastPublished, shortAlphaNumeric)
+      : relativeTime(lastPublished),
   );
 };
 
-const TimestampContainer = ({ updated, published }) => {
+const TimestampContainer = ({ lastPublished, firstPublished }) => {
   if (
-    !isValidDateTime(new Date(updated)) ||
-    !isValidDateTime(new Date(published))
+    !isValidDateTime(new Date(lastPublished)) ||
+    !isValidDateTime(new Date(firstPublished))
   ) {
     return null;
   }
 
   return (
     <GridItemConstrainedMedium>
-      {defaultTimestamp(published)}
-      {updatedTimestamp(updated, published)}
+      {defaultTimestamp(firstPublished)}
+      {updatedTimestamp(lastPublished, firstPublished)}
     </GridItemConstrainedMedium>
   );
 };
 
 TimestampContainer.propTypes = {
-  updated: number.isRequired,
-  published: number.isRequired,
+  firstPublished: number.isRequired,
+  lastPublished: number.isRequired,
 };
 
 export default TimestampContainer;

--- a/src/app/containers/Timestamp/index.stories.jsx
+++ b/src/app/containers/Timestamp/index.stories.jsx
@@ -3,5 +3,5 @@ import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-e
 import Timestamp from '.';
 
 storiesOf('TimestampContainer', module).add('default', () => (
-  <Timestamp updated={1552666749637} published={1530947227000} />
+  <Timestamp firstPublished={1530947227000} lastPublished={1552666749637} />
 ));

--- a/src/app/containers/Timestamp/index.test.jsx
+++ b/src/app/containers/Timestamp/index.test.jsx
@@ -20,22 +20,25 @@ describe('Timestamp', () => {
   shouldMatchSnapshot(
     'should render without a leading zero on the day',
     <Timestamp
-      updated={noLeadingZeroTimestamp}
-      published={noLeadingZeroTimestamp}
+      firstPublished={noLeadingZeroTimestamp}
+      lastPublished={noLeadingZeroTimestamp}
     />,
   );
   shouldMatchSnapshot(
     'should render correctly',
-    <Timestamp updated={timestamp} published={timestamp} />,
+    <Timestamp lastPublished={timestamp} firstPublished={timestamp} />,
   );
   shouldMatchSnapshot(
     'should handle an invalid timestamp',
-    <Timestamp updated={invalidTimestamp} published={invalidTimestamp} />,
+    <Timestamp
+      firstPublished={invalidTimestamp}
+      lastPublished={invalidTimestamp}
+    />,
   );
 
   it('should display only one timestamp when published === updated', () => {
     const renderedWrapper = renderedTimestamps(
-      <Timestamp updated={fifthJan} published={fifthJan} />,
+      <Timestamp firstPublished={fifthJan} lastPublished={fifthJan} />,
     );
     expect(renderedWrapper[0].children[0].data).toEqual('5 January 2019');
     expect(renderedWrapper.length).toEqual(1);
@@ -44,7 +47,7 @@ describe('Timestamp', () => {
   it('should display a relative timestamp when updated < 10 hours ago', () => {
     const sixHoursAgo = timestampGenerator({ hours: 6 });
     const renderedWrapper = renderedTimestamps(
-      <Timestamp updated={sixHoursAgo} published={fifthJan} />,
+      <Timestamp firstPublished={fifthJan} lastPublished={sixHoursAgo} />,
     );
 
     expect(renderedWrapper.length).toEqual(2);
@@ -57,7 +60,7 @@ describe('Timestamp', () => {
 
   it('should display an absolute timestamp when updated > 10 hours ago', () => {
     const renderedWrapper = renderedTimestamps(
-      <Timestamp updated={eighthMarch} published={fifthJan} />,
+      <Timestamp firstPublished={fifthJan} lastPublished={eighthMarch} />,
     );
 
     expect(renderedWrapper.length).toEqual(2);

--- a/src/app/dataValidator/rules/timestamp.js
+++ b/src/app/dataValidator/rules/timestamp.js
@@ -14,8 +14,8 @@ const augmentWithTimestamp = jsonRaw => {
     const timestampBlock = {
       type: 'timestamp',
       model: {
-        published: firstPublished,
-        updated: lastPublished,
+        firstPublished,
+        lastPublished,
       },
     };
     return insertTimestampBlock(jsonRaw, timestampBlock);

--- a/src/app/dataValidator/rules/timestamp.js
+++ b/src/app/dataValidator/rules/timestamp.js
@@ -5,9 +5,9 @@ import deepGet from '../../helpers/json/deepGet';
 const augmentWithTimestamp = jsonRaw => {
   // safely get deeply nested JSON values
   const firstPublished = deepGet(['metadata', 'firstPublished'], jsonRaw);
-  const lastUpdated = deepGet(['metadata', 'lastUpdated'], jsonRaw);
+  const lastPublished = deepGet(['metadata', 'lastPublished'], jsonRaw);
   const hasBlocks = deepGet(['content', 'model', 'blocks'], jsonRaw);
-  const canRenderTimestamp = firstPublished && lastUpdated && hasBlocks;
+  const canRenderTimestamp = firstPublished && lastPublished && hasBlocks;
 
   if (canRenderTimestamp) {
     // construct a new block from the metadata
@@ -15,7 +15,7 @@ const augmentWithTimestamp = jsonRaw => {
       type: 'timestamp',
       model: {
         published: firstPublished,
-        updated: lastUpdated,
+        updated: lastPublished,
       },
     };
     return insertTimestampBlock(jsonRaw, timestampBlock);

--- a/src/app/dataValidator/rules/timestamp.test.js
+++ b/src/app/dataValidator/rules/timestamp.test.js
@@ -76,8 +76,8 @@ describe('Timestamp rules', () => {
             {
               type: 'timestamp',
               model: {
-                published: 1514808060000,
-                updated: 1514811600000,
+                firstPublished: 1514808060000,
+                lastPublished: 1514811600000,
               },
             },
             paragraphBlock,
@@ -110,8 +110,8 @@ describe('Timestamp rules', () => {
             {
               type: 'timestamp',
               model: {
-                published: 1514808060000,
-                updated: 1514811600000,
+                firstPublished: 1514808060000,
+                lastPublished: 1514811600000,
               },
             },
           ],

--- a/src/app/dataValidator/rules/timestamp.test.js
+++ b/src/app/dataValidator/rules/timestamp.test.js
@@ -60,7 +60,7 @@ describe('Timestamp rules', () => {
     const fixtureData = {
       metadata: {
         firstPublished: 1514808060000,
-        lastUpdated: 1514811600000,
+        lastPublished: 1514811600000,
         blockTypes: ['text', 'paragraph', 'fragment'],
       },
       content: {
@@ -92,7 +92,7 @@ describe('Timestamp rules', () => {
     const fixtureData = {
       metadata: {
         firstPublished: 1514808060000,
-        lastUpdated: 1514811600000,
+        lastPublished: 1514811600000,
         blockTypes: ['headline', 'text', 'paragraph', 'fragment'],
       },
       content: {


### PR DESCRIPTION
No ticket. Cypress test on the Test environment is failing. This is the reason for this PR.  

**Overall change:** Use `lastPublished` for the 'Updated' timestamp.  
Ensure Cypress screenshots are saved when Cypress test fails (useful for debugging)

**Code changes:**

- Enable screenshots when Cypress tests fail - this is to enable us to debug issues on Live.
- Use `lastPublished`
- Update the timestamp preprocessor file and Timestamp Container file to use the props `lastPublished` and `firstPublished`. 
- Update the Storybook Cypress test DOM selector - due to an update in Storybook UI.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
