### PR TITLE
Video props

### DIFF
--- a/src/app/components/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/Video/__snapshots__/index.test.jsx.snap
@@ -28,5 +28,25 @@ exports[`Video with data should render the video with valid props 1`] = `
     }
 ]
   </div>
+  <div>
+    statsAppName: 
+    news
+  </div>
+  <div>
+    statsAppType: 
+    responsive
+  </div>
+  <div>
+    statsCountername: 
+    news.articles.c0000000000o.page
+  </div>
+  <div>
+    statsDestination: 
+    NEWS_PS_TEST
+  </div>
+  <div>
+    uiLocale: 
+    en-GB
+  </div>
 </div>
 `;

--- a/src/app/components/Video/index.jsx
+++ b/src/app/components/Video/index.jsx
@@ -1,13 +1,29 @@
 import React from 'react';
 import { videoComponentPropTypes } from '../../models/propTypes';
 
-const Video = ({ pid, kind, title, items, holdingImageUrl }) => (
+const Video = ({
+  pid,
+  kind,
+  title,
+  items,
+  holdingImageUrl,
+  statsAppName,
+  statsAppType,
+  statsCountername,
+  statsDestination,
+  uiLocale,
+}) => (
   <div>
     <div>video pid: {pid}</div>
     <div>kind: {kind}</div>
     <div>title: {title}</div>
     <div>holdingImageURL: {holdingImageUrl}</div>
     <div>items: {JSON.stringify(items, null, 4)}</div>
+    <div>statsAppName: {statsAppName}</div>
+    <div>statsAppType: {statsAppType}</div>
+    <div>statsCountername: {statsCountername}</div>
+    <div>statsDestination: {statsDestination}</div>
+    <div>uiLocale: {uiLocale}</div>
   </div>
 );
 

--- a/src/app/components/Video/index.stories.jsx
+++ b/src/app/components/Video/index.stories.jsx
@@ -14,6 +14,11 @@ const props = {
     },
   ],
   holdingImageUrl: 'https://www.foo.bar/baz.png',
+  statsAppName: 'news',
+  statsAppType: 'responsive',
+  statsCountername: 'news.articles.c0000000000o.page',
+  statsDestination: 'NEWS_PS_TEST',
+  uiLocale: 'en-GB',
 };
 
 storiesOf('Video', module).add('default', () => <Video {...props} />);

--- a/src/app/components/Video/index.test.jsx
+++ b/src/app/components/Video/index.test.jsx
@@ -16,6 +16,11 @@ describe('Video', () => {
         },
       ],
       holdingImageUrl: 'https://foo/bar/baz.png',
+      statsAppName: 'news',
+      statsAppType: 'responsive',
+      statsCountername: 'news.articles.c0000000000o.page',
+      statsDestination: 'NEWS_PS_TEST',
+      uiLocale: 'en-GB',
     };
 
     shouldShallowMatchSnapshot(

--- a/src/app/containers/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Video/__snapshots__/index.test.jsx.snap
@@ -1,13 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video with data and a caption should render the video and caption 1`] = `
+exports[`Video with data amp - should render the video without a caption 1`] = `
 <Context.Provider
   value={
     Object {
       "id": "c0000000000o",
       "isUK": true,
       "origin": "https://www.test.bbc.co.uk",
-      "platform": undefined,
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01k6msm",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01k6msm",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "They may be tiny, but us humans could learn a thing or two from ants.",
+                  },
+                  "title": "Five things ants can teach us about management",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 191,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01k6msp",
+                      "warnings": Object {
+                        "long": "Contains strong language and adult humour.",
+                        "short": "Contains strong language and adult humour.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": 1080,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "originCode": null,
+                        "width": 1920,
+                      },
+                      "type": "rawImage",
+                    },
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "blocks": Array [
+                                      Object {
+                                        "model": Object {
+                                          "attributes": Array [],
+                                          "text": "Ants",
+                                        },
+                                        "type": "fragment",
+                                      },
+                                    ],
+                                    "text": "Ants",
+                                  },
+                                  "type": "paragraph",
+                                },
+                              ],
+                            },
+                            "type": "text",
+                          },
+                        ],
+                      },
+                      "type": "altText",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`Video with data and a caption amp - should render the video and caption 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
       "statsDestination": "NEWS_PS_TEST",
       "statsPageIdentifier": "news.articles.c0000000000o.page",
     }
