### PR TITLE
Privacy banner update

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -76,7 +76,7 @@ Object.keys(config)
             getCookieBanner(service).should('not.be.visible');
 
             assertCookieValues({
-              ckns_privacy: '1',
+              ckns_privacy: 'july2019',
               ckns_policy: '000',
             });
 
@@ -89,7 +89,7 @@ Object.keys(config)
 
             assertCookieValues({
               ckns_explicit: '1',
-              ckns_privacy: '1',
+              ckns_privacy: 'july2019',
               ckns_policy: '111',
             });
 
@@ -107,7 +107,7 @@ Object.keys(config)
             getCookieBanner(service).should('not.be.visible');
 
             assertCookieValues({
-              ckns_privacy: '1',
+              ckns_privacy: 'july2019',
               ckns_policy: '000',
             });
 
@@ -118,7 +118,7 @@ Object.keys(config)
 
             assertCookieValues({
               ckns_explicit: '1',
-              ckns_privacy: '1',
+              ckns_privacy: 'july2019',
               ckns_policy: '000',
             });
 
@@ -130,7 +130,7 @@ Object.keys(config)
 
           it("should show cookie banner (and NOT privacy banner) if user has visited the page before and didn't explicitly 'accept' cookies", () => {
             cy.clearCookies();
-            cy.setCookie('ckns_privacy', '1');
+            cy.setCookie('ckns_privacy', 'july2019');
             visitPage(service, pageType);
 
             getPrivacyBanner(service).should('not.be.visible');

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.js
@@ -5,9 +5,11 @@ const PRIVACY_COOKIE = 'ckns_privacy';
 const EXPLICIT_COOKIE = 'ckns_explicit';
 const POLICY_COOKIE = 'ckns_policy';
 const COOKIE_EXPIRY = 365;
-const BANNER_APPROVED = '1';
+const COOKIE_BANNER_APPROVED = '1';
 const POLICY_APPROVED = '111';
 const POLICY_DENIED = '000';
+const PRIVACY_COOKIE_CURRENT = 'july2019';
+const PRIVACY_COOKIE_PREVIOUS_VALUES = ['0', '1'];
 
 const onClient = typeof window !== 'undefined';
 
@@ -19,15 +21,22 @@ const setPolicyCookie = (value, logger) => {
   setCookieOven(POLICY_COOKIE, value, logger);
 };
 
-const seenPrivacyBanner = () => Cookie.get(PRIVACY_COOKIE) === BANNER_APPROVED;
-const seenCookieBanner = () => Cookie.get(EXPLICIT_COOKIE) === BANNER_APPROVED;
+const showPrivacyBanner = () => {
+  const privacyCookie = Cookie.get(PRIVACY_COOKIE);
+  return (
+    !privacyCookie || PRIVACY_COOKIE_PREVIOUS_VALUES.includes(privacyCookie)
+  );
+};
+const seenCookieBanner = () =>
+  Cookie.get(EXPLICIT_COOKIE) === COOKIE_BANNER_APPROVED;
 const policyCookieSet = () => !!Cookie.get(POLICY_COOKIE);
 
-const setSeenPrivacyBanner = () => setCookie(PRIVACY_COOKIE, BANNER_APPROVED);
+const setSeenPrivacyBanner = () =>
+  setCookie(PRIVACY_COOKIE, PRIVACY_COOKIE_CURRENT);
 const setDefaultPolicy = logger => setPolicyCookie(POLICY_DENIED, logger);
 const setApprovedPolicy = logger => setPolicyCookie(POLICY_APPROVED, logger);
 const setDismissedCookieBanner = () =>
-  setCookie(EXPLICIT_COOKIE, BANNER_APPROVED);
+  setCookie(EXPLICIT_COOKIE, COOKIE_BANNER_APPROVED);
 
 const consentBannerUtilities = ({
   setShowPrivacyBanner,
@@ -36,7 +45,7 @@ const consentBannerUtilities = ({
 }) => {
   const runInitial = () => {
     if (onClient) {
-      if (!seenPrivacyBanner()) {
+      if (showPrivacyBanner()) {
         setShowPrivacyBanner(true);
         setSeenPrivacyBanner();
       }

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.js
@@ -27,8 +27,8 @@ const showPrivacyBanner = () => {
     !privacyCookie || PRIVACY_COOKIE_PREVIOUS_VALUES.includes(privacyCookie)
   );
 };
-const seenCookieBanner = () =>
-  Cookie.get(EXPLICIT_COOKIE) === COOKIE_BANNER_APPROVED;
+const showCookieBanner = () =>
+  Cookie.get(EXPLICIT_COOKIE) !== COOKIE_BANNER_APPROVED;
 const policyCookieSet = () => !!Cookie.get(POLICY_COOKIE);
 
 const setSeenPrivacyBanner = () =>
@@ -50,7 +50,7 @@ const consentBannerUtilities = ({
         setSeenPrivacyBanner();
       }
 
-      if (!seenCookieBanner()) {
+      if (showCookieBanner()) {
         // Up to the application renderer to show the privacy
         // banner and cookie banner in the correct order
         setShowCookieBanner(true);

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
@@ -7,9 +7,9 @@ let Cookie;
 let setCookieOvenMock;
 const setShowPrivacyBannerMock = jest.fn();
 const setShowCookieBannerMock = jest.fn();
-
+const PRIVACY_COOKIE_CURRENT = 'july2019';
 const setCookieGetMock = ({
-  privacy = '1',
+  privacy = PRIVACY_COOKIE_CURRENT,
   explicit = '1',
   policy = '111',
 }) => {
@@ -51,8 +51,8 @@ describe('Consent Banner Utilities', () => {
   });
 
   describe('runInitial', () => {
-    it('does not show the privacy banner when PRIVACY_COOKIE is july2019', () => {
-      setCookieGetMock({ privacy: '1' });
+    it('does not show the privacy banner when PRIVACY_COOKIE is current policy value', () => {
+      setCookieGetMock({ privacy: PRIVACY_COOKIE_CURRENT });
 
       const { runInitial } = getConsentBannerUtilities();
 
@@ -81,9 +81,13 @@ describe('Consent Banner Utilities', () => {
       runInitial();
 
       expect(Cookie.set).toHaveBeenCalledTimes(1);
-      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
-        expires: 365,
-      });
+      expect(Cookie.set).toHaveBeenCalledWith(
+        PRIVACY_COOKIE,
+        PRIVACY_COOKIE_CURRENT,
+        {
+          expires: 365,
+        },
+      );
       expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
     });
 
@@ -95,23 +99,13 @@ describe('Consent Banner Utilities', () => {
       runInitial();
 
       expect(Cookie.set).toHaveBeenCalledTimes(1);
-      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
-        expires: 365,
-      });
-      expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
-    });
-
-    it('sets PRIVACY_COOKIE and shows privacy banner when cookie is july2019', () => {
-      setCookieGetMock({ privacy: 'july2019' });
-
-      const { runInitial } = getConsentBannerUtilities();
-
-      runInitial();
-
-      expect(Cookie.set).toHaveBeenCalledTimes(1);
-      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
-        expires: 365,
-      });
+      expect(Cookie.set).toHaveBeenCalledWith(
+        PRIVACY_COOKIE,
+        PRIVACY_COOKIE_CURRENT,
+        {
+          expires: 365,
+        },
+      );
       expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
     });
 
@@ -123,9 +117,13 @@ describe('Consent Banner Utilities', () => {
       runInitial();
 
       expect(Cookie.set).toHaveBeenCalledTimes(1);
-      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, '1', {
-        expires: 365,
-      });
+      expect(Cookie.set).toHaveBeenCalledWith(
+        PRIVACY_COOKIE,
+        PRIVACY_COOKIE_CURRENT,
+        {
+          expires: 365,
+        },
+      );
       expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
     });
 

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
@@ -51,7 +51,7 @@ describe('Consent Banner Utilities', () => {
   });
 
   describe('runInitial', () => {
-    it('does not show the privacy banner when PRIVACY_COOKIE is 1', () => {
+    it('does not show the privacy banner when PRIVACY_COOKIE is july2019', () => {
       setCookieGetMock({ privacy: '1' });
 
       const { runInitial } = getConsentBannerUtilities();
@@ -62,7 +62,18 @@ describe('Consent Banner Utilities', () => {
       expect(setShowPrivacyBannerMock).not.toHaveBeenCalled();
     });
 
-    it('sets PRIVACY_COOKIE and shows privacy banner when cookie is 0', () => {
+    it('does not show the privacy banner when PRIVACY_COOKIE is anythingelse', () => {
+      setCookieGetMock({ privacy: 'anythingelse' });
+
+      const { runInitial } = getConsentBannerUtilities();
+
+      runInitial();
+
+      expect(Cookie.set).toHaveBeenCalledTimes(0);
+      expect(setShowPrivacyBannerMock).not.toHaveBeenCalled();
+    });
+
+    it('sets PRIVACY_COOKIE and shows the privacy banner when PRIVACY_COOKIE is 0', () => {
       setCookieGetMock({ privacy: '0' });
 
       const { runInitial } = getConsentBannerUtilities();
@@ -70,7 +81,35 @@ describe('Consent Banner Utilities', () => {
       runInitial();
 
       expect(Cookie.set).toHaveBeenCalledTimes(1);
-      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, '1', {
+      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
+        expires: 365,
+      });
+      expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
+    });
+
+    it('sets PRIVACY_COOKIE and shows the privacy banner when PRIVACY_COOKIE is 1', () => {
+      setCookieGetMock({ privacy: '1' });
+
+      const { runInitial } = getConsentBannerUtilities();
+
+      runInitial();
+
+      expect(Cookie.set).toHaveBeenCalledTimes(1);
+      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
+        expires: 365,
+      });
+      expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
+    });
+
+    it('sets PRIVACY_COOKIE and shows privacy banner when cookie is july2019', () => {
+      setCookieGetMock({ privacy: 'july2019' });
+
+      const { runInitial } = getConsentBannerUtilities();
+
+      runInitial();
+
+      expect(Cookie.set).toHaveBeenCalledTimes(1);
+      expect(Cookie.set).toHaveBeenCalledWith(PRIVACY_COOKIE, 'july2019', {
         expires: 365,
       });
       expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);


### PR DESCRIPTION
Resolves #3446

**Overall change:** Updates Privacy banner logic according to these rules:

Cookie name | Value | Behaviour of Privacy banner
-- | -- | --
ckns_privacy | not present or value is undefined or null | Show banner
ckns_privacy | '0' or '1' (e.g. previousVersion) | Show banner
ckns_privacy | 'july2019' (e.g. currentVersion) | Do not show banner
ckns_privacy | anything else | Do not show banner

**Code changes:**

- Update logic & add unit tests. 





---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
