### PR TITLE
Update assetsFilter to stop excluding part of vendor bundle

### DIFF
--- a/src/server/assets/assetsFilter/index.js
+++ b/src/server/assets/assetsFilter/index.js
@@ -1,6 +1,6 @@
 const assetRegex = type => {
   if (process.env.NODE_ENV === 'development') {
-    return new RegExp(`\\/static\\/js\\/${type}[\\w.~-]*.js$`);
+    return new RegExp(`\\/static\\/js\\/${type}[\\w\\.~@-]*\\.js$`);
   }
 
   return new RegExp(`\\/static\\/js\\/${type}-\\w+\\.\\w+\\.js$`);

--- a/src/server/assets/assetsFilter/index.test.js
+++ b/src/server/assets/assetsFilter/index.test.js
@@ -140,7 +140,7 @@ describe('assetsFilter', () => {
         'http://localhost:1124/static/js/vendor-._node_modules_r.js',
         'http://localhost:1124/static/js/vendor-._node_modules_p.js',
         'http://localhost:1124/static/js/main-._m.js',
-        'http://localhost:1124/static/js/vendor-._node_modules_..js',
+        'http://localhost:1124/static/js/vendor-._node_modules_@.js',
         'http://localhost:1124/static/js/pidgin-._n.js',
         'http://localhost:1124/static/js/persian-._n.js',
         'http://localhost:1124/static/js/news-._n.js',
@@ -153,7 +153,7 @@ describe('assetsFilter', () => {
         'http://localhost:1124/static/js/vendor-._node_modules_react-dom_cjs_react-dom.development.js-61bb2bf2.js',
         'http://localhost:1124/static/js/vendor-._node_modules_r.js',
         'http://localhost:1124/static/js/vendor-._node_modules_p.js',
-        'http://localhost:1124/static/js/vendor-._node_modules_..js',
+        'http://localhost:1124/static/js/vendor-._node_modules_@.js',
         'http://localhost:1124/static/js/vendor-._node_modules_h.js',
         'http://localhost:1124/static/js/main-._m.js',
       ];


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/3042

**Overall change:** _Updates regular expression used by assets filter which was was causing some of the vendor bundle to be excluded to file naming changes caused by something upstream_

**Unanswered questions**
- What has caused the change in bundle file naming?
- How can we avoid a repetition?

**Code changes:**

- Update regex and amend tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Tests added for new features
- [NA] Test engineer approval
