### PR TITLE
use correct build result value

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -139,6 +139,7 @@ node {
                     colour: 'danger',
                     emoji: '😱',
                   ]
+                  echo "Build Result: ${currentBuild.currentResult}"
                   notifySlack(messageParameters)
                 }
                 break

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -98,6 +98,9 @@ node {
           echo "The pipeline has failed with the error: ${e}"
           throw e
         } finally {
+          echo "currentBuild.currentResult: ${currentBuild.currentResult}"
+          echo "currentBuild.result: ${currentBuild.result}"
+
           if (env.BRANCH_NAME == 'latest') {
             switch (currentBuild.currentResult) {
               case 'SUCCESS':
@@ -139,7 +142,6 @@ node {
                     colour: 'danger',
                     emoji: '😱',
                   ]
-                  echo "Build Result: ${currentBuild.currentResult}"
                   notifySlack(messageParameters)
                 }
                 break

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -99,7 +99,7 @@ node {
           throw e
         } finally {
           if (env.BRANCH_NAME == 'latest') {
-            switch (currentBuild.result) {
+            switch (currentBuild.currentResult) {
               case 'SUCCESS':
                 def messageParameters = [
                   buildStatus: 'SUCCESS',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 

When using `currentBuild.result` you have to set the build result yourself.

**Code changes:**

Switches to using `currentBuild.currentResult` which is automatically set and should never be null

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
