### PR TITLE
Fix propType warnings for article published times

### DIFF
--- a/src/app/components/Metadata/index.jsx
+++ b/src/app/components/Metadata/index.jsx
@@ -172,9 +172,9 @@ Metadata.propTypes = {
     propTypeCheck(props, propName, 'Metadata', arrayOf(string)),
   themeColor: string.isRequired,
   timeFirstPublished: (props, propName) =>
-    propTypeCheck(props, propName, 'Metadata', number.isRequired),
+    propTypeCheck(props, propName, 'Metadata', string.isRequired),
   timeLastPublished: (props, propName) =>
-    propTypeCheck(props, propName, 'Metadata', number.isRequired),
+    propTypeCheck(props, propName, 'Metadata', string.isRequired),
   title: string.isRequired,
   twitterCreator: string.isRequired,
   twitterSite: string.isRequired,


### PR DESCRIPTION
Resolves [NO ISSUE]

**Overall change:** _Fixes console errors thrown by failing prop-type validation for first/last published times on article pages in development mode_

Errors were:
```
Warning: Failed prop type: Invalid prop `timeFirstPublished` of type `string` supplied to `Metadata`, expected `number`.
```

**Testing notes**
- Look at various articles in dev mode (`npm run dev`)

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
