### PR TITLE
title and subtitle for liveradio from config translations

### DIFF
--- a/src/app/containers/MediaPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPage/__snapshots__/index.test.jsx.snap
@@ -117,7 +117,15 @@ Array [
       </div>
     </div>
   </header>,
-  .c0 {
+  .c4 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  color: #3F3F42;
+  padding-bottom: 1.5rem;
+  margin: 0;
+}
+
+.c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -139,14 +147,6 @@ Array [
 .c5:hover {
   color: #B80000;
   border-bottom: 2px solid #B80000;
-}
-
-.c4 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  color: #3F3F42;
-  padding-bottom: 1.5rem;
-  margin: 0;
 }
 
 .c3 {
@@ -173,6 +173,20 @@ Array [
 .c1 {
   grid-column: 1 / span 6;
   padding-bottom: 4rem;
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
 }
 
 @media (max-width:37.4375rem) {
@@ -212,20 +226,6 @@ Array [
     display: grid;
     max-width: initial;
     margin: initial;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
-    font-size: 1rem;
-    line-height: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c4 {
-    font-size: 1rem;
-    line-height: 1.375rem;
   }
 }
 

--- a/src/app/containers/MediaPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPageMain/__snapshots__/index.test.jsx.snap
@@ -2,11 +2,21 @@
 
 exports[`Media Page Main snapshots should match scaffold snapshot 1`] = `
 .c2 {
+  font-size: 1.75rem;
+  line-height: 2rem;
   color: #3F3F42;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   margin: 0;
   padding: 2rem 0;
   font-weight: 500;
+}
+
+.c3 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  color: #3F3F42;
+  padding-bottom: 1.5rem;
+  margin: 0;
 }
 
 .c0 {
@@ -18,9 +28,37 @@ exports[`Media Page Main snapshots should match scaffold snapshot 1`] = `
   grid-column: 1 / span 6;
 }
 
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 2.75rem;
+    line-height: 3rem;
+  }
+}
+
 @media (min-width:37.5rem) {
   .c2 {
     padding: 2.5rem 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c3 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    font-size: 1rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -115,9 +153,13 @@ exports[`Media Page Main snapshots should match scaffold snapshot 1`] = `
       <h1
         className="c2"
       >
-        Default Brand Name
-         - Live Radio
+        ያድምጡ
       </h1>
+      <p
+        className="c3"
+      >
+        ዝግጅቶቻችንን
+      </p>
       <ul>
         <li>
           <strong>

--- a/src/app/containers/MediaPageMain/index.jsx
+++ b/src/app/containers/MediaPageMain/index.jsx
@@ -1,30 +1,38 @@
-import React, { useContext } from 'react';
+import React, { Fragment, useContext } from 'react';
 import { string, shape } from 'prop-types';
 import { Headline } from '@bbc/psammead-headings';
+import Paragraph from '@bbc/psammead-paragraph';
+import pathOr from 'ramda/src/pathOr';
 
 import { Grid, GridItemConstrainedMedium } from '../../lib/styledGrid';
 import { ServiceContext } from '../../contexts/ServiceContext';
 
 const MediaPageMain = props => {
   const { service, match } = props;
-  const { brandName, script } = useContext(ServiceContext);
+  const { serviceId, mediaId } = match.params;
+  const { script, translations } = useContext(ServiceContext);
+
+  const { title, subtitle } = pathOr(null, ['media', serviceId], translations);
 
   return (
     <main role="main">
       <Grid>
         <GridItemConstrainedMedium>
           <Headline script={script} service={service}>
-            {brandName} - Live Radio
+            {title}
           </Headline>
+          <Paragraph script={script} service={service}>
+            {subtitle}
+          </Paragraph>
           <ul>
             <li>
               <strong>Service</strong>: {service}
             </li>
             <li>
-              <strong>Brand</strong>: {match.params.serviceId}
+              <strong>Brand</strong>: {serviceId}
             </li>
             <li>
-              <strong>MediaId</strong>: {match.params.mediaId}
+              <strong>MediaId</strong>: {mediaId}
             </li>
           </ul>
         </GridItemConstrainedMedium>

--- a/src/app/containers/MediaPageMain/index.jsx
+++ b/src/app/containers/MediaPageMain/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useContext } from 'react';
+import React, { useContext } from 'react';
 import { string, shape } from 'prop-types';
 import { Headline } from '@bbc/psammead-headings';
 import Paragraph from '@bbc/psammead-paragraph';

--- a/src/app/containers/MediaPageMain/index.test.jsx
+++ b/src/app/containers/MediaPageMain/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import MediaPageMain from '.';
 import { shouldMatchSnapshot } from '../../../testHelpers';
+import amharicConfig from '../../lib/config/services/amharic';
 
 const liveRadioScaffoldProps = {
   service: 'amharic',
@@ -11,6 +12,17 @@ const liveRadioScaffoldProps = {
     },
   },
 };
+
+jest.mock('react', () => {
+  const original = jest.requireActual('react');
+  return {
+    ...original,
+    useContext: jest.fn(),
+  };
+});
+
+const { useContext } = jest.requireMock('react');
+useContext.mockReturnValue(amharicConfig);
 
 describe('Media Page Main', () => {
   describe('snapshots', () => {


### PR DESCRIPTION
Resolves #2317, #2741

**Overall change:** Adds a headline and paragraph using the title and subtitle respectively for the service_id (EG: `bbc-persian_radio`) in the URL.

**Code changes:**

- Renders Headline with the title value from the service config translations object
- Renders a Paragraph with the subtitle value from the service config translations object
- Updates the updatesnapshots showing the check typography for Amharic for Headline?paragraph

Known issue that RTL sites aren't currently showing in RTL direction. Raising an issue seperate see comments.

Example URLs: 
http://localhost:7080/persian/bbc_dari_radio/liveradio
http://localhost:7080/persian/bbc_persian_radio/liveradio
http://localhost:7080/indonesia/bbc_indonesian_radio/liveradio
http://localhost:7080/afrique/bbc_afrique_radio/liveradio

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [ ] Test engineer approval
