### PR TITLE
Correct typo in e2e test

### DIFF
--- a/cypress/integration/cookieBannerWS.js
+++ b/cypress/integration/cookieBannerWS.js
@@ -32,7 +32,7 @@ Object.keys(services).forEach(index => {
         cy.worldServiceCookieBannerTranslations(
           `${serviceConfig.translations.consentBanner.privacy.title}`,
           `${serviceConfig.translations.consentBanner.cookie.title}`,
-          `/${service}`,
+          `/${service}.amp`,
           `${serviceConfig.translations.consentBanner.privacy.accept}`,
           `${serviceConfig.translations.consentBanner.cookie.accept}`,
         );


### PR DESCRIPTION
Resolves typo in this commit: https://github.com/bbc/simorgh/commit/8daebb4e9692194e4905779b20afedec7b6b1623

**Overall change:** adds .amp to a test

---

- [x] I have assigned myself to this PR and the corresponding issues
~- [ ] Tests added for new features~
~- [ ] Test engineer approval~
