### PR TITLE
POC: AMP to AMP onward journey navigation

### DIFF
--- a/src/app/containers/InlineLink/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/InlineLink/__snapshots__/index.test.jsx.snap
@@ -127,6 +127,38 @@ exports[`InlineLinkContainer internal link not matching SPA route should render 
 </a>
 `;
 
+exports[`InlineLinkContainer link matching routes for SPA should render amp link if current platform is amp 1`] = `
+.c0 {
+  color: #222222;
+  border-bottom: 1px solid #B80000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:visited {
+  color: #757575;
+  border-bottom: 1px solid #757575;
+}
+
+.c0:focus {
+  color: #B80000;
+  border-bottom: 2px solid #B80000;
+}
+
+.c0:hover {
+  color: #B80000;
+  border-bottom: 2px solid #B80000;
+}
+
+<a
+  className="-Link c0"
+  href="/news/articles/cn7769kpk9mo.amp"
+  onClick={[Function]}
+>
+  This is text for an internal link
+</a>
+`;
+
 exports[`InlineLinkContainer link matching routes for SPA should render correctly 1`] = `
 .c0 {
   color: #222222;

--- a/src/app/containers/InlineLink/index.jsx
+++ b/src/app/containers/InlineLink/index.jsx
@@ -4,6 +4,7 @@ import pathToRegexp from 'path-to-regexp';
 import InlineLink from '@bbc/psammead-inline-link';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { ServiceContext } from '../../contexts/ServiceContext';
+import { RequestContext } from '../../contexts/RequestContext';
 import Blocks from '../Blocks';
 import fragment from '../Fragment';
 import { inlineLinkModelPropTypes } from '../../models/propTypes/inlineLink';
@@ -15,6 +16,8 @@ const componentsToRender = { fragment };
 
 const InlineLinkContainer = ({ locator, isExternal, blocks }) => {
   const { externalLinkText } = useContext(ServiceContext);
+  const { platform } = useContext(RequestContext);
+
   const regexp = pathToRegexp(articleRegexPath, [], {
     start: false,
     end: false,
@@ -24,7 +27,12 @@ const InlineLinkContainer = ({ locator, isExternal, blocks }) => {
   // if URL matches a valid route, use a react-router link
   if (result) {
     // the path is the first item in the array
-    const path = result[0];
+    let path = result[0];
+
+    if (platform === 'amp') {
+      path += '.amp';
+    }
+
     return (
       <InternalInlineLink to={path}>
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />

--- a/src/app/containers/InlineLink/index.test.jsx
+++ b/src/app/containers/InlineLink/index.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StaticRouter } from 'react-router-dom';
+import { RequestContextProvider } from '../../contexts/RequestContext';
 import { shouldMatchSnapshot } from '../../helpers/tests/testHelpers';
 import InlineLinkContainer from './index';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
@@ -12,18 +13,33 @@ const fragmentBlock = (text, attributes = []) => ({
   },
 });
 
-const testInternalInlineLink = (description, locator, blocks, isExternal) => {
+const testInternalInlineLink = (
+  description,
+  locator,
+  blocks,
+  isExternal,
+  platform = 'canonical',
+) => {
   shouldMatchSnapshot(
     description,
     /*
       for the value it would bring, it is much simpler to wrap a react-router Link in a Router, rather than mock a Router or pass some mocked context.
     */
     <StaticRouter>
-      <InlineLinkContainer
-        locator={locator}
-        blocks={blocks}
-        isExternal={isExternal}
-      />
+      <RequestContextProvider
+        isUk
+        origin="https://www.bbc.co.uk"
+        id="c0000000000o"
+        platform={platform}
+        statsDestination="NEWS_PS_TEST"
+        statsPageIdentifier="news.articles.c0000000000o"
+      >
+        <InlineLinkContainer
+          locator={locator}
+          blocks={blocks}
+          isExternal={isExternal}
+        />
+      </RequestContextProvider>
     </StaticRouter>,
   );
 };
@@ -42,6 +58,14 @@ describe('InlineLinkContainer', () => {
       'https://www.test.bbc.com/news/articles/cn7769kpk9mo',
       [fragmentBlock('This is text for an internal link')],
       false,
+    );
+
+    testInternalInlineLink(
+      'should render amp link if current platform is amp',
+      'https://www.bbc.com/news/articles/cn7769kpk9mo',
+      [fragmentBlock('This is text for an internal link')],
+      false,
+      'amp',
     );
   });
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Set internal links to navigate to AMP version of article if user already on AMP platform.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
