### PR TITLE
Fix react-amphtml to older working version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1095,6 +1095,11 @@
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.3.5.tgz",
           "integrity": "sha512-55p7WnK8L8eUIgK8R6J1aKfQKXlpUrh2udoTekUqdwAamGLcGxyulf8nyNPQ78G880KDXv+HLyruzQ3/Q9G1+Q=="
+        },
+        "@bbc/psammead-visually-hidden-text": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.14.tgz",
+          "integrity": "sha512-0pRKV8BxUa+jGp3BhOa4EbMx//tOIkLF8AJKZOyMQWl0ecRzeNNUOokO3Zf7Oh+ZF3ZYGBp4lG7DN+XUH/9pIA=="
         }
       }
     },
@@ -8468,13 +8473,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
@@ -8485,7 +8490,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
@@ -8512,13 +8517,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
@@ -15693,11 +15698,11 @@
       }
     },
     "react-amphtml": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-amphtml/-/react-amphtml-3.1.1.tgz",
-      "integrity": "sha512-tZJgc4WiydRI+sDfHjO7gW76mleXyUEGx0nCycfjUJQ0nieDoYWMqZ1Eh16wnGbcxrCOZZkILt+3PcgS8mnYIg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-amphtml/-/react-amphtml-3.0.1.tgz",
+      "integrity": "sha512-RRxk1Pv73xingk5lhnITqj7dIZzFf/y/qMiWQR+A/M4d6fwpFY2/43SyMCBZrTY3OaWwjbo1BmMO2ljiTZ8e7Q==",
       "requires": {
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.6.1"
       }
     },
     "react-clientside-effect": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "polyfill-crypto.getrandomvalues": "1.0.0",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
-    "react-amphtml": "3.1.1",
+    "react-amphtml": "3.0.1",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.0",
     "react-lazyload": "^2.6.1",


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/2178

**Overall change:** Fixes react-amphtml to older version without arrow function

**Code changes:**

- Fixes react-amphtml to older version without arrow function

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
