### PR TITLE
Revise code ownership coverage and names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,11 @@
 # Order is important. The last matching pattern has the most precedence.
 # Protected files
-**/*webpack*    @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-/src/server/    @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-/src/client.js  @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-/envConfig/     @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-/scripts/       @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-package.json    @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-.travis.yml     @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-Jenkinsfile     @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
-/cypress/       @benjaminhobbs @jamesdonoh @pjlee11 @sareh @hindsc52 @dr3 @jblaut
+**/*webpack*    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+/src/    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+/envConfig/     @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+/scripts/       @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+package.json    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+.travis.yml     @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3
+Jenkinsfile     @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3
+/cypress/       @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
 **/*CODEOWNERS* @bbc/simorgh-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Order is important. The last matching pattern has the most precedence.
 # Protected files
 **/*webpack*    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
-/src/    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
+/src/           @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
 /envConfig/     @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
 /scripts/       @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14
 package.json    @benjaminhobbs @jamesdonoh @sareh @hindsc52 @dr3 @jblaut @jroebu14


### PR DESCRIPTION
Significant revision of code ownership:
1. src/ is now protected in its entirity
2. Phil (soon leaving) is replaced by Jonathan Roebuck