### PR TITLE
Stop redirection causing flaking unit tests

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -77,6 +77,7 @@ if (process.env.APP_ENV === 'local') {
       expressStaticGzip(publicDirectory, {
         enableBrotli: true,
         orderPreference: ['br'],
+        redirect: false,
       }),
     )
     .get(articleDataRegexPath, async ({ params }, res, next) => {


### PR DESCRIPTION
Resolves none

**Overall change:** We are experiencing flaked tests on latest (locally), where e.g. the /igbo routes are redirecting in supertest tests.

**Code changes:**

Stop redirection on express.static by passing in the option: docs for express http://expressjs.com/en/api.html#express.static docs for the dep we use that uses express.static: https://www.npmjs.com/package/express-static-gzip

---

- [x] I have assigned myself to this PR and the corresponding issues
Manual testing by QA not needed, just local checking out and test running.

~~- [ ] Tests added for new features~~
~~- [ ] Test engineer approval~~
~~- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-~~
~~infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.~~
