### PR TITLE
Cypress fix - Consent banner

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -12,18 +12,22 @@ const filterPageTypes = (service, pageType) =>
 
 const getPrivacyBanner = service =>
   cy.contains(appConfig[service].translations.consentBanner.privacy.title);
-
 const getCookieBanner = service =>
   cy.contains(appConfig[service].translations.consentBanner.cookie.title);
-
-const getPrivacyAccept = service =>
-  cy.contains(appConfig[service].translations.consentBanner.privacy.accept);
-
-const getCookieAccept = service =>
-  cy.contains(appConfig[service].translations.consentBanner.cookie.accept);
-
-const getCookieReject = service =>
-  cy.contains(appConfig[service].translations.consentBanner.cookie.reject);
+const getPrivacyBannerContainer = service => getPrivacyBanner(service).parent();
+const getCookieBannerContainer = service => getCookieBanner(service).parent();
+const getPrivacyBannerAccept = service =>
+  getPrivacyBannerContainer(service)
+    .find('button')
+    .contains(appConfig[service].translations.consentBanner.privacy.accept);
+const getCookieBannerAccept = service =>
+  getCookieBannerContainer(service)
+    .find('button')
+    .contains(appConfig[service].translations.consentBanner.cookie.accept);
+const getCookieBannerReject = service =>
+  getCookieBannerContainer(service)
+    .find('a')
+    .contains(appConfig[service].translations.consentBanner.cookie.reject);
 
 const visitPage = (service, pageType) => {
   cy.visit(`${config[service].pageTypes[pageType].path}.amp`, {
@@ -48,19 +52,19 @@ Object.keys(config)
               getPrivacyBanner(service).should('be.visible');
               getCookieBanner(service).should('not.be.visible');
 
-              getPrivacyAccept(service).click();
+              getPrivacyBannerAccept(service).click();
 
               getCookieBanner(service).should('be.visible');
               getPrivacyBanner(service).should('not.be.visible');
 
-              getCookieAccept(service).click();
+              getCookieBannerAccept(service).click();
 
               getCookieBanner(service).should('not.be.visible');
               getPrivacyBanner(service).should('not.be.visible');
             });
 
             it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
-              getPrivacyAccept(service).click();
+              getPrivacyBannerAccept(service).click();
 
               visitPage(service, pageType);
 
@@ -69,8 +73,8 @@ Object.keys(config)
             });
 
             it('should not show privacy & cookie banners once both accepted, on reload', () => {
-              getPrivacyAccept(service).click();
-              getCookieAccept(service).click();
+              getPrivacyBannerAccept(service).click();
+              getCookieBannerAccept(service).click();
 
               visitPage(service, pageType);
 
@@ -82,8 +86,8 @@ Object.keys(config)
               getPrivacyBanner(service).should('be.visible');
               getCookieBanner(service).should('not.be.visible');
 
-              getPrivacyAccept(service).click();
-              getCookieReject(service).click();
+              getPrivacyBannerAccept(service).click();
+              getCookieBannerReject(service).click();
 
               visitPage(service, pageType);
 

--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -5,7 +5,7 @@ import describeForEuOnly from '../../../support/helpers/describeForEuOnly';
 // Limited to 1 UK & 1 WS service when a smoke test due to time test takes to run per page.
 // This is why this file doesn't check smoke test values.
 const serviceFilter = service =>
-  Cypress.env('SMOKE') ? ['news', 'persian'].includes(service) : service;
+  Cypress.env('SMOKE') ? ['news', 'thai'].includes(service) : service;
 
 const filterPageTypes = (service, pageType) =>
   config[service].pageTypes[pageType].path !== undefined;

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -4,7 +4,7 @@ import config from '../../../support/config/services';
 // Limited to 1 UK & 1 WS service when a smoke test due to time test takes to run per page.
 // This is why this file doesn't check smoke test values.
 const serviceFilter = service =>
-  Cypress.env('SMOKE') ? ['news', 'persian'].includes(service) : service;
+  Cypress.env('SMOKE') ? ['news', 'thai'].includes(service) : service;
 
 const assertCookieValue = (cookieName, value) => {
   cy.getCookie(cookieName).should('have.property', 'value', value);

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -30,17 +30,17 @@ const getCookieBanner = service =>
 const getPrivacyBannerContainer = service => getPrivacyBanner(service).parent();
 const getCookieBannerContainer = service => getCookieBanner(service).parent();
 const getPrivacyBannerAccept = service =>
-  getPrivacyBannerContainer(service).contains(
-    appConfig[service].translations.consentBanner.privacy.accept,
-  );
+  getPrivacyBannerContainer(service)
+    .find('button')
+    .contains(appConfig[service].translations.consentBanner.privacy.accept);
 const getCookieBannerAccept = service =>
-  getCookieBannerContainer(service).contains(
-    appConfig[service].translations.consentBanner.cookie.accept,
-  );
+  getCookieBannerContainer(service)
+    .find('button')
+    .contains(appConfig[service].translations.consentBanner.cookie.accept);
 const getCookieBannerReject = service =>
-  getCookieBannerContainer(service).contains(
-    appConfig[service].translations.consentBanner.cookie.reject,
-  );
+  getCookieBannerContainer(service)
+    .find('a')
+    .contains(appConfig[service].translations.consentBanner.cookie.reject);
 
 const ensureCookieExpiryDates = () => {
   const inOneYear = (new Date() / 1000 + 60 * 60 * 24 * 365).toFixed();

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -388,7 +388,7 @@ module.exports = {
             : '/igbo/articles/cxvxrj8tvppo',
         smoke: true,
       },
-      frontPage: { path: '/igbo', smoke: true },
+      frontPage: { path: '/igbo', smoke: false },
       liveRadio: { path: undefined, smoke: false },
     },
   },
@@ -993,7 +993,7 @@ module.exports = {
       },
       frontPage: {
         path: '/thai',
-        smoke: false,
+        smoke: true,
       },
       liveRadio: { path: undefined, smoke: false },
     },


### PR DESCRIPTION
Resolves #3465

**Overall change:** Be more specific when selecting elements (this was failing for Thai since the text for `Accept` was also in the Heading text of the component, so Cypress was trying to click on the heading instead of the button).

**Code changes:**

- Change to use frontPage for Thai for smoke tests instead of Igbo (since Thai has more complexity in its page config than Igbo does)
- Change to run `specialFeatures/cookieBanner` tests for Thai instead of Persian as the example WS service
- Specifically find the button / link elements for the getCookieBannerAccept/Reject
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
