### PR TITLE
Disable naidheachdan on test

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -289,7 +289,7 @@ export default {
     isWorldService: false,
     pageTypes: {
       articles:
-        Cypress.env('APP_ENV') === 'live' && Cypress.env('APP_ENV') === 'test'
+        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
           ? undefined
           : '/naidheachdan/articles/c18q7nedn2ko',
       errorPage404:
@@ -297,7 +297,7 @@ export default {
           ? undefined
           : '/naidheachdan/articles/c123456abcdo',
       frontPage:
-        Cypress.env('APP_ENV') === 'live' && Cypress.env('APP_ENV') === 'test'
+        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
           ? undefined
           : '/naidheachdan',
     },

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -289,7 +289,7 @@ export default {
     isWorldService: false,
     pageTypes: {
       articles:
-        Cypress.env('APP_ENV') === 'live'
+        Cypress.env('APP_ENV') === 'live' && Cypress.env('APP_ENV') === 'test'
           ? undefined
           : '/naidheachdan/articles/c18q7nedn2ko',
       errorPage404:
@@ -297,7 +297,9 @@ export default {
           ? undefined
           : '/naidheachdan/articles/c123456abcdo',
       frontPage:
-        Cypress.env('APP_ENV') === 'live' ? undefined : '/naidheachdan',
+        Cypress.env('APP_ENV') === 'live' && Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : '/naidheachdan',
     },
   },
   nepali: {


### PR DESCRIPTION
**Overall change:** naidheachdan is causing the e2es to hang on test

https://www.test.bbc.co.uk/naidheachdan/articles/c18q7nedn2ko doesnt redirect to .com outside the UK which may be a problem

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
