### PR TITLE
Fix dev experience js regex

### DIFF
--- a/src/server/assets/assetsFilter/index.js
+++ b/src/server/assets/assetsFilter/index.js
@@ -1,6 +1,6 @@
 const assetRegex = type => {
   if (process.env.NODE_ENV === 'development') {
-    return new RegExp(`\\/static\\/js\\/${type}[\\w_.~-]*.js$`);
+    return new RegExp(`\\/static\\/js\\/${type}[\\w.~-]*.js$`);
   }
 
   return new RegExp(`\\/static\\/js\\/${type}-\\w+\\.\\w+\\.js$`);

--- a/src/server/assets/assetsFilter/index.js
+++ b/src/server/assets/assetsFilter/index.js
@@ -1,5 +1,10 @@
-const assetRegex = type =>
-  new RegExp(`\\/static\\/js\\/${type}-\\w+\\.\\w+\\.js$`);
+const assetRegex = type => {
+  if (process.env.NODE_ENV === 'development') {
+    return new RegExp(`\\/static\\/js\\/${type}[\\w_.~-]*.js$`);
+  }
+
+  return new RegExp(`\\/static\\/js\\/${type}-\\w+\\.\\w+\\.js$`);
+};
 
 const assetsFilter = (assets, service) => {
   const serviceAssets = assets.filter(asset => assetRegex(service).test(asset));

--- a/src/server/assets/assetsFilter/index.test.js
+++ b/src/server/assets/assetsFilter/index.test.js
@@ -1,123 +1,163 @@
 import assetsFilter from './index';
 
 describe('assetsFilter', () => {
-  it('should order assets service bundle, vendor, main on local', () => {
-    const input = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/pidgin-31ecd969.652d66cc.js',
-      'http://localhost:7080/static/js/news-31ecd969.c141cfdc.js',
-      'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
-    ];
+  describe('production build', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
 
-    const output = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
-      'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
-    ];
+    it('should order assets service bundle, vendor, main on local', () => {
+      const input = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/pidgin-31ecd969.652d66cc.js',
+        'http://localhost:7080/static/js/news-31ecd969.c141cfdc.js',
+        'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
+      ];
 
-    expect(assetsFilter(input, 'yoruba')).toEqual(output);
+      const output = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
+        'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
+      ];
+
+      expect(assetsFilter(input, 'yoruba')).toEqual(output);
+    });
+
+    it('should order assets service bundle, vendor, main on test', () => {
+      const input = [
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/yoruba-31ecd969.d4952cef.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/main-d0ae3f07.e24ffe78.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-f9ca8911.836b5376.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/pidgin-31ecd969.652d66cc.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/news-31ecd969.c141cfdc.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-1f20a385.ff6d3f55.js',
+      ];
+
+      const output = [
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/yoruba-31ecd969.d4952cef.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-f9ca8911.836b5376.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-1f20a385.ff6d3f55.js',
+        'https://news.test.files.bbci.co.uk/include/articles/public/static/js/main-d0ae3f07.e24ffe78.js',
+      ];
+
+      expect(assetsFilter(input, 'yoruba')).toEqual(output);
+    });
+
+    it('should order assets when url contains service', () => {
+      const input = [
+        'https://pidgin.com/static/js/yoruba-31ecd969.d4952cef.js',
+        'https://pidgin.com/static/js/main-d0ae3f07.e24ffe78.js',
+        'https://pidgin.com/static/js/vendor-f9ca8911.836b5376.js',
+        'https://pidgin.com/static/js/pidgin-31ecd969.652d66cc.js',
+        'https://pidgin.com/static/js/news-31ecd969.c141cfdc.js',
+        'https://pidgin.com/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'https://pidgin.com/static/js/vendor-1f20a385.ff6d3f55.js',
+      ];
+
+      const output = [
+        'https://pidgin.com/static/js/pidgin-31ecd969.652d66cc.js',
+        'https://pidgin.com/static/js/vendor-f9ca8911.836b5376.js',
+        'https://pidgin.com/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'https://pidgin.com/static/js/vendor-1f20a385.ff6d3f55.js',
+        'https://pidgin.com/static/js/main-d0ae3f07.e24ffe78.js',
+      ];
+
+      expect(assetsFilter(input, 'pidgin')).toEqual(output);
+    });
+
+    it('should order assets correctly with multiple of each bundle type', () => {
+      const input = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/pidgin-31ecd969.652d66cc.js',
+        'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
+        'http://localhost:7080/static/js/yoruba-q2eq22q2.awdawdaw.js',
+        'http://localhost:7080/static/js/main-n32bnb23.jk2k2jk2.js',
+        'http://localhost:7080/static/js/news-31ecd969.c141cfdc.js',
+        'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'http://localhost:7080/static/js/main-lkkl21k2.mklk2l1l.js',
+        'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
+      ];
+
+      const output = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/yoruba-q2eq22q2.awdawdaw.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
+        'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
+        'http://localhost:7080/static/js/main-n32bnb23.jk2k2jk2.js',
+        'http://localhost:7080/static/js/main-lkkl21k2.mklk2l1l.js',
+      ];
+
+      expect(assetsFilter(input, 'yoruba')).toEqual(output);
+    });
+
+    it('should remove any duplicates', () => {
+      const input = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+      ];
+
+      const output = [
+        'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
+        'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
+        'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
+      ];
+
+      expect(assetsFilter(input, 'yoruba')).toEqual(output);
+    });
   });
 
