### PR TITLE
Reorder non smoke e2e job to be in order we care about most to least

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -40,6 +40,27 @@ node {
           stage ('Install & Setup') {
             sh 'make install'
           }
+          stage ('Live E2Es') {
+            try {
+              sh 'make liveE2Es'
+            } catch (Throwable e) {
+              def messageParameters = [
+                buildStatus: 'Failed',
+                env: 'LIVE',
+                branch: env.BRANCH_NAME,
+                colour: 'danger',
+                emoji: '😱',
+              ]
+              
+              if (env.BRANCH_NAME == 'latest') {
+                notifySlack(messageParameters)
+                stageHasFailed = true
+              }
+
+              currentBuild.result = 'FAILURE'
+              throw e
+            }
+          }
           stage ('Local Prod Tests') {
             try {
               sh 'CYPRESS_SMOKE=false npm run build && xvfb-run -a npm run test:prod:ci;'
@@ -68,27 +89,6 @@ node {
               def messageParameters = [
                 buildStatus: 'Failed',
                 env: 'TEST',
-                branch: env.BRANCH_NAME,
-                colour: 'danger',
-                emoji: '😱',
-              ]
-              
-              if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters)
-                stageHasFailed = true
-              }
-
-              currentBuild.result = 'FAILURE'
-              throw e
-            }
-          }
-          stage ('Live E2Es') {
-            try {
-              sh 'make liveE2Es'
-            } catch (Throwable e) {
-              def messageParameters = [
-                buildStatus: 'Failed',
-                env: 'LIVE',
                 branch: env.BRANCH_NAME,
                 colour: 'danger',
                 emoji: '😱',

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -51,7 +51,7 @@ node {
                 colour: 'danger',
                 emoji: '😱',
               ]
-              
+
               if (env.BRANCH_NAME == 'latest') {
                 notifySlack(messageParameters)
                 stageHasFailed = true
@@ -80,7 +80,7 @@ node {
 
               currentBuild.result = 'FAILURE'
               throw e
-            }   
+            }
           }
           stage ('Test E2Es') {
             try {
@@ -93,7 +93,7 @@ node {
                 colour: 'danger',
                 emoji: '😱',
               ]
-              
+
               if (env.BRANCH_NAME == 'latest') {
                 notifySlack(messageParameters)
                 stageHasFailed = true


### PR DESCRIPTION
Resolves n/a

**Overall change:** Reorders these e2es to live, local, test rather than local, test, live

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
