### PR TITLE
Remove the unnecessary npm version force in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
     - ~/.cache/Cypress
 env:
   - CC_TEST_REPORTER_ID=f5b40344b76ccf66fbab5aa40bd5db671464c74f255cc3d4063f8bcd7c0812cf
-before_install: npm install -g npm@6.4.1; npm -v
 jobs:
   include:
     - stage: test


### PR DESCRIPTION

**Overall change:** 
Since we are not always using the npm version that is bound to the node version we should remove this pre install

**Code changes:**

- Removing an unnecessary npm global install pre isntall script 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
