### PR TITLE
uninstall dev dependencies in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       script:
         - npm run build
         - xvfb-run -a npm run test:prod:travis
+        - npm prune --production
     - stage: test
       if: branch = latest AND type = push
       name: 'Test third party dependencies'


### PR DESCRIPTION
Resolves: n/a

**Overall change:** _Mimic the production build by adding npm prune --production to the 2nd test stage in travis_

**no testing required, as it is a change to our travis only**

**Code changes:**

- _add npm prune --production to uninstall dev deps_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