@@ -144,14 +259,158 @@ exports[`Video with data and a caption should render the video and caption 1`] =
 </Context.Provider>
 `;
 
-exports[`Video with data and a caption should render the video without a caption 1`] = `
+exports[`Video with data and a caption canonical - should render the video and caption 1`] = `
 <Context.Provider
   value={
     Object {
       "id": "c0000000000o",
       "isUK": true,
       "origin": "https://www.test.bbc.co.uk",
-      "platform": undefined,
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01k6msm",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01k6msm",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "They may be tiny, but us humans could learn a thing or two from ants.",
+                  },
+                  "title": "Five things ants can teach us about management",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 191,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01k6msp",
+                      "warnings": Object {
+                        "long": "Contains strong language and adult humour.",
+                        "short": "Contains strong language and adult humour.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": 1080,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "originCode": null,
+                        "width": 1920,
+                      },
+                      "type": "rawImage",
+                    },
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "blocks": Array [
+                                      Object {
+                                        "model": Object {
+                                          "attributes": Array [],
+                                          "text": "Ants",
+                                        },
+                                        "type": "fragment",
+                                      },
+                                    ],
+                                    "text": "Ants",
+                                  },
+                                  "type": "paragraph",
+                                },
+                              ],
+                            },
+                            "type": "text",
+                          },
+                        ],
+                      },
+                      "type": "altText",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "attributes": Array [],
+                              "text": "p01k6msm: Video, Clip, UK and non-UK, guidance, subtitles (about bees)",
+                            },
+                            "type": "fragment",
+                          },
+                        ],
+                        "text": "p01k6msm: Video, Clip, UK and non-UK, guidance, subtitles (about bees)",
+                      },
+                      "type": "paragraph",
+                    },
+                  ],
+                },
+                "type": "text",
+              },
+            ],
+          },
+          "type": "caption",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`Video with data canonical - should render the video without a caption 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
       "statsDestination": "NEWS_PS_TEST",
       "statsPageIdentifier": "news.articles.c0000000000o.page",
     }
