### PR TITLE
Update the patch version of Node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 def dockerRegistry = "329802642264.dkr.ecr.eu-west-1.amazonaws.com"
-def nodeImageVersion = "0.0.1"
+def nodeImageVersion = "0.0.2"
 def nodeImage = "${dockerRegistry}/bbc-news/node-10-lts:${nodeImageVersion}"
 def nodeName
 def stageName = ""


### PR DESCRIPTION
Resolves #1708 

**Overall change:** 
While the npmrc is pointing to the correct version of Node, the docker container running the pipeline is running a version of node that is 3 patch versions behind. The docker image containing the node version v10.15.3 has already been built and is present under the label 0.0.2. 
**Code changes:**

- Bumped up the label version for the docker container used to run in the pipeline.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.