### PR TITLE
Increase the bundle entry point size limit

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = (shell = {}) => {
     performance: !START_DEV_SERVER
       ? {
           maxAssetSize: 245760, // 240kb - individual bundles
-          maxEntrypointSize: 630784, // 616kb - total bundles
+          maxEntrypointSize: 730000, // 730kb - total bundles
           hints: 'error',
         }
       : undefined,


### PR DESCRIPTION
Resolves No Issue

**Overall change:** Increases the bundle size limit to 730kb, this should be a temporary measure whilst we work on bundle splitting.

**Code changes:**

- Increase webpacks bundle size limit

---

- [X] I have assigned myself to this PR and the corresponding issues
- [N/A] Tests added for new features
- [ ] Test engineer approval
- [X] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
