### PR TITLE
Remove now deploy step from travis and now.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,6 @@ jobs:
         - npm run build
         - xvfb-run -a npm run test:prod:travis
         - xvfb-run -a npm run test:lighthouse:ci
-    - stage: deploy
-      if: type = push AND branch = latest
-      before_script: npm install now --no-save
-      script:
-        - build-storybook -c .storybook -o simorghstorybook
-        - now --token $now_token ./simorghstorybook --public && now alias --token $now_token
-        - now rm -y --token $now_token --safe simorghstorybook
-      after_script: now rm -y --token $now_token --safe simorghstorybook
-  allow_failures:
-    - after_script: now rm -y --token $now_token --safe simorghstorybook
 notifications:
   email: false
   slack:

--- a/now.json
+++ b/now.json
@@ -1,4 +1,0 @@
-{
-    "alias": "simorghstorybook",
-    "name": "simorghstorybook"
-}


### PR DESCRIPTION
Resolves #1252 

**Overall change:** 
This PR removes the now.sh deploy stage from Travis which was used to deploy the Simorgh Storybook to Now.

**Code changes:**

- Removed now.sh deploy stage from travis.yaml
- Removed now.json as it it no longer required

---

- [X] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [ ] Test engineer approval
- [X] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
