### PR TITLE
Uk e2es fix locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,6 @@ Further details on using the Cypress CLI can be found at https://docs.cypress.io
 
 Cypress can be run interactively using `npm run test:e2e:interactive`. This loads a user interface which easily allows for indivdual tests to be run alongside a visual stream of the browser, as the tests run.
 
-#### Running e2e in the UK against LIVE
-**This affects UK developers only**
-
-Cypress .visit() function is locked to visiting a single domain per test. This becomes problematic when you launch the e2e tests from within the UK, due to redirects from `.com` to `.co.uk`. By default cypress tests will run as if they were ran outside of the uk. In order to run these tests from the UK you have to pass in the `UK` Cypress environment variable to the tests. This will replace the URL endings to `.co.uk`, which will allow you to run these tests successfully.
-
-Here is an example command:
-
-```
-CYPRESS_APP_ENV=test CYPRESS_UK=true npm run cypress:interactive
-```
-
 #### Storybook
 
 We also have a [Cypress](https://www.cypress.io/) project which runs a different set of end-to-end tests on [Storybook](https://github.com/bbc/simorgh#storybook-ui-development-environmentstyle-guide). For running the tests locally we need two terminals running:

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,6 @@
   "video": false,
   "chromeWebSecurity": false,
   "env": {
-    "APP_ENV": "local",
-    "UK": false
+    "APP_ENV": "local"
   }
 }

--- a/cypress/integration/cookieBanner.amp.js
+++ b/cypress/integration/cookieBanner.amp.js
@@ -29,7 +29,6 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
   it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
     cy.contains('OK').click();
 
-    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
     cy.reload();
 
     getPrivacyBanner().should('be.visible');
@@ -40,7 +39,6 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
     cy.contains('OK').click();
     cy.contains('Yes, I agree').click();
 
-    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
     cy.reload();
 
     getPrivacyBanner().should('not.be.visible');
@@ -54,7 +52,6 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
     cy.contains('OK').click();
     cy.contains('No, take me to settings').click();
 
-    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
     cy.reload();
 
     getPrivacyBanner().should('not.be.visible'); // flakey

--- a/cypress/integration/cookieBanner.amp.js
+++ b/cypress/integration/cookieBanner.amp.js
@@ -29,7 +29,8 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
   it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
     cy.contains('OK').click();
 
-    cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    cy.reload();
 
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
@@ -39,7 +40,8 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
     cy.contains('OK').click();
     cy.contains('Yes, I agree').click();
 
-    cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    cy.reload();
 
     getPrivacyBanner().should('not.be.visible');
     getCookieBanner().should('not.be.visible');
@@ -52,9 +54,10 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
     cy.contains('OK').click();
     cy.contains('No, take me to settings').click();
 
-    cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    // cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
+    cy.reload();
 
-    getPrivacyBanner().should('not.be.visible');
-    getCookieBanner().should('not.be.visible');
+    getPrivacyBanner().should('not.be.visible'); // flakey
+    getCookieBanner().should('not.be.visible'); // flakey
   });
 });

--- a/cypress/integration/cookieBanner.amp.js
+++ b/cypress/integration/cookieBanner.amp.js
@@ -7,7 +7,9 @@ const getPrivacyBanner = () =>
 const getCookieBanner = () => cy.contains('Let us know you agree to cookies');
 
 describeForEuOnly('Amp Cookie Banner Test', () => {
-  beforeEach(() => {
+  // eslint-disable-next-line no-undef
+  before(() => {
+    cy.clearCookies();
     cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
   });
 
@@ -27,6 +29,8 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
   });
 
   it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
+    cy.reload();
+
     cy.contains('OK').click();
 
     cy.reload();
@@ -36,6 +40,8 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
   });
 
   it('should not show privacy & cookie banners once both accepted, on reload', () => {
+    cy.reload();
+
     cy.contains('OK').click();
     cy.contains('Yes, I agree').click();
 
@@ -46,15 +52,17 @@ describeForEuOnly('Amp Cookie Banner Test', () => {
   });
 
   it('should not show privacy & cookie banners once cookie banner declined, on reload', () => {
+    cy.reload();
+
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
 
     cy.contains('OK').click();
     cy.contains('No, take me to settings').click();
 
-    cy.reload();
+    cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
 
-    getPrivacyBanner().should('not.be.visible'); // flakey
-    getCookieBanner().should('not.be.visible'); // flakey
+    getPrivacyBanner().should('not.be.visible');
+    getCookieBanner().should('not.be.visible');
   });
 });

