### PR TITLE
Fix issue 570

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,14 +1,3 @@
-// Overwriting Cypress Commands should very rarely be done.
-Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
-  cy.request({ url, failOnStatusCode: false }).then(({ headers }) => {
-    // Always ensure we're not seeing the Mozart fallback
-    if (expect(headers).not.have.property('x-mfa')) {
-      return originalFn(url, options);
-    }
-
-    return false;
-  });
-});
 
 // Addding Cypress Commands is safe, add away...
 Cypress.Commands.add('testResponseCodeAndType', (path, responseCode, type) => {


### PR DESCRIPTION
Remove the overwrite function which cause the bug because we can't use if statement for negative result here

Resolves https://github.com/bbc/simorgh-infrastructure/issues/570

**Overall change:** _A very high-level summary of easily-reproducible changes that can be Regarding to this docs, there is no way to use conditional-testing using IF statement https://docs.cypress.io/guides/core-concepts/conditional-testing.html#Definition.
So I removed this part of code to run without overwrite.

**Code changes:**
Remove the overwrite function which cause the bug because we can't use if statement for negative result here

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