@@ -258,29 +517,3 @@ exports[`Video with data and a caption should render the video without a caption
   />
 </Context.Provider>
 `;
-
-exports[`Video with data should return a valid VideoContainer 1`] = `
-<React.Fragment>
-  <ForwardRef>
-    <Video
-      holdingImageUrl="https://foo/bar/baz.png"
-      items={
-        Array [
-          Object {
-            "duration": 100,
-            "kind": "clip",
-            "versionID": "bar",
-          },
-        ]
-      }
-      kind="clip"
-      pid="foo"
-      title="Hello World!"
-    />
-  </ForwardRef>
-</React.Fragment>
-`;
-
-exports[`Video with no aresMedia should only render the video 1`] = `null`;
-
-exports[`Video with no data should not render anything 1`] = `null`;

--- a/src/app/containers/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Video/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,759 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video with data amp - should render the video without a caption 1`] = `
+exports[`AudioVideo with Audio data amp - should render audio clip UK only 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d3c",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio",
+                  "id": "p01m7d3c",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d3c.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is some sound from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham Checkout 2",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d3h",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d3c.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data amp - should render audio clip global with guidance 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d07",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": false,
+                  "format": "audio",
+                  "id": "p01m7d07",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d07.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "Some audio from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham checkout",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d09",
+                      "warnings": Object {
+                        "long": "Contains some strong language.",
+                        "short": "Contains some strong language.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d07.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data amp - should render audio clip non-UK only 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d4m",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio",
+                  "id": "p01m7d4m",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d4m.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is some audio from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham Checkout 3",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d4p",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d4m.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data amp - should render audio episode global 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01mbrvl",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": false,
+                  "format": "audio",
+                  "id": "p01mbrvl",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/episode/p01mbrvl.jpg",
+                  "subType": "episode",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is a test asset created for the articles project",
+                  },
+                  "title": "Test audio episode for articles, worldwide",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01mbrx4",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/episode/p01mbrvl.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data canonical - should render audio clip UK only 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d3c",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio",
+                  "id": "p01m7d3c",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d3c.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is some sound from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham Checkout 2",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d3h",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d3c.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data canonical - should render audio clip global with guidance 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d07",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": false,
+                  "format": "audio",
+                  "id": "p01m7d07",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d07.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "Some audio from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham checkout",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d09",
+                      "warnings": Object {
+                        "long": "Contains some strong language.",
+                        "short": "Contains some strong language.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d07.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data canonical - should render audio clip non-UK only 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7d4m",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio",
+                  "id": "p01m7d4m",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d4m.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is some audio from a supermarket checkout in Birmingham",
+                  },
+                  "title": "Birmingham Checkout 3",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01m7d4p",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/clip/p01m7d4m.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Audio data canonical - should render audio episode global 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01mbrvl",
+                "model": Object {
+                  "advertising": false,
+                  "caption": null,
+                  "embedding": false,
+                  "format": "audio",
+                  "id": "p01mbrvl",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/episode/p01mbrvl.jpg",
+                  "subType": "episode",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is a test asset created for the articles project",
+                  },
+                  "title": "Test audio episode for articles, worldwide",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 127,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01mbrx4",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/legacy/episode/p01mbrvl.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data amp - should render portrait video with global visibility 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7hmc",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01m7hmc",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01m7hny.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is a really plain green test vertical video",
+                  },
+                  "title": "Test vertical video",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 11,
+                      "types": Array [
+                        "Portrait",
+                      ],
+                      "versionId": "p01m7hmf",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01m7hny.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data amp - should render the video without a caption 1`] = `
 <Context.Provider
   value={
     Object {
@@ -115,7 +868,213 @@ exports[`Video with data amp - should render the video without a caption 1`] = `
 </Context.Provider>
 `;
 
-exports[`Video with data and a caption amp - should render the video and caption 1`] = `
+exports[`AudioVideo with Video data amp - should render the video without a caption 2`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01kdbns",
+                "model": Object {
+                  "advertising": true,
+                  "caption": "How do Germans remember the World Wars?",
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01kdbns",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "long": "Can people in today's Germany mourn their dead without whitewashing their country's past? We ask three Germans, ahead of the 100th anniversary of the end of World War One.",
+                    "medium": "Can people in today's Germany mourn their dead without whitewashing their country's past?",
+                    "short": "Remembrance Day: How Germans remember the World Wars",
+                  },
+                  "title": "How Germans remember the World Wars",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 162,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01kdbnv",
+                      "warnings": Object {
+                        "long": "Contains some strong language.",
+                        "short": "Contains some strong language.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": 1080,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+                        "originCode": null,
+                        "width": 1920,
+                      },
+                      "type": "rawImage",
+                    },
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "blocks": Array [
+                                      Object {
+                                        "model": Object {
+                                          "attributes": Array [],
+                                          "text": "Description of picture (ALT TEXT)",
+                                        },
+                                        "type": "fragment",
+                                      },
+                                    ],
+                                    "text": "Description of picture (ALT TEXT)",
+                                  },
+                                  "type": "paragraph",
+                                },
+                              ],
+                            },
+                            "type": "text",
+                          },
+                        ],
+                      },
+                      "type": "altText",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data amp - should render the video without a caption 3`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "amp",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01kdbpz",
+                "model": Object {
+                  "advertising": true,
+                  "caption": "Stephen Richardson had to have his leg amputated because of type 2 diabetes",
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01kdbpz",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbs1.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "long": "Every week 170 people in the UK lose a limb because of diabetes. 
+Around four million people in the UK are living with diabetes - and around 90% of them have type 2 diabetes, which is often linked to being overweight or inactive. 
+Diabetes prescriptions are costing the NHS in England more than £1 billion a year, according to figures from NHS Digital.
+And a further 12 million people could be at risk of getting type 2 diabetes in the future.
+Stephen Richardson has told the BBC he blames himself for the loss of his limb.",
+                    "medium": "Stephen Richardson admits he ignored advice about diet and exercise.",
+                    "short": "Diabetes type 2: 'I blame myself for the loss of my leg'",
+                  },
+                  "title": "'I lost my leg to type 2 diabetes' (NON UK)",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 122,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01kdbq2",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbs1.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data and a caption amp - should render the video and caption 1`] = `
 <Context.Provider
   value={
     Object {
@@ -259,7 +1218,7 @@ exports[`Video with data and a caption amp - should render the video and caption
 </Context.Provider>
 `;
 
-exports[`Video with data and a caption canonical - should render the video and caption 1`] = `
+exports[`AudioVideo with Video data and a caption canonical - should render the video and caption 1`] = `
 <Context.Provider
   value={
     Object {
@@ -403,7 +1362,90 @@ exports[`Video with data and a caption canonical - should render the video and c
 </Context.Provider>
 `;
 
-exports[`Video with data canonical - should render the video without a caption 1`] = `
+exports[`AudioVideo with Video data canonical - should render portrait video with global visibility 1`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01m7hmc",
+                "model": Object {
+                  "advertising": true,
+                  "caption": null,
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01m7hmc",
+                  "image": null,
+                  "imageCopyright": null,
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01m7hny.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "short": "This is a really plain green test vertical video",
+                  },
+                  "title": "Test vertical video",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 11,
+                      "types": Array [
+                        "Portrait",
+                      ],
+                      "versionId": "p01m7hmf",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": null,
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01m7hny.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data canonical - should render the video without a caption 1`] = `
 <Context.Provider
   value={
     Object {
@@ -503,6 +1545,212 @@ exports[`Video with data canonical - should render the video without a caption 1
                         ],
                       },
                       "type": "altText",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data canonical - should render the video without a caption 2`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01kdbns",
+                "model": Object {
+                  "advertising": true,
+                  "caption": "How do Germans remember the World Wars?",
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01kdbns",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "long": "Can people in today's Germany mourn their dead without whitewashing their country's past? We ask three Germans, ahead of the 100th anniversary of the end of World War One.",
+                    "medium": "Can people in today's Germany mourn their dead without whitewashing their country's past?",
+                    "short": "Remembrance Day: How Germans remember the World Wars",
+                  },
+                  "title": "How Germans remember the World Wars",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": false,
+                        "uk": true,
+                      },
+                      "availableUntil": null,
+                      "duration": 162,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01kdbnv",
+                      "warnings": Object {
+                        "long": "Contains some strong language.",
+                        "short": "Contains some strong language.",
+                      },
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": 1080,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+                        "originCode": null,
+                        "width": 1920,
+                      },
+                      "type": "rawImage",
+                    },
+                    Object {
+                      "model": Object {
+                        "blocks": Array [
+                          Object {
+                            "model": Object {
+                              "blocks": Array [
+                                Object {
+                                  "model": Object {
+                                    "blocks": Array [
+                                      Object {
+                                        "model": Object {
+                                          "attributes": Array [],
+                                          "text": "Description of picture (ALT TEXT)",
+                                        },
+                                        "type": "fragment",
+                                      },
+                                    ],
+                                    "text": "Description of picture (ALT TEXT)",
+                                  },
+                                  "type": "paragraph",
+                                },
+                              ],
+                            },
+                            "type": "text",
+                          },
+                        ],
+                      },
+                      "type": "altText",
+                    },
+                  ],
+                },
+                "type": "image",
+              },
+            ],
+          },
+          "type": "aresMedia",
+        },
+      ]
+    }
+  />
+</Context.Provider>
+`;
+
+exports[`AudioVideo with Video data canonical - should render the video without a caption 3`] = `
+<Context.Provider
+  value={
+    Object {
+      "id": "c0000000000o",
+      "isUK": true,
+      "origin": "https://www.test.bbc.co.uk",
+      "platform": "canonical",
+      "statsDestination": "NEWS_PS_TEST",
+      "statsPageIdentifier": "news.articles.c0000000000o.page",
+    }
+  }
+>
+  <VideoContainer
+    blocks={
+      Array [
+        Object {
+          "model": Object {
+            "blocks": Array [
+              Object {
+                "blockId": "urn:bbc:ares::clip:p01kdbpz",
+                "model": Object {
+                  "advertising": true,
+                  "caption": "Stephen Richardson had to have his leg amputated because of type 2 diabetes",
+                  "embedding": true,
+                  "format": "audio_video",
+                  "id": "p01kdbpz",
+                  "image": null,
+                  "imageCopyright": "BBC",
+                  "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbs1.jpg",
+                  "subType": "clip",
+                  "syndication": Object {
+                    "destinations": Array [],
+                  },
+                  "synopses": Object {
+                    "long": "Every week 170 people in the UK lose a limb because of diabetes. 
+Around four million people in the UK are living with diabetes - and around 90% of them have type 2 diabetes, which is often linked to being overweight or inactive. 
+Diabetes prescriptions are costing the NHS in England more than £1 billion a year, according to figures from NHS Digital.
+And a further 12 million people could be at risk of getting type 2 diabetes in the future.
+Stephen Richardson has told the BBC he blames himself for the loss of his limb.",
+                    "medium": "Stephen Richardson admits he ignored advice about diet and exercise.",
+                    "short": "Diabetes type 2: 'I blame myself for the loss of my leg'",
+                  },
+                  "title": "'I lost my leg to type 2 diabetes' (NON UK)",
+                  "versions": Array [
+                    Object {
+                      "availableTerritories": Object {
+                        "nonUk": true,
+                        "uk": false,
+                      },
+                      "availableUntil": null,
+                      "duration": 122,
+                      "types": Array [
+                        "Original",
+                      ],
+                      "versionId": "p01kdbq2",
+                      "warnings": Object {},
+                    },
+                  ],
+                },
+                "type": "aresMediaMetadata",
+              },
+              Object {
+                "model": Object {
+                  "blocks": Array [
+                    Object {
+                      "model": Object {
+                        "copyrightHolder": "BBC",
+                        "height": null,
+                        "locator": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbs1.jpg",
+                        "originCode": null,
+                        "width": null,
+                      },
+                      "type": "rawImage",
                     },
                   ],
                 },

--- a/src/app/containers/Video/fixtureData.jsx
+++ b/src/app/containers/Video/fixtureData.jsx
@@ -4,7 +4,6 @@ import VideoContainer from '.';
 import { RequestContextProvider } from '../../contexts/RequestContext';
 import {
   captionBlock,
-  noAresMediaMetadata,
   videoClipGlobalGuidanceBlock,
   videoClipGlobalPortraitBlock,
   videoClipUkGuidanceBlock,
@@ -43,12 +42,6 @@ export const NoData = ({ platform }) =>
 
 export const NoAresMedia = ({ platform }) =>
   generateFixtureData({ platform, blocks: [captionBlock] });
-
-export const NoAresMediaMetadata = ({ platform }) =>
-  generateFixtureData({
-    platform,
-    blocks: [noAresMediaMetadata, captionBlock],
-  });
 
 export const VideoClipGlobalWithCaption = ({ platform }) =>
   generateFixtureData({

--- a/src/app/containers/Video/fixtureData.jsx
+++ b/src/app/containers/Video/fixtureData.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import VideoContainer from '.';
 import { RequestContextProvider } from '../../contexts/RequestContext';
-import { blockArrayModel } from '../../models/blocks';
 import {
   captionBlock,
+  noAresMediaMetadata,
   videoClipGlobalGuidanceBlock,
   videoClipGlobalPortraitBlock,
   videoClipUkGuidanceBlock,
@@ -38,38 +38,68 @@ generateFixtureData.defaultProps = {
   blocks: '',
 };
 
-export const VideoClipGlobalWithCaption = generateFixtureData(
-  blockArrayModel([videoClipGlobalGuidanceBlock, captionBlock]),
-);
+export const NoData = ({ platform }) =>
+  generateFixtureData({ platform, blocks: null });
 
-export const VideoClipGlobalWithoutCaption = generateFixtureData(
-  blockArrayModel([videoClipGlobalGuidanceBlock]),
-);
+export const NoAresMedia = ({ platform }) =>
+  generateFixtureData({ platform, blocks: [captionBlock] });
 
-export const VideoClipGlobalPortrait = generateFixtureData(
-  blockArrayModel([videoClipGlobalPortraitBlock]),
-);
+export const NoAresMediaMetadata = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [noAresMediaMetadata, captionBlock],
+  });
 
-export const VideoClipUkWithGuidance = generateFixtureData(
-  blockArrayModel([videoClipUkGuidanceBlock]),
-);
+export const VideoClipGlobalWithCaption = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [videoClipGlobalGuidanceBlock, captionBlock],
+  });
 
-export const VideoClipNonUk = generateFixtureData(
-  blockArrayModel([videoClipNonUkBlock]),
-);
+export const VideoClipGlobalWithoutCaption = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [videoClipGlobalGuidanceBlock],
+  });
 
-export const AudioClipGlobalGuidance = generateFixtureData(
-  blockArrayModel([audioClipGlobalGuidanceBlock]),
-);
+export const VideoClipGlobalPortrait = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [videoClipGlobalPortraitBlock],
+  });
 
-export const AudioClipUk = generateFixtureData(
-  blockArrayModel([audioClipUkOnlyBlock]),
-);
+export const VideoClipUkWithGuidance = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [videoClipUkGuidanceBlock],
+  });
 
