### PR TITLE
Update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,5 +34,9 @@ If applicable, add screenshots to help explain your problem.
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]
 
+**Testing notes**
+
+- [ ] This is bug fix expected to need manual testing
+
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,7 +36,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Testing notes**
 
-- [ ] This is bug fix expected to need manual testing
+- [ ] This bug fix is expected to need manual testing.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 Dev insight: Will Cypress tests be required or are unit tests sufficient? Will there be any potential regression? etc
 
-- [ ] This feature is expected to need manual testing
+- [ ] This feature is expected to need manual testing.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,5 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 Dev insight: Will Cypress tests be required or are unit tests sufficient? Will there be any potential regression? etc
 
+- [ ] This feature is expected to need manual testing
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@ Resolves #NUMBER
 
 - [ ] I have assigned myself to this PR and the corresponding issues
 - [ ] Tests added for new features
-- [ ] Test engineer approval
+- [ ] This PR requires manual testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@ Resolves #NUMBER
 ---
 
 - [ ] I have assigned myself to this PR and the corresponding issues
-- [ ] Tests added for new features
+- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
 - [ ] This PR requires manual testing


### PR DESCRIPTION
**Overall change:** Update github templates
**Code changes:**

- Adds a 'this is expected to need manual testing' check to the issue templates
- Adds a 'this needs manual testing' check to the PR templates
- Removes the `Test engineer approval` check because I dont remember it ever being used

---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Tests added for new features~
- ~[ ] Test engineer approval~
