### PR TITLE
Add libgconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ cache:
     - ~/.cache/Cypress
 env:
   - CC_TEST_REPORTER_ID=f5b40344b76ccf66fbab5aa40bd5db671464c74f255cc3d4063f8bcd7c0812cf
-addons:
-  apt:
-    packages:
-    - libgconf-2-4
+before_install:
+  - sudo apt-get install -y libgconf-2-4
 jobs:
   include:
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - CC_TEST_REPORTER_ID=f5b40344b76ccf66fbab5aa40bd5db671464c74f255cc3d4063f8bcd7c0812cf
 addons:
   apt:
-    update: true
     packages:
     - libgconf-2-4
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
   apt:
     update: true
     packages:
-      - libgconf-2-4
+    - libgconf-2-4
 jobs:
   include:
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ cache:
     - ~/.cache/Cypress
 env:
   - CC_TEST_REPORTER_ID=f5b40344b76ccf66fbab5aa40bd5db671464c74f255cc3d4063f8bcd7c0812cf
+addons:
+  apt:
+    update: true
+    packages:
+      - libgconf-2-4
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
Resolves #NUMBER

Fix

```
/home/travis/.cache/Cypress/3.4.1/Cypress/Cypress: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
```

**Code changes:**

- Add the libgconf package which isn't available by default in Ubuntu 16
```
before_install:
  - sudo apt-get install -y libgconf-2-4
```

**Reference**

https://github.com/cypress-io/cypress/issues/1526
https://github.com/cypress-io/cypress/issues/4807
https://github.com/cypress-io/cypress/issues/4069#issuecomment-488315675

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
