### PR TITLE
Fix live E2E tests using getBlockByType func

### DIFF
--- a/cypress/support/bodyTestHelper.js
+++ b/cypress/support/bodyTestHelper.js
@@ -18,9 +18,8 @@ export const shouldMatchReturnedData = (data, element) => {
   getElement(element).should('contain', data);
 };
 
-export const getBlockData = (blockType, win) => {
+export const getBlockByType = (blocks, blockType) => {
   let blockData;
-  const { blocks } = win.SIMORGH_DATA.pageData.content.model;
 
   blocks.forEach(block => {
     if (!blockData && block.type === blockType) {
@@ -28,6 +27,12 @@ export const getBlockData = (blockType, win) => {
     }
   });
   return blockData;
+};
+
+export const getBlockData = (blockType, win) => {
+  const { blocks } = win.SIMORGH_DATA.pageData.content.model;
+
+  return getBlockByType(blocks, blockType);
 };
 
 export const firstHeadlineDataWindow = () => {
@@ -61,7 +66,11 @@ export const firstParagraphDataWindow = () => {
 export const copyrightDataWindow = () => {
   cy.window().then(win => {
     const copyrightData = getBlockData('image', win);
-    const { copyrightHolder } = copyrightData.model.blocks[0].model;
+    const rawImageblock = getBlockByType(
+      copyrightData.model.blocks,
+      'rawImage',
+    );
+    const { copyrightHolder } = rawImageblock.model;
     const copyrightLabel = getElement('figure p').eq(0);
 
     shouldContainText(copyrightLabel, copyrightHolder);


### PR DESCRIPTION
~Resolves #NUMBER~

Live E2Es were failing because the payload had array items in a different order than the tests expected

**Overall change:** _Fixes the live E2E tests because they were dependant on the order of the blocks in the payload. Does this by adding a `getBlockByType` helper function and uses it for the failing copyright test. There is a follow up piece of work to change all tests that access an array using a number (EG: `array[0]`)._

**Code changes:**

- Adds a helper function and uses it to fix the failing E2E tests.

---

To test this ensure that `newBodySpec` tests pass when running `CYPRESS_APP_ENV=live npm run cypress:interactive`. The complete test suite is likely to fail due to running against live on the local env. 

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [x] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
