### PR TITLE
adding chromatic credentials to test prod stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,9 @@ pipeline {
             }
           }
           steps {
-            runDevelopmentTests()
+            withCredentials([string(credentialsId: 'simorgh-chromatic-app-code', variable: 'CHROMATIC_APP_CODE')]) {
+              runDevelopmentTests()
+            }
           }
         }
         stage ('Test Production and Zip Production') {
@@ -158,9 +160,8 @@ pipeline {
           }
           steps {
             // Testing
-            withCredentials([string(credentialsId: 'simorgh-chromatic-app-code', variable: 'CHROMATIC_APP_CODE')]) {
-              runProductionTests()
-            }
+            runProductionTests()
+
 
             // Moving files necessary for production to `pack` directory.
             sh "./scripts/jenkinsProductionFiles.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,9 @@ pipeline {
           }
           steps {
             // Testing
-            runProductionTests()
+            withCredentials([string(credentialsId: 'simorgh-chromatic-app-code', variable: 'CHROMATIC_APP_CODE')]) {
+              runProductionTests()
+            }
 
             // Moving files necessary for production to `pack` directory.
             sh "./scripts/jenkinsProductionFiles.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,6 @@ pipeline {
             // Testing
             runProductionTests()
 
-
             // Moving files necessary for production to `pack` directory.
             sh "./scripts/jenkinsProductionFiles.sh"
 


### PR DESCRIPTION
Resolves n/a

**Overall change:**

Wraps the runDevelopmentTest() method in the credentials provider so chromatic can access the env variable for its app code.

Doesn't need testing

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
