### PR TITLE
Revert "route for explore page"

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -148,17 +148,6 @@ server
         .send(`Welcome to the temporary ${service} homepage simorgh route`);
     },
   )
-  .get('/:service(news)/explore:amp(.amp)?', ({ params }, res) => {
-    // This is also a temporary route to unblock route setup in Mozart.
-    // Simple 200 response which can be routed to.
-    const { amp, service } = params;
-    const variant = amp ? 'amp' : 'canonical';
-    res
-      .status(200)
-      .send(
-        `Welcome to the ${variant} variant of the temporary ${service} explore page route on Simorgh.`,
-      );
-  })
   .get(articleRegexPath, async ({ url, headers }, res) => {
     try {
       const { service, isAmp, route, match } = getRouteProps(routes, url);

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -148,22 +148,6 @@ describe('Server', () => {
     });
   });
 
-  describe('Temporary explore page routes', () => {
-    const expectedRoutes = [
-      { path: '/news/explore', service: 'news', variant: 'canonical' },
-      { path: '/news/explore.amp', service: 'news', variant: 'amp' },
-    ];
-
-    expectedRoutes.forEach(({ path, service, variant }) => {
-      it('should respond with text', async () => {
-        const { text } = await makeRequest(path);
-        expect(text).toEqual(
-          `Welcome to the ${variant} variant of the temporary ${service} explore page route on Simorgh.`,
-        );
-      });
-    });
-  });
-
   describe('/{service}/articles/{optimoID}', () => {
     const successDataResponse = {
       isAmp: false,


### PR DESCRIPTION
UnResolves #1806 

**Overall change:** Removes a route for the explore page

**Code changes:**

- Disables requests for `/news/explore` and `/news/explore.amp`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
