### PR TITLE
Make Frontpage E2Es run only locally

### DIFF
--- a/cypress/integration/frontpageLayoutSpec.js
+++ b/cypress/integration/frontpageLayoutSpec.js
@@ -79,7 +79,7 @@ Object.keys(services).forEach(index => {
     });
   });
 
-  describe('<script> tags', () => {
+  describeForLocalOnly('<script> tags', () => {
     // Testing the actual fetch is not currently possible
     it('should have script to fetch bundle', () => {
       cy.get('script')


### PR DESCRIPTION
**Overall change:** Resolves failing e2e

**Code changes:**

- Ensures all frontpage E2Es only run locally
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
