### PR TITLE
Use Stage data on live simorgh

### DIFF
--- a/envConfig/live.env
+++ b/envConfig/live.env
@@ -1,5 +1,5 @@
 SIMORGH_BASE_URL=https://www.bbc.com
-SIMORGH_FRONTPAGE_BASE_URL=http://localhost:7080
+SIMORGH_FRONTPAGE_BASE_URL=https://www.stage.bbc.com
 SIMORGH_ASSETS_MANIFEST_PATH=build/assets-live.json
 SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN=https://news.files.bbci.co.uk
 SIMORGH_PUBLIC_STATIC_ASSETS_PATH=/include/articles/public


### PR DESCRIPTION
**Overall change:** Use stage data on live simorgh for ws frontpages

**Code changes:**

- Use https://www.stage.bbc.com for data, which is live CPS

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
