### PR TITLE
add data/ to pack/ for building the RPM

### DIFF
--- a/scripts/jenkinsProductionFiles.sh
+++ b/scripts/jenkinsProductionFiles.sh
@@ -19,6 +19,7 @@ cp -rf ./cypress ./pack/cypress
 cp -rf ./.storybook ./pack/.storybook
 cp -rf ./envConfig ./pack/envConfig
 cp -rf ./public ./pack/public
+cp -rf ./data ./pack/data # remove this when Ares has data for the liveradio media pages - https://github.com/bbc/simorgh/issues/3114
 
 # Copy the needed files in the root directory
 cp package.json ./pack


### PR DESCRIPTION
Resolves #https://github.com/bbc/simorgh/issues/3113

**Overall change:** Add the `data/` directory to the `/pack` directory so that it is included in the RPM so that the liveradio pages stop 404'ing on the TEST env. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~
