### PR TITLE
Stage should use live env

### DIFF
--- a/src/app/contexts/RequestContext/getEnv/index.js
+++ b/src/app/contexts/RequestContext/getEnv/index.js
@@ -7,10 +7,6 @@ const getEnv = origin => {
     return 'test';
   }
 
-  if (origin.includes('stage')) {
-    return 'stage';
-  }
-
   return 'live';
 };
 

--- a/src/app/contexts/RequestContext/getEnv/index.test.js
+++ b/src/app/contexts/RequestContext/getEnv/index.test.js
@@ -8,7 +8,7 @@ const tests = [
   },
   {
     input: 'https://www.stage.bbc.co.uk',
-    expected: 'stage',
+    expected: 'live',
     assertion: 'should return expected output for stage',
   },
   {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Stage now should replicate live.

**Code changes:**

- Remove `stage` condition from `getEnv` so that it falls to the default return of `live`
- Update tests to reflect this change

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
