### PR TITLE
Add frontpage & frontpage/beta route with dummy content

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -136,15 +136,18 @@ server
       }
     });
   })
-  .get('/:service(igbo|pidgin|yoruba)(/beta)?', ({ params }, res) => {
-    // This is a temporary route to unblock route setup in Mozart.
-    // Simply returns a 200 response which can we route to until
-    // it's set up properly in simorgh.
-    const { service } = params;
-    res
-      .status(200)
-      .send(`Welcome to the temporary ${service} homepage simorgh route`);
-  })
+  .get(
+    '/:service(igbo|pidgin|yoruba)(.amp|/beta|/beta.amp)?',
+    ({ params }, res) => {
+      // This is a temporary route to unblock route setup in Mozart.
+      // Simply returns a 200 response which can we route to until
+      // it's set up properly in simorgh.
+      const { service } = params;
+      res
+        .status(200)
+        .send(`Welcome to the temporary ${service} homepage simorgh route`);
+    },
+  )
   .get(articleRegexPath, async ({ url, headers }, res) => {
     try {
       const data = await loadInitialData(url, routes);

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -136,6 +136,15 @@ server
       }
     });
   })
+  .get('/:service(igbo|pidgin|yoruba)(/beta)?', ({ params }, res) => {
+    // This is a temporary route to unblock route setup in Mozart.
+    // Simply returns a 200 response which can we route to until
+    // it's set up properly in simorgh.
+    const { service } = params;
+    res
+      .status(200)
+      .send(`Welcome to the temporary ${service} homepage simorgh route`);
+  })
   .get(articleRegexPath, async ({ url, headers }, res) => {
     try {
       const data = await loadInitialData(url, routes);

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -97,6 +97,26 @@ describe('Server', () => {
     });
   });
 
+  describe('Temporary frontpage routes', () => {
+    const expectedRoutes = [
+      { path: '/igbo', service: 'igbo' },
+      { path: '/igbo/beta', service: 'igbo' },
+      { path: '/pidgin', service: 'pidgin' },
+      { path: '/pidgin/beta', service: 'pidgin' },
+      { path: '/yoruba', service: 'yoruba' },
+      { path: '/yoruba/beta', service: 'yoruba' },
+    ];
+
+    expectedRoutes.forEach(({ path, service }) => {
+      it('should respond with text', async () => {
+        const { text } = await makeRequest(path);
+        expect(text).toEqual(
+          `Welcome to the temporary ${service} homepage simorgh route`,
+        );
+      });
+    });
+  });
+
   describe('/{service}/articles/{optimoID}', () => {
     const successDataResponse = {
       isAmp: false,

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -105,6 +105,12 @@ describe('Server', () => {
       { path: '/pidgin/beta', service: 'pidgin' },
       { path: '/yoruba', service: 'yoruba' },
       { path: '/yoruba/beta', service: 'yoruba' },
+      { path: '/igbo.amp', service: 'igbo' },
+      { path: '/igbo/beta.amp', service: 'igbo' },
+      { path: '/pidgin.amp', service: 'pidgin' },
+      { path: '/pidgin/beta.amp', service: 'pidgin' },
+      { path: '/yoruba.amp', service: 'yoruba' },
+      { path: '/yoruba/beta.amp', service: 'yoruba' },
     ];
 
     expectedRoutes.forEach(({ path, service }) => {


### PR DESCRIPTION
Resolves #1754

**Overall change:** Adds dummy frontpage routes to unblock routing in mozart
**Code changes:**

- Adds simply dummy route
- Adds some unit tests

Test that the new Route works for:
`/igbo`
`/pidgin`
`/yoruba`
`/igbo/beta`
`/pidgin/beta`
`/yoruba/beta`
`/igbo.amp`
`/pidgin.amp`
`/yoruba.amp`
`/igbo/beta.amp`
`/pidgin/beta.amp`
`/yoruba/beta.amp`

Ensure it does not work for nested requests on these routes:
`/pidgin/foo`
`/pidgin/beta/bar`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
