### PR TITLE
Immediate patch for cypress:ci failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:live": "cp envConfig/live.env .env && NODE_ENV=production webpack",
     "cypress": "cypress run",
     "cypress:interactive": "cypress open",
-    "cypress:storybook": "wait-on -t 60000 http://localhost:9001 && cypress run --project ./.storybook/.",
+    "cypress:storybook": "wait-on -t 120000 http://localhost:9001 && cypress run --project ./.storybook/.",
     "cypress:storybook:interactive": "cypress open --project ./.storybook/.",
     "dataValidate": "node dataValidator/index.js",
     "dataValidate:debug": "npm run dataValidate --DEBUG_MODE=true",


### PR DESCRIPTION
**Overall change:**
It looks like building of storybook takes more than 60 seconds. In order to free up the builds I have decided to bump up this time-out to 120 seconds. In any case storybook should build faster than 60 seconds.

**Code changes:**

- Bumped up the wait-on timeout to 120000 milliseconds

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
