### PR TITLE
Adding Cypress tests for APUP sites

### DIFF
--- a/cypress/integration/articleBodySpec.js
+++ b/cypress/integration/articleBodySpec.js
@@ -55,45 +55,46 @@ Object.keys(config)
           });
       });
 
-      it('should have a visible image without a caption, and also not be lazyloaded', () => {
+      it('should have a visible image that is not lazyloaded and no noscript fallback', () => {
         cy.get('figure')
           .eq(0)
           .should('be.visible')
           .should('to.have.descendants', 'img')
-          .should('not.to.have.descendants', 'figcaption')
+
           .within(() => cy.get('noscript').should('not.exist'));
       });
 
-      if (service === 'news') {
-        it('should have a visible image with a caption that is lazyloaded and has a noscript fallback image', () => {
-          cy.get('figure')
-            .eq(2)
-            .within(() => {
-              cy.get('div div div div').should(
-                'have.class',
-                'lazyload-placeholder',
-              );
-            })
-            .scrollIntoView();
+      it('should have a visible image that is lazyloaded and has a noscript fallback image', () => {
+        cy.get('figure')
+          .eq(1)
 
+          .within(() => {
+            cy.get('div div div div').should(
+              'have.class',
+              'lazyload-placeholder',
+            );
+          })
+          .scrollIntoView();
+
+        // NB: If this test starts failing unexpectedly it's a good sign that the dom is being
+        // cleared during hydration. React won't render noscript tags on the client so if they
+        // get cleared during hydration, the following render wont re-add them.
+        // See https://github.com/facebook/react/issues/11423#issuecomment-341751071 or
+        // https://github.com/bbc/simorgh/pull/1872 for more infomation.
+        cy.get('figure')
+          .eq(1)
+          .within(() => {
+            cy.get('div div').should('not.have.class', 'lazyload-placeholder');
+            cy.get('noscript').contains('<img ');
+          });
+      });
+
+      if (service === 'news') {
+        it('should have a visible caption', () => {
           cy.get('figure')
-            .eq(2)
             .should('be.visible')
             .should('to.have.descendants', 'img')
-            .should('to.have.descendants', 'figcaption')
-
-            // NB: If this test starts failing unexpectedly it's a good sign that the dom is being
-            // cleared during hydration. React won't render noscript tags on the client so if they
-            // get cleared during hydration, the following render wont re-add them.
-            // See https://github.com/facebook/react/issues/11423#issuecomment-341751071 or
-            // https://github.com/bbc/simorgh/pull/1872 for more infomation.
-            .within(() => {
-              cy.get('noscript').contains('<img ');
-              cy.get('div div').should(
-                'not.have.class',
-                'lazyload-placeholder',
-              );
-            });
+            .should('to.have.descendants', 'figcaption');
         });
       }
 
@@ -104,7 +105,9 @@ Object.keys(config)
       it('should render a title', () => {
         cy.window().then(win => {
           const { seoHeadline } = win.SIMORGH_DATA.pageData.promo.headlines;
-            cy.renderedTitle(`${seoHeadline} - ${serviceConfig[service].brandName}`);
+          cy.renderedTitle(
+            `${seoHeadline} - ${serviceConfig[service].brandName}`,
+          );
         });
       });
 

--- a/cypress/integration/articleBodySpec.js
+++ b/cypress/integration/articleBodySpec.js
@@ -1,5 +1,6 @@
 import { BBC_BLOCKS } from '@bbc/psammead-assets/svgs';
 import config from '../support/config/services';
+import serviceConfig from '../../src/app/lib/config/services';
 
 const serviceHasArticlePageType = service =>
   config[service].pageTypes.articles !== undefined;
@@ -63,33 +64,38 @@ Object.keys(config)
           .within(() => cy.get('noscript').should('not.exist'));
       });
 
-      it('should have a visible image with a caption that is lazyloaded and has a noscript fallback image', () => {
-        cy.get('figure')
-          .eq(2)
-          .within(() => {
-            cy.get('div div div div').should(
-              'have.class',
-              'lazyload-placeholder',
-            );
-          })
-          .scrollIntoView();
+      if (service === 'news') {
+        it('should have a visible image with a caption that is lazyloaded and has a noscript fallback image', () => {
+          cy.get('figure')
+            .eq(2)
+            .within(() => {
+              cy.get('div div div div').should(
+                'have.class',
+                'lazyload-placeholder',
+              );
+            })
+            .scrollIntoView();
 
-        cy.get('figure')
-          .eq(2)
-          .should('be.visible')
-          .should('to.have.descendants', 'img')
-          .should('to.have.descendants', 'figcaption')
+          cy.get('figure')
+            .eq(2)
+            .should('be.visible')
+            .should('to.have.descendants', 'img')
+            .should('to.have.descendants', 'figcaption')
 
-          // NB: If this test starts failing unexpectedly it's a good sign that the dom is being
-          // cleared during hydration. React won't render noscript tags on the client so if they
-          // get cleared during hydration, the following render wont re-add them.
-          // See https://github.com/facebook/react/issues/11423#issuecomment-341751071 or
-          // https://github.com/bbc/simorgh/pull/1872 for more infomation.
-          .within(() => {
-            cy.get('noscript').contains('<img ');
-            cy.get('div div').should('not.have.class', 'lazyload-placeholder');
-          });
-      });
+            // NB: If this test starts failing unexpectedly it's a good sign that the dom is being
+            // cleared during hydration. React won't render noscript tags on the client so if they
+            // get cleared during hydration, the following render wont re-add them.
+            // See https://github.com/facebook/react/issues/11423#issuecomment-341751071 or
+            // https://github.com/bbc/simorgh/pull/1872 for more infomation.
+            .within(() => {
+              cy.get('noscript').contains('<img ');
+              cy.get('div div').should(
+                'not.have.class',
+                'lazyload-placeholder',
+              );
+            });
+        });
+      }
 
       it('should have an image copyright label with styling', () => {
         cy.copyrightDataWindow();
@@ -98,11 +104,7 @@ Object.keys(config)
       it('should render a title', () => {
         cy.window().then(win => {
           const { seoHeadline } = win.SIMORGH_DATA.pageData.promo.headlines;
-          if (win.SIMORGH_DATA.pageData.metadata.language === 'en-gb') {
-            cy.renderedTitle(`${seoHeadline} - BBC News`);
-          } else {
-            cy.renderedTitle(`${seoHeadline} - BBC News فارسی`);
-          }
+            cy.renderedTitle(`${seoHeadline} - ${serviceConfig[service].brandName}`);
         });
       });
 

--- a/cypress/integration/frontpageLayoutSpec.js
+++ b/cypress/integration/frontpageLayoutSpec.js
@@ -34,12 +34,16 @@ Object.keys(services).forEach(index => {
             .should('be.visible');
         });
 
-        it('should have one visible navigation', () => {
-          cy.get('nav')
-            .should('have.lengthOf', 1)
-            .should('be.visible');
-        });
-
+        const apuServices = ['arabic', 'pashto', 'urdu'];
+        // Currently, these services do not have a nav bar so this test will fail.
+        // However, all the other tests in this spec file are valid.
+        if (!apuServices.includes(service)) {
+          it('should have one visible navigation', () => {
+            cy.get('nav')
+              .should('have.lengthOf', 1)
+              .should('be.visible');
+          });
+        }
         it('should have a visually hidden top-level header', () => {
           cy.get('h1').should('have.length', 1);
         });

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -26,7 +26,7 @@ export default {
   arabic: {
     font: 'Nassim',
     pageTypes: {
-        articles:
+      articles:
         Cypress.env('APP_ENV') === 'test'
           ? undefined
           : {
@@ -195,7 +195,7 @@ export default {
   pashto: {
     font: 'Nassim',
     pageTypes: {
-        articles:
+      articles:
         Cypress.env('APP_ENV') === 'test'
           ? undefined
           : {
@@ -353,7 +353,7 @@ export default {
   urdu: {
     font: 'Nassim',
     pageTypes: {
-        articles:
+      articles:
         Cypress.env('APP_ENV') === 'test'
           ? undefined
           : {

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -24,11 +24,18 @@ export default {
     },
   },
   arabic: {
-    font: undefined,
+    font: 'Nassim',
     pageTypes: {
-      articles: undefined,
-      errorPage404: undefined,
-      frontPage: undefined,
+        articles:
+        Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : {
+              asset: 'c69dvq19k63o',
+            },
+      errorPage404: {
+        asset: 'c69d1239k63o',
+      },
+      frontPage: '/arabic',
     },
   },
   azeri: {
@@ -100,7 +107,7 @@ export default {
     pageTypes: {
       articles: undefined,
       errorPage404:
-        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+        Cypress.env('APP_ENV') === 'live' || 'test'
           ? undefined
           : {
               asset: 'cxvxrj8tvppo',
@@ -179,21 +186,25 @@ export default {
         asset:
           Cypress.env('APP_ENV') === 'live' ? 'c5ll353v7y9o' : 'c6v11qzyv8po',
       },
-      errorPage404:
-        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-          ? undefined
-          : {
-              asset: 'cxvxrj8tvppo',
-            },
+      errorPage404: {
+        asset: 'cxvxrj8tvppo',
+      },
       frontPage: undefined,
     },
   },
   pashto: {
-    font: undefined,
+    font: 'Nassim',
     pageTypes: {
-      articles: undefined,
-      errorPage404: undefined,
-      frontPage: undefined,
+        articles:
+        Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : {
+              asset: 'cng0e8v85eko',
+            },
+      errorPage404: {
+        asset: 'c69d1239k63o',
+      },
+      frontPage: '/pashto',
     },
   },
   persian: {
@@ -219,7 +230,7 @@ export default {
     pageTypes: {
       articles: undefined,
       errorPage404:
-        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+        Cypress.env('APP_ENV') === 'live' || 'test'
           ? undefined
           : {
               asset: 'cxvxrj8tvppo',
@@ -340,11 +351,18 @@ export default {
     },
   },
   urdu: {
-    font: undefined,
+    font: 'Nassim',
     pageTypes: {
-      articles: undefined,
-      errorPage404: undefined,
-      frontPage: undefined,
+        articles:
+        Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : {
+              asset: 'cx621klkm1ro',
+            },
+      errorPage404: {
+        asset: 'c69d1239k63o',
+      },
+      frontPage: '/urdu',
     },
   },
   uzbek: {
@@ -368,7 +386,7 @@ export default {
     pageTypes: {
       articles: undefined,
       errorPage404:
-        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+        Cypress.env('APP_ENV') === 'live' || 'test'
           ? undefined
           : {
               asset: 'cxvxrj8tvppo',


### PR DESCRIPTION
Resolves #2731 

**Overall change:** _Amending Cypress config file to point to APUP fixture file and Cypress tests for the new APUP services._

**Code changes:**

- _Amended Cypress config file to point to new APUP fixture data._
- _Amending Cypress tests. (This part may likely be reverted)_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
