### PR TITLE
Build the storybook archive in Simorgh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ reports/*
 log
 cypress/screenshots
 pack
+storybook_dist

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ def nodeImage = "${dockerRegistry}/bbc-news/node-10-lts:${nodeImageVersion}"
 def nodeName
 def stageName = ""
 def packageName = 'simorgh.zip'
+def storybookDist = 'storybook.zip'
+
 def getCommitInfo = {
   infraGitCommitAuthor = sh(returnStdout: true, script: "git --no-pager show -s --format='%an' ${GIT_COMMIT}").trim()
   appGitCommit = sh(returnStdout: true, script: "cd ${APP_DIRECTORY}; git rev-parse HEAD")
@@ -96,6 +98,20 @@ pipeline {
             sh 'make installProd'
             sh 'make productionTests'
           }
+        }
+        stage('Build storybook dist') {
+          agent {
+            docker {
+              image "${nodeImage}"
+              args '-u root -v /etc/pki:/certs'
+            }
+          }
+          steps {
+            sh 'make install'
+            sh 'make buildStorybook'
+            zip archive: true, dir: 'storybook_dist', glob: '', zipFile: storybookDist
+            stash name: 'simorgh_storybook', includes: storybookDist
+          }
         }    
       }
       post {
@@ -142,6 +158,20 @@ pipeline {
             sh "rm -f ${packageName}"
             zip archive: true, dir: 'pack/', glob: '', zipFile: packageName
             stash name: 'simorgh', includes: packageName
+          }
+        }
+        stage('Build storybook dist') {
+          agent {
+            docker {
+              image "${nodeImage}"
+              args '-u root -v /etc/pki:/certs'
+            }
+          }
+          steps {
+            sh 'make install'
+            sh 'make buildStorybook'
+            zip archive: true, dir: 'storybook_dist', glob: '', zipFile: storybookDist
+            stash name: 'simorgh_storybook', includes: storybookDist
           }
         }    
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,21 +98,7 @@ pipeline {
             sh 'make installProd'
             sh 'make productionTests'
           }
-        }
-        stage('Build storybook dist') {
-          agent {
-            docker {
-              image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
-            }
-          }
-          steps {
-            sh 'make install'
-            sh 'make buildStorybook'
-            zip archive: true, dir: 'storybook_dist', glob: '', zipFile: storybookDist
-            stash name: 'simorgh_storybook', includes: storybookDist
-          }
-        }    
+        }  
       }
       post {
         always {

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ developmentTests:
 
 productionTests:
 	cd ${APP_DIRECTORY}; npm run build; xvfb-run npm run test:prod:ci;
+
+buildStorybook:
+	cd ${APP_DIRECTORY}; npm run build:storybook

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bbcA11y": "bbc-a11y",
     "build:ci": "export NODE_ENV=production && rm -rf build && npm run build:test && npm run build:live",
     "build": "rm -rf build && cp envConfig/local.env .env && NODE_ENV=production webpack",
+    "build:storybook": "build-storybook -c .storybook -o storybook_dist",
     "build:test": "cp envConfig/test.env .env && NODE_ENV=production webpack",
     "build:live": "cp envConfig/live.env .env && NODE_ENV=production webpack",
     "cypress": "cypress run",


### PR DESCRIPTION
Resolves #1639 

**Overall change:** 
The outcome of the PR is actually very different to what the issue #1639 suggest. The issue was written under the assumption that the outcome of the storybook build is too big to be passed as an archive. This led to the idea that storybook should be built in the CD pipeline. However this proves to be problematic since a) the storybook directory ends up in the final deploy artifact b) the building requires the dev dependencies which adds more time in the CD pipeline. It turns out however, that the zipped storybook distribution folder is under 1MB which means it can actually be passed around as an archive. This makes the process much simpler.

**Code changes:**

- Added the `build:storybook` npm command. This command builds the sotrybook to the `storybook_dist` folder.
- Added a step in the jenkins pipeline that invokes `npm run build:storybook`, then zips the folder and uploads it as an archive under the name `simorgh_storybook` (Making it available to CD once this PR is merged in) 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
