### PR TITLE
[WIP] Chartbeat ping bug

### DIFF
--- a/src/app/containers/ChartbeatAnalytics/ChartbeatConfig/index.jsx
+++ b/src/app/containers/ChartbeatAnalytics/ChartbeatConfig/index.jsx
@@ -1,0 +1,65 @@
+import { useContext } from 'react';
+import { ServiceContext } from '../../../contexts/ServiceContext';
+import { RequestContext } from '../../../contexts/RequestContext';
+import { getReferrer } from '../../../lib/analyticsUtils';
+import onClient from '../../../lib/utilities/onClient';
+import {
+  chartbeatUID,
+  useCanonical,
+  getSylphidCookie,
+  getDomain,
+  buildSections,
+  getType,
+  getTitle,
+} from '../../../lib/analyticsUtils/chartbeat';
+
+const generateConfig = values => {
+  const {
+    data,
+    service,
+    brandName,
+    env,
+    platform,
+    pageType,
+    previousPath,
+    origin,
+  } = values;
+  const referrer = getReferrer(platform, origin, previousPath);
+  const title = getTitle(pageType, data, brandName);
+  const domain = env !== 'live' ? getDomain('test') : getDomain(service);
+  const sections = buildSections(service, pageType);
+  const cookie = getSylphidCookie();
+  const type = getType(pageType);
+  const isAmp = platform === 'amp';
+  const currentPath = onClient() && window.location.pathname;
+
+  return {
+    domain,
+    sections,
+    uid: chartbeatUID,
+    title,
+    virtualReferrer: referrer,
+    ...(isAmp && { contentType: type }),
+    ...(!isAmp && { type, useCanonical, path: currentPath }),
+    ...(cookie && { idSync: { bbc_hid: cookie } }),
+  };
+};
+
+const ChartbeatConfig = data => {
+  const { service, brandName } = useContext(ServiceContext);
+  const { env, platform, pageType, previousPath, origin } = useContext(
+    RequestContext,
+  );
+  return generateConfig({
+    data,
+    service,
+    brandName,
+    env,
+    platform,
+    pageType,
+    previousPath,
+    origin,
+  });
+};
+
+export default ChartbeatConfig;

--- a/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
+++ b/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
@@ -15,6 +15,9 @@ const CanonicalChartbeatBeacon = ({ chartbeatConfig, chartbeatSource }) => {
     });
   }, [title, path, virtualReferrer]);
 
+  const hasChartbeatScriptLoaded =
+    typeof window !== 'undefined' && window.pSUPERFLY;
+
   return (
     <Helmet>
       <script async type="text/javascript">
@@ -28,7 +31,9 @@ const CanonicalChartbeatBeacon = ({ chartbeatConfig, chartbeatSource }) => {
         })();
       `}
       </script>
-      <script async type="text/javascript" src={chartbeatSource} />
+      {!hasChartbeatScriptLoaded && (
+        <script async type="text/javascript" src={chartbeatSource} />
+      )}
     </Helmet>
   );
 };

--- a/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
+++ b/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
@@ -1,19 +1,19 @@
 import React, { useEffect } from 'react';
 import { string, shape, number, bool, oneOf, oneOfType } from 'prop-types';
 import Helmet from 'react-helmet';
+import { trackPage } from '../../../lib/analyticsUtils/chartbeat';
 
 const CanonicalChartbeatBeacon = ({ chartbeatConfig, chartbeatSource }) => {
+  const { path, title, virtualReferrer } = chartbeatConfig;
+  console.log('chartbeatConfig', chartbeatConfig);
+
   useEffect(() => {
-    return () => {
-      if (typeof window !== 'undefined' && window.pSUPERFLY) {
-        /*
-          This function is always called to update config values on page changes
-          https://chartbeat.zendesk.com/hc/en-us/articles/210271287-Handling-virtual-page-changes
-        */
-        window.pSUPERFLY.virtualPage(chartbeatConfig);
-      }
-    };
-  }, [chartbeatConfig]);
+    trackPage({
+      title,
+      path,
+      virtualReferrer,
+    });
+  }, [title, path, virtualReferrer]);
 
   return (
     <Helmet>
@@ -23,7 +23,7 @@ const CanonicalChartbeatBeacon = ({ chartbeatConfig, chartbeatSource }) => {
           var _sf_async_config = window._sf_async_config = (window._sf_async_config || {});
           var config = ${JSON.stringify(chartbeatConfig)};
           for (var key in config) {
-            _sf_async_config[key] = config[key];
+              _sf_async_config[key] = config[key];
           }
         })();
       `}
@@ -39,6 +39,7 @@ CanonicalChartbeatBeacon.propTypes = {
     sections: string.isRequired,
     uid: number.isRequired,
     title: string.isRequired,
+    path: string.isRequired,
     type: string.isRequired,
     useCanonical: bool.isRequired,
     virtualReferrer: oneOfType([string, oneOf([null])]),

--- a/src/app/lib/analyticsUtils/chartbeat/index.js
+++ b/src/app/lib/analyticsUtils/chartbeat/index.js
@@ -65,3 +65,20 @@ export const getTitle = (pageType, pageData, brandName) => {
       return null;
   }
 };
+
+export const trackPage = values => {
+  if (typeof window !== 'undefined' && window.pSUPERFLY) {
+    // eslint-disable-next-line no-underscore-dangle
+    const currentConfig = window._sf_async_config;
+    const shouldUpdate = currentConfig.path !== values.path;
+    if (shouldUpdate) {
+      console.log('tracking page');
+      console.log('values', values);
+      /*
+        This function is always called to update config values on page changes
+        https://chartbeat.zendesk.com/hc/en-us/articles/210271287-Handling-virtual-page-changes
+      */
+      window.pSUPERFLY.virtualPage(values);
+    }
+  }
+};


### PR DESCRIPTION
Resolves #3369

**Overall change:** Adds an `isLoading` state to render chartbeat just once

*Code changes:*

- add config generator
- add flag to restrict fetching of `chartbeat.js`
- add an `isLoading` state to render chartbeat once

*To Test:*
- Go to http://localhost:7080/news/articles/c6v11qzyv8po
- Click the inline link to http://localhost:7080/news/articles/c0g992jmmkko
- See that the chartbeat beacons sent has the appropriate `p` and `v` values in the network tab, check the 't' value to make sure it's consistent across pings.
- log the value of `window._sf_async_config` to ensure that it's consistent with config values
- Test for amp pages as well



- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
