### PR TITLE
PoC: Allow tests to be run only when toggle enabled

### DIFF
--- a/cypress/support/limitEnvRuns.js
+++ b/cypress/support/limitEnvRuns.js
@@ -1,17 +1,25 @@
-// Allow tests to skipped on live or test and live.
-// Used currently to stop persian tests running on
-// live due to them not yet being routed in the STMs
+// Allow tests to be only run on certain environments or if the appropriate
+// toggle is enabled for that environment
 
-// For use before routes are open in test env
+import defaultToggles from '../../lib/config/toggles';
+
+// For use when behaviour can only be tested locally
 export const describeForLocalOnly = (name, func) => {
   if (Cypress.env('APP_ENV') === 'local') {
     describe(name, func);
   }
 };
 
-// For use before routes are open in live env
+// For use when behaviour can be tested locally and always in the test env
 export const describeForLocalAndTest = (name, func) => {
   if (Cypress.env('APP_ENV') === 'local' || Cypress.env('APP_ENV') === 'test') {
+    describe(name, func);
+  }
+};
+
+// For use when testability of behaviour for each envionment is governed by a toggle
+export const describeIfToggleEnabled = (toggleName, name, func) => {
+  if (defaultToggles(Cypress.env('APP_ENV'))[toggleName]['enabled']) {
     describe(name, func);
   }
 };


### PR DESCRIPTION
Accidentally relates to https://github.com/bbc/simorgh/issues/2571

**Overall change:** Adds a Cypress helper function to allow the running of tests in each environment to be governed by their [toggle value](https://github.com/bbc/simorgh/tree/latest/src/app/containers/Toggle)

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
