### PR TITLE
Set lang values to the better than live values

### DIFF
--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -4,7 +4,7 @@ import { portuguese as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/America/Sao_Paulo';
 
 const service = {
-  lang: `pt`,
+  lang: `pt-BR`,
   articleAuthor: `https://www.facebook.com/bbcbrasil`,
   articleTimestampPrefix: 'Updated',
   atiAnalyticsAppName: 'news-portuguese',

--- a/src/app/lib/config/services/uzbek.js
+++ b/src/app/lib/config/services/uzbek.js
@@ -4,7 +4,7 @@ import { news as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Europe/London';
 
 const service = {
-  lang: `uz`,
+  lang: `uz-Cyrl`,
   articleAuthor: `https://www.facebook.com/#!/bbcuzbek`,
   articleTimestampPrefix: 'Updated',
   atiAnalyticsAppName: 'news-uzbek',


### PR DESCRIPTION
There has been a decision to use these lang codes which aren't currently used on live. Verified by Product Manager for WS (Neil D)

**Overall change:** Update lang values

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
