### PR TITLE
add bbc_afaanoromoo_radio route and translations

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.js
+++ b/src/app/lib/config/services/afaanoromoo.js
@@ -118,6 +118,10 @@ const service = {
         title: 'Dhaggeeffadhaa',
         subtitle: 'Sagantaawwan keenya',
       },
+      bbc_afaanoromoo_radio: {
+        title: 'Dhaggeeffadhaa',
+        subtitle: 'Sagantaawwan keenya',
+      },
     },
   },
   brandSVG,

--- a/src/app/routes/config/index.js
+++ b/src/app/routes/config/index.js
@@ -1,5 +1,5 @@
 const servicesWithRadioOrTv = {
-  afaanoromoo: ['bbc_oromo_radio'], // how to handle vanity URL of bbc_afaanoromoo_radio ?
+  afaanoromoo: ['bbc_oromo_radio', 'bbc_afaanoromoo_radio'],
   afrique: ['bbc_afrique_radio', 'bbc_afrique_tv'],
   amharic: ['bbc_amharic_radio'],
   arabic: ['bbc_arabic_radio'],


### PR DESCRIPTION
Forgot the vanity URL in the initial routing

**Overall change:** Adds a URL and translation for `bbc_afaanoromoo_radio` which is a vanity URL to expose the content from `bbc_oromo_radio`

![image](https://user-images.githubusercontent.com/7791726/62057067-ca9fb680-b216-11e9-9004-b53818a1b937.png)


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- ~[ ] Test engineer approval~
