### PR TITLE
Pull in @bbc/psammead-brand@latest and update snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -929,24 +929,29 @@
       "integrity": "sha512-Ps2eogFG4Thr1qn8+pCUSouQZzyplRpm7rYmXxhcCCGoIz5I5ddwHaKo0QW9wZk5mXE1d/0k6xXBV6kYarfUrg=="
     },
     "@bbc/psammead-brand": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-4.1.4.tgz",
-      "integrity": "sha512-Bml8Dbhpvbkvl/nIKGbQ4ccWXIt3/rTkU1x1lMOMW6wAdVMHrB8iGktVlXTgm1RWHajvIAkDZPk4yCbin6c29Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-4.1.9.tgz",
+      "integrity": "sha512-h2yMZjK2pr9y8RFoiNF0pRmUQe9qQAaoZ075dacUsKD1SJaaEYDAtyDzF326uvJP7fOTUw67AP294b45lpBMZA==",
       "requires": {
-        "@bbc/gel-foundations": "^3.0.0",
-        "@bbc/psammead-styles": "^0.3.2",
-        "@bbc/psammead-visually-hidden-text": "^0.1.10"
+        "@bbc/gel-foundations": "^3.0.2",
+        "@bbc/psammead-styles": "^1.1.2",
+        "@bbc/psammead-visually-hidden-text": "^1.0.4"
       },
       "dependencies": {
+        "@bbc/gel-foundations": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-3.0.2.tgz",
+          "integrity": "sha512-8z9+7PVXX7Sd51ziSC0jYIzlA2qMZ6ZQDoSvluwyjbvogcIilajC/bf5zfAkl78lIBQwtrOVxaWRkP0edDqxew=="
+        },
         "@bbc/psammead-styles": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-0.3.5.tgz",
-          "integrity": "sha512-55p7WnK8L8eUIgK8R6J1aKfQKXlpUrh2udoTekUqdwAamGLcGxyulf8nyNPQ78G880KDXv+HLyruzQ3/Q9G1+Q=="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-1.1.2.tgz",
+          "integrity": "sha512-bEHPHnQwpIQHMOVNATDVEFweOAEtlwU8g7cwwTi2QspNntmq9mTPlXGTqZT1EaFczTwgS8cnQaP/zoXN4F4z6A=="
         },
         "@bbc/psammead-visually-hidden-text": {
-          "version": "0.1.14",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-0.1.14.tgz",
-          "integrity": "sha512-0pRKV8BxUa+jGp3BhOa4EbMx//tOIkLF8AJKZOyMQWl0ecRzeNNUOokO3Zf7Oh+ZF3ZYGBp4lG7DN+XUH/9pIA=="
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-visually-hidden-text/-/psammead-visually-hidden-text-1.0.4.tgz",
+          "integrity": "sha512-cRd0hMsIWIVhZwctJumAxEeGxrkMLnyPRrRRJAF5twOqi9l70s1NDGVeBTIaBb1STIjVsPvZeWAygd0M2v006Q=="
         }
       }
     },
@@ -8625,7 +8630,7 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "nopt": {
@@ -13716,7 +13721,7 @@
     },
     "node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "optional": true,
       "requires": {
@@ -13851,13 +13856,13 @@
     },
     "npm-bundled": {
       "version": "1.0.6",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "optional": true
     },
     "npm-packlist": {
       "version": "1.4.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@babel/runtime": "^7.3.4",
     "@bbc/gel-foundations": "3.0.1",
     "@bbc/psammead-assets": "^1.0.2",
-    "@bbc/psammead-brand": "^4.1.2",
+    "@bbc/psammead-brand": "^4.1.9",
     "@bbc/psammead-caption": "^1.1.7",
     "@bbc/psammead-consent-banner": "^1.0.0",
     "@bbc/psammead-copyright": "^1.0.2",

--- a/scripts/bundleSize.sh
+++ b/scripts/bundleSize.sh
@@ -2,8 +2,8 @@
 
 # Size limit for all bundles used by each service (K)
 # Keep these +/- 5K and update frequently!
-min=604
-max=622
+min=609
+max=629
 
 services=( "news" "persian" "igbo" "yoruba" "pidgin" )
 failure=false

--- a/src/app/containers/Brand/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Brand/__snapshots__/index.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`BrandContainer should render correctly 1`] = `
   overflow: hidden;
   position: absolute;
   width: 1px;
+  margin: 0;
 }
 
 .c1 {
@@ -33,9 +34,11 @@ exports[`BrandContainer should render correctly 1`] = `
 
 .c4 {
   box-sizing: content-box;
-  fill: #FFFFFF;
+  color: #FFFFFF;
+  fill: currentColor;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 10.496849999999998rem;
   min-width: 6.9979rem;

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`Header should render correctly 1`] = `
   overflow: hidden;
   position: absolute;
   width: 1px;
+  margin: 0;
 }
 
 .c1 {
@@ -34,9 +35,11 @@ exports[`Header should render correctly 1`] = `
 
 .c4 {
   box-sizing: content-box;
-  fill: #FFFFFF;
+  color: #FFFFFF;
+  fill: currentColor;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 10.496849999999998rem;
   min-width: 6.9979rem;

--- a/src/app/containers/PageHandlers/__snapshots__/withPageWrapper.test.jsx.snap
+++ b/src/app/containers/PageHandlers/__snapshots__/withPageWrapper.test.jsx.snap
@@ -11,6 +11,7 @@ Array [
   overflow: hidden;
   position: absolute;
   width: 1px;
+  margin: 0;
 }
 
 .c1 {
@@ -35,9 +36,11 @@ Array [
 
 .c4 {
   box-sizing: content-box;
-  fill: #FFFFFF;
+  color: #FFFFFF;
+  fill: currentColor;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 10.496849999999998rem;
   min-width: 6.9979rem;
@@ -126,6 +129,7 @@ Array [
   overflow: hidden;
   position: absolute;
   width: 1px;
+  margin: 0;
 }
 
 .c2 {
@@ -150,9 +154,11 @@ Array [
 
 .c5 {
   box-sizing: content-box;
-  fill: #FFFFFF;
+  color: #FFFFFF;
+  fill: currentColor;
   padding-top: 1rem;
   padding-bottom: 0.75rem;
+  height: 1.5rem;
   width: 100%;
   max-width: 10.496849999999998rem;
   min-width: 6.9979rem;


### PR DESCRIPTION
Resolves #2314 

**Overall change:** 
Pulls in new version of psammead-brand to fix high contrast accessibility issue, also pulls in work from:
- bbc/psammead#789 4.1.6 which adds height to make the Brand SVG scale as the text is resized
- bbc/psammead#783 to pull in updates from `psammead-test-helpers`
- bbc/psammead#892 to bump dependencies

**Code changes:**
- Update package.json & package_lock.json
- Updates snapshots to expect changes

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
