### PR TITLE
use latest storybook helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,9 +1204,9 @@
       }
     },
     "@bbc/psammead-storybook-helpers": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-3.3.0.tgz",
-      "integrity": "sha512-R48jMwob3X8A3aRFMTQnVM9IoOmxFRbc97kH96mp0SOiL3mx1m0ZgbXIK8N+eFNySwztqSyUDBAug3ZNgnLyPg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-storybook-helpers/-/psammead-storybook-helpers-3.3.1.tgz",
+      "integrity": "sha512-QxOxhXbwCy0jbJht0G3Yvl+5CLDPHjY0nZ02mSrw1k/xyWiWJgcCSqF5OwnFLTozuiSfGq3fFOv/XMRVUz816Q==",
       "dev": true,
       "requires": {
         "@bbc/gel-foundations": "^3.0.3",
@@ -8761,7 +8761,7 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "needle": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "devDependencies": {
     "@bbc/apache2-license-checker": "^1.1.4",
-    "@bbc/psammead-storybook-helpers": "^3.3.0",
+    "@bbc/psammead-storybook-helpers": "^3.3.1",
     "@storybook/addon-knobs": "^5.1.9",
     "@storybook/react": "^5.1.9",
     "@storybook/theming": "^5.1.9",


### PR DESCRIPTION
Resolves: #2719

**Overall change:** _Uses latest storybook helper which fixes the way we import scripts from gel-foundations. This should fix the currently broken storybook containers._ _change made in this PR: https://github.com/bbc/psammead/pull/1479_

**Code changes:**

- _bump psammead-storybook-helper to v3.3.1_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
