### PR TITLE
Only run error page 404 test on local for news

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -179,9 +179,12 @@ export default {
         asset:
           Cypress.env('APP_ENV') === 'live' ? 'c5ll353v7y9o' : 'c6v11qzyv8po',
       },
-      errorPage404: {
-        asset: 'cxvxrj8tvppo',
-      },
+      errorPage404:
+        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : {
+              asset: 'cxvxrj8tvppo',
+            },
       frontPage: undefined,
     },
   },


### PR DESCRIPTION
Resolves N/A

**Overall change:** 

The js bundle script tests now run against the 404 error pages, however the error pages on test are not currently the new dynamic ones which will have the js bundles. 

So the errorPage4040 tests for news on test fail.

This PR ensure those tests do not run when on test or live.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
