### PR TITLE
Only run Manifest tests for WS locally

### DIFF
--- a/cypress/integration/manifest.js
+++ b/cypress/integration/manifest.js
@@ -1,9 +1,16 @@
 import { testResponseCode } from '../support/metaTestHelper';
+import describeForLocalOnly from '../support/describeForLocalOnly';
+
+const testManifest200s = service => {
+  it(`should return a 200 status code for ${service}`, () => {
+    testResponseCode(`/${service}/articles/manifest.json`, 200);
+  });
+};
 
 describe('Manifest.json files', () => {
-  ['news', 'persian', 'igbo', 'pidgin', 'yoruba'].forEach(service => {
-    it(`should return a 200 status code for ${service}`, () => {
-      testResponseCode(`/${service}/articles/manifest.json`, 200);
-    });
-  });
+  ['news', 'persian'].forEach(testManifest200s);
+});
+
+describeForLocalOnly('Local Env - Manifest.json files', () => {
+  ['igbo', 'pidgin', 'yoruba'].forEach(testManifest200s);
 });


### PR DESCRIPTION
Resolves failing e2s

**Overall change:** The manifest json files for WS arnt routed on test or live, so our E2Es fail for those envs

**Code changes:**

- Make the manifest tests for igbo, pidigin and yoruba only run locally

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
