### PR TITLE
version bump for psammead-locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,9 +1231,9 @@
       }
     },
     "@bbc/psammead-locales": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.2.0.tgz",
-      "integrity": "sha512-AP8Jhfk28QOLBlrQzJvxXOe0FVyFK+o+Bivg3yY+yaL6Sz53qp8WC2JkNsdlEzychSYlqJUgCbgpIrwHO90E8w==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-2.2.3.tgz",
+      "integrity": "sha512-DnJpET/Nalcd8v3MjboTj7CBKw4+P6kr0tXcd69wamxlCqzsPNljRIuGpgWUFoCIUE2NfXjT3o3UAcrpBwViHw==",
       "requires": {
         "jalaali-js": "1.0.0",
         "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@bbc/psammead-image": "^1.2.2",
     "@bbc/psammead-image-placeholder": "^1.2.7",
     "@bbc/psammead-inline-link": "^1.3.5",
-    "@bbc/psammead-locales": "^2.2.0",
+    "@bbc/psammead-locales": "^2.2.3",
     "@bbc/psammead-media-indicator": "^2.5.6",
     "@bbc/psammead-media-player": "^1.0.1-alpha.3",
     "@bbc/psammead-navigation": "^2.2.8",


### PR DESCRIPTION
Related to https://github.com/bbc/psammead/pull/2048

**Overall change:** Bump `psammead-locales` version for bug fix.

**Code changes:**

- Updated package-lock to version 2.2.3

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
