### PR TITLE
deepGet: don't clobber falsy values with null

### DIFF
--- a/src/app/helpers/json/deepGet.js
+++ b/src/app/helpers/json/deepGet.js
@@ -9,7 +9,7 @@
  */
 const deepGet = (path, object) =>
   typeof object === 'object'
-    ? path.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), object)
+    ? path.reduce((xs, x) => (xs && xs[x] !== undefined ? xs[x] : null), object)
     : null;
 
 export default deepGet;

--- a/src/app/helpers/json/deepGet.test.js
+++ b/src/app/helpers/json/deepGet.test.js
@@ -9,9 +9,9 @@ const fixtureData = {
     nada: false,
     thingsJonSnowKnows: 0,
     foobar: {
-        barfoo: {
-            zilch: '',
-        },
+      barfoo: {
+        zilch: '',
+      },
     },
   },
 };

--- a/src/app/helpers/json/deepGet.test.js
+++ b/src/app/helpers/json/deepGet.test.js
@@ -8,7 +8,11 @@ const fixtureData = {
   nothing: {
     nada: false,
     thingsJonSnowKnows: 0,
-    zilch: '',
+    foobar: {
+        barfoo: {
+            zilch: '',
+        },
+    },
   },
 };
 
@@ -51,6 +55,8 @@ describe('deepGet', () => {
   it('should not clobber falsy, defined, non-null values', () => {
     expect(deepGet(['nothing', 'nada'], fixtureData)).toEqual(false);
     expect(deepGet(['nothing', 'thingsJonSnowKnows'], fixtureData)).toEqual(0);
-    expect(deepGet(['nothing', 'zilch'], fixtureData)).toEqual('');
+    expect(
+      deepGet(['nothing', 'foobar', 'barfoo', 'zilch'], fixtureData),
+    ).toEqual('');
   });
 });

--- a/src/app/helpers/json/deepGet.test.js
+++ b/src/app/helpers/json/deepGet.test.js
@@ -5,6 +5,11 @@ const fixtureData = {
   bar: {
     baz: 456,
   },
+  nothing: {
+    nada: false,
+    thingsJonSnowKnows: 0,
+    zilch: '',
+  },
 };
 
 const fixtureDataWithArrays = {
@@ -41,5 +46,11 @@ describe('deepGet', () => {
     expect(deepGet(['foo', 'bar'], undefined)).toEqual(null);
     expect(deepGet(['foo', 'bar'], 'string')).toEqual(null);
     expect(deepGet(['foo', 'bar'], 23)).toEqual(null);
+  });
+
+  it('should not clobber falsy, defined, non-null values', () => {
+    expect(deepGet(['nothing', 'nada'], fixtureData)).toEqual(false);
+    expect(deepGet(['nothing', 'thingsJonSnowKnows'], fixtureData)).toEqual(0);
+    expect(deepGet(['nothing', 'zilch'], fixtureData)).toEqual('');
   });
 });


### PR DESCRIPTION
Resolves a bug

Not strictly related to a particular pod, so I've added a bunch of labels to make it visible

**Overall change:** deepGet replaced any [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) items it found with `null`. But sometimes, you might actually want to retrieve a `0` or a `''` or a `false`.

**Code changes:**

- Only replace `undefined` values with `null`. (`null`s will still be `null` :) )

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
