### PR TITLE
Increase lazyload Cypress scroll duration

### DIFF
--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -59,7 +59,7 @@ describe('Article Body Tests', () => {
       const noscriptImg = getElement('noscript');
       noscriptImg.contains('<img ');
 
-      cy.scrollTo('bottom', { duration: 500 });
+      cy.scrollTo('bottom', { duration: 1000 });
 
       const ImageContainer = getElement('div div');
       ImageContainer.should('not.have.class', 'lazyload-placeholder');


### PR DESCRIPTION
Resolves #1881 

**Overall change:** This has increased the scroll duration to `1000ms` on the Cypress lazyload test. This should **not** be a permanent solution to this problem, as two PRs in the last two days have increased this timeout. A more robust solution should be considered early next week, but in the mean time to prevent this blocking anyone else's work, this should suffice.

I'm also convinced it's something to do with the recent upgrade to Cypress 3.3.0, as it has become more of an issue since we upgraded that dependency earlier today.

**Code changes:**

- Increase timeout for Cypress lazyload test

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
