### PR TITLE
Remove all traces of NPM audit until the NPM audit service issues are…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
         - npm run test
         - ./cc-test-reporter after-build -t lcov --debug --exit-code $TRAVIS_TEST_RESULT
         - xvfb-run -a npm run test:e2e:storybook:ci
-        - npm run audit:ci
     - stage: test
       install: npm ci --only=prod
       script:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ installProd:
 	npm ci --only=production
 
 developmentTests:
-	npm run audit:ci;
 	npx apache2-license-checker;
 	npm run test;
 	xvfb-run npm run test:e2e:storybook:ci;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2994,26 +2994,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
-    "audit-ci": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-1.6.0.tgz",
-      "integrity": "sha512-auyZzIL4Booqgb4ulh2i/hNNbBVfdKob1yBLu1RssWLyex13ih4j5S4mROU0LMlwJQdzPHpslby0zS95nd8uHQ==",
-      "dev": true,
-      "requires": {
-        "byline": "^5.0.0",
-        "cross-spawn": "6.0.5",
-        "semver": "^6.0.0",
-        "yargs": "12.0.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
-          "dev": true
-        }
-      }
-    },
     "autoprefixer": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
@@ -4302,12 +4282,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-    },
-    "byline": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-      "dev": true
     },
     "bytes": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Simorgh",
   "scripts": {
     "amp:validate": "wait-on http://localhost:7080/news/articles/cl55zn0w0l4o.amp && amphtml-validator http://localhost:7080/news/articles/cl55zn0w0l4o.amp",
-    "audit:ci": "audit-ci --low",
     "bbcA11y": "bbc-a11y",
     "build:ci": "export NODE_ENV=production && rm -rf build && npm run build:test && npm run build:live",
     "build": "rm -rf build && cp envConfig/local.env .env && NODE_ENV=production webpack",
@@ -137,7 +136,6 @@
     "@bbc/apache2-license-checker": "^1.1.4",
     "@storybook/react": "^4.1.12",
     "amphtml-validator": "^1.0.23",
-    "audit-ci": "^1.2.1",
     "babel-eslint": "^10.0.0",
     "bbc-a11y": "^2.3.0",
     "chalk": "^2.4.1",


### PR DESCRIPTION
… resolved

Resolves N/A

**Overall change:** Removes all traces of NPM audit until the NPM audit service is stable again

Issue to re-instate NPM Audit once stable: https://github.com/bbc/simorgh-infrastructure/issues/438

[NPM Issue Tracker](https://status.npmjs.org/incidents/1jdmllbx0q59?_ga=2.107255874.1130125350.1558356462-877631025.1558356462)

- [X] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [] Test engineer approval
- [X] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
