### PR TITLE
Disable world service cookie banner checks

### DIFF
--- a/cypress/integration/cookieBannerWS.js
+++ b/cypress/integration/cookieBannerWS.js
@@ -6,7 +6,7 @@ const services = Object.keys(config);
 
 describe('World Service Cookie Banner Transations - Canonical', () => {
   services.forEach(serviceName => {
-    it(`should load the relevant translations for ${serviceName}`, () => {
+    xit(`should load the relevant translations for ${serviceName}`, () => {
       worldServiceCookieBannerTranslations(
         `${config[serviceName].assets.privacyStatement}`,
         `${config[serviceName].assets.performanceStatement}`,
@@ -20,7 +20,7 @@ describe('World Service Cookie Banner Transations - Canonical', () => {
 
 describeForEuOnly('World Service Cookie Banner Transations - AMP', () => {
   services.forEach(serviceName => {
-    it(`should load the relevant translations for ${serviceName}`, () => {
+    xit(`should load the relevant translations for ${serviceName}`, () => {
       worldServiceCookieBannerTranslations(
         `${config[serviceName].assets.privacyStatement}`,
         `${config[serviceName].assets.performanceStatement}`,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Disable the World Service cookie banner tests until routing is completed.

**Code changes:**

- Disable the `cookieBannerWS.js` tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
