### PR TITLE
Fix proptype warning in story promo

### DIFF
--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -37,7 +37,7 @@ const StoryPromoImage = ({ imageValues, lazyLoad }) => {
 
 StoryPromoImage.propTypes = {
   lazyLoad: bool.isRequired,
-  imageValues: storyItem.indexImage.isRequired,
+  imageValues: shape(storyItem.indexImage).isRequired,
 };
 
 const StoryPromo = ({ item, lazyLoadImage }) => {


### PR DESCRIPTION
Resolves #1995

**Overall change:** Fixes propType warnings in StoryPromo component

**Code changes:**
- Added `shape()` around the `storyItemImage` object

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