-export const AudioClipNonUk = generateFixtureData(
-  blockArrayModel([audioClipNonUkBlock]),
-);
+export const VideoClipNonUk = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [videoClipNonUkBlock],
+  });
 
-export const AudioEpisodeGlobal = generateFixtureData(
-  blockArrayModel([audioEpisodeGlobalBlock]),
-);
+export const AudioClipGlobalGuidance = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [audioClipGlobalGuidanceBlock],
+  });
+
+export const AudioClipUk = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [audioClipUkOnlyBlock],
+  });
+
+export const AudioClipNonUk = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [audioClipNonUkBlock],
+  });
+
+export const AudioEpisodeGlobal = ({ platform }) =>
+  generateFixtureData({
+    platform,
+    blocks: [audioEpisodeGlobalBlock],
+  });

--- a/src/app/containers/Video/index.jsx
+++ b/src/app/containers/Video/index.jsx
@@ -11,14 +11,26 @@ import {
   emptyBlockArrayDefaultProps,
 } from '../../models/propTypes';
 import { filterForBlockType } from '../../helpers/blockHandlers';
+import { RequestContext } from '../../contexts/RequestContext';
 
 const VideoContainer = ({ blocks }) => {
-  const captionBlock = filterForBlockType(blocks, 'caption');
+  const { platform, statsDestination, statsPageIdentifier } = React.useContext(
+    RequestContext,
+  );
+
+  if (!blocks) {
+    return null;
+  }
+
   const aresMediaBlock = filterForBlockType(blocks, 'aresMedia');
-  const metadata = videoMetadata(aresMediaBlock);
+
   if (!aresMediaBlock) {
     return null;
   }
+
+  const metadata = videoMetadata(aresMediaBlock);
+
+  const captionBlock = filterForBlockType(blocks, 'caption');
 
   const nestedModel = deepGet(['model', 'blocks', 0, 'model'], aresMediaBlock);
   const kind = deepGet(['subType'], nestedModel);
@@ -57,6 +69,11 @@ const VideoContainer = ({ blocks }) => {
           title={title}
           items={items}
           holdingImageUrl={holdingImageUrl}
+          statsAppName="news"
+          statsAppType={platform === 'amp' ? 'amp' : 'responsive'}
+          statsCountername={statsPageIdentifier}
+          statsDestination={statsDestination}
+          uiLocale="en-GB"
         />
         {captionBlock ? <Caption block={captionBlock} video /> : null}
       </Figure>

--- a/src/app/containers/Video/index.stories.jsx
+++ b/src/app/containers/Video/index.stories.jsx
@@ -13,42 +13,60 @@ import {
 import AmpDecorator from '../../helpers/storybook/ampDecorator';
 
 storiesOf('Video Container', module)
-  .add(
-    'video, clip, with guidance, with caption',
-    () => VideoClipGlobalWithCaption,
+  .add('video, clip, with guidance, with caption', () =>
+    VideoClipGlobalWithCaption({ platform: 'canonical' }),
   )
-  .add(
-    'video, clip, with guidance, without caption',
-    () => VideoClipGlobalWithoutCaption,
+  .add('video, clip, with guidance, without caption', () =>
+    VideoClipGlobalWithoutCaption({ platform: 'canonical' }),
   )
-  .add('video, clip, UK, with guidance', () => VideoClipUkWithGuidance)
-  .add('video, clip, non-UK, without guidance', () => VideoClipNonUk)
-  .add(
-    'video, clip, global, without guidance, portrait',
-    () => VideoClipGlobalPortrait,
+  .add('video, clip, UK, with guidance', () =>
+    VideoClipUkWithGuidance({ platform: 'canonical' }),
   )
-  .add('audio, clip, global, with guidance', () => AudioClipGlobalGuidance)
-  .add('audio, clip, UK, without guidance', () => AudioClipUk)
-  .add('audio, clip, non-UK, without guidance', () => AudioClipNonUk)
-  .add('audio, episode, global, without guidance', () => AudioEpisodeGlobal);
+  .add('video, clip, non-UK, without guidance', () =>
+    VideoClipNonUk({ platform: 'canonical' }),
+  )
+  .add('video, clip, global, without guidance, portrait', () =>
+    VideoClipGlobalPortrait({ platform: 'canonical' }),
+  )
+  .add('audio, clip, global, with guidance', () =>
+    AudioClipGlobalGuidance({ platform: 'canonical' }),
+  )
+  .add('audio, clip, UK, without guidance', () =>
+    AudioClipUk({ platform: 'canonical' }),
+  )
+  .add('audio, clip, non-UK, without guidance', () =>
+    AudioClipNonUk({ platform: 'canonical' }),
+  )
+  .add('audio, episode, global, without guidance', () =>
+    AudioEpisodeGlobal({ platform: 'canonical' }),
+  );
 
 storiesOf('Video Container - AMP', module)
   .addDecorator(AmpDecorator)
-  .add(
-    'video, clip, with guidance, with caption',
-    () => VideoClipGlobalWithCaption,
+  .add('video, clip, with guidance, with caption', () =>
+    VideoClipGlobalWithCaption({ platform: 'amp' }),
   )
-  .add(
-    'video, clip, with guidance, without caption',
-    () => VideoClipGlobalWithoutCaption,
+  .add('video, clip, with guidance, without caption', () =>
+    VideoClipGlobalWithoutCaption({ platform: 'amp' }),
   )
-  .add('video, clip, UK, with guidance', () => VideoClipUkWithGuidance)
-  .add('video, clip, non-UK, without guidance', () => VideoClipNonUk)
-  .add(
-    'video, clip, global, without guidance, portrait',
-    () => VideoClipGlobalPortrait,
+  .add('video, clip, UK, with guidance', () =>
+    VideoClipUkWithGuidance({ platform: 'amp' }),
   )
-  .add('audio, clip, global, with guidance', () => AudioClipGlobalGuidance)
-  .add('audio, clip, UK, without guidance', () => AudioClipUk)
-  .add('audio, clip, non-UK, without guidance', () => AudioClipNonUk)
-  .add('audio, episode, global, without guidance', () => AudioEpisodeGlobal);
+  .add('video, clip, non-UK, without guidance', () =>
+    VideoClipNonUk({ platform: 'amp' }),
+  )
+  .add('video, clip, global, without guidance, portrait', () =>
+    VideoClipGlobalPortrait({ platform: 'amp' }),
+  )
+  .add('audio, clip, global, with guidance', () =>
+    AudioClipGlobalGuidance({ platform: 'amp' }),
+  )
+  .add('audio, clip, UK, without guidance', () =>
+    AudioClipUk({ platform: 'amp' }),
+  )
+  .add('audio, clip, non-UK, without guidance', () =>
+    AudioClipNonUk({ platform: 'amp' }),
+  )
+  .add('audio, episode, global, without guidance', () =>
+    AudioEpisodeGlobal({ platform: 'amp' }),
+  );

--- a/src/app/containers/Video/index.test.jsx
+++ b/src/app/containers/Video/index.test.jsx
@@ -1,88 +1,47 @@
-import React from 'react';
-import { shouldShallowMatchSnapshot } from '../../helpers/tests/testHelpers';
-import { blockArrayModel, singleTextBlock } from '../../models/blocks';
-import VideoContainer from './index';
 import {
+  shouldShallowMatchSnapshot,
+  isNull,
+} from '../../helpers/tests/testHelpers';
+import {
+  NoData,
+  NoAresMedia,
   VideoClipGlobalWithCaption,
   VideoClipGlobalWithoutCaption,
 } from './fixtureData';
 
 describe('Video', () => {
   describe('with no data', () => {
-    shouldShallowMatchSnapshot(
-      'should not render anything',
-      <VideoContainer />,
-    );
+    isNull('canonical - should render null', NoData({ platform: 'canonical' }));
+    isNull('amp - should render null', NoData({ platform: 'amp' }));
   });
 
-  describe('with no aresMedia', () => {
-    const captionBlock = {
-      model: {
-        blocks: [
-          singleTextBlock(
-            'p01k6msm: Video, Clip, UK and non-UK, guidance, subtitles (about bees)',
-          ),
-        ],
-      },
-      type: 'caption',
-    };
-    const data = blockArrayModel([captionBlock]);
+  describe('with no aresMedia block', () => {
+    isNull(
+      'canonical - should render null',
+      NoAresMedia({ platform: 'canonical' }),
+    );
+    isNull('amp - should render null', NoAresMedia({ platform: 'amp' }));
+  });
 
+  describe('with data', () => {
     shouldShallowMatchSnapshot(
-      'should only render the video',
-      <VideoContainer {...data} />,
+      'canonical - should render the video without a caption',
+      VideoClipGlobalWithoutCaption({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render the video without a caption',
+      VideoClipGlobalWithoutCaption({ platform: 'amp' }),
     );
   });
 
   describe('with data and a caption', () => {
     shouldShallowMatchSnapshot(
-      'should render the video and caption',
-      VideoClipGlobalWithCaption,
+      'canonical - should render the video and caption',
+      VideoClipGlobalWithCaption({ platform: 'canonical' }),
     );
-
     shouldShallowMatchSnapshot(
-      'should render the video without a caption',
-      VideoClipGlobalWithoutCaption,
-    );
-  });
-
-  describe('with data', () => {
-    const dataBlock = {
-      type: 'aresMedia',
-      model: {
-        blocks: [
-          {
-            model: {
-              id: 'foo',
-              subType: 'clip',
-              title: 'Hello World!',
-              versions: [
-                {
-                  versionId: 'bar',
-                  duration: 100,
-                },
-              ],
-            },
-          },
-          {
-            model: {
-              blocks: [
-                {
-                  model: {
-                    locator: 'https://foo/bar/baz.png',
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    };
-    const data = blockArrayModel([dataBlock]);
-
-    shouldShallowMatchSnapshot(
-      'should return a valid VideoContainer',
-      <VideoContainer {...data} />,
+      'amp - should render the video and caption',
+      VideoClipGlobalWithCaption({ platform: 'amp' }),
     );
   });
 });

--- a/src/app/containers/Video/index.test.jsx
+++ b/src/app/containers/Video/index.test.jsx
@@ -7,9 +7,16 @@ import {
   NoAresMedia,
   VideoClipGlobalWithCaption,
   VideoClipGlobalWithoutCaption,
+  VideoClipGlobalPortrait,
+  VideoClipUkWithGuidance,
+  VideoClipNonUk,
+  AudioClipGlobalGuidance,
+  AudioClipUk,
+  AudioClipNonUk,
+  AudioEpisodeGlobal,
 } from './fixtureData';
 
-describe('Video', () => {
+describe('AudioVideo', () => {
   describe('with no data', () => {
     isNull('canonical - should render null', NoData({ platform: 'canonical' }));
     isNull('amp - should render null', NoData({ platform: 'amp' }));
@@ -23,7 +30,7 @@ describe('Video', () => {
     isNull('amp - should render null', NoAresMedia({ platform: 'amp' }));
   });
 
-  describe('with data', () => {
+  describe('with Video data', () => {
     shouldShallowMatchSnapshot(
       'canonical - should render the video without a caption',
       VideoClipGlobalWithoutCaption({ platform: 'canonical' }),
@@ -32,9 +39,36 @@ describe('Video', () => {
       'amp - should render the video without a caption',
       VideoClipGlobalWithoutCaption({ platform: 'amp' }),
     );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render portrait video with global visibility',
+      VideoClipGlobalPortrait({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render portrait video with global visibility',
+      VideoClipGlobalPortrait({ platform: 'amp' }),
+    );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render the video without a caption',
+      VideoClipUkWithGuidance({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render the video without a caption',
+      VideoClipUkWithGuidance({ platform: 'amp' }),
+    );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render the video without a caption',
+      VideoClipNonUk({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render the video without a caption',
+      VideoClipNonUk({ platform: 'amp' }),
+    );
   });
 
-  describe('with data and a caption', () => {
+  describe('with Video data and a caption', () => {
     shouldShallowMatchSnapshot(
       'canonical - should render the video and caption',
       VideoClipGlobalWithCaption({ platform: 'canonical' }),
@@ -42,6 +76,44 @@ describe('Video', () => {
     shouldShallowMatchSnapshot(
       'amp - should render the video and caption',
       VideoClipGlobalWithCaption({ platform: 'amp' }),
+    );
+  });
+
+  describe('with Audio data', () => {
+    shouldShallowMatchSnapshot(
+      'canonical - should render audio clip global with guidance',
+      AudioClipGlobalGuidance({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render audio clip global with guidance',
+      AudioClipGlobalGuidance({ platform: 'amp' }),
+    );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render audio clip UK only',
+      AudioClipUk({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render audio clip UK only',
+      AudioClipUk({ platform: 'amp' }),
+    );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render audio clip non-UK only',
+      AudioClipNonUk({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render audio clip non-UK only',
+      AudioClipNonUk({ platform: 'amp' }),
+    );
+
+    shouldShallowMatchSnapshot(
+      'canonical - should render audio episode global',
+      AudioEpisodeGlobal({ platform: 'canonical' }),
+    );
+    shouldShallowMatchSnapshot(
+      'amp - should render audio episode global',
+      AudioEpisodeGlobal({ platform: 'amp' }),
     );
   });
 });

--- a/src/app/models/propTypes/index.js
+++ b/src/app/models/propTypes/index.js
@@ -52,6 +52,11 @@ export const videoComponentPropTypes = {
     }),
   ).isRequired,
   holdingImageUrl: string.isRequired,
+  statsAppName: string.isRequired,
+  statsAppType: string.isRequired,
+  statsCountername: string.isRequired,
+  statsDestination: string.isRequired,
+  uiLocale: string.isRequired,
 };
 
 const baseDefaultPropTypes = {


### PR DESCRIPTION
Resolves #1636

**Overall change:** Adds remaining Video props to the Video component & determines the values within the Video container. 
Updates unit tests

**Code changes:**

- Add stats props to Video component
- Pass in stats props to Video Component from Video Container
- Update unit tests to ensure null is returned when no blocks are passed in
- Ensure RequestContext values are passed in for tests & storybook examples
- Update snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