-  it('should order assets service bundle, vendor, main on test', () => {
-    const input = [
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/yoruba-31ecd969.d4952cef.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/main-d0ae3f07.e24ffe78.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-f9ca8911.836b5376.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/pidgin-31ecd969.652d66cc.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/news-31ecd969.c141cfdc.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-1f20a385.ff6d3f55.js',
-    ];
+  describe('dev build', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
 
-    const output = [
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/yoruba-31ecd969.d4952cef.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-f9ca8911.836b5376.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/vendor-1f20a385.ff6d3f55.js',
-      'https://news.test.files.bbci.co.uk/include/articles/public/static/js/main-d0ae3f07.e24ffe78.js',
-    ];
+    it('should allow and order dev bundles', () => {
+      const input = [
+        'http://localhost:1124/static/js/yoruba-._n.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_react-dom_cjs_react-dom.development.js-61bb2bf2.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_r.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_p.js',
+        'http://localhost:1124/static/js/main-._m.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_..js',
+        'http://localhost:1124/static/js/pidgin-._n.js',
+        'http://localhost:1124/static/js/persian-._n.js',
+        'http://localhost:1124/static/js/news-._n.js',
+        'http://localhost:1124/static/js/igbo-._n.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_h.js',
+      ];
 
-    expect(assetsFilter(input, 'yoruba')).toEqual(output);
-  });
+      const output = [
+        'http://localhost:1124/static/js/yoruba-._n.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_react-dom_cjs_react-dom.development.js-61bb2bf2.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_r.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_p.js',
+        'http://localhost:1124/static/js/vendor-._node_modules_..js',
+        'http://localhost:1124/static/js/vendor-._node_modules_h.js',
+        'http://localhost:1124/static/js/main-._m.js',
+      ];
 
-  it('should order assets when url contains service', () => {
-    const input = [
-      'https://pidgin.com/static/js/yoruba-31ecd969.d4952cef.js',
-      'https://pidgin.com/static/js/main-d0ae3f07.e24ffe78.js',
-      'https://pidgin.com/static/js/vendor-f9ca8911.836b5376.js',
-      'https://pidgin.com/static/js/pidgin-31ecd969.652d66cc.js',
-      'https://pidgin.com/static/js/news-31ecd969.c141cfdc.js',
-      'https://pidgin.com/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'https://pidgin.com/static/js/vendor-1f20a385.ff6d3f55.js',
-    ];
-
-    const output = [
-      'https://pidgin.com/static/js/pidgin-31ecd969.652d66cc.js',
-      'https://pidgin.com/static/js/vendor-f9ca8911.836b5376.js',
-      'https://pidgin.com/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'https://pidgin.com/static/js/vendor-1f20a385.ff6d3f55.js',
-      'https://pidgin.com/static/js/main-d0ae3f07.e24ffe78.js',
-    ];
-
-    expect(assetsFilter(input, 'pidgin')).toEqual(output);
-  });
-
-  it('should order assets correctly with multiple of each bundle type', () => {
-    const input = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/pidgin-31ecd969.652d66cc.js',
-      'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
-      'http://localhost:7080/static/js/yoruba-q2eq22q2.awdawdaw.js',
-      'http://localhost:7080/static/js/main-n32bnb23.jk2k2jk2.js',
-      'http://localhost:7080/static/js/news-31ecd969.c141cfdc.js',
-      'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'http://localhost:7080/static/js/main-lkkl21k2.mklk2l1l.js',
-      'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
-    ];
-
-    const output = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/yoruba-q2eq22q2.awdawdaw.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/vendor-b23bnb22.nmn32mn2.js',
-      'http://localhost:7080/static/js/vendor-1f20a385.ff6d3f55.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/main-d0ae3f07.e24ffe78.js',
-      'http://localhost:7080/static/js/main-n32bnb23.jk2k2jk2.js',
-      'http://localhost:7080/static/js/main-lkkl21k2.mklk2l1l.js',
-    ];
-
-    expect(assetsFilter(input, 'yoruba')).toEqual(output);
-  });
-
-  it('should remove any duplicates', () => {
-    const input = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-    ];
-
-    const output = [
-      'http://localhost:7080/static/js/yoruba-31ecd969.d4952cef.js',
-      'http://localhost:7080/static/js/vendor-f9ca8911.836b5376.js',
-      'http://localhost:7080/static/js/main-bh32bjhb.jhjkh423.js',
-    ];
-
-    expect(assetsFilter(input, 'yoruba')).toEqual(output);
+      expect(assetsFilter(input, 'yoruba')).toEqual(output);
+    });
   });
 });

--- a/src/server/assets/index.js
+++ b/src/server/assets/index.js
@@ -28,6 +28,8 @@ const getAssetsArray = service => {
     );
   }
 
+  console.log(assets);
+
   return assetsFilter(assets, service);
 };
 

--- a/src/server/assets/index.js
+++ b/src/server/assets/index.js
@@ -28,8 +28,6 @@ const getAssetsArray = service => {
     );
   }
 
-  console.log(assets);
-
   return assetsFilter(assets, service);
 };
 


### PR DESCRIPTION
**Overall change:** Fixes regex to allow webpack hot reloading and dev bundles
**Code changes:**

- Fixes regex to allow webpack hot reloading and dev bundles

Ensures that the dev bundles are deduped and ordered in the same manner as prod bundles to ensure closer matching functionality between dev and prod. Examples of this are the requirement to have service bundles before 'main' bundles to properly hydrate.
 
**Testing:**
With this fix all client side JS, like cookie banned and lazy loaded images should resume working on `npm run dev`. `npm run build` should be unaffected

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
