### PR TITLE
Fix Timestamp Snapshot tests

### DIFF
--- a/src/app/containers/Timestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Timestamp/__snapshots__/index.test.jsx.snap
@@ -28,11 +28,11 @@ exports[`Timestamp should add prefix and suffix 1`] = `
 
 <time
   className="c0"
-  dateTime="2018-10-20"
+  dateTime="2018-10-19"
 >
-  It was 
-  192 days ago
-   that this was last updated
+  Prefix here  
+  19 October 2018
+    suffix here
 </time>
 `;
 

--- a/src/app/containers/Timestamp/index.test.jsx
+++ b/src/app/containers/Timestamp/index.test.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { isNull, shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
-import { timestampGenerator } from './helpers/testHelpers';
 import Timestamp from '.';
 
 const defaultTimestamp = 1539969006000; // 19 October 2018
 const noLeadingZeroTimestamp = 1530947227000; // 07 July 2018
 const invalidData = '8640000000000001'; // A day holds 86,400,000 milliseconds - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#Description
-const oneNinetyTwoDaysAgo = timestampGenerator({ days: 192 });
 
 describe('Timestamp', () => {
   describe('with no data', () => {
@@ -39,19 +37,19 @@ describe('Timestamp', () => {
       timestamp={invalidData}
       dateTimeFormat="YYYY-MM-DD"
       format="D MMMM YYYY"
-      isRelative
+      isRelative={false}
     />,
   );
 
   shouldMatchSnapshot(
     'should add prefix and suffix',
     <Timestamp
-      timestamp={oneNinetyTwoDaysAgo}
+      timestamp={defaultTimestamp}
       dateTimeFormat="YYYY-MM-DD"
       format="D MMMM YYYY"
-      isRelative
-      prefix="It was"
-      suffix="that this was last updated"
+      isRelative={false}
+      prefix="Prefix here "
+      suffix=" suffix here"
     />,
   );
 });


### PR DESCRIPTION
Test for relative time is failing
<img width="630" alt="Screen Shot 2019-05-02 at 12 46 52" src="https://user-images.githubusercontent.com/3028997/57073237-64b79780-6cd8-11e9-8323-6ce8dede2f8f.png">

This is because the snapshot `dateTime` attribute updates every day, when rendering the timestamp in `relative` mode. 

**Overall change:** Ensure timestamp tests pass
Change snapshot tests to use absolute time examples instead of relative examples
There is sufficient test coverage of the relative timestamp logic via the enzyme assertion tests

**Code changes:**

- Update snapshot tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
