### PR TITLE
update package-lock to fix audit vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,11 +85,6 @@
             "lodash": "^4.17.11",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
         }
       }
     },
@@ -631,7 +626,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
       "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -910,15 +904,6 @@
         "semver": "^5.5.0"
       },
       "dependencies": {
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz",
-          "integrity": "sha512-KCx0z3y7y8ipZUMAEEJOyNi11lMb/FOPUjjB113tfowgw0c16EGYos7worCKBcUAh2oG+OBnoUhsnTSoLpV9uA==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-          }
-        },
         "@babel/plugin-transform-async-to-generator": {
           "version": "7.5.0",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
@@ -944,17 +929,6 @@
           "requires": {
             "@babel/helper-module-transforms": "^7.1.0",
             "@babel/helper-plugin-utils": "^7.0.0",
-            "babel-plugin-dynamic-import-node": "^2.3.0"
-          }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-          "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
-          "requires": {
-            "@babel/helper-module-transforms": "^7.4.4",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-simple-access": "^7.1.0",
             "babel-plugin-dynamic-import-node": "^2.3.0"
           }
         },
@@ -1880,14 +1854,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.13"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
-        }
       }
     },
     "@snyk/dep-graph": {
@@ -17995,12 +17961,6 @@
             "ms": "^2.1.1"
           }
         },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
-        },
         "opn": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -18174,12 +18134,6 @@
         "tslib": "1.9.3"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
-        },
         "tslib": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,11 @@
             "lodash": "^4.17.11",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
         }
       }
     },
@@ -6241,6 +6246,12 @@
             "graceful-fs": "^4.1.6"
           }
         },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
         "ramda": {
           "version": "0.24.1",
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
@@ -8710,17 +8721,17 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -12857,9 +12868,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash-es": {
       "version": "4.17.14",
@@ -14054,7 +14065,7 @@
     },
     "node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "optional": true,
       "requires": {
@@ -14189,13 +14200,13 @@
     },
     "npm-bundled": {
       "version": "1.0.6",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "optional": true
     },
     "npm-packlist": {
       "version": "1.4.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "optional": true,
       "requires": {


### PR DESCRIPTION
Runs `npm aduit fix` && `npm dedupe`. From 3695 high severity vulnerabilities down to 1.

**Overall change:** Fixes vulnerabilities highlighted by `npm audit` caused by loadash. Also dedupes the package versions in the lock file. 

**Before PR - `npm ci && npm audit`**

![image](https://user-images.githubusercontent.com/7791726/61289016-44b85000-a7c0-11e9-916a-3eabcda8a621.png)

**After PR - `npm ci && npm audit`**

![image](https://user-images.githubusercontent.com/7791726/61288956-1fc3dd00-a7c0-11e9-874c-7e287d83e783.png)
