### PR TITLE
Un-parallelise the e2es

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -30,72 +30,68 @@ node {
           stage ('Install & Setup') {
             sh 'make install'
           }
-          stage ('Running E2Es across environments') {
-            parallel (
-              'Local Prod Tests': {
-                try {
-                  sh 'CYPRESS_SMOKE=false npm run build && xvfb-run -a npm run test:prod:ci;'
-                } catch (Throwable e) {
-                  def messageParameters = [
-                    buildStatus: 'Failed',
-                    env: 'LOCAL',
-                    branch: env.BRANCH_NAME,
-                    colour: 'danger',
-                    emoji: '😱',
-                  ]
+          stage ('Local Prod Tests') {
+            try {
+              sh 'CYPRESS_SMOKE=false npm run build && xvfb-run -a npm run test:prod:ci;'
+            } catch (Throwable e) {
+              def messageParameters = [
+                buildStatus: 'Failed',
+                env: 'LOCAL',
+                branch: env.BRANCH_NAME,
+                colour: 'danger',
+                emoji: '😱',
+              ]
 
-                  if (env.BRANCH_NAME == 'latest') {
-                    notifySlack(messageParameters)
-                    stageHasFailed = true
-                  }
-
-                  currentBuild.result = 'FAILURE'
-                  throw e
-                }   
-              },
-              'Test E2Es': {
-                try {
-                  sh 'make testE2Es'
-                } catch (Throwable e) {
-                  def messageParameters = [
-                    buildStatus: 'Failed',
-                    env: 'TEST',
-                    branch: env.BRANCH_NAME,
-                    colour: 'danger',
-                    emoji: '😱',
-                  ]
-                  
-                  if (env.BRANCH_NAME == 'latest') {
-                    notifySlack(messageParameters)
-                    stageHasFailed = true
-                  }
-
-                  currentBuild.result = 'FAILURE'
-                  throw e
-                }
-              },
-              'Live E2Es': {
-                try {
-                  sh 'make liveE2Es'
-                } catch (Throwable e) {
-                  def messageParameters = [
-                    buildStatus: 'Failed',
-                    env: 'LIVE',
-                    branch: env.BRANCH_NAME,
-                    colour: 'danger',
-                    emoji: '😱',
-                  ]
-                  
-                  if (env.BRANCH_NAME == 'latest') {
-                    notifySlack(messageParameters)
-                    stageHasFailed = true
-                  }
-
-                  currentBuild.result = 'FAILURE'
-                  throw e
-                } 
+              if (env.BRANCH_NAME == 'latest') {
+                notifySlack(messageParameters)
+                stageHasFailed = true
               }
-            )
+
+              currentBuild.result = 'FAILURE'
+              throw e
+            }   
+          }
+          stage ('Test E2Es') {
+            try {
+              sh 'make testE2Es'
+            } catch (Throwable e) {
+              def messageParameters = [
+                buildStatus: 'Failed',
+                env: 'TEST',
+                branch: env.BRANCH_NAME,
+                colour: 'danger',
+                emoji: '😱',
+              ]
+              
+              if (env.BRANCH_NAME == 'latest') {
+                notifySlack(messageParameters)
+                stageHasFailed = true
+              }
+
+              currentBuild.result = 'FAILURE'
+              throw e
+            }
+          }
+          stage ('Live E2Es') {
+            try {
+              sh 'make liveE2Es'
+            } catch (Throwable e) {
+              def messageParameters = [
+                buildStatus: 'Failed',
+                env: 'LIVE',
+                branch: env.BRANCH_NAME,
+                colour: 'danger',
+                emoji: '😱',
+              ]
+              
+              if (env.BRANCH_NAME == 'latest') {
+                notifySlack(messageParameters)
+                stageHasFailed = true
+              }
+
+              currentBuild.result = 'FAILURE'
+              throw e
+            }
           }
         } catch (Throwable e) {
           echo "The pipeline has failed with the error: ${e}"


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 

Removes the parallel steps from the pipeline in a attempt to ensure each stage does not try and use the same Xvfb port

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
