### PR TITLE
More robust way of testing lazyloading functionality

### DIFF
--- a/cypress/integration/newsBodySpec.js
+++ b/cypress/integration/newsBodySpec.js
@@ -51,25 +51,25 @@ describe('Article Body Tests', () => {
   });
 
   it('should have a visible image with a caption that is lazyloaded and has a noscript fallback image', () => {
-    let thirdFigure;
+    const imageHasNotLoaded = getElement('figure').eq(2);
 
-    thirdFigure = getElement('figure').eq(2);
-
-    thirdFigure.within(() => {
+    imageHasNotLoaded.within(() => {
       const lazyLoadPlaceholder = getElement('div div');
       lazyLoadPlaceholder.should('have.class', 'lazyload-placeholder');
+    });
 
+    imageHasNotLoaded.scrollIntoView();
+
+    const imageHasLoaded = getElement('figure').eq(2);
+
+    visibleImageWithCaption(imageHasLoaded);
+    imageHasLoaded.within(() => {
       const noscriptImg = getElement('noscript');
       noscriptImg.contains('<img ');
-
-      cy.scrollTo('bottom', { duration: 1000 });
 
       const ImageContainer = getElement('div div');
       ImageContainer.should('not.have.class', 'lazyload-placeholder');
     });
-
-    thirdFigure = getElement('figure').eq(2);
-    visibleImageWithCaption(thirdFigure);
   });
 
   it('should have an image copyright label with styling', () => {

--- a/cypress/integration/persianBodySpec.js
+++ b/cypress/integration/persianBodySpec.js
@@ -38,25 +38,25 @@ describeForLocalOnly('Article Body Tests', () => {
   });
 
   it('should have a visible image with a caption', () => {
-    let thirdFigure;
+    const imageHasNotLoaded = getElement('figure').eq(2);
 
-    thirdFigure = getElement('figure').eq(2);
-
-    thirdFigure.within(() => {
+    imageHasNotLoaded.within(() => {
       const lazyLoadPlaceholder = getElement('div div');
       lazyLoadPlaceholder.should('have.class', 'lazyload-placeholder');
+    });
 
+    imageHasNotLoaded.scrollIntoView();
+
+    const imageHasLoaded = getElement('figure').eq(2);
+
+    visibleImageWithCaption(imageHasLoaded);
+    imageHasLoaded.within(() => {
       const noscriptImg = getElement('noscript');
       noscriptImg.contains('<img ');
-
-      cy.scrollTo('bottom', { duration: 200 });
 
       const ImageContainer = getElement('div div');
       ImageContainer.should('not.have.class', 'lazyload-placeholder');
     });
-
-    thirdFigure = getElement('figure').eq(2);
-    visibleImageWithCaption(thirdFigure);
   });
 
   it('should render a title', () => {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Change how we test lazyloading

**Code changes:**

- Use Cypress `scrollIntoView` method to ensure lazyloaded image has the chance to load, as oppose to `scrollTo('bottom')`, as this may have been running before the page fully rendered.
---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
