### PR TITLE
Make need to do hosts file locally more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then you can run the following commands to install Simorgh
 ```
 git clone git@github.com:bbc/simorgh.git
 cd simorgh
-npm install
+npm ci
 ```
 
 Finally you need to add to your hosts file (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ cd simorgh
 npm install
 ```
 
+To hit simorgh URLs locally you need to add a hosts file entry (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):
+
+```
+127.0.0.1 localhost.bbc.co.uk
+127.0.0.1 localhost.bbc.com
+```
+
 ## Local Development
 
 To run this application locally, with hot-reloading, run
@@ -98,13 +105,6 @@ To run LIVE bundles on localhost:
 - In `envConfig/live.env` change the value of `LOG_DIR='/var/log/simorgh'` to `LOG_DIR='log'`
 - Then run `rm -rf build && npm run build:live && npm run start`
 - Visit a live article: http://localhost.bbc.com:7080/news/articles/c8xxl4l3dzeo
-
-If these urls do not work, you may need to add a hosts file entry (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):
-
-```
-127.0.0.1 localhost.bbc.co.uk
-127.0.0.1 localhost.bbc.com
-```
 
 ## Changing request location
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd simorgh
 npm install
 ```
 
-To hit simorgh URLs locally you need to add a hosts file entry (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):
+Finally you need to add to your hosts file (`/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`):
 
 ```
 127.0.0.1 localhost.bbc.co.uk


### PR DESCRIPTION
**Overall change:** It is now REQUIRED that simorgh users add a hosts file entry (😢), we can no longer use localhost due to CORs errors with JS locally.

Because of this, we should be really obvious that this is requirement when installing

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- [ ] Test engineer approval
