### PR TITLE
Revert "Re-enable browser security in Cypress on Test and Live"

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "video": false,
+  "chromeWebSecurity": false,
   "env": {
     "APP_ENV": "local",
     "UK": false

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -3,10 +3,6 @@ const envConfig = require('../support/config/envs');
 /* eslint-disable no-param-reassign */
 module.exports = (on, config) => {
   config.baseUrl = envConfig(config.env.APP_ENV, config.env.UK).baseUrl;
-  config.chromeWebSecurity = envConfig(
-    config.env.APP_ENV,
-    config.env.UK,
-  ).chromeWebSecurity;
 
   return config;
 };

--- a/cypress/support/config/envs.js
+++ b/cypress/support/config/envs.js
@@ -5,7 +5,6 @@ const config = {
     assetUrl: 'https://news.files.bbci.co.uk/include/articles/public',
     assetOrigin: 'https://news.files.bbci.co.uk',
     atiAnalyticsWSBucket: '598342',
-    chromeWebSecurity: true,
   },
   test: {
     baseUrl: 'https://www.test.bbc.com',
@@ -13,7 +12,6 @@ const config = {
     assetUrl: 'https://news.test.files.bbci.co.uk/include/articles/public',
     assetOrigin: 'https://news.test.files.bbci.co.uk',
     atiAnalyticsWSBucket: '598343',
-    chromeWebSecurity: true,
   },
   local: {
     baseUrl: 'http://localhost:7080',
@@ -21,7 +19,6 @@ const config = {
     assetUrl: 'http://localhost:7080',
     assetOrigin: 'http://localhost:7080',
     atiAnalyticsWSBucket: '598343',
-    chromeWebSecurity: false,
   },
 };
 


### PR DESCRIPTION
Reverts bbc/simorgh#2274

The cypress tests are failin on test since the cookie page domain is outside of the test route. 