### PR TITLE
Pin to psammead-styles@0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       }
     },
     "@bbc/psammead-styles": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.4.1.tgz",
-      "integrity": "sha512-0hHXZXMkrib90YIoDYgdmb4TSSDP734BgzLKLrptVN9ZdUpi3QmSZNDd3AHEWUo+r1WQP6w+r0CiqTD82koNIg=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.3.5.tgz",
+      "integrity": "sha512-55p7WnK8L8eUIgK8R6J1aKfQKXlpUrh2udoTekUqdwAamGLcGxyulf8nyNPQ78G880KDXv+HLyruzQ3/Q9G1+Q=="
     },
     "@bbc/psammead-timestamp": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@bbc/psammead-sitewide-links": "^0.3.9",
     "@bbc/psammead-story-promo": "^0.2.0-alpha.5",
     "@bbc/psammead-story-promo-list": "^0.1.0-alpha.2",
-    "@bbc/psammead-styles": "^0.4.1",
+    "@bbc/psammead-styles": "0.3.5",
     "@bbc/psammead-timestamp-container": "^1.1.0",
     "@bbc/psammead-visually-hidden-text": "^0.1.10",
     "assets-webpack-plugin": "^3.9.8",


### PR DESCRIPTION


No ticket - resolves issue where we were using `psammead-styles@0.4.1`, updating to use the next major version of fonts `https://gel.files.bbci.co.uk/r2.511*` without the font-face declarations and therefore downloading 16 font files per page. 


**Overall change:** Pin to psammead-styles@0.3.5 

**Code changes:**
- By pinning to v0.3.5 we're using just the font-file versions `https://gel.files.bbci.co.uk/r2.302*`

<img width="1156" alt="Screen Shot font files downloaded" src="https://user-images.githubusercontent.com/3028997/59696903-d4c8a100-91e4-11e9-8ea2-65a09a252da7.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
