### PR TITLE
Revert "Adding mobile viewport Cypress tests && fixing Thai top-story component"

### DIFF
--- a/cypress/integration/pages/frontPage.js
+++ b/cypress/integration/pages/frontPage.js
@@ -34,15 +34,6 @@ const runTests = ({ service }) =>
                 cy.get('h2').should('have.lengthOf', 1);
               });
             });
-          cy.viewport(320, 480);
-          cy.get('section')
-            .should('have.length.of.at.least', 1)
-            .should('be.visible')
-            .each($section => {
-              cy.wrap($section).within(() => {
-                cy.get('h2').should('have.lengthOf', 1);
-              });
-            });
         });
 
         it('should contain at least one story promo', () => {
@@ -58,32 +49,6 @@ const runTests = ({ service }) =>
             cy.get('p')
               .should('have.length.of.at.least', 1)
               .should('be.visible');
-            cy.get('time')
-              .should('have.length.of.at.least', 1)
-              .should('be.visible');
-          });
-          cy.viewport(320, 480);
-          cy.get('section').within(() => {
-            cy.get('img')
-              .should('have.length.of.at.least', 1)
-              .should('be.visible');
-            cy.get('h3')
-              .should('have.length.of.at.least', 1)
-              .should('be.visible')
-              .find('a')
-              .should('have.attr', 'href');
-            cy.get('p')
-              .eq(0)
-              .should('be.visible');
-            cy.get('p')
-              .eq(1)
-              .should('be.hidden');
-            cy.get('p')
-              .eq(2)
-              .should('be.hidden');
-            cy.get('p')
-              .eq(3)
-              .should('be.hidden');
             cy.get('time')
               .should('have.length.of.at.least', 1)
               .should('be.visible');

--- a/data/thai/frontpage/index.json
+++ b/data/thai/frontpage/index.json
@@ -113,9 +113,6 @@
                       "type": "cps"
                   }
               ],
-              "strapline": {
-                "name": "ข่าวเด่น"
-            },
               "semanticGroupName": "Top story"
           },
           {

--- a/src/app/lib/utilities/preprocessor/rules/__snapshots__/topstories.test.js.snap
+++ b/src/app/lib/utilities/preprocessor/rules/__snapshots__/topstories.test.js.snap
@@ -864,9 +864,6 @@ Object {
             "type": "cps",
           },
         ],
-        "strapline": Object {
-          "name": "ข่าวเด่น",
-        },
         "title": "Top stories",
         "type": "top-stories",
       },


### PR DESCRIPTION
Reverts bbc/simorgh#3305

e2e tests are failing after merging of this PR

test arabic isn't showing a top story because the first group doesn't have a strapline, so the code which ignores straplineless groups looks like it should be moved to the preprocessor and then hopefully we'll always have a top story