### PR TITLE
Upload fixture data onto the box for frontpage launch

### DIFF
--- a/scripts/jenkinsProductionFiles.sh
+++ b/scripts/jenkinsProductionFiles.sh
@@ -20,6 +20,10 @@ cp -rf ./.storybook ./pack/.storybook
 cp -rf ./envConfig ./pack/envConfig
 cp -rf ./public ./pack/public
 
+# Temp for frontpage launch
+# To be removed in https://github.com/bbc/simorgh/issues/1996
+cp -rf ./data ./pack/data
+
 # Copy the needed files in the root directory
 cp package.json ./pack
 cp package-lock.json ./pack


### PR DESCRIPTION
Fix forward for https://github.com/bbc/simorgh/pull/1983

We need to use fixture data for the frontpage STM change, which 1982 intended to do. However we dont currently upload the data for it to use, this adds it :)

**Overall change:** Upload fixture data to the box

**Code changes:**

- Upload fixture data to the box

To be reverted in https://github.com/bbc/simorgh/issues/1996

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
