### PR TITLE
Wales homepage 404 on test

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -116,7 +116,10 @@ export default {
         Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
           ? undefined
           : '/cymrufyw/articles/c123456abcdo',
-      frontPage: Cypress.env('APP_ENV') === 'live' ? undefined : '/cymrufyw',
+      frontPage:
+        Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+          ? undefined
+          : '/cymrufyw',
     },
   },
   gahuza: {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** Wales homepage 404 on test, disable cypress test

**Code changes:**

-  disable cypress testing welsh homepage as it 404's


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Tests added for new features
- [ ] Test engineer approval
