### PR TITLE
only override with frontPageTitle on front pages

### DIFF
--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -198,7 +198,10 @@ const MetadataContainer = ({ metadata, promo }) => {
     icon: ['72x72', '96x96', '192x192'],
   };
 
-  const title = frontPageTitle || getTitle(promo);
+  const title =
+    pageType === 'frontPage' && frontPageTitle
+      ? frontPageTitle
+      : getTitle(promo);
 
   return (
     <>


### PR DESCRIPTION
Resolves failing e2e tests

**Overall change:** Only override the title with the frontPageTitle config value when we're on a front page

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
