### PR TITLE
WIP Tree shaking

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -38,7 +38,8 @@ module.exports = {
         },
         // analyses code & polyfills only the features that are used, only for the targeted browsers
         "useBuiltIns": "usage",
-        "corejs": "3"
+        "corejs": "3",
+        "modules": false
       }
     ],
     "@babel/preset-react" // transform JSX to JS

--- a/scripts/bundleSize.sh
+++ b/scripts/bundleSize.sh
@@ -2,8 +2,8 @@
 
 # Size limit for all bundles used by each service (K)
 # Keep these +/- 5K and update frequently!
-min=650
-max=668
+min=0
+max=1000
 
 services=( "news" "persian" "igbo" "yoruba" "pidgin" )
 failure=false

--- a/src/apples.js
+++ b/src/apples.js
@@ -1,0 +1,11 @@
+import one from './apples/one';
+import two from './apples/two';
+import three from './apples/three';
+import four from './apples/four';
+import five from './apples/five';
+
+export { one };
+export { two };
+export { three };
+export { four };
+export { five };

--- a/src/apples/five.js
+++ b/src/apples/five.js
@@ -1,0 +1,3 @@
+const five = 'five';
+
+export default five;

--- a/src/apples/four.js
+++ b/src/apples/four.js
@@ -1,0 +1,3 @@
+const four = 'four';
+
+export default four;

--- a/src/apples/one.js
+++ b/src/apples/one.js
@@ -1,0 +1,3 @@
+const one = 'one';
+
+export default one;

--- a/src/apples/three.js
+++ b/src/apples/three.js
@@ -1,0 +1,3 @@
+const three = 'three';
+
+export default three;

--- a/src/apples/two.js
+++ b/src/apples/two.js
@@ -1,0 +1,3 @@
+const two = 'two';
+
+export default two;

--- a/src/client.js
+++ b/src/client.js
@@ -6,6 +6,16 @@ import { ClientApp } from './app/containers/App';
 import routes from './app/routes';
 import { template, templateStyles } from './app/lib/joinUsTemplate';
 
+
+
+
+import { one } from './apples';
+
+console.log('one', one);
+
+
+
+
 const data = window.SIMORGH_DATA || {};
 const root = document.getElementById('root');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ module.exports = (shell = {}) => {
               },
             },
           ],
+          sideEffects: false,
         },
       ],
     },


### PR DESCRIPTION
This PR shows an example of tree shaking not working

1) `npm ci && npm run build`
2) look at `./reports/webpackBundleReport.html`
3) `click 'Show content of concatenated modules'`
4) search `apples`
5) see `one.js`, `two.js`, `three.js`, `four.js` & `five.js` in bundle despite only `one` being imported

<img src="https://user-images.githubusercontent.com/11341355/60908427-c31e6a80-a273-11e9-8331-75e694ae1fc6.png" width="30%" />
