### PR TITLE
Enable ATI e2e tests for live radio pages

### DIFF
--- a/cypress/integration/pages/liveRadio/tests.js
+++ b/cypress/integration/pages/liveRadio/tests.js
@@ -32,11 +32,11 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
     });
 
     describe('LinkedData', () => {
-      // will be addressed by this https://github.com/bbc/simorgh/issues/3117
-      it.skip('should include mainEntityOfPage in the LinkedData', () => {
-        cy.get('script[type="application/ld+json"]')
-          .should('contain', 'mainEntityOfPage')
-          .and('contain', 'headline');
+      it('should include mainEntityOfPage in the LinkedData', () => {
+        cy.get('script[type="application/ld+json"]').should(
+          'contain',
+          'mainEntityOfPage',
+        );
       });
     });
   });

--- a/cypress/integration/pages/liveRadio/testsForAMPOnly.js
+++ b/cypress/integration/pages/liveRadio/testsForAMPOnly.js
@@ -24,7 +24,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
     });
 
     describe('ATI', () => {
-      it.skip('should have an amp-analytics tag with the ati url', () => {
+      it('should have an amp-analytics tag with the ati url', () => {
         cy.hasAmpAnalyticsAtiUrl(
           envConfig.atiUrl,
           config[service].isWorldService ? envConfig.atiAnalyticsWSBucket : '',

--- a/cypress/integration/pages/liveRadio/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/liveRadio/testsForCanonicalOnly.js
@@ -13,9 +13,8 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   pageType,
 }) =>
   describe(`Canonical Tests for ${service} ${pageType}`, () => {
-    // will be addressed by https://github.com/bbc/simorgh/issues/3324
     describe('ATI', () => {
-      it.skip('should have a noscript tag with an 1px image with the ati url', () => {
+      it('should have a noscript tag with an 1px image with the ati url', () => {
         cy.hasNoscriptImgAtiUrl(
           envConfig.atiUrl,
           config[service].isWorldService ? envConfig.atiAnalyticsWSBucket : '',

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -90,7 +90,7 @@ module.exports = {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/amharic/bbc_amharic_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -419,7 +419,7 @@ module.exports = {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/indonesia/bbc_indonesian_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -475,7 +475,7 @@ module.exports = {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/korean/bbc_korean_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },
@@ -1025,7 +1025,7 @@ module.exports = {
           Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/tigrinya/bbc_tigrinya_radio/liveradio',
-        smoke: false,
+        smoke: true,
       },
     },
   },


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/3324

**Overall change:** Enables the live radio page ATI e2e tests for Amharic, Afaan Oromoo, Indonesian, Korean and Tigrinya services.

**Code changes:**

- Add `smoke = true` for `amharic`, `indonesian`, `korean` and `tigrinya` in `cypress/support/config/services.js`.
- Remove `.skip` call for canonical and amp ATI tests.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing

**Testing notes**
No testing required.