### PR TITLE
Revert "Revert "Enable navigation for articles & error pages""

### DIFF
--- a/cypress/integration/pages/frontPage.js
+++ b/cypress/integration/pages/frontPage.js
@@ -1,9 +1,8 @@
 import iterator from '../../support/iterator';
 import envConfig from '../../support/config/envs';
 import config from '../../support/config/services';
-import appConfig from '../../../src/app/lib/config/services';
 
-const runTests = ({ service }) =>
+const runTests = () =>
   describe(`Tests`, () => {
     describe('Frontpage body', () => {
       before(() => {
@@ -11,14 +10,6 @@ const runTests = ({ service }) =>
       });
 
       describe('Header', () => {
-        if (appConfig[service].navigation) {
-          it('should have one visible navigation', () => {
-            cy.get('nav')
-              .should('have.lengthOf', 1)
-              .should('be.visible');
-          });
-        }
-
         it('should have a visually hidden top-level header', () => {
           cy.get('h1').should('have.length', 1);
         });

--- a/cypress/integration/pages/index.js
+++ b/cypress/integration/pages/index.js
@@ -2,6 +2,7 @@ import config from '../../support/config/services';
 import envConfig from '../../support/config/envs';
 import appConfig from '../../../src/app/lib/config/services';
 import describeForEuOnly from '../../support/describeForEuOnly';
+import toggles from '../../support/toggles';
 
 const runCommonTests = ({ service, pageType }) => {
   describe('Always tests', () => {
@@ -62,6 +63,28 @@ const runCommonTests = ({ service, pageType }) => {
           .find('svg')
           .should('be.visible');
       });
+
+      if (appConfig[service].navigation) {
+        if (
+          pageType !== 'articles' ||
+          (pageType === 'articles' && toggles.navOnArticles.enabled)
+        ) {
+          it('should have one visible navigation with a skiplink to h1', () => {
+            cy.get('nav')
+              .should('have.lengthOf', 1)
+              .should('be.visible')
+              .find('a[class^="SkipLink"]')
+              .should('have.lengthOf', 1)
+              .should('have.attr', 'href', '#content');
+            cy.get('nav a[class^="StyledLink"]')
+              .should('have.attr', 'href', appConfig[service].navigation[0].url)
+              .should('contain', appConfig[service].navigation[0].title);
+            cy.get('h1')
+              .should('have.lengthOf', 1)
+              .should('have.attr', 'id', 'content');
+          });
+        }
+      }
     });
 
     describe('Footer Tests', () => {

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -8,18 +8,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/afaanoromoo/articles/c4g19kgl85ko',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afaanoromoo/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/afaanoromoo',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
@@ -39,25 +39,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/afrique/articles/cz216x22106o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afrique/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/afrique',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afrique/bbc_afrique_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -70,7 +70,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/amharic/articles/c3rykrrvy19o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
@@ -81,7 +81,7 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/amharic',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
@@ -112,14 +112,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/arabic',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/arabic/bbc_arabic_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -132,20 +132,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/azeri/articles/c5k08pqnzexo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/azeri/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/azeri',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   bengali: {
@@ -157,25 +157,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/bengali/articles/c6p3yp5zzmeo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/bengali/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/bengali',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/bengali/bbc_bangla_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -188,25 +188,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/burmese/articles/c3w1kwwmm5yo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/burmese/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/burmese',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/burmese/bbc_burmese_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -235,7 +235,7 @@ export default {
             : '/cymrufyw',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   gahuza: {
@@ -247,25 +247,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/gahuza/articles/cey23zx8wx8o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gahuza/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/gahuza',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gahuza/bbc_gahuza_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -278,20 +278,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/gujarati/articles/cr5el5kw591o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gujarati/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/gujarati',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   hausa: {
@@ -303,25 +303,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/hausa/articles/c2nr6xqmnewo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hausa/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/hausa',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hausa/bbc_hausa_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -334,25 +334,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/hindi/articles/c0469479x9xo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hindi/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/hindi',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hindi/bbc_hindi_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -365,7 +365,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/igbo/articles/cr1lw620ygjo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
@@ -375,7 +375,7 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/igbo', smoke: true },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   indonesia: {
@@ -387,18 +387,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/indonesia/articles/c0q2zq8pzvzo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/indonesia/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/indonesia',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
@@ -431,7 +431,7 @@ export default {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/japanese',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   korean: {
@@ -443,18 +443,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/korean/articles/cpv9kv2yzk6o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/korean/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/korean',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
@@ -474,25 +474,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/kyrgyz/articles/c3xd4xg3rm9o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/kyrgyz/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/kyrgyz',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/kyrgyz/bbc_kyrgyz_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -505,20 +505,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/marathi/articles/cp47g4myxz7o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/marathi/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/marathi',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   mundo: {
@@ -530,20 +530,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/mundo/articles/c45965g63xno',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/mundo/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/mundo',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   naidheachdan: {
@@ -571,7 +571,7 @@ export default {
             : '/naidheachdan',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   nepali: {
@@ -583,25 +583,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/nepali/articles/cl90j9m3mn6o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/nepali/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/nepali',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/nepali/bbc_nepali_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -623,8 +623,8 @@ export default {
             : '/news/articles/cxvxrj8tvppo',
         smoke: true,
       },
-      frontPage: { path: undefined, smoke: false },
-      liveRadio: { path: undefined, smoke: false },
+      frontPage: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   pashto: {
@@ -643,18 +643,18 @@ export default {
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/pashto/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/pashto',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/pashto/bbc_pashto_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -678,14 +678,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/persian',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/persian/bbc_persian_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -698,7 +698,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/pidgin/articles/cwl08rd38l6o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
@@ -708,26 +708,26 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/pidgin', smoke: true },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   portuguese: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: false },
+      articles: { path: undefined, smoke: true },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/portuguese/articles/cxvxrj8tvppo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/portuguese',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   punjabi: {
@@ -738,20 +738,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/punjabi/articles/c0l79lr39qyo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/punjabi/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/punjabi',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   russian: {
@@ -763,29 +763,29 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/russian/articles/ck7pz7re3zgo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/russian/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/russian',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   serbian: {
     font: undefined,
     pageTypes: {
-      articles: { path: undefined, smoke: false },
-      errorPage404: { path: undefined, smoke: false },
-      frontPage: { path: undefined, smoke: false },
-      liveRadio: { path: undefined, smoke: false },
+      articles: { path: undefined, smoke: true },
+      errorPage404: { path: undefined, smoke: true },
+      frontPage: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   sinhala: {
@@ -797,25 +797,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/sinhala/articles/c45w255zlexo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/sinhala/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/sinhala',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/sinhala/bbc_sinhala_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -827,35 +827,35 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/somali/articles/cgn6emk3jm8o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/somali/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/somali',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/somali/bbc_somali_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
   sport: {
     font: undefined,
     pageTypes: {
-      articles: { path: undefined, smoke: false },
-      errorPage404: { path: undefined, smoke: false },
-      frontPage: { path: undefined, smoke: false },
-      liveRadio: { path: undefined, smoke: false },
+      articles: { path: undefined, smoke: true },
+      errorPage404: { path: undefined, smoke: true },
+      frontPage: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   swahili: {
@@ -867,25 +867,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/swahili/articles/czjqge2jwn2o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/swahili/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/swahili',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/swahili/bbc_swahili_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -898,25 +898,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/tamil/articles/cwl08ll3me8o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tamil/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/tamil',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tamil/bbc_tamil_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -929,20 +929,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/telugu/articles/cq0y4008d4vo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/telugu/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/telugu',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   thai: {
@@ -954,7 +954,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/thai/articles/c3qxeqm7ldjo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
@@ -967,7 +967,7 @@ export default {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/thai',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   tigrinya: {
@@ -979,18 +979,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/tigrinya/articles/c12g32eldk6o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tigrinya/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/tigrinya',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
@@ -1010,30 +1010,30 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/turkce/articles/cr2d32lwww2o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/turkce/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/turkce',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   ukchina: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: false },
-      errorPage404: { path: undefined, smoke: false },
-      frontPage: { path: undefined, smoke: false },
-      liveRadio: { path: undefined, smoke: false },
+      articles: { path: undefined, smoke: true },
+      errorPage404: { path: undefined, smoke: true },
+      frontPage: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   ukrainian: {
@@ -1045,20 +1045,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/ukrainian/articles/c0glz45kqz6o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/ukrainian/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/ukrainian',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   urdu: {
@@ -1081,14 +1081,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/urdu',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/urdu/bbc_urdu_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -1101,25 +1101,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/uzbek/articles/cxj3rjxm6r0o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/uzbek/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/uzbek',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/uzbek/bbc_uzbek_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -1132,20 +1132,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/vietnamese/articles/c3y59g5zm19o',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/vietnamese/articles/c123456abcdo',
-        smoke: false,
+        smoke: true,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/vietnamese',
-        smoke: false,
+        smoke: true,
       },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   yoruba: {
@@ -1157,7 +1157,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/yoruba/articles/clw06m0nj8qo',
-        smoke: false,
+        smoke: true,
       },
       errorPage404: {
         path:
@@ -1167,17 +1167,17 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/yoruba', smoke: true },
-      liveRadio: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
   zhongwen: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: false },
-      errorPage404: { path: undefined, smoke: false },
-      frontPage: { path: undefined, smoke: false },
-      liveRadio: { path: undefined, smoke: false },
+      articles: { path: undefined, smoke: true },
+      errorPage404: { path: undefined, smoke: true },
+      frontPage: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: true },
     },
   },
 };

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -8,18 +8,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/afaanoromoo/articles/c4g19kgl85ko',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afaanoromoo/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/afaanoromoo',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
@@ -39,25 +39,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/afrique/articles/cz216x22106o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afrique/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/afrique',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afrique/bbc_afrique_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -70,7 +70,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/amharic/articles/c3rykrrvy19o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
@@ -81,7 +81,7 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/amharic',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
@@ -112,14 +112,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/arabic',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/arabic/bbc_arabic_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -132,20 +132,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/azeri/articles/c5k08pqnzexo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/azeri/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/azeri',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   bengali: {
@@ -157,25 +157,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/bengali/articles/c6p3yp5zzmeo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/bengali/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/bengali',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/bengali/bbc_bangla_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -188,25 +188,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/burmese/articles/c3w1kwwmm5yo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/burmese/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/burmese',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/burmese/bbc_burmese_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -235,7 +235,7 @@ export default {
             : '/cymrufyw',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   gahuza: {
@@ -247,25 +247,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/gahuza/articles/cey23zx8wx8o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gahuza/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/gahuza',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gahuza/bbc_gahuza_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -278,20 +278,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/gujarati/articles/cr5el5kw591o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/gujarati/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/gujarati',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   hausa: {
@@ -303,25 +303,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/hausa/articles/c2nr6xqmnewo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hausa/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/hausa',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hausa/bbc_hausa_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -334,25 +334,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/hindi/articles/c0469479x9xo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hindi/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/hindi',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/hindi/bbc_hindi_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -365,7 +365,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/igbo/articles/cr1lw620ygjo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
@@ -375,7 +375,7 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/igbo', smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   indonesia: {
@@ -387,18 +387,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/indonesia/articles/c0q2zq8pzvzo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/indonesia/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/indonesia',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
@@ -431,7 +431,7 @@ export default {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/japanese',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   korean: {
@@ -443,18 +443,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/korean/articles/cpv9kv2yzk6o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/korean/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/korean',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
@@ -474,25 +474,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/kyrgyz/articles/c3xd4xg3rm9o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/kyrgyz/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/kyrgyz',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/kyrgyz/bbc_kyrgyz_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -505,20 +505,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/marathi/articles/cp47g4myxz7o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/marathi/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/marathi',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   mundo: {
@@ -530,20 +530,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/mundo/articles/c45965g63xno',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/mundo/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/mundo',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   naidheachdan: {
@@ -571,7 +571,7 @@ export default {
             : '/naidheachdan',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   nepali: {
@@ -583,25 +583,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/nepali/articles/cl90j9m3mn6o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/nepali/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/nepali',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/nepali/bbc_nepali_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -623,8 +623,8 @@ export default {
             : '/news/articles/cxvxrj8tvppo',
         smoke: true,
       },
-      frontPage: { path: undefined, smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      frontPage: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   pashto: {
@@ -643,18 +643,18 @@ export default {
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/pashto/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/pashto',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/pashto/bbc_pashto_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -678,14 +678,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/persian',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/persian/bbc_persian_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -698,7 +698,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/pidgin/articles/cwl08rd38l6o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
@@ -708,26 +708,26 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/pidgin', smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   portuguese: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: true },
+      articles: { path: undefined, smoke: false },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/portuguese/articles/cxvxrj8tvppo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/portuguese',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   punjabi: {
@@ -738,20 +738,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/punjabi/articles/c0l79lr39qyo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/punjabi/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/punjabi',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   russian: {
@@ -763,29 +763,29 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/russian/articles/ck7pz7re3zgo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/russian/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/russian',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   serbian: {
     font: undefined,
     pageTypes: {
-      articles: { path: undefined, smoke: true },
-      errorPage404: { path: undefined, smoke: true },
-      frontPage: { path: undefined, smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      articles: { path: undefined, smoke: false },
+      errorPage404: { path: undefined, smoke: false },
+      frontPage: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   sinhala: {
@@ -797,25 +797,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/sinhala/articles/c45w255zlexo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/sinhala/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/sinhala',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/sinhala/bbc_sinhala_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -827,35 +827,35 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/somali/articles/cgn6emk3jm8o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/somali/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/somali',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/somali/bbc_somali_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
   sport: {
     font: undefined,
     pageTypes: {
-      articles: { path: undefined, smoke: true },
-      errorPage404: { path: undefined, smoke: true },
-      frontPage: { path: undefined, smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      articles: { path: undefined, smoke: false },
+      errorPage404: { path: undefined, smoke: false },
+      frontPage: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   swahili: {
@@ -867,25 +867,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/swahili/articles/czjqge2jwn2o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/swahili/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/swahili',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/swahili/bbc_swahili_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -898,25 +898,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/tamil/articles/cwl08ll3me8o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tamil/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/tamil',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tamil/bbc_tamil_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -929,20 +929,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/telugu/articles/cq0y4008d4vo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/telugu/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/telugu',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   thai: {
@@ -954,7 +954,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/thai/articles/c3qxeqm7ldjo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
@@ -967,7 +967,7 @@ export default {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/thai',
         smoke: true,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   tigrinya: {
@@ -979,18 +979,18 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/tigrinya/articles/c12g32eldk6o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/tigrinya/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/tigrinya',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
@@ -1010,30 +1010,30 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/turkce/articles/cr2d32lwww2o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/turkce/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/turkce',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   ukchina: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: true },
-      errorPage404: { path: undefined, smoke: true },
-      frontPage: { path: undefined, smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      articles: { path: undefined, smoke: false },
+      errorPage404: { path: undefined, smoke: false },
+      frontPage: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   ukrainian: {
@@ -1045,20 +1045,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/ukrainian/articles/c0glz45kqz6o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/ukrainian/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/ukrainian',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   urdu: {
@@ -1081,14 +1081,14 @@ export default {
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/urdu',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/urdu/bbc_urdu_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -1101,25 +1101,25 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/uzbek/articles/cxj3rjxm6r0o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/uzbek/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/uzbek',
-        smoke: true,
+        smoke: false,
       },
       liveRadio: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/uzbek/bbc_uzbek_radio/liveradio',
-        smoke: true,
+        smoke: false,
       },
     },
   },
@@ -1132,20 +1132,20 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/vietnamese/articles/c3y59g5zm19o',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/vietnamese/articles/c123456abcdo',
-        smoke: true,
+        smoke: false,
       },
       frontPage: {
         path: Cypress.env('APP_ENV') === 'live' ? undefined : '/vietnamese',
-        smoke: true,
+        smoke: false,
       },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   yoruba: {
@@ -1157,7 +1157,7 @@ export default {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/yoruba/articles/clw06m0nj8qo',
-        smoke: true,
+        smoke: false,
       },
       errorPage404: {
         path:
@@ -1167,17 +1167,17 @@ export default {
         smoke: true,
       },
       frontPage: { path: '/yoruba', smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
   zhongwen: {
     font: undefined,
     isWorldService: true,
     pageTypes: {
-      articles: { path: undefined, smoke: true },
-      errorPage404: { path: undefined, smoke: true },
-      frontPage: { path: undefined, smoke: true },
-      liveRadio: { path: undefined, smoke: true },
+      articles: { path: undefined, smoke: false },
+      errorPage404: { path: undefined, smoke: false },
+      frontPage: { path: undefined, smoke: false },
+      liveRadio: { path: undefined, smoke: false },
     },
   },
 };

--- a/cypress/support/toggles.js
+++ b/cypress/support/toggles.js
@@ -1,0 +1,5 @@
+import togglesConfig from '../../src/app/lib/config/toggles';
+
+const toggles = togglesConfig[Cypress.env('APP_ENV')];
+
+export default toggles;

--- a/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -201,6 +201,7 @@ exports[`ErrorMain should correctly render for an error page for News 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -444,6 +445,7 @@ exports[`ErrorMain should correctly render for an error page for arabic 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -687,6 +689,7 @@ exports[`ErrorMain should correctly render for an error page for pashto 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -930,6 +933,7 @@ exports[`ErrorMain should correctly render for an error page for persian 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -1173,6 +1177,7 @@ exports[`ErrorMain should correctly render for an error page for urdu 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"

--- a/src/app/components/ErrorPage/index.jsx
+++ b/src/app/components/ErrorPage/index.jsx
@@ -42,7 +42,7 @@ const ErrorPage = ({
   <main role="main">
     <GhostGrid>
       <LongGridItemConstrainedMedium>
-        <ShortHeadline script={script} service={service}>
+        <ShortHeadline id="content" script={script} service={service}>
           <StatusCode script={script}>{statusCode}</StatusCode>
           {title}
         </ShortHeadline>

--- a/src/app/containers/Article/fixtureData.js
+++ b/src/app/containers/Article/fixtureData.js
@@ -122,3 +122,16 @@ export const articleDataPersian = articleDataBuilder(
   'خلاصه مقاله',
   emptyThings,
 );
+
+export const articleDataPidgin = articleDataBuilder(
+  'cwl08rd38l6o',
+  'Pidgin',
+  'pcm',
+  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
+  'Article Headline in Pidgin',
+  'A paragraph in Pidgin.',
+  'Article Headline for SEO in Pidgin',
+  'Article Headline for Promo in Pidgin',
+  'Article summary in Pidgin',
+  emptyThings,
+);

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -1,276 +1,398 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ArticleMain should render a news article correctly 1`] = `
-<RequestContextProvider
-  bbcOrigin="https://www.test.bbc.co.uk"
-  id="c0000000000o"
-  isAmp={false}
-  pageType="article"
-  previousPath={null}
-  service="news"
->
-  <ArticleMain
-    articleData={
-      Object {
-        "content": Object {
-          "model": Object {
-            "blocks": Array [
-              Object {
-                "id": 1,
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "id": 1,
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "id": 1,
-                            "model": Object {
-                              "blocks": Array [
-                                Object {
-                                  "id": 1,
-                                  "model": Object {
-                                    "attributes": Array [],
-                                    "text": "Article Headline",
+<ToggleContextProvider>
+  <RequestContextProvider
+    bbcOrigin="https://www.test.bbc.co.uk"
+    id="c0000000000o"
+    isAmp={false}
+    pageType="article"
+    previousPath={null}
+    service="news"
+  >
+    <ArticleMain
+      articleData={
+        Object {
+          "content": Object {
+            "model": Object {
+              "blocks": Array [
+                Object {
+                  "id": 1,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 1,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 1,
+                              "model": Object {
+                                "blocks": Array [
+                                  Object {
+                                    "id": 1,
+                                    "model": Object {
+                                      "attributes": Array [],
+                                      "text": "Article Headline",
+                                    },
+                                    "type": "fragment",
                                   },
-                                  "type": "fragment",
-                                },
-                              ],
-                              "text": "Article Headline",
+                                ],
+                                "text": "Article Headline",
+                              },
+                              "type": "paragraph",
                             },
-                            "type": "paragraph",
-                          },
-                        ],
+                          ],
+                        },
+                        "type": "text",
                       },
-                      "type": "text",
-                    },
-                  ],
+                    ],
+                  },
+                  "type": "headline",
                 },
-                "type": "headline",
-              },
-              Object {
-                "id": 2,
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "id": 2,
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "id": 2,
-                            "model": Object {
-                              "attributes": Array [],
-                              "text": "A paragraph.",
+                Object {
+                  "id": 2,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 2,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 2,
+                              "model": Object {
+                                "attributes": Array [],
+                                "text": "A paragraph.",
+                              },
+                              "type": "fragment",
                             },
-                            "type": "fragment",
-                          },
-                        ],
-                        "text": "A paragraph.",
+                          ],
+                          "text": "A paragraph.",
+                        },
+                        "type": "paragraph",
                       },
-                      "type": "paragraph",
-                    },
-                  ],
+                    ],
+                  },
+                  "type": "text",
                 },
-                "type": "text",
-              },
-            ],
+              ],
+            },
           },
-        },
-        "metadata": Object {
-          "created": 1514808060000,
-          "createdBy": "News",
-          "firstPublished": 1514808060000,
-          "id": "urn:bbc:ares::article:c0000000001o",
-          "lastPublished": 1514811600000,
-          "lastUpdated": 1514815200000,
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+          "metadata": Object {
+            "created": 1514808060000,
+            "createdBy": "News",
+            "firstPublished": 1514808060000,
+            "id": "urn:bbc:ares::article:c0000000001o",
+            "lastPublished": 1514811600000,
+            "lastUpdated": 1514815200000,
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+            },
+            "passport": Object {
+              "category": "news",
+              "genre": null,
+              "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
+              "language": "en-gb",
+            },
+            "tags": Object {
+              "about": Array [
+                Object {
+                  "curationType": Array [
+                    "vivo-stream",
+                  ],
+                  "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
+                  "thingLabel": "Royal Wedding 2018",
+                  "thingSameAs": Array [
+                    "http://dbpedia.org/resource/Queen_Victoria",
+                    "http://rdf.freebase.com/ns/m.0cw10",
+                  ],
+                  "thingType": Array [
+                    "Thing",
+                    "Event",
+                  ],
+                  "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
+                  "topicId": "cpwpy79d6dxt",
+                  "topicName": "Royal Wedding 2018",
+                },
+                Object {
+                  "curationType": Array [
+                    "vivo-stream",
+                  ],
+                  "thingId": "803eaeb9-c0c3-4f1b-9a66-90efac3df2dc",
+                  "thingLabel": "Duchess of Sussex",
+                  "thingSameAs": Array [],
+                  "thingType": Array [
+                    "Person",
+                  ],
+                  "thingUri": "http://www.bbc.co.uk/things/803eaeb9-c0c3-4f1b-9a66-90efac3df2dc#id",
+                  "topicId": "cg3mq45zq4xt",
+                  "topicName": "Duchess of Sussex",
+                },
+              ],
+              "mentions": Array [
+                Object {
+                  "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
+                  "thingLabel": "Queen Victoria",
+                  "thingType": Array [
+                    "Person",
+                    "Thing",
+                  ],
+                  "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
+                },
+              ],
+            },
+            "type": "article",
           },
-          "passport": Object {
-            "category": "news",
-            "genre": null,
-            "home": "http://www.bbc.co.uk/ontologies/passport/home/News",
-            "language": "en-gb",
+          "promo": Object {
+            "headlines": Object {
+              "promoHeadline": "Article Headline for Promo",
+              "seoHeadline": "Article Headline for SEO",
+            },
+            "id": "urn:bbc:ares::article:c0000000001o",
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
+            },
+            "summary": "Article summary.",
+            "timestamp": 1514811600000,
           },
-          "tags": Object {
-            "about": Array [
-              Object {
-                "curationType": Array [
-                  "vivo-stream",
-                ],
-                "thingId": "2351f2b2-ce36-4f44-996d-c3c4f7f90eaa",
-                "thingLabel": "Royal Wedding 2018",
-                "thingSameAs": Array [
-                  "http://dbpedia.org/resource/Queen_Victoria",
-                  "http://rdf.freebase.com/ns/m.0cw10",
-                ],
-                "thingType": Array [
-                  "Thing",
-                  "Event",
-                ],
-                "thingUri": "http://www.bbc.co.uk/things/2351f2b2-ce36-4f44-996d-c3c4f7f90eaa#id",
-                "topicId": "cpwpy79d6dxt",
-                "topicName": "Royal Wedding 2018",
-              },
-              Object {
-                "curationType": Array [
-                  "vivo-stream",
-                ],
-                "thingId": "803eaeb9-c0c3-4f1b-9a66-90efac3df2dc",
-                "thingLabel": "Duchess of Sussex",
-                "thingSameAs": Array [],
-                "thingType": Array [
-                  "Person",
-                ],
-                "thingUri": "http://www.bbc.co.uk/things/803eaeb9-c0c3-4f1b-9a66-90efac3df2dc#id",
-                "topicId": "cg3mq45zq4xt",
-                "topicName": "Duchess of Sussex",
-              },
-            ],
-            "mentions": Array [
-              Object {
-                "thingId": "1efbf3e5-b330-49a1-b531-b507ab027c96",
-                "thingLabel": "Queen Victoria",
-                "thingType": Array [
-                  "Person",
-                  "Thing",
-                ],
-                "thingUri": "http://www.bbc.co.uk/things/1efbf3e5-b330-49a1-b531-b507ab027c96#id",
-              },
-            ],
-          },
-          "type": "article",
-        },
-        "promo": Object {
-          "headlines": Object {
-            "promoHeadline": "Article Headline for Promo",
-            "seoHeadline": "Article Headline for SEO",
-          },
-          "id": "urn:bbc:ares::article:c0000000001o",
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c0000000001o",
-          },
-          "summary": "Article summary.",
-          "timestamp": 1514811600000,
-        },
+        }
       }
-    }
-  />
-</RequestContextProvider>
+    />
+  </RequestContextProvider>
+</ToggleContextProvider>
 `;
 
 exports[`ArticleMain should render a persian article correctly 1`] = `
-<RequestContextProvider
-  bbcOrigin="https://www.test.bbc.co.uk"
-  id="c0000000000o"
-  isAmp={false}
-  pageType="article"
-  previousPath={null}
-  service="persian"
->
-  <ArticleMain
-    articleData={
-      Object {
-        "content": Object {
-          "model": Object {
-            "blocks": Array [
-              Object {
-                "id": 1,
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "id": 1,
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "id": 1,
-                            "model": Object {
-                              "blocks": Array [
-                                Object {
-                                  "id": 1,
-                                  "model": Object {
-                                    "attributes": Array [],
-                                    "text": "سرصفحه مقاله",
+<ToggleContextProvider>
+  <RequestContextProvider
+    bbcOrigin="https://www.test.bbc.co.uk"
+    id="c0000000000o"
+    isAmp={false}
+    pageType="article"
+    previousPath={null}
+    service="persian"
+  >
+    <ArticleMain
+      articleData={
+        Object {
+          "content": Object {
+            "model": Object {
+              "blocks": Array [
+                Object {
+                  "id": 1,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 1,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 1,
+                              "model": Object {
+                                "blocks": Array [
+                                  Object {
+                                    "id": 1,
+                                    "model": Object {
+                                      "attributes": Array [],
+                                      "text": "سرصفحه مقاله",
+                                    },
+                                    "type": "fragment",
                                   },
-                                  "type": "fragment",
-                                },
-                              ],
-                              "text": "سرصفحه مقاله",
+                                ],
+                                "text": "سرصفحه مقاله",
+                              },
+                              "type": "paragraph",
                             },
-                            "type": "paragraph",
-                          },
-                        ],
+                          ],
+                        },
+                        "type": "text",
                       },
-                      "type": "text",
-                    },
-                  ],
+                    ],
+                  },
+                  "type": "headline",
                 },
-                "type": "headline",
-              },
-              Object {
-                "id": 2,
-                "model": Object {
-                  "blocks": Array [
-                    Object {
-                      "id": 2,
-                      "model": Object {
-                        "blocks": Array [
-                          Object {
-                            "id": 2,
-                            "model": Object {
-                              "attributes": Array [],
-                              "text": "یک پاراگراف.",
+                Object {
+                  "id": 2,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 2,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 2,
+                              "model": Object {
+                                "attributes": Array [],
+                                "text": "یک پاراگراف.",
+                              },
+                              "type": "fragment",
                             },
-                            "type": "fragment",
-                          },
-                        ],
-                        "text": "یک پاراگراف.",
+                          ],
+                          "text": "یک پاراگراف.",
+                        },
+                        "type": "paragraph",
                       },
-                      "type": "paragraph",
-                    },
-                  ],
+                    ],
+                  },
+                  "type": "text",
                 },
-                "type": "text",
-              },
-            ],
+              ],
+            },
           },
-        },
-        "metadata": Object {
-          "created": 1514808060000,
-          "createdBy": "Persian",
-          "firstPublished": 1514808060000,
-          "id": "urn:bbc:ares::article:c4vlle3q337o",
-          "lastPublished": 1514811600000,
-          "lastUpdated": 1514815200000,
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c4vlle3q337o",
+          "metadata": Object {
+            "created": 1514808060000,
+            "createdBy": "Persian",
+            "firstPublished": 1514808060000,
+            "id": "urn:bbc:ares::article:c4vlle3q337o",
+            "lastPublished": 1514811600000,
+            "lastUpdated": 1514815200000,
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c4vlle3q337o",
+            },
+            "passport": Object {
+              "category": "news",
+              "genre": null,
+              "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
+              "language": "fa",
+            },
+            "tags": Object {
+              "about": null,
+              "mentions": null,
+            },
+            "type": "article",
           },
-          "passport": Object {
-            "category": "news",
-            "genre": null,
-            "home": "http://www.bbc.co.uk/ontologies/passport/home/Persian",
-            "language": "fa",
+          "promo": Object {
+            "headlines": Object {
+              "promoHeadline": "سرصفحه مقاله برای ارتقاء",
+              "seoHeadline": "سرصفحه مقاله",
+            },
+            "id": "urn:bbc:ares::article:c4vlle3q337o",
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:c4vlle3q337o",
+            },
+            "summary": "خلاصه مقاله",
+            "timestamp": 1514811600000,
           },
-          "tags": Object {
-            "about": null,
-            "mentions": null,
-          },
-          "type": "article",
-        },
-        "promo": Object {
-          "headlines": Object {
-            "promoHeadline": "سرصفحه مقاله برای ارتقاء",
-            "seoHeadline": "سرصفحه مقاله",
-          },
-          "id": "urn:bbc:ares::article:c4vlle3q337o",
-          "locators": Object {
-            "optimoUrn": "urn:bbc:optimo:asset:c4vlle3q337o",
-          },
-          "summary": "خلاصه مقاله",
-          "timestamp": 1514811600000,
-        },
+        }
       }
-    }
-  />
-</RequestContextProvider>
+    />
+  </RequestContextProvider>
+</ToggleContextProvider>
+`;
+
+exports[`ArticleMain should render a pidgin article correctly (with navigation) 1`] = `
+<ToggleContextProvider>
+  <RequestContextProvider
+    bbcOrigin="https://www.test.bbc.co.uk"
+    id="c0000000000o"
+    isAmp={false}
+    pageType="article"
+    previousPath={null}
+    service="pidgin"
+  >
+    <ArticleMain
+      articleData={
+        Object {
+          "content": Object {
+            "model": Object {
+              "blocks": Array [
+                Object {
+                  "id": 1,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 1,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 1,
+                              "model": Object {
+                                "blocks": Array [
+                                  Object {
+                                    "id": 1,
+                                    "model": Object {
+                                      "attributes": Array [],
+                                      "text": "Article Headline in Pidgin",
+                                    },
+                                    "type": "fragment",
+                                  },
+                                ],
+                                "text": "Article Headline in Pidgin",
+                              },
+                              "type": "paragraph",
+                            },
+                          ],
+                        },
+                        "type": "text",
+                      },
+                    ],
+                  },
+                  "type": "headline",
+                },
+                Object {
+                  "id": 2,
+                  "model": Object {
+                    "blocks": Array [
+                      Object {
+                        "id": 2,
+                        "model": Object {
+                          "blocks": Array [
+                            Object {
+                              "id": 2,
+                              "model": Object {
+                                "attributes": Array [],
+                                "text": "A paragraph in Pidgin.",
+                              },
+                              "type": "fragment",
+                            },
+                          ],
+                          "text": "A paragraph in Pidgin.",
+                        },
+                        "type": "paragraph",
+                      },
+                    ],
+                  },
+                  "type": "text",
+                },
+              ],
+            },
+          },
+          "metadata": Object {
+            "created": 1514808060000,
+            "createdBy": "Pidgin",
+            "firstPublished": 1514808060000,
+            "id": "urn:bbc:ares::article:cwl08rd38l6o",
+            "lastPublished": 1514811600000,
+            "lastUpdated": 1514815200000,
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:cwl08rd38l6o",
+            },
+            "passport": Object {
+              "category": "news",
+              "genre": null,
+              "home": "http://www.bbc.co.uk/ontologies/passport/home/Pidgin",
+              "language": "pcm",
+            },
+            "tags": Object {
+              "about": null,
+              "mentions": null,
+            },
+            "type": "article",
+          },
+          "promo": Object {
+            "headlines": Object {
+              "promoHeadline": "Article Headline for Promo in Pidgin",
+              "seoHeadline": "Article Headline for SEO in Pidgin",
+            },
+            "id": "urn:bbc:ares::article:cwl08rd38l6o",
+            "locators": Object {
+              "optimoUrn": "urn:bbc:optimo:asset:cwl08rd38l6o",
+            },
+            "summary": "Article summary in Pidgin",
+            "timestamp": 1514811600000,
+          },
+        }
+      }
+    />
+  </RequestContextProvider>
+</ToggleContextProvider>
 `;

--- a/src/app/containers/ArticleMain/index.test.jsx
+++ b/src/app/containers/ArticleMain/index.test.jsx
@@ -2,23 +2,30 @@ import React from 'react';
 import { string, node } from 'prop-types';
 import ArticleMain from '.';
 import { RequestContextProvider } from '../../contexts/RequestContext';
+import { ToggleContextProvider } from '../../contexts/ToggleContext';
 import { shouldShallowMatchSnapshot } from '../../../testHelpers';
-import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
+import {
+  articleDataNews,
+  articleDataPersian,
+  articleDataPidgin,
+} from '../Article/fixtureData';
 
 // temporary: will be removed with https://github.com/bbc/simorgh/issues/836
 const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
 articleDataNewsNoHeadline.content.model.blocks.shift();
 
 const Context = ({ service, children }) => (
-  <RequestContextProvider
-    bbcOrigin="https://www.test.bbc.co.uk"
-    id="c0000000000o"
-    isAmp={false}
-    pageType="article"
-    service={service}
-  >
-    {children}
-  </RequestContextProvider>
+  <ToggleContextProvider>
+    <RequestContextProvider
+      bbcOrigin="https://www.test.bbc.co.uk"
+      id="c0000000000o"
+      isAmp={false}
+      pageType="article"
+      service={service}
+    >
+      {children}
+    </RequestContextProvider>
+  </ToggleContextProvider>
 );
 Context.propTypes = {
   children: node.isRequired,
@@ -37,6 +44,13 @@ describe('ArticleMain', () => {
     'should render a persian article correctly',
     <Context service="persian">
       <ArticleMain articleData={articleDataPersian} />
+    </Context>,
+  );
+
+  shouldShallowMatchSnapshot(
+    'should render a pidgin article correctly (with navigation)',
+    <Context service="pidgin">
+      <ArticleMain articleData={articleDataPidgin} />
     </Context>,
   );
 });

--- a/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -201,6 +201,7 @@ exports[`ErrorMain should correctly render for 404 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -449,6 +450,7 @@ exports[`ErrorMain should correctly render for 404 for persian 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -697,6 +699,7 @@ exports[`ErrorMain should correctly render for 500 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -940,6 +943,7 @@ exports[`ErrorMain should correctly render for 500 for persian 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"
@@ -1183,6 +1187,7 @@ exports[`ErrorMain should correctly render for other status code 1`] = `
     >
       <h1
         className="c2"
+        id="content"
       >
         <span
           className="c3"

--- a/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
@@ -402,6 +402,9 @@ exports[`FrontPageMain snapshots should render a pidgin frontpage correctly 1`] 
               "statusCode": "500",
               "title": "Mperi",
             },
+            "currentPage": "Current page",
+            "home": "Akụkọ",
+            "skipLinkText": "Wụga n’ọdịnaya",
           },
           "home": "Akụkọ",
           "media": Object {

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,723 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header should render correctly 1`] = `
+exports[`Header should render correctly for WS frontPage 1`] = `
+.c11 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c7 {
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c6 {
+  background-color: #B80000;
+  height: 3.5rem;
+  width: 100%;
+  padding: 0 0.5rem;
+}
+
+.c9 {
+  display: inline-block;
+  width: 100%;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
+}
+
+.c10 {
+  box-sizing: content-box;
+  color: #FFFFFF;
+  fill: currentColor;
+  padding-top: 1rem;
+  padding-bottom: 0.75rem;
+  height: 1.5rem;
+  width: 100%;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
+}
+
+.c8:hover .c10,
+.c8:focus .c10 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c12 {
+  background-color: #B80000;
+}
+
+.c13 {
+  position: relative;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c14 {
+  position: absolute;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  padding: 0.75rem 0.5rem;
+  background-color: #ffffff;
+  border: 0.1875rem solid #000;
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c14:focus {
+  -webkit-clip-path: none;
+  clip-path: none;
+  -webkit-clip: auto;
+  clip: auto;
+  height: auto;
+  width: auto;
+  top: -3rem;
+  left: 0.5rem;
+}
+
+.c15 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.c16 {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+}
+
+.c16::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  width: 80rem;
+  border-bottom: 0.0625rem solid #eab3b3;
+  z-index: -1;
+  left: 0;
+}
+
+.c17 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c17:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.3125rem solid #FFFFFF;
+}
+
+.c17:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c19 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c19:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c19:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c18::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c0 {
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #323232;
+  padding: 1rem 0.5rem;
+}
+
+.c1 {
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c1::after {
+  content: '\\0020';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.c2 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  color: #FFFFFF;
+  font-weight: 700;
+  padding: 0;
+  margin: 0;
+}
+
+.c4 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  color: #F6A21D;
+  font-weight: 600;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.c4 li + li {
+  padding-top: 0.5rem;
+}
+
+.c3 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  color: #BEBEBE;
+}
+
+.c3 a {
+  color: #F6A21D;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3 a:focus,
+.c3 a:hover {
+  color: #FFFFFF;
+}
+
+.c5 button {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  color: #F6A21D;
+  font-weight: 700;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c5 button:focus,
+.c5 button:hover {
+  color: #FFFFFF;
+}
+
+.c5 a {
+  color: #F6A21D;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5 a:focus,
+.c5 a:hover {
+  color: #FFFFFF;
+}
+
+@media (min-width:25rem) {
+  .c6 {
+    height: 5rem;
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c10 {
+    padding-top: 1.75rem;
+    padding-bottom: 1.5rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),print {
+  .c10 {
+    fill: windowText;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c14 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c14 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c14:focus {
+    top: -4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c14:focus {
+    left: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c17 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c17 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c19 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    padding: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    float: left;
+    margin-right: 3.5%;
+    width: 22%;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    width: 18%;
+    float: right;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c3 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    margin: 0;
+    float: left;
+    width: 53%;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c5 button {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c5 button {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+<header
+  role="banner"
+>
+  <div
+    className="c0"
+    dir="ltr"
+    hidden={null}
+    id={null}
+  >
+    <div
+      className="c1"
+      dir="ltr"
+    >
+      <h2
+        className="c2"
+        dir="ltr"
+      >
+        Let us know say you agree to cookies
+      </h2>
+      <p
+        className="c3"
+        dir="ltr"
+      >
+        We and our partners use technologies, like 
+        <a
+          href="https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/"
+        >
+          cookies
+        </a>
+        , and collect browsing information to give you di best online experience and to make wetin dey inside personal and wetin pipo dey advertise appear for you. Abeg let us know if you agree.
+      </p>
+      <ul
+        className="c4"
+        dir="ltr"
+      >
+        <li
+          className="c5"
+          dir="ltr"
+        >
+          <button
+            onClick={[Function]}
+            type="button"
+          >
+            Yes, I agree
+          </button>
+        </li>
+        <li
+          className="c5"
+          dir="ltr"
+        >
+          <a
+            href="https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+            onClick={[Function]}
+          >
+            No, cari me go settings
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="c6"
+  >
+    <div
+      className="c7"
+    >
+      <a
+        className="c8 c9"
+        href="/pidgin"
+      >
+        <svg
+          aria-hidden="true"
+          className="c10"
+          focusable="false"
+          height={24}
+          viewBox="0 0 238 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fillRule="evenodd"
+            stroke="#000"
+            strokeWidth=".335"
+            style={
+              Object {
+                "stroke": "#fff",
+              }
+            }
+          >
+            <path
+              d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
+            />
+            <path
+              d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
+            />
+            <path
+              d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74zM185.18 16.87V6.28h3.35a3.46 3.46 0 0 1 2.41.82 2.82 2.82 0 0 1 .9 2.19 2.94 2.94 0 0 1-.46 1.63 2.64 2.64 0 0 1-1.26 1 6.42 6.42 0 0 1-2.3.32h-1.12v4.59zm3.09-9.24h-1.57v3.31h1.66a2.1 2.1 0 0 0 1.42-.44 1.56 1.56 0 0 0 .5-1.25q0-1.62-2.01-1.62zM194 6.3h1.51v10.57H194zM198.78 16.85V6.3h3.56a7.51 7.51 0 0 1 3.41.65 4.88 4.88 0 0 1 2 1.9 5.29 5.29 0 0 1 .74 2.74 5.18 5.18 0 0 1-.41 2 5.23 5.23 0 0 1-3 2.85 5.33 5.33 0 0 1-1.1.31 14.65 14.65 0 0 1-1.91.08zm3.41-9.21h-1.89v7.86h1.94a7.75 7.75 0 0 0 1.76-.16 4.12 4.12 0 0 0 1-.39 3.59 3.59 0 0 0 .77-.59 3.92 3.92 0 0 0 1.12-2.87 3.63 3.63 0 0 0-1.15-2.78 3.68 3.68 0 0 0-1-.66 4.07 4.07 0 0 0-1-.34 10.57 10.57 0 0 0-1.56-.07zM216.8 11.66h3.55v4.48a9.68 9.68 0 0 1-3.87.85 5.75 5.75 0 0 1-4.2-1.53 5.07 5.07 0 0 1-1.57-3.78 5.26 5.26 0 0 1 1.63-3.94 5.63 5.63 0 0 1 4.08-1.57 7.22 7.22 0 0 1 1.7.19 13.82 13.82 0 0 1 2 .71V8.6a7.43 7.43 0 0 0-3.75-1.1 4 4 0 0 0-2.92 1.18 3.93 3.93 0 0 0-1.19 2.9 3.9 3.9 0 0 0 1.19 2.94 4.23 4.23 0 0 0 3.06 1.14 7.12 7.12 0 0 0 2.17-.42h.14V13h-2zM223.5 6.3h1.5v10.57h-1.5zM236.65 6.3h1.44v10.57h-1.3l-7.07-8.14v8.14h-1.42V6.3h1.23l7.13 8.21z"
+            />
+            <path
+              d="M168.37 0v22.59"
+              strokeWidth="2"
+            />
+          </g>
+        </svg>
+        <span
+          className="c11"
+          role="text"
+        >
+          <span
+            lang="en-GB"
+          >
+            BBC News
+          </span>
+          , 
+          Pidgin
+        </span>
+      </a>
+    </div>
+  </div>
+  <nav
+    className="c12"
+    role="navigation"
+  >
+    <div
+      className="c13"
+    >
+      <a
+        className="c14"
+        href="#content"
+      >
+        Waka go wetin de inside
+      </a>
+      <ul
+        className="c15"
+        role="list"
+      >
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c17"
+            href="/pidgin"
+          >
+            <span
+              className="c18"
+              role="text"
+            >
+              <span
+                className="c11"
+              >
+                Page where you dey
+                , 
+              </span>
+              Home
+            </span>
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/topics/3d5d5e30-dd50-4041-96d5-c970b20005b9"
+          >
+            Nigeria
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/topics/d2c2ba68-f9ad-4185-a6d1-7f6437256735"
+          >
+            Africa
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/world"
+          >
+            World
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/media/video"
+          >
+            Video
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/media/audio"
+          >
+            Audio
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/sport"
+          >
+            Sport
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/topics/1c3b60a9-14eb-484b-a750-9f5b1aeaac31"
+          >
+            Entertainment
+          </a>
+        </li>
+        <li
+          className="c16"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c19"
+            href="/pidgin/popular/read"
+          >
+            Most popular
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>
+`;
+
+exports[`Header should render correctly for WS media page 1`] = `
 .c5 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -29,8 +746,8 @@ exports[`Header should render correctly 1`] = `
 .c3 {
   display: inline-block;
   width: 100%;
-  max-width: 10.496849999999998rem;
-  min-width: 6.9979rem;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
 }
 
 .c4 {
@@ -41,14 +758,159 @@ exports[`Header should render correctly 1`] = `
   padding-bottom: 0.75rem;
   height: 1.5rem;
   width: 100%;
-  max-width: 10.496849999999998rem;
-  min-width: 6.9979rem;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
 }
 
 .c2:hover .c4,
 .c2:focus .c4 {
   -webkit-text-decoration: none;
   text-decoration: none;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c6 {
+  background-color: #B80000;
+}
+
+.c7 {
+  position: relative;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c8 {
+  position: absolute;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  padding: 0.75rem 0.5rem;
+  background-color: #ffffff;
+  border: 0.1875rem solid #000;
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c8:focus {
+  -webkit-clip-path: none;
+  clip-path: none;
+  -webkit-clip: auto;
+  clip: auto;
+  height: auto;
+  width: auto;
+  top: -3rem;
+  left: 0.5rem;
+}
+
+.c9 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+}
+
+.c10::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  width: 80rem;
+  border-bottom: 0.0625rem solid #eab3b3;
+  z-index: -1;
+  left: 0;
+}
+
+.c11 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c11:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.3125rem solid #FFFFFF;
+}
+
+.c11:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c13 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c13:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c13:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c12::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
@@ -72,6 +934,72 @@ exports[`Header should render correctly 1`] = `
   }
 }
 
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8:focus {
+    top: -4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c8:focus {
+    left: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c11 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c11 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c13 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c13 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c13 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
 <header
   role="banner"
 >
@@ -83,14 +1011,14 @@ exports[`Header should render correctly 1`] = `
     >
       <a
         className="c2 c3"
-        href="/news"
+        href="/pidgin"
       >
         <svg
           aria-hidden="true"
           className="c4"
           focusable="false"
           height={24}
-          viewBox="0 0 167.95 24"
+          viewBox="0 0 238 24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <g
@@ -110,17 +1038,653 @@ exports[`Header should render correctly 1`] = `
               d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
             />
             <path
-              d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74z"
+              d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74zM185.18 16.87V6.28h3.35a3.46 3.46 0 0 1 2.41.82 2.82 2.82 0 0 1 .9 2.19 2.94 2.94 0 0 1-.46 1.63 2.64 2.64 0 0 1-1.26 1 6.42 6.42 0 0 1-2.3.32h-1.12v4.59zm3.09-9.24h-1.57v3.31h1.66a2.1 2.1 0 0 0 1.42-.44 1.56 1.56 0 0 0 .5-1.25q0-1.62-2.01-1.62zM194 6.3h1.51v10.57H194zM198.78 16.85V6.3h3.56a7.51 7.51 0 0 1 3.41.65 4.88 4.88 0 0 1 2 1.9 5.29 5.29 0 0 1 .74 2.74 5.18 5.18 0 0 1-.41 2 5.23 5.23 0 0 1-3 2.85 5.33 5.33 0 0 1-1.1.31 14.65 14.65 0 0 1-1.91.08zm3.41-9.21h-1.89v7.86h1.94a7.75 7.75 0 0 0 1.76-.16 4.12 4.12 0 0 0 1-.39 3.59 3.59 0 0 0 .77-.59 3.92 3.92 0 0 0 1.12-2.87 3.63 3.63 0 0 0-1.15-2.78 3.68 3.68 0 0 0-1-.66 4.07 4.07 0 0 0-1-.34 10.57 10.57 0 0 0-1.56-.07zM216.8 11.66h3.55v4.48a9.68 9.68 0 0 1-3.87.85 5.75 5.75 0 0 1-4.2-1.53 5.07 5.07 0 0 1-1.57-3.78 5.26 5.26 0 0 1 1.63-3.94 5.63 5.63 0 0 1 4.08-1.57 7.22 7.22 0 0 1 1.7.19 13.82 13.82 0 0 1 2 .71V8.6a7.43 7.43 0 0 0-3.75-1.1 4 4 0 0 0-2.92 1.18 3.93 3.93 0 0 0-1.19 2.9 3.9 3.9 0 0 0 1.19 2.94 4.23 4.23 0 0 0 3.06 1.14 7.12 7.12 0 0 0 2.17-.42h.14V13h-2zM223.5 6.3h1.5v10.57h-1.5zM236.65 6.3h1.44v10.57h-1.3l-7.07-8.14v8.14h-1.42V6.3h1.23l7.13 8.21z"
+            />
+            <path
+              d="M168.37 0v22.59"
+              strokeWidth="2"
             />
           </g>
         </svg>
         <span
           className="c5"
+          role="text"
         >
-          BBC News
+          <span
+            lang="en-GB"
+          >
+            BBC News
+          </span>
+          , 
+          Pidgin
         </span>
       </a>
     </div>
   </div>
+  <nav
+    className="c6"
+    role="navigation"
+  >
+    <div
+      className="c7"
+    >
+      <a
+        className="c8"
+        href="#content"
+      >
+        Waka go wetin de inside
+      </a>
+      <ul
+        className="c9"
+        role="list"
+      >
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c11"
+            href="/pidgin"
+          >
+            <span
+              className="c12"
+              role="text"
+            >
+              <span
+                className="c5"
+              >
+                Page where you dey
+                , 
+              </span>
+              Home
+            </span>
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/3d5d5e30-dd50-4041-96d5-c970b20005b9"
+          >
+            Nigeria
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/d2c2ba68-f9ad-4185-a6d1-7f6437256735"
+          >
+            Africa
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/world"
+          >
+            World
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/media/video"
+          >
+            Video
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/media/audio"
+          >
+            Audio
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/sport"
+          >
+            Sport
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/1c3b60a9-14eb-484b-a750-9f5b1aeaac31"
+          >
+            Entertainment
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/popular/read"
+          >
+            Most popular
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</header>
+`;
+
+exports[`Header should render correctly for news article 1`] = `
+.c5 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c1 {
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c0 {
+  background-color: #B80000;
+  height: 3.5rem;
+  width: 100%;
+  padding: 0 0.5rem;
+  border-bottom: 0.0625rem solid transparent;
+}
+
+.c3 {
+  display: inline-block;
+  width: 100%;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
+}
+
+.c4 {
+  box-sizing: content-box;
+  color: #FFFFFF;
+  fill: currentColor;
+  padding-top: 1rem;
+  padding-bottom: 0.75rem;
+  height: 1.5rem;
+  width: 100%;
+  max-width: 14.880600000000001rem;
+  min-width: 9.9204rem;
+}
+
+.c2:hover .c4,
+.c2:focus .c4 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c6 {
+  background-color: #B80000;
+}
+
+.c7 {
+  position: relative;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.c8 {
+  position: absolute;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  padding: 0.75rem 0.5rem;
+  background-color: #ffffff;
+  border: 0.1875rem solid #000;
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+.c8:focus {
+  -webkit-clip-path: none;
+  clip-path: none;
+  -webkit-clip: auto;
+  clip: auto;
+  height: auto;
+  width: auto;
+  top: -3rem;
+  left: 0.5rem;
+}
+
+.c9 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.c10 {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+}
+
+.c10::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  width: 80rem;
+  border-bottom: 0.0625rem solid #eab3b3;
+  z-index: -1;
+  left: 0;
+}
+
+.c11 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c11:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.3125rem solid #FFFFFF;
+}
+
+.c11:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c13 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #FDFDFD;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+}
+
+.c13:hover::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+.c13:focus::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+  top: 0;
+  border: 0.25rem solid #FFFFFF;
+}
+
+.c12::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 0.25rem solid #FFFFFF;
+}
+
+@media (min-width:25rem) {
+  .c0 {
+    height: 5rem;
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c4 {
+    padding-top: 1.75rem;
+    padding-bottom: 1.5rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),print {
+  .c4 {
+    fill: windowText;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8:focus {
+    top: -4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c8:focus {
+    left: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c11 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c11 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c13 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c13 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c13 {
+    padding: 0.75rem 0.5rem;
+  }
+}
+
+<header
+  role="banner"
+>
+  <div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <a
+        className="c2 c3"
+        href="/pidgin"
+      >
+        <svg
+          aria-hidden="true"
+          className="c4"
+          focusable="false"
+          height={24}
+          viewBox="0 0 238 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            fillRule="evenodd"
+            stroke="#000"
+            strokeWidth=".335"
+            style={
+              Object {
+                "stroke": "#fff",
+              }
+            }
+          >
+            <path
+              d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
+            />
+            <path
+              d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
+            />
+            <path
+              d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74zM185.18 16.87V6.28h3.35a3.46 3.46 0 0 1 2.41.82 2.82 2.82 0 0 1 .9 2.19 2.94 2.94 0 0 1-.46 1.63 2.64 2.64 0 0 1-1.26 1 6.42 6.42 0 0 1-2.3.32h-1.12v4.59zm3.09-9.24h-1.57v3.31h1.66a2.1 2.1 0 0 0 1.42-.44 1.56 1.56 0 0 0 .5-1.25q0-1.62-2.01-1.62zM194 6.3h1.51v10.57H194zM198.78 16.85V6.3h3.56a7.51 7.51 0 0 1 3.41.65 4.88 4.88 0 0 1 2 1.9 5.29 5.29 0 0 1 .74 2.74 5.18 5.18 0 0 1-.41 2 5.23 5.23 0 0 1-3 2.85 5.33 5.33 0 0 1-1.1.31 14.65 14.65 0 0 1-1.91.08zm3.41-9.21h-1.89v7.86h1.94a7.75 7.75 0 0 0 1.76-.16 4.12 4.12 0 0 0 1-.39 3.59 3.59 0 0 0 .77-.59 3.92 3.92 0 0 0 1.12-2.87 3.63 3.63 0 0 0-1.15-2.78 3.68 3.68 0 0 0-1-.66 4.07 4.07 0 0 0-1-.34 10.57 10.57 0 0 0-1.56-.07zM216.8 11.66h3.55v4.48a9.68 9.68 0 0 1-3.87.85 5.75 5.75 0 0 1-4.2-1.53 5.07 5.07 0 0 1-1.57-3.78 5.26 5.26 0 0 1 1.63-3.94 5.63 5.63 0 0 1 4.08-1.57 7.22 7.22 0 0 1 1.7.19 13.82 13.82 0 0 1 2 .71V8.6a7.43 7.43 0 0 0-3.75-1.1 4 4 0 0 0-2.92 1.18 3.93 3.93 0 0 0-1.19 2.9 3.9 3.9 0 0 0 1.19 2.94 4.23 4.23 0 0 0 3.06 1.14 7.12 7.12 0 0 0 2.17-.42h.14V13h-2zM223.5 6.3h1.5v10.57h-1.5zM236.65 6.3h1.44v10.57h-1.3l-7.07-8.14v8.14h-1.42V6.3h1.23l7.13 8.21z"
+            />
+            <path
+              d="M168.37 0v22.59"
+              strokeWidth="2"
+            />
+          </g>
+        </svg>
+        <span
+          className="c5"
+          role="text"
+        >
+          <span
+            lang="en-GB"
+          >
+            BBC News
+          </span>
+          , 
+          Pidgin
+        </span>
+      </a>
+    </div>
+  </div>
+  <nav
+    className="c6"
+    role="navigation"
+  >
+    <div
+      className="c7"
+    >
+      <a
+        className="c8"
+        href="#content"
+      >
+        Waka go wetin de inside
+      </a>
+      <ul
+        className="c9"
+        role="list"
+      >
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c11"
+            href="/pidgin"
+          >
+            <span
+              className="c12"
+              role="text"
+            >
+              <span
+                className="c5"
+              >
+                Page where you dey
+                , 
+              </span>
+              Home
+            </span>
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/3d5d5e30-dd50-4041-96d5-c970b20005b9"
+          >
+            Nigeria
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/d2c2ba68-f9ad-4185-a6d1-7f6437256735"
+          >
+            Africa
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/world"
+          >
+            World
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/media/video"
+          >
+            Video
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/media/audio"
+          >
+            Audio
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/sport"
+          >
+            Sport
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/topics/1c3b60a9-14eb-484b-a750-9f5b1aeaac31"
+          >
+            Entertainment
+          </a>
+        </li>
+        <li
+          className="c10"
+          dir="ltr"
+          role="listitem"
+        >
+          <a
+            className="c13"
+            href="/pidgin/popular/read"
+          >
+            Most popular
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </header>
 `;

--- a/src/app/containers/Header/index.jsx
+++ b/src/app/containers/Header/index.jsx
@@ -3,11 +3,14 @@ import BrandContainer from '../Brand';
 import NavigationContainer from '../Navigation';
 import { RequestContext } from '../../contexts/RequestContext';
 import ConsentBanner from '../ConsentBanner';
+import useToggle from '../Toggle/useToggle';
 
 const HeaderContainer = () => {
   const { pageType } = useContext(RequestContext);
   const borderBottom = pageType !== 'frontPage';
-  const showNavBar = ['frontPage', 'media'].includes(pageType);
+  const { enabled } = useToggle('navOnArticles');
+  const showNavBar =
+    ['frontPage', 'media', 'error'].includes(pageType) || enabled;
 
   return (
     <header role="banner">

--- a/src/app/containers/Header/index.stories.jsx
+++ b/src/app/containers/Header/index.stories.jsx
@@ -6,6 +6,7 @@ import HeaderContainer from '.';
 import { RequestContextProvider } from '../../contexts/RequestContext';
 import services from '../../lib/config/services';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
+import { ToggleContextProvider } from '../../contexts/ToggleContext';
 
 storiesOf('Containers|Header', module)
   .addDecorator(withKnobs)
@@ -15,15 +16,18 @@ storiesOf('Containers|Header', module)
       null,
       ({ service }) => {
         return (
-          <ServiceContextProvider service={service}>
-            <RequestContextProvider
-              pageType="frontPage"
-              isAmp={false}
-              service={service}
-            >
-              <HeaderContainer />
-            </RequestContextProvider>
-          </ServiceContextProvider>
+          <ToggleContextProvider>
+            <ServiceContextProvider service={service}>
+              <RequestContextProvider
+                isAmp={false}
+                pageType="frontPage"
+                service={service}
+                bbcOrigin="https://www.test.bbc.com"
+              >
+                <HeaderContainer />
+              </RequestContextProvider>
+            </ServiceContextProvider>
+          </ToggleContextProvider>
         );
       },
       Object.keys(services),

--- a/src/app/containers/Header/index.test.jsx
+++ b/src/app/containers/Header/index.test.jsx
@@ -1,27 +1,75 @@
 import React from 'react';
-import { news as brandSVG } from '@bbc/psammead-assets/svgs';
+import { string, shape } from 'prop-types';
 import HeaderContainer from './index';
+import { RequestContextProvider } from '../../contexts/RequestContext';
 import { ServiceContext } from '../../contexts/ServiceContext';
+import { ToggleContext } from '../../contexts/ToggleContext';
 import { shouldMatchSnapshot } from '../../../testHelpers';
+import pidginServiceConfig from '../../lib/config/services/pidgin';
 
-const newsServiceContextStub = {
-  product: 'BBC News',
-  service: 'news',
-  brandSVG,
-  svgHeight: 24,
-  maxWidth: 280,
-  minWidth: 180,
+const defaultToggleState = {
+  test: {
+    navOnArticles: {
+      enabled: true,
+    },
+  },
+  live: {
+    navOnArticles: {
+      enabled: false,
+    },
+  },
 };
 
-const HeaderContainerWithContext = context => (
-  <ServiceContext.Provider value={context}>
-    <HeaderContainer />
-  </ServiceContext.Provider>
+const mockToggleDispatch = jest.fn();
+
+const HeaderContainerWithContext = ({ pageType, service, serviceContext }) => (
+  <ToggleContext.Provider
+    value={{
+      toggleState: defaultToggleState,
+      toggleDispatch: mockToggleDispatch,
+    }}
+  >
+    <ServiceContext.Provider value={serviceContext}>
+      <RequestContextProvider
+        isAmp={false}
+        pageType={pageType}
+        service={service}
+        bbcOrigin="https://www.test.bbc.com"
+      >
+        <HeaderContainer />
+      </RequestContextProvider>
+    </ServiceContext.Provider>
+  </ToggleContext.Provider>
 );
+HeaderContainerWithContext.propTypes = {
+  pageType: string.isRequired,
+  service: string.isRequired,
+  serviceContext: shape({}).isRequired,
+};
 
 describe(`Header`, () => {
   shouldMatchSnapshot(
-    'should render correctly',
-    HeaderContainerWithContext(newsServiceContextStub),
+    'should render correctly for news article',
+    HeaderContainerWithContext({
+      pageType: 'article',
+      service: 'news',
+      serviceContext: pidginServiceConfig,
+    }),
+  );
+  shouldMatchSnapshot(
+    'should render correctly for WS frontPage',
+    HeaderContainerWithContext({
+      pageType: 'frontPage',
+      service: 'pidgin',
+      serviceContext: pidginServiceConfig,
+    }),
+  );
+  shouldMatchSnapshot(
+    'should render correctly for WS media page',
+    HeaderContainerWithContext({
+      pageType: 'media',
+      service: 'pidgin',
+      serviceContext: pidginServiceConfig,
+    }),
   );
 });

--- a/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`Headings with headline data should render correctly 1`] = `
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     This is a headline!
   </h1>
@@ -141,7 +141,7 @@ exports[`Headings with plain text headline should render h1 containing correct t
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     Plain headline
   </h1>
@@ -303,7 +303,7 @@ exports[`Headings with rich text headline with bold text should render h1 with <
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     <b>
       All is bold
@@ -387,7 +387,7 @@ exports[`Headings with rich text headline with italic text should render h1 with
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     <i
       className="c2"
@@ -473,7 +473,7 @@ exports[`Headings with rich text should render headline with bold & italic text 
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     <i
       className="c2"
@@ -561,7 +561,7 @@ exports[`Headings with rich text should render headline with italic & bold text 
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     <b>
       <i
@@ -649,7 +649,7 @@ exports[`Headings with rich text with different attributes should render headlin
 >
   <h1
     className="c1"
-    id={null}
+    id="content"
   >
     This is 
     <i

--- a/src/app/containers/Headings/index.jsx
+++ b/src/app/containers/Headings/index.jsx
@@ -46,11 +46,13 @@ const HeadingsContainer = ({ blocks, type }) => {
     <Blocks blocks={arrayOfFragments} componentsToRender={componentsToRender} />
   );
 
+  const headingId = 'content'; // Used for the skiplink
   const subHeadingId = sanitiseSubheadline(type, text);
+  const id = type === 'headline' ? headingId : subHeadingId;
 
   return (
     <GridConstrain>
-      <Heading script={script} service={service} id={subHeadingId}>
+      <Heading script={script} service={service} id={id}>
         {renderText()}
       </Heading>
     </GridConstrain>

--- a/src/app/containers/Headings/index.test.jsx
+++ b/src/app/containers/Headings/index.test.jsx
@@ -98,9 +98,9 @@ describe('Headings', () => {
         HeadingsContainerWithContext(data),
       );
 
-      it('should not have an id', () => {
+      it('should have an id for the skiplink with value "content"', () => {
         const headlineHeading = render(HeadingsContainerWithContext(data));
-        expect(getId(headlineHeading)).toBe(undefined);
+        expect(getId(headlineHeading)).toBe('content');
       });
     });
 

--- a/src/app/containers/PageHandlers/withPageWrapper/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PageHandlers/withPageWrapper/__snapshots__/index.test.jsx.snap
@@ -532,6 +532,5 @@ Array [
       </div>
     </div>
   </footer>,
-  ",",
 ]
 `;

--- a/src/app/containers/PageHandlers/withPageWrapper/index.test.jsx
+++ b/src/app/containers/PageHandlers/withPageWrapper/index.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '../../../../testHelpers';
+import { RequestContextProvider } from '../../../contexts/RequestContext';
 import { ServiceContextProvider } from '../../../contexts/ServiceContext';
+import { ToggleContext } from '../../../contexts/ToggleContext';
 import WithPageWrapper from '.';
 
 const dataProps = {
@@ -9,13 +11,42 @@ const dataProps = {
   route: { pageType: 'article' },
 };
 
+const defaultToggleState = {
+  test: {
+    navOnArticles: {
+      enabled: true,
+    },
+  },
+  live: {
+    navOnArticles: {
+      enabled: false,
+    },
+  },
+};
+
+const mockToggleDispatch = jest.fn();
+
 describe('with pageWrapper', () => {
   const PageWrapperContainer = () => <h1>Holla</h1>;
   const PageWrapperHOC = WithPageWrapper(PageWrapperContainer);
   shouldMatchSnapshot(
     `should render correctly`,
-    <ServiceContextProvider service="news">
-      <PageWrapperHOC {...dataProps} />,
-    </ServiceContextProvider>,
+    <ToggleContext.Provider
+      value={{
+        toggleState: defaultToggleState,
+        toggleDispatch: mockToggleDispatch,
+      }}
+    >
+      <ServiceContextProvider service="news">
+        <RequestContextProvider
+          isAmp={false}
+          pageType="article"
+          service="news"
+          bbcOrigin="https://www.test.bbc.com"
+        >
+          <PageWrapperHOC {...dataProps} />
+        </RequestContextProvider>
+      </ServiceContextProvider>
+    </ToggleContext.Provider>,
   );
 });

--- a/src/app/contexts/ToggleContext/__snapshots__/index.test.jsx.snap
+++ b/src/app/contexts/ToggleContext/__snapshots__/index.test.jsx.snap
@@ -2,6 +2,6 @@
 
 exports[`ToggleContext should provide a toggles object 1`] = `
 <span>
-  {"toggleState":{"test":{"mpulse":{"enabled":false},"mediaPlayer":{"enabled":true},"chartbeatAnalytics":{"enabled":true}},"live":{"mpulse":{"enabled":false},"mediaPlayer":{"enabled":false},"chartbeatAnalytics":{"enabled":false}}}}
+  {"toggleState":{"local":{"chartbeatAnalytics":{"enabled":true},"mediaPlayer":{"enabled":true},"mpulse":{"enabled":false},"navOnArticles":{"enabled":true}},"test":{"chartbeatAnalytics":{"enabled":true},"mediaPlayer":{"enabled":true},"mpulse":{"enabled":false},"navOnArticles":{"enabled":true}},"live":{"chartbeatAnalytics":{"enabled":false},"mediaPlayer":{"enabled":false},"mpulse":{"enabled":false},"navOnArticles":{"enabled":false}}}}
 </span>
 `;

--- a/src/app/lib/config/services/afaanoromoo.js
+++ b/src/app/lib/config/services/afaanoromoo.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Oduu',
+    currentPage: 'Current page',
+    skipLinkText: 'Qabiyyeetti darbi',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/afrique.js
+++ b/src/app/lib/config/services/afrique.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Accueil',
+    currentPage: 'Current page',
+    skipLinkText: 'Aller au contenu',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/amharic.js
+++ b/src/app/lib/config/services/amharic.js
@@ -37,6 +37,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'ዜና',
+    currentPage: 'Current page',
+    skipLinkText: 'ወደ ዋናው ይዘት ይለፉ',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -38,6 +38,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'رئيسية',
+    currentPage: 'Current page',
+    skipLinkText: 'إذهب الى المحتوى',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/azeri.js
+++ b/src/app/lib/config/services/azeri.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Xəbərlər',
+    currentPage: 'Current page',
+    skipLinkText: 'Mətnə keçid',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/bengali.js
+++ b/src/app/lib/config/services/bengali.js
@@ -37,6 +37,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'মূলপাতা',
+    currentPage: 'Current page',
+    skipLinkText: 'সরাসরি কনটেন্টে যান',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'ပင်မစာမျက်နှာ',
+    currentPage: 'Current page',
+    skipLinkText: 'အကြောင်းအရာများဆီ ကျော်သွားပါ',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/cymrufyw.js
+++ b/src/app/lib/config/services/cymrufyw.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Hafan',
+    currentPage: 'Current page',
+    skipLinkText: `Neidio i'r cynnwys`,
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/gahuza.js
+++ b/src/app/lib/config/services/gahuza.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: `Urupapuro rw'itangiriro`,
+    currentPage: 'Current page',
+    skipLinkText: 'Simbira ku birimwo',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/gujarati.js
+++ b/src/app/lib/config/services/gujarati.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'સમાચાર',
+    currentPage: 'Current page',
+    skipLinkText: 'સામગ્રી પર જાઓ',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/hausa.js
+++ b/src/app/lib/config/services/hausa.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Labaran Duniya',
+    currentPage: 'Current page',
+    skipLinkText: 'Tsallaka zuwa abubuwan da ke ciki',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/hindi.js
+++ b/src/app/lib/config/services/hindi.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'होम पेज',
+    currentPage: 'Current page',
+    skipLinkText: 'सामग्री को स्किप करें',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/igbo.js
+++ b/src/app/lib/config/services/igbo.js
@@ -36,6 +36,9 @@ const igbo = {
     currentPage: 'Peegi ị nọ ugbua',
     skipLinkText: 'Wụga n’ọdịnaya',
     error: {
+      home: 'Akụkọ',
+      currentPage: 'Current page',
+      skipLinkText: 'Wụga n’ọdịnaya',
       404: {
         statusCode: '404',
         title: 'Ahụghị ibe akwụkwọ a',

--- a/src/app/lib/config/services/indonesia.js
+++ b/src/app/lib/config/services/indonesia.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Berita',
+    currentPage: 'Current page',
+    skipLinkText: 'Langsung ke konten',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'ホーム',
+    currentPage: 'Current page',
+    skipLinkText: 'コンテンツへ移動',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/korean.js
+++ b/src/app/lib/config/services/korean.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: '뉴스',
+    currentPage: 'Current page',
+    skipLinkText: '내용으로 건너뛰기',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/kyrgyz.js
+++ b/src/app/lib/config/services/kyrgyz.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Башталгыч бет',
+    currentPage: 'Current page',
+    skipLinkText: 'Сайтка өтүү',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/marathi.js
+++ b/src/app/lib/config/services/marathi.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'बातम्या',
+    currentPage: 'Current page',
+    skipLinkText: 'सामग्रीवर जा',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Noticias',
+    currentPage: 'Current page',
+    skipLinkText: 'Ir al contenido',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/naidheachdan.js
+++ b/src/app/lib/config/services/naidheachdan.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Alba',
+    currentPage: 'Current page',
+    skipLinkText: 'Air adhart',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/nepali.js
+++ b/src/app/lib/config/services/nepali.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'मुख पृष्ठ',
+    currentPage: 'Current page',
+    skipLinkText: 'यो सामग्री स्कीप गर्नुहोस्',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/news.js
+++ b/src/app/lib/config/services/news.js
@@ -43,6 +43,9 @@ const news = {
   manifestPath: '/articles/manifest.json',
   swPath: '/articles/sw.js',
   translations: {
+    home: 'Home',
+    currentPage: 'Current page',
+    skipLinkText: 'Skip to content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/pashto.js
+++ b/src/app/lib/config/services/pashto.js
@@ -38,6 +38,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'کور پاڼه',
+    currentPage: 'Current page',
+    skipLinkText: 'مطلب ته ورشئ',
     error: {
       404: {
         statusCode: '۴۰۴',

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -39,6 +39,9 @@ const persian = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'صفحه اول',
+    currentPage: 'Current page',
+    skipLinkText: 'مشاهده محتوا',
     error: {
       404: {
         statusCode: '۴۰۴',

--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Notícias',
+    currentPage: 'Current page',
+    skipLinkText: 'Ir para o conteúdo',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Главная',
+    currentPage: 'Current page',
+    skipLinkText: 'Перейти к содержанию',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/serbian.js
+++ b/src/app/lib/config/services/serbian.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Home',
+    currentPage: 'Current page',
+    skipLinkText: 'Skip to content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/sinhala.js
+++ b/src/app/lib/config/services/sinhala.js
@@ -37,6 +37,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'මුල් පිටුව',
+    currentPage: 'Current page',
+    skipLinkText: 'අන්තර්ගතයට පිවිසෙන්න',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/somali.js
+++ b/src/app/lib/config/services/somali.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'War',
+    currentPage: 'Current page',
+    skipLinkText: 'U gudub qaybta macluumaadka',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/swahili.js
+++ b/src/app/lib/config/services/swahili.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Habari',
+    currentPage: 'Current page',
+    skipLinkText: 'Ruka hadi maelezo',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/tamil.js
+++ b/src/app/lib/config/services/tamil.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'முகப்பு',
+    currentPage: 'Current page',
+    skipLinkText: 'உள்ளடக்கத்துக்குத் தாண்டிச் செல்க',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/telugu.js
+++ b/src/app/lib/config/services/telugu.js
@@ -34,6 +34,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'వార్తలు',
+    currentPage: 'Current page',
+    skipLinkText: 'కంటెంట్‌కు దాటవేయండి',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/thai.js
+++ b/src/app/lib/config/services/thai.js
@@ -34,6 +34,7 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'หน้าแรก',
     currentPage: 'หน้าปัจจุบัน',
     skipLinkText: 'ข้ามไปยังเนื้อหา',
     error: {

--- a/src/app/lib/config/services/tigrinya.js
+++ b/src/app/lib/config/services/tigrinya.js
@@ -37,6 +37,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'ዜና',
+    currentPage: 'Current page',
+    skipLinkText: 'እቲ ትሕዝቶ ዝለል',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Haberler',
+    currentPage: 'Current page',
+    skipLinkText: 'Siteye gir',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/ukchina.js
+++ b/src/app/lib/config/services/ukchina.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Home',
+    currentPage: 'Current page',
+    skipLinkText: 'Skip to content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/ukrainian.js
+++ b/src/app/lib/config/services/ukrainian.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Головна',
+    currentPage: 'Current page',
+    skipLinkText: 'Перейти до змісту',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/urdu.js
+++ b/src/app/lib/config/services/urdu.js
@@ -38,6 +38,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'صفحۂ اول',
+    currentPage: 'Current page',
+    skipLinkText: 'مواد پر جائیں',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/uzbek.js
+++ b/src/app/lib/config/services/uzbek.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Бош саҳифа',
+    currentPage: 'Current page',
+    skipLinkText: 'Саҳифага ўтиш',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/vietnamese.js
+++ b/src/app/lib/config/services/vietnamese.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Tin chính',
+    currentPage: 'Current page',
+    skipLinkText: 'Bỏ qua để xem nội dung',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/zhongwen.js
+++ b/src/app/lib/config/services/zhongwen.js
@@ -33,6 +33,9 @@ const service = {
   manifestPath: '/manifest.json',
   swPath: '/sw.js',
   translations: {
+    home: 'Home',
+    currentPage: 'Current page',
+    skipLinkText: 'Skip to content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/toggles/index.js
+++ b/src/app/lib/config/toggles/index.js
@@ -1,23 +1,43 @@
 const toggles = {
-  test: {
-    mpulse: {
-      enabled: false,
+  local: {
+    chartbeatAnalytics: {
+      enabled: true,
     },
     mediaPlayer: {
       enabled: true,
     },
+    mpulse: {
+      enabled: false,
+    },
+    navOnArticles: {
+      enabled: true,
+    },
+  },
+  test: {
     chartbeatAnalytics: {
+      enabled: true,
+    },
+    mediaPlayer: {
+      enabled: true,
+    },
+    mpulse: {
+      enabled: false,
+    },
+    navOnArticles: {
       enabled: true,
     },
   },
   live: {
-    mpulse: {
+    chartbeatAnalytics: {
       enabled: false,
     },
     mediaPlayer: {
       enabled: false,
     },
-    chartbeatAnalytics: {
+    mpulse: {
+      enabled: false,
+    },
+    navOnArticles: {
       enabled: false,
     },
   },


### PR DESCRIPTION
Reverts the revert: bbc/simorgh#3335. This is because the Cypress tests for the Navigation PR were not failing. They were failing due to changes in other PRs. 