### PR TITLE
Redirect route without

### DIFF
--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,10 +1,7 @@
 import Article from '../containers/Article';
 import getInitialData from './getInitialData';
-import services from '../lib/config/services';
+import serviceRegex from './serviceRegex';
 
-const serviceRegex = Object.keys(services)
-  .filter(serviceName => serviceName !== 'default')
-  .join('|');
 const idRegex = 'c[a-zA-Z0-9]{10}o';
 const ampRegex = '.amp';
 

--- a/src/app/routes/serviceRegex.js
+++ b/src/app/routes/serviceRegex.js
@@ -1,7 +1,7 @@
 import services from '../lib/config/services';
 
 const serviceRegex = Object.keys(services)
-    .filter(serviceName => serviceName !== 'default')
-    .join('|');
+  .filter(serviceName => serviceName !== 'default')
+  .join('|');
 
 export default serviceRegex;

--- a/src/app/routes/serviceRegex.js
+++ b/src/app/routes/serviceRegex.js
@@ -1,0 +1,7 @@
+import services from '../lib/config/services';
+
+const serviceRegex = Object.keys(services)
+    .filter(serviceName => serviceName !== 'default')
+    .join('|');
+
+export default serviceRegex;

--- a/src/app/routes/serviceRegex.test.js
+++ b/src/app/routes/serviceRegex.test.js
@@ -3,7 +3,7 @@ import serviceRegex from './serviceRegex';
 describe('Service Regex', () => {
   const matchedServices = 'news|persian';
 
-  test('It should return an string of supported services', () => {
+  test('It should return a string of supported services', () => {
     expect(serviceRegex).toEqual(matchedServices);
   });
 });

--- a/src/app/routes/serviceRegex.test.js
+++ b/src/app/routes/serviceRegex.test.js
@@ -1,0 +1,9 @@
+import serviceRegex from './serviceRegex';
+
+describe('Service Regex', () => {
+  const matchedServices = 'news|persian';
+
+  test('It should return an string of supported services', () => {
+    expect(serviceRegex).toEqual(matchedServices);
+  });
+});

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -13,6 +13,7 @@ import routes, {
   manifestRegexPath,
   swRegexPath,
 } from '../app/routes';
+import serviceRegex from '../app/routes/serviceRegex';
 import nodeLogger from '../app/helpers/logger.node';
 import renderDocument from './Document';
 
@@ -137,6 +138,10 @@ server
       logger.error(`status: ${status || 500} - ${message}`);
       res.status(500).send(message);
     }
+  })
+  .get(`/:service(${serviceRegex})\/articles`, (req, res) => {
+    const { service } = req.params;
+    res.redirect(`/${service}`)
   });
 
 export default server;

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -139,9 +139,9 @@ server
       res.status(500).send(message);
     }
   })
-  .get(`/:service(${serviceRegex})\/articles`, (req, res) => {
+  .get(`/:service(${serviceRegex})/articles`, (req, res) => {
     const { service } = req.params;
-    res.redirect(`/${service}`)
+    res.redirect(`/${service}`);
   });
 
 export default server;


### PR DESCRIPTION
Resolves #1540 

**Overall change:** 
This PR adds a 302 redirect for routes matching `/<supported_service>/articles` e.g. `/news/articles`, Redirecting to `/<supported_service>` e.g. `/news`
**Code changes:**

- Move service regex logic into it's own file so it can be used in express server routes
- Add unit test for service regex match
- Add new route to express server for `/<service>/articles`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
