### PR TITLE
Add test e2e pipeline

### DIFF
--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -40,34 +40,13 @@ node {
           stage ('Install & Setup') {
             sh 'make install'
           }
-          stage ('Live E2Es') {
+          stage ('Test E2Es') {
             try {
-              sh 'make liveE2Es'
+              sh 'make testE2Es'
             } catch (Throwable e) {
               def messageParameters = [
                 buildStatus: 'Failed',
-                env: 'LIVE',
-                branch: env.BRANCH_NAME,
-                colour: 'danger',
-                emoji: '😱',
-              ]
-
-              if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters)
-                stageHasFailed = true
-              }
-
-              currentBuild.result = 'FAILURE'
-              throw e
-            }
-          }
-          stage ('Local Prod Tests') {
-            try {
-              sh 'CYPRESS_SMOKE=false npm run build && npm run test:ci;'
-            } catch (Throwable e) {
-              def messageParameters = [
-                buildStatus: 'Failed',
-                env: 'LOCAL',
+                env: 'TEST',
                 branch: env.BRANCH_NAME,
                 colour: 'danger',
                 emoji: '😱',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 

removes the test e2e stage from the e2e pipelines and moves it to its own pipeline, keeping all the same settings for now

**Code changes:**

- Creates a new pipeline for test e2e's

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
