### PR TITLE
Run ErrorSpec style tests on localhost and live only

### DIFF
--- a/cypress/integration/errorPageNews.js
+++ b/cypress/integration/errorPageNews.js
@@ -33,23 +33,29 @@ describe('Article Body Tests', () => {
     },
   );
 
-  it('should display a relevant error message on screen', () => {
-    cy.visit(`/news/articles/${config.assets.nonExistent}`, {
-      failOnStatusCode: false,
-    });
-    errorMessage(news);
+  describeForLocalOnly(
+    'should display a relevant error message on screen',
+    () => {
+      cy.visit(`/news/articles/${config.assets.nonExistent}`, {
+        failOnStatusCode: false,
+      });
+      errorMessage(news);
 
-    cy.visit(`/news/articles/${config.assets.nonExistent}`, {
-      failOnStatusCode: false,
-    });
-    errorMessage(news);
-  });
+      cy.visit(`/news/articles/${config.assets.nonExistent}`, {
+        failOnStatusCode: false,
+      });
+      errorMessage(news);
+    },
+  );
 
-  it('should have an inline link on the page that is linked to the home page', () => {
-    errorPageInlineLink(news);
-  });
+  describeForLocalOnly(
+    'should have an inline link on the page that is linked to the home page',
+    () => {
+      errorPageInlineLink(news);
+    },
+  );
 
-  it('should have a relevant error title in the head', () => {
+  describeForLocalOnly('should have a relevant error title in the head', () => {
     errorTitle(news);
   });
 });

--- a/cypress/integration/errorPageNews.js
+++ b/cypress/integration/errorPageNews.js
@@ -37,31 +37,20 @@ describe('Article Body Tests', () => {
   );
 
   describeForLocalAndLive(
-    'should display a relevant error message on screen',
+    'Temporary fix to limit to local and live Simorgh error page',
     () => {
-      cy.visit(`/news/articles/${config.assets.nonExistent}`, {
-        failOnStatusCode: false,
+      it('should display a relevant error message on screen', () => {
+        cy.visit(`/news/articles/${config.assets.nonExistent}`, {
+          failOnStatusCode: false,
+        });
+        errorMessage(news);
       });
-      errorMessage(news);
-
-      cy.visit(`/news/articles/${config.assets.nonExistent}`, {
-        failOnStatusCode: false,
+      it('should have an inline link on the page that is linked to the home page', () => {
+        errorPageInlineLink(news);
       });
-      errorMessage(news);
-    },
-  );
-
-  describeForLocalAndLive(
-    'should have an inline link on the page that is linked to the home page',
-    () => {
-      errorPageInlineLink(news);
-    },
-  );
-
-  describeForLocalAndLive(
-    'should have a relevant error title in the head',
-    () => {
-      errorTitle(news);
+      it('should have a relevant error title in the head', () => {
+        errorTitle(news);
+      });
     },
   );
 });

--- a/cypress/integration/errorPageNews.js
+++ b/cypress/integration/errorPageNews.js
@@ -5,7 +5,10 @@ import {
   errorTitle,
   hasHtmlLangDirAttributes,
 } from '../support/bodyTestHelper';
-import { describeForLocalOnly } from '../support/limitEnvRuns';
+import {
+  describeForLocalOnly,
+  describeForLocalAndLive,
+} from '../support/limitEnvRuns';
 import news from '../../src/app/lib/config/services/news';
 
 describe('Article Body Tests', () => {
@@ -33,7 +36,7 @@ describe('Article Body Tests', () => {
     },
   );
 
-  describeForLocalOnly(
+  describeForLocalAndLive(
     'should display a relevant error message on screen',
     () => {
       cy.visit(`/news/articles/${config.assets.nonExistent}`, {
@@ -48,14 +51,17 @@ describe('Article Body Tests', () => {
     },
   );
 
-  describeForLocalOnly(
+  describeForLocalAndLive(
     'should have an inline link on the page that is linked to the home page',
     () => {
       errorPageInlineLink(news);
     },
   );
 
-  describeForLocalOnly('should have a relevant error title in the head', () => {
-    errorTitle(news);
-  });
+  describeForLocalAndLive(
+    'should have a relevant error title in the head',
+    () => {
+      errorTitle(news);
+    },
+  );
 });

--- a/cypress/support/limitEnvRuns.js
+++ b/cypress/support/limitEnvRuns.js
@@ -15,3 +15,9 @@ export const describeForLocalAndTest = (name, func) => {
     describe(name, func);
   }
 };
+
+export const describeForLocalAndLive = (name, func) => {
+  if (Cypress.env('APP_ENV') === 'local' || Cypress.env('APP_ENV') === 'live') {
+    describe(name, func);
+  }
+};


### PR DESCRIPTION
**Overall change:** 
Due to BBC middleware not updating the 404 page correctly. It was decided to run certain error page tests on localhost and live

**Code changes:**

- Disabled running the style tests for news error pages on TEST

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
- [ ] I have followed [the merging checklist](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/MERGE_PROCESS.md) and this is ready to merge.
