### PR TITLE
Update error page lang to en-GB

### DIFF
--- a/3rdPartyCypress/cypress/integration/errorPageNews.js
+++ b/3rdPartyCypress/cypress/integration/errorPageNews.js
@@ -10,7 +10,7 @@ describe('Test the mozart 404 page', () => {
   });
 
   it('should have the correct lang & dir attributes', () => {
-    cy.get('html').should('have.attr', 'lang', 'en_GB');
+    cy.get('html').should('have.attr', 'lang', 'en-GB');
   });
 
   it('should display a relevant error message on screen', () => {


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/1503

**Overall change:** Updates 3rd Party Cypress test to use the correct lang value for error pages.

**Code changes:**

- Updates 3rd Party Cypress test to use the correct lang value for error pages.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
