### PR TITLE
Put mpulse behind a cookie restriction

### DIFF
--- a/src/app/components/MPulseBeacon/index.jsx
+++ b/src/app/components/MPulseBeacon/index.jsx
@@ -2,8 +2,17 @@ import React from 'react';
 import { string } from 'prop-types';
 
 const snippet = apiKey => `
-(function() {
-    if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+(window.SIMORGH_BOOMR = function() {
+    console.log('INIT BOOMR');
+    function getCookie(name) {
+      var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+      if (match) return match[2];
+    }
+    function performanceCookiesEnabled() {
+        var policy = getCookie('ckns_policy');
+        return policy && policy.length == 3 && policy[1] == '1'
+    }
+    if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted) || !performanceCookiesEnabled()) {
         return;
     }
     window.BOOMR = window.BOOMR || {};

--- a/src/app/components/MPulseBeacon/index.jsx
+++ b/src/app/components/MPulseBeacon/index.jsx
@@ -3,7 +3,6 @@ import { string } from 'prop-types';
 
 const snippet = apiKey => `
 (window.SIMORGH_BOOMR = function() {
-    console.log('INIT BOOMR');
     function getCookie(name) {
       var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
       if (match) return match[2];

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.js
@@ -65,6 +65,12 @@ const consentBannerUtilities = ({
     setShowCookieBanner(false);
     setDismissedCookieBanner();
     setApprovedPolicy(logger);
+
+    // Call mPulse initialisation now that cookie banner is accepted
+    // This is temp code and shouldnt be moved outside of simorgh.
+    // If this logic is being moved to psammead, please move
+    // this code to keep it in simorgh.
+    if (window.SIMORGH_BOOMR) window.SIMORGH_BOOMR();
   };
 
   const cookieOnReject = () => {


### PR DESCRIPTION
Resolves #1630

**Overall change:** Put mpulse behind a cookie restriction

**Code changes:**

- Put mpulse behind a cookie restriction
- Call the mpulse code again if the user accepts the cookie banner

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
