### PR TITLE
Fix test:storybook:ci failing on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:live": "cp envConfig/live.env .env && NODE_ENV=production webpack",
     "cypress": "cypress run",
     "cypress:interactive": "cypress open",
-    "cypress:storybook": "sleep 10 && cypress run --project ./.storybook/.",
+    "cypress:storybook": "wait-on -t 20000 http://localhost:9001 && cypress run --project ./.storybook/.",
     "cypress:storybook:interactive": "cypress open --project ./.storybook/.",
     "dataValidate": "node src/app/dataValidator/index.js",
     "dataValidate:debug": "npm run dataValidate --DEBUG_MODE=true",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:live": "cp envConfig/live.env .env && NODE_ENV=production webpack",
     "cypress": "cypress run",
     "cypress:interactive": "cypress open",
-    "cypress:storybook": "wait-on -t 20000 http://localhost:9001 && cypress run --project ./.storybook/.",
+    "cypress:storybook": "wait-on -t 60000 http://localhost:9001 && cypress run --project ./.storybook/.",
     "cypress:storybook:interactive": "cypress open --project ./.storybook/.",
     "dataValidate": "node src/app/dataValidator/index.js",
     "dataValidate:debug": "npm run dataValidate --DEBUG_MODE=true",


### PR DESCRIPTION
**Overall change:**
- Added a `wait-on` on the storybook cypress step so that cypress runs deterministically after storybook starts.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
