### PR TITLE
Don't require ID; it's not expected in front pages

### DIFF
--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -51,13 +51,14 @@ const PageWrapper = ({ bbcOrigin, children, id, service, isAmp }) => {
 PageWrapper.propTypes = {
   bbcOrigin: string,
   children: node.isRequired,
-  id: string.isRequired,
+  id: string,
   isAmp: bool.isRequired,
   service: string.isRequired,
 };
 
 PageWrapper.defaultProps = {
   bbcOrigin: null,
+  id: null,
 };
 
 PageWrapper.defaultProps = {};

--- a/src/app/contexts/RequestContext/index.jsx
+++ b/src/app/contexts/RequestContext/index.jsx
@@ -28,10 +28,14 @@ export const RequestContextProvider = ({
 
 RequestContextProvider.propTypes = {
   children: node.isRequired,
-  id: string.isRequired,
+  id: string,
   platform: string.isRequired,
   isUK: bool.isRequired,
   origin: string.isRequired,
   statsDestination: string.isRequired,
   statsPageIdentifier: string.isRequired,
+};
+
+RequestContextProvider.defaultProps = {
+  id: null,
 };


### PR DESCRIPTION
Resolves #1785 

**Overall change:** Make the ID prop optional in the request context provider and page wrapper.

**Code changes:**

- It shouldn't be a required prop; it's not valid on the front pages.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
