### PR TITLE
Replace react warnings with errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,8 +220,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-      "dev": true
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
     },
     "@babel/helper-regex": {
       "version": "7.5.5",
@@ -389,7 +388,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.2.0.tgz",
       "integrity": "sha512-adsydM8DQF4i5DLNO4ySAU5VtHTPewOtNBV3u7F4lNMPADFF9bWQ+iDtUUe8+033cYCUz+bFlQdXQJmJOwoLpw==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-throw-expressions": "^7.2.0"
@@ -482,7 +480,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.2.0.tgz",
       "integrity": "sha512-ngwynuqu1Rx0JUS9zxSDuPgW1K8TyVZCi2hHehrL4vyjqE7RGoNHWlZsS7KQT2vw9Yjk4YLa0+KldBXTRdPLRg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,7 +220,8 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.5.5",
@@ -388,6 +389,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.2.0.tgz",
       "integrity": "sha512-adsydM8DQF4i5DLNO4ySAU5VtHTPewOtNBV3u7F4lNMPADFF9bWQ+iDtUUe8+033cYCUz+bFlQdXQJmJOwoLpw==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-throw-expressions": "^7.2.0"
@@ -480,6 +482,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.2.0.tgz",
       "integrity": "sha512-ngwynuqu1Rx0JUS9zxSDuPgW1K8TyVZCi2hHehrL4vyjqE7RGoNHWlZsS7KQT2vw9Yjk4YLa0+KldBXTRdPLRg==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/src/testHelpers/setupTests.js
+++ b/src/testHelpers/setupTests.js
@@ -12,9 +12,6 @@ const REACT_ERRORS_REGEX = new RegExp(REACT_ERRORS.join('|'));
 
 const { error } = console;
 
-let reactErrorsCountPerTestSuite = 0;
-const reactErrorsLimitPerTestSuite = 6; // The goal is to have zero React errors per suite so keep fixing errors and lowering this limit
-
 const didSuppressWarning = message => {
   const { expectedWarnings } = window;
   if (expectedWarnings && Array.isArray(expectedWarnings)) {
@@ -36,18 +33,14 @@ console.error = (message, ...rest) => {
   if (didSuppressWarning(message)) return;
 
   if (REACT_ERRORS_REGEX.test(message)) {
-    reactErrorsCountPerTestSuite += 1;
-
-    if (reactErrorsCountPerTestSuite > reactErrorsLimitPerTestSuite) {
-      throw new Error(
-        [
-          chalk.red.bold(
-            'Test failed because too many React warnings were detected. Please fix the following:',
-          ),
-          chalk.red(message),
-        ].join('\n'),
-      );
-    }
+    throw new Error(
+      [
+        chalk.red.bold(
+          'Test failed because a React warning was detected. Please fix the following:',
+        ),
+        chalk.red(message),
+      ].join('\n'),
+    );
   }
 
   error(message, ...rest);


### PR DESCRIPTION
**Overall change:** _React warnings have been replaced with react errors._

**Code changes:**

- _Developers can't push their changes until react errors are resolved._
- _Unused variables have been removed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
