### PR TITLE
Add default labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: bug
 ---
 
 **Describe the bug**
@@ -35,5 +36,3 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
-
-- [ ] Initially labelled with ["bug"](https://github.com/bbc/simorgh/labels/bug)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels: Refinement Needed
 ---
 
 **Is your feature request related to a problem? Please describe.**
@@ -20,5 +20,3 @@ Dev insight: Will Cypress tests be required or are unit tests sufficient? Will t
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
-
-- [ ] Initially labelled with ["Refinement needed"](https://github.com/bbc/simorgh/labels/Refinement%20Needed)


### PR DESCRIPTION
Resolves #1631 

**Overall change:** Add default labels to issue templates and remove checkbox

**Code changes:**

- Add `bug` label to bug report template
- Add `Refinement Needed` label to bug report template

---

- [x] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
