### PR TITLE
Use tests data on frontpage test

### DIFF
--- a/envConfig/test.env
+++ b/envConfig/test.env
@@ -1,5 +1,5 @@
 SIMORGH_BASE_URL=https://www.test.bbc.com
-SIMORGH_FRONTPAGE_BASE_URL=http://localhost:7080
+SIMORGH_FRONTPAGE_BASE_URL=https://www.test.bbc.com
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets-test.json
 SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN=https://news.test.files.bbci.co.uk
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=/include/articles/public


### PR DESCRIPTION
**Overall change:** Use test data on test for frontpages

**Code changes:**

- Use test data on test for frontpages

Expected behaviour:
On https://www.test.bbc.co.uk/igbo you see real test data (not fixture)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
