### PR TITLE
Hide cookie banner when ckns_explicit = 2

### DIFF
--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.js
@@ -6,6 +6,7 @@ const EXPLICIT_COOKIE = 'ckns_explicit';
 const POLICY_COOKIE = 'ckns_policy';
 const COOKIE_EXPIRY = 365;
 const COOKIE_BANNER_APPROVED = '1';
+const EXPLICIT_COOKIE_ACCEPTED_VALUES = ['1', '2'];
 const POLICY_APPROVED = '111';
 const POLICY_DENIED = '000';
 const PRIVACY_COOKIE_CURRENT = 'july2019';
@@ -28,7 +29,7 @@ const showPrivacyBanner = () => {
   );
 };
 const showCookieBanner = () =>
-  Cookie.get(EXPLICIT_COOKIE) !== COOKIE_BANNER_APPROVED;
+  !EXPLICIT_COOKIE_ACCEPTED_VALUES.includes(Cookie.get(EXPLICIT_COOKIE));
 const policyCookieSet = () => !!Cookie.get(POLICY_COOKIE);
 
 const setSeenPrivacyBanner = () =>

--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.test.js
@@ -127,15 +127,17 @@ describe('Consent Banner Utilities', () => {
       expect(setShowPrivacyBannerMock).toHaveBeenCalledWith(true);
     });
 
-    it('does not show the cookie banner when EXPLICIT_COOKIE is 1', () => {
-      setCookieGetMock({ explicit: '1' });
+    it('does not show the cookie banner when EXPLICIT_COOKIE is 1 or 2', () => {
+      ['1', '2'].forEach(value => {
+        setCookieGetMock({ explicit: value });
 
-      const { runInitial } = getConsentBannerUtilities();
+        const { runInitial } = getConsentBannerUtilities();
 
-      runInitial();
+        runInitial();
 
-      expect(Cookie.set).toHaveBeenCalledTimes(0);
-      expect(setShowCookieBannerMock).not.toHaveBeenCalled();
+        expect(Cookie.set).toHaveBeenCalledTimes(0);
+        expect(setShowCookieBannerMock).not.toHaveBeenCalled();
+      });
     });
 
     it('shows cookie banner when EXPLICIT_COOKIE is 0 and PRIVACY_COOKIE is set', () => {


### PR DESCRIPTION
Resolves #3477 

**Overall change:** _Update the cookie banner logic to hide it when `ckns_explicit` is set to `2`._

**Code changes:**

- _Update the cookie banner logic to hide it when `ckns_explicit` is set to `2`_
- _Update unit tests._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