--- a/cypress/integration/cookieBanner.amp.js
+++ b/cypress/integration/cookieBanner.amp.js
@@ -9,7 +9,6 @@ const getCookieBanner = () => cy.contains('Let us know you agree to cookies');
 describeForEuOnly('Amp Cookie Banner Test', () => {
   // eslint-disable-next-line no-undef
   before(() => {
-    cy.clearCookies();
     cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}.amp`);
   });
 

--- a/cypress/integration/cookieBanner.canonical.js
+++ b/cypress/integration/cookieBanner.canonical.js
@@ -23,14 +23,19 @@ const assertCookieValues = cookies => {
   });
 };
 
-const visitArticle = () => {
-  cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
-};
+// const visitArticle = () => {
+//   cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
+// };
 
 describe('Canonical Cookie Banner Tests', () => {
+  before(() => {
+    // cy.clearCookies();
+    cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
+  });
   it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
-    cy.clearCookies();
-    visitArticle();
+    // cy.clearCookies();
+    // visitArticle();
+    // cy.reload();
 
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
@@ -64,8 +69,9 @@ describe('Canonical Cookie Banner Tests', () => {
   });
 
   it('should have a privacy banner that disappears once accepted but a cookie banner that is rejected', () => {
-    cy.clearCookies();
-    visitArticle();
+    // cy.clearCookies();
+    // visitArticle();
+    cy.reload();
 
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
@@ -97,18 +103,20 @@ describe('Canonical Cookie Banner Tests', () => {
   });
 
   it("should show cookie banner (and NOT privacy banner) if user has visited the page before and didn't explicitly 'accept' cookies", () => {
-    cy.clearCookies();
+    // cy.clearCookies();
     cy.setCookie('ckns_privacy', '1');
-    visitArticle();
+    // visitArticle();
+    cy.reload();
 
     getPrivacyBanner().should('not.be.visible');
     getCookieBanner().should('be.visible');
   });
 
   it("should not override the user's default cookie policy", () => {
-    cy.clearCookies();
+    // cy.clearCookies();
     cy.setCookie('ckns_policy', 'made_up_value');
-    visitArticle();
+    // visitArticle();
+    cy.reload();
 
     assertCookieValues({
       ckns_policy: 'made_up_value',

--- a/cypress/integration/cookieBanner.canonical.js
+++ b/cypress/integration/cookieBanner.canonical.js
@@ -51,7 +51,7 @@ describe('Canonical Cookie Banner Tests', () => {
 
     assertCookieValues({
       ckns_explicit: '1',
-      ckns_privacy: '1',
+      ckns_privacy: '1', // flakes here
       ckns_policy: '111',
     });
 

--- a/cypress/integration/cookieBanner.canonical.js
+++ b/cypress/integration/cookieBanner.canonical.js
@@ -23,20 +23,13 @@ const assertCookieValues = cookies => {
   });
 };
 
-// const visitArticle = () => {
-//   cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
-// };
-
 describe('Canonical Cookie Banner Tests', () => {
+  // eslint-disable-next-line no-undef
   before(() => {
-    // cy.clearCookies();
     cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
   });
-  it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
-    // cy.clearCookies();
-    // visitArticle();
-    // cy.reload();
 
+  it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
 
@@ -69,8 +62,6 @@ describe('Canonical Cookie Banner Tests', () => {
   });
 
   it('should have a privacy banner that disappears once accepted but a cookie banner that is rejected', () => {
-    // cy.clearCookies();
-    // visitArticle();
     cy.reload();
 
     getPrivacyBanner().should('be.visible');
@@ -103,9 +94,7 @@ describe('Canonical Cookie Banner Tests', () => {
   });
 
   it("should show cookie banner (and NOT privacy banner) if user has visited the page before and didn't explicitly 'accept' cookies", () => {
-    // cy.clearCookies();
     cy.setCookie('ckns_privacy', '1');
-    // visitArticle();
     cy.reload();
 
     getPrivacyBanner().should('not.be.visible');
@@ -113,9 +102,7 @@ describe('Canonical Cookie Banner Tests', () => {
   });
 
   it("should not override the user's default cookie policy", () => {
-    // cy.clearCookies();
     cy.setCookie('ckns_policy', 'made_up_value');
-    // visitArticle();
     cy.reload();
 
     assertCookieValues({

--- a/cypress/integration/cookieBanner.canonical.js
+++ b/cypress/integration/cookieBanner.canonical.js
@@ -26,6 +26,7 @@ const assertCookieValues = cookies => {
 describe('Canonical Cookie Banner Tests', () => {
   // eslint-disable-next-line no-undef
   before(() => {
+    cy.clearCookies();
     cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
   });
 
@@ -42,6 +43,7 @@ describe('Canonical Cookie Banner Tests', () => {
       .contains('OK')
       .click();
 
+    cy.wait(1000);
     getCookieBanner().should('be.visible');
     getPrivacyBanner().should('not.be.visible');
 
@@ -50,9 +52,9 @@ describe('Canonical Cookie Banner Tests', () => {
       .click();
 
     assertCookieValues({
-      ckns_explicit: '1',
-      ckns_privacy: '1', // flakes here
-      ckns_policy: '111',
+      ckns_explicit: '1', // flakes here in terminal not interactive
+      ckns_privacy: '1', // flakes here in terminal not interactive
+      ckns_policy: '111', // flakes here in terminal not interactive
     });
 
     getCookieBanner().should('not.be.visible');

--- a/cypress/integration/cookieBanner.canonical.js
+++ b/cypress/integration/cookieBanner.canonical.js
@@ -26,11 +26,12 @@ const assertCookieValues = cookies => {
 describe('Canonical Cookie Banner Tests', () => {
   // eslint-disable-next-line no-undef
   before(() => {
-    cy.clearCookies();
     cy.visit(`/news/articles/${services.news.pageTypes.articles.asset}`);
   });
 
   it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
+    cy.clearCookies();
+    cy.reload(); // done to avoid the redirect when run from the uk breaking the cookies (marked below) from being set
     getPrivacyBanner().should('be.visible');
     getCookieBanner().should('not.be.visible');
 
@@ -52,9 +53,9 @@ describe('Canonical Cookie Banner Tests', () => {
       .click();
 
     assertCookieValues({
-      ckns_explicit: '1', // flakes here in terminal not interactive
-      ckns_privacy: '1', // flakes here in terminal not interactive
-      ckns_policy: '111', // flakes here in terminal not interactive
+      ckns_explicit: '1', // the reload above fixes this
+      ckns_privacy: '1',
+      ckns_policy: '111', // the reload above fixes this
     });
 
     getCookieBanner().should('not.be.visible');

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -2,7 +2,7 @@ const envConfig = require('../support/config/envs');
 
 /* eslint-disable no-param-reassign */
 module.exports = (on, config) => {
-  config.baseUrl = envConfig(config.env.APP_ENV, config.env.UK).baseUrl;
+  config.baseUrl = envConfig(config.env.APP_ENV).baseUrl;
 
   return config;
 };

--- a/cypress/support/config/envs.js
+++ b/cypress/support/config/envs.js
@@ -22,18 +22,7 @@ const config = {
   },
 };
 
-const geoLocate = (conf, isUk = false) => {
-  if (!isUk) return conf;
-
-  // eslint-disable-next-line no-param-reassign
-  conf.baseUrl = conf.baseUrl.replace('.com', '.co.uk');
-  // eslint-disable-next-line no-param-reassign
-  conf.dataUrl = conf.dataUrl.replace('.com', '.co.uk');
-
-  return conf;
-};
-
 module.exports =
   typeof Cypress !== 'undefined'
-    ? geoLocate(config[Cypress.env('APP_ENV')], Cypress.env('UK'))
-    : (env, uk) => geoLocate(config[env], uk);
+    ? config[Cypress.env('APP_ENV')]
+    : env => config[env];


### PR DESCRIPTION
Resolves #2123
BUT when running locally against test or live it only passes in the command line, running all tests at once in interactive mode fails (running them individually is fine) - it seems to get itself into a redirect loop. As we're going to be cutting news from this anyway I think this is less bother than changing location manually.

**Overall change:** Doesn't throw cross domain errors, does highlight flakey tests

**Code changes:**

- Revert PR 2040
- Revise tests to not repeatedly use visits.

---

- [x] I have assigned myself to this PR and the corresponding issues
~~- [ ] Tests added for new features~~
- [ ] Test engineer approval
