### PR TITLE
Add frontpage e2e

### DIFF
--- a/cypress/integration/frontpageLayoutSpec.js
+++ b/cypress/integration/frontpageLayoutSpec.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-undef */
+/* eslint-disable func-names */
+/* eslint-disable prefer-arrow-callback */
+import services from '../support/worldServices'
+
+Object.keys(services).map(function(index, key) {
+  const serviceObject = services[index]
+  const service = index;
+  
+  describe('frontpage tests for ' + service, function() {
+    before(function() {
+      cy.visit(serviceObject.url);
+    });
+
+    context('should render the page at 1008', function() {
+      before(() => {
+        cy.viewport(1008, 768);
+      });
+
+      it('verifies the layout at 1008', function() {
+        cy.document().then(function(doc) {
+          cy.log(doc.documentElement.getBoundingClientRect().width);
+        });
+      });
+    });
+
+    context('should render the page at 600', () => {
+      before(() => {
+        cy.viewport(600, 1024);
+      });
+
+      it('verifies the layout at 600', function() {
+        cy.document().then(function(doc) {
+          cy.log(doc.documentElement.getBoundingClientRect().width);
+        });
+      });
+    });
+
+    context('should render the page at 360', () => {
+      before(() => {
+        cy.viewport(360, 667);
+      });
+
+      it('verifies the layout at 360', function() {
+        cy.document().then(function(doc) {
+          cy.log(doc.documentElement.getBoundingClientRect().width);
+        });
+      });
+    });
+
+    context('should render the page at 240', () => {
+      before(() => {
+        cy.viewport(240, 480);
+      });
+
+      it('verifies the layout at 1008', function() {
+        cy.document().then(function(doc) {
+          cy.log(doc.documentElement.getBoundingClientRect().width);
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/frontpageLayoutSpec.js
+++ b/cypress/integration/frontpageLayoutSpec.js
@@ -1,13 +1,14 @@
 /* eslint-disable no-undef */
 /* eslint-disable func-names */
 /* eslint-disable prefer-arrow-callback */
-import services from '../support/worldServices'
+import services from '../support/worldServices';
 
-Object.keys(services).map(function(index, key) {
-  const serviceObject = services[index]
+// eslint-disable-next-line array-callback-return
+Object.keys(services).map(function(index) {
+  const serviceObject = services[index];
   const service = index;
-  
-  describe('frontpage tests for ' + service, function() {
+
+  describe(`frontpage tests for ${service}`, function() {
     before(function() {
       cy.visit(serviceObject.url);
     });
@@ -24,7 +25,7 @@ Object.keys(services).map(function(index, key) {
       });
     });
 
-    context('should render the page at 600', () => {
+    context('should render the page at 600', function() {
       before(() => {
         cy.viewport(600, 1024);
       });

--- a/cypress/support/worldServices.js
+++ b/cypress/support/worldServices.js
@@ -1,0 +1,5 @@
+export default {
+  igbo: { url: '/igbo' },
+  yoruba: { url: '/yoruba' },
+  pidgin: { url: '/pidgin' },
+};


### PR DESCRIPTION
Resolves #1829

Added two files frontpageLayoutSpec.js and worldServices.js. The test file frontpageLayoutSpec loops through the three services and just sets their widths at the moment.

**Code changes:**
- Three lint exceptions added. Basically these are needed because at some point we are going to need to use the `this` context and we cannot do that with arrow functions. There's also something to be said for `function` syntax being more immediately familiar to those who are starting to learn JavaScript.
  - /* eslint-disable no-undef */
  - /* eslint-disable func-names */
  - /* eslint-disable prefer-arrow-callback */

- worldServices.js is a simple object at the moment but it will no doubt get bigger. That's why it is its a separate file. In time there'll be tests that will need to access common properties (worldServices.js) but also service specific properties or functions, these will be contained in an object specific to that spec.

You can mostly ignore the rest of the tests, it's just some logging top ensure that the responsive breakpoints are being set correctly.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
