### PR TITLE
Use front pages PropTypes for ATI container

### DIFF
--- a/src/app/containers/ATIAnalytics/index.jsx
+++ b/src/app/containers/ATIAnalytics/index.jsx
@@ -6,7 +6,7 @@ import AmpATIAnalytics from './amp';
 import ArticleAtiParams from './ArticleAtiParams';
 import FrontPageAtiParams from './FrontPageAtiParams';
 
-import { articleDataPropTypes } from '../../models/propTypes/article';
+import { frontPageDataPropTypes } from '../../models/propTypes/frontPage';
 
 const ATIAnalytics = ({ data }) => {
   const { pageType, platform } = React.useContext(RequestContext);
@@ -31,6 +31,6 @@ const ATIAnalytics = ({ data }) => {
 };
 
 ATIAnalytics.propTypes = {
-  data: oneOfType([articleDataPropTypes]).isRequired,
+  data: oneOfType([frontPageDataPropTypes]).isRequired,
 };
 export default ATIAnalytics;


### PR DESCRIPTION
Resolves #2459 

**Overall change:** _Use front pages PropTypes for ATI container._

**Code changes:**

- _Validate ATIanalytics with with `frontPageDataPropTypes` instead of `articleDataPropTypes`._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
