### PR TITLE
Bump psammead-locales for Punjabi updated locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,9 +1231,9 @@
       }
     },
     "@bbc/psammead-locales": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.1.3.tgz",
-      "integrity": "sha512-uY3Ba/48GH7Rgi4jvZ/4IcavyJ1isBRPb3SaUJar17A7pbY8KCRaNKYQ8L2tw+O6fYzkllB8BcpnhyzLdNv3cA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.2.0.tgz",
+      "integrity": "sha512-AP8Jhfk28QOLBlrQzJvxXOe0FVyFK+o+Bivg3yY+yaL6Sz53qp8WC2JkNsdlEzychSYlqJUgCbgpIrwHO90E8w==",
       "requires": {
         "jalaali-js": "1.0.0",
         "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@bbc/psammead-image": "^1.2.2",
     "@bbc/psammead-image-placeholder": "^1.2.7",
     "@bbc/psammead-inline-link": "^1.3.5",
-    "@bbc/psammead-locales": "^2.1.3",
+    "@bbc/psammead-locales": "^2.2.0",
     "@bbc/psammead-media-indicator": "^2.5.6",
     "@bbc/psammead-media-player": "^1.0.1-alpha.3",
     "@bbc/psammead-navigation": "^2.2.8",

--- a/src/app/lib/config/services/punjabi.js
+++ b/src/app/lib/config/services/punjabi.js
@@ -1,7 +1,7 @@
 import { C_POSTBOX } from '@bbc/psammead-styles/colours';
 import { nepali } from '@bbc/gel-foundations/scripts';
 import { punjabi as brandSVG } from '@bbc/psammead-assets/svgs';
-import 'moment/locale/pa-in';
+import '@bbc/psammead-locales/moment/pa-in';
 import '@bbc/moment-timezone-include/tz/Asia/Kolkata';
 
 const service = {


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/1990

**Overall change:** Update `psammead-locales` to pull in updated locale which overrides Punjabi numerals

**Code changes:**

- Update `psammead-locales` version
- Update Punjabi config to use `psammead-locales` with the updated locale

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
