### PR TITLE
add jquery as aduit-ci exceptions and use --low as per docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simorgh",
   "scripts": {
     "amp:validate": "wait-on http://localhost:7080/news/articles/cl55zn0w0l4o.amp && amphtml-validator http://localhost:7080/news/articles/cl55zn0w0l4o.amp",
-    "audit:ci": "audit-ci -low",
+    "audit:ci": "audit-ci --low --whitelist jquery",
     "bbcA11y": "bbc-a11y",
     "build:ci": "export NODE_ENV=production && rm -rf build && npm run build:test && npm run build:live",
     "build": "rm -rf build && cp envConfig/local.env .env && NODE_ENV=production webpack",


### PR DESCRIPTION
Work around for https://github.com/bbc/simorgh/issues/1625

- Adds `--whitelist jquery` to the `audit-ci` command
- [`audit-ci` docs](https://www.npmjs.com/package/audit-ci) state that we should use `-l` or `--low` so also updated to be explicilty `--low`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
