### PR TITLE
Add Related Content to service configs

### DIFF
--- a/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
@@ -421,6 +421,7 @@ exports[`FrontPageMain snapshots should render a pidgin frontpage correctly 1`] 
             "photogallery": "Image gallery",
             "video": "Vidio",
           },
+          "relatedContent": "Related content",
           "seeAll": "Lee ha niile",
           "skipLinkText": "Wụga n’ọdịnaya",
         },

--- a/src/app/containers/StoryPromo/IndexAlsos/index.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.jsx
@@ -41,14 +41,14 @@ const buildIndexAlsosMediaIndicator = (cpsType, mediaType, service) => {
  */
 const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
   const {
-    translations: { media: mediaTranslations },
+    translations: { media: mediaTranslations, relatedContent },
   } = useContext(ServiceContext);
 
   const IndexAlsosWrapper = alsoItems.length > 1 ? IndexAlsosUl : Fragment;
   const IndexAlsoItem = alsoItems.length > 1 ? IndexAlsosLi : IndexAlso;
 
   return (
-    <IndexAlsos offScreenText="Related content">
+    <IndexAlsos offScreenText={relatedContent}>
       <IndexAlsosWrapper>
         {alsoItems.slice(0, MAX_NUM_INDEX_ALSOS).map(item => {
           const { id, cpsType, mediaType } = item;

--- a/src/app/lib/config/services/afaanoromoo.js
+++ b/src/app/lib/config/services/afaanoromoo.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Oduu',
     currentPage: 'Current page',
     skipLinkText: 'Qabiyyeetti darbi',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/afrique.js
+++ b/src/app/lib/config/services/afrique.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Accueil',
     currentPage: 'Current page',
     skipLinkText: 'Aller au contenu',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/amharic.js
+++ b/src/app/lib/config/services/amharic.js
@@ -41,6 +41,7 @@ const service = {
     home: 'ዜና',
     currentPage: 'Current page',
     skipLinkText: 'ወደ ዋናው ይዘት ይለፉ',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -43,6 +43,7 @@ const service = {
     home: 'رئيسية',
     currentPage: 'Current page',
     skipLinkText: 'إذهب الى المحتوى',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/azeri.js
+++ b/src/app/lib/config/services/azeri.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Xəbərlər',
     currentPage: 'Hazırda olduğunuz səhifə',
     skipLinkText: 'Mətnə keçid',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/bengali.js
+++ b/src/app/lib/config/services/bengali.js
@@ -43,6 +43,7 @@ const service = {
     home: 'মূলপাতা',
     currentPage: 'Current page',
     skipLinkText: 'সরাসরি কনটেন্টে যান',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -40,6 +40,7 @@ const service = {
     home: 'ပင်မစာမျက်နှာ',
     currentPage: 'Current page',
     skipLinkText: 'အကြောင်းအရာများဆီ ကျော်သွားပါ',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/cymrufyw.js
+++ b/src/app/lib/config/services/cymrufyw.js
@@ -39,6 +39,7 @@ const service = {
     home: 'Hafan',
     currentPage: 'Current page',
     skipLinkText: `Neidio i'r cynnwys`,
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/gahuza.js
+++ b/src/app/lib/config/services/gahuza.js
@@ -38,6 +38,7 @@ const service = {
     home: `Urupapuro rw'itangiriro`,
     currentPage: 'Current page',
     skipLinkText: 'Simbira ku birimwo',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/gujarati.js
+++ b/src/app/lib/config/services/gujarati.js
@@ -38,6 +38,7 @@ const service = {
     home: 'સમાચાર',
     currentPage: 'Current page',
     skipLinkText: 'સામગ્રી પર જાઓ',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/hausa.js
+++ b/src/app/lib/config/services/hausa.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Labaran Duniya',
     currentPage: 'Current page',
     skipLinkText: 'Tsallaka zuwa abubuwan da ke ciki',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/hindi.js
+++ b/src/app/lib/config/services/hindi.js
@@ -39,6 +39,7 @@ const service = {
     home: 'होम पेज',
     currentPage: 'Current page',
     skipLinkText: 'सामग्री को स्किप करें',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/igbo.js
+++ b/src/app/lib/config/services/igbo.js
@@ -38,6 +38,7 @@ const igbo = {
     home: 'Akụkọ',
     currentPage: 'Peegi ị nọ ugbua',
     skipLinkText: 'Wụga n’ọdịnaya',
+    relatedContent: 'Related content',
     error: {
       home: 'Akụkọ',
       currentPage: 'Current page',

--- a/src/app/lib/config/services/indonesia.js
+++ b/src/app/lib/config/services/indonesia.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Berita',
     currentPage: 'Current page',
     skipLinkText: 'Langsung ke konten',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -39,6 +39,7 @@ const service = {
     home: 'ホーム',
     currentPage: 'Current page',
     skipLinkText: 'コンテンツへ移動',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/korean.js
+++ b/src/app/lib/config/services/korean.js
@@ -38,6 +38,7 @@ const service = {
     home: '뉴스',
     currentPage: 'Current page',
     skipLinkText: '내용으로 건너뛰기',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/kyrgyz.js
+++ b/src/app/lib/config/services/kyrgyz.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Башталгыч бет',
     currentPage: 'Current page',
     skipLinkText: 'Сайтка өтүү',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/marathi.js
+++ b/src/app/lib/config/services/marathi.js
@@ -38,6 +38,7 @@ const service = {
     home: 'बातम्या',
     currentPage: 'Current page',
     skipLinkText: 'सामग्रीवर जा',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Noticias',
     currentPage: 'Current page',
     skipLinkText: 'Ir al contenido',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/naidheachdan.js
+++ b/src/app/lib/config/services/naidheachdan.js
@@ -39,6 +39,7 @@ const service = {
     home: 'Alba',
     currentPage: 'Current page',
     skipLinkText: 'Air adhart',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/nepali.js
+++ b/src/app/lib/config/services/nepali.js
@@ -39,6 +39,7 @@ const service = {
     home: 'मुख पृष्ठ',
     currentPage: 'Current page',
     skipLinkText: 'यो सामग्री स्कीप गर्नुहोस्',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/news.js
+++ b/src/app/lib/config/services/news.js
@@ -47,6 +47,7 @@ const news = {
     home: 'Home',
     currentPage: 'Current page',
     skipLinkText: 'Skip to content',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/pashto.js
+++ b/src/app/lib/config/services/pashto.js
@@ -43,6 +43,7 @@ const service = {
     home: 'کور پاڼه',
     currentPage: 'Current page',
     skipLinkText: 'مطلب ته ورشئ',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '۴۰۴',

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -44,6 +44,7 @@ const persian = {
     home: 'صفحه اول',
     currentPage: 'Current page',
     skipLinkText: 'مشاهده محتوا',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '۴۰۴',

--- a/src/app/lib/config/services/pidgin.js
+++ b/src/app/lib/config/services/pidgin.js
@@ -38,6 +38,7 @@ const pidgin = {
     home: 'Home',
     currentPage: 'Page where you dey',
     skipLinkText: 'Waka go wetin de inside',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Notícias',
     currentPage: 'Current page',
     skipLinkText: 'Ir para o conteúdo',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/punjabi.js
+++ b/src/app/lib/config/services/punjabi.js
@@ -39,6 +39,7 @@ const service = {
     home: 'ਖ਼ਬਰਾਂ',
     currentPage: 'ਮੌਜੂਦਾ ਪੇਜ',
     skipLinkText: `ਸਮੱਗਰੀ 'ਤੇ ਜਾਓ`,
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Главная',
     currentPage: 'Current page',
     skipLinkText: 'Перейти к содержанию',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/serbian.js
+++ b/src/app/lib/config/services/serbian.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Home',
     currentPage: 'Current page',
     skipLinkText: 'Skip to content',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/sinhala.js
+++ b/src/app/lib/config/services/sinhala.js
@@ -42,6 +42,7 @@ const service = {
     home: 'මුල් පිටුව',
     currentPage: 'Current page',
     skipLinkText: 'අන්තර්ගතයට පිවිසෙන්න',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/somali.js
+++ b/src/app/lib/config/services/somali.js
@@ -38,6 +38,7 @@ const service = {
     home: 'War',
     currentPage: 'Current page',
     skipLinkText: 'U gudub qaybta macluumaadka',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/swahili.js
+++ b/src/app/lib/config/services/swahili.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Habari',
     currentPage: 'Ukurasa uliopo',
     skipLinkText: 'Ruka hadi maelezo',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/tamil.js
+++ b/src/app/lib/config/services/tamil.js
@@ -39,6 +39,7 @@ const service = {
     home: 'முகப்பு',
     currentPage: 'Current page',
     skipLinkText: 'உள்ளடக்கத்துக்குத் தாண்டிச் செல்க',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/telugu.js
+++ b/src/app/lib/config/services/telugu.js
@@ -39,6 +39,7 @@ const service = {
     home: 'వార్తలు',
     currentPage: 'Current page',
     skipLinkText: 'కంటెంట్‌కు దాటవేయండి',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/thai.js
+++ b/src/app/lib/config/services/thai.js
@@ -37,10 +37,11 @@ const service = {
   swPath: '/sw.js',
   frontPageTitle: 'ข่าว ข่าววันนี้ ข่าวล่าสุด วีดีโอ',
   translations: {
+    seeAll: 'ดูทั้งหมด',
     home: 'หน้าแรก',
     currentPage: 'หน้าปัจจุบัน',
     skipLinkText: 'ข้ามไปยังเนื้อหา',
-    seeAll: 'ดูทั้งหมด',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/tigrinya.js
+++ b/src/app/lib/config/services/tigrinya.js
@@ -42,6 +42,7 @@ const service = {
     home: 'ዜና',
     currentPage: 'Current page',
     skipLinkText: 'እቲ ትሕዝቶ ዝለል',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Haberler',
     currentPage: 'Current page',
     skipLinkText: 'Siteye gir',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/ukchina.js
+++ b/src/app/lib/config/services/ukchina.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Home',
     currentPage: 'Current page',
     skipLinkText: 'Skip to content',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/ukrainian.js
+++ b/src/app/lib/config/services/ukrainian.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Головна',
     currentPage: 'Current page',
     skipLinkText: 'Перейти до змісту',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/urdu.js
+++ b/src/app/lib/config/services/urdu.js
@@ -45,6 +45,7 @@ const service = {
     home: 'صفحۂ اول',
     currentPage: 'Current page',
     skipLinkText: 'مواد پر جائیں',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/uzbek.js
+++ b/src/app/lib/config/services/uzbek.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Бош саҳифа',
     currentPage: 'Current page',
     skipLinkText: 'Саҳифага ўтиш',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/vietnamese.js
+++ b/src/app/lib/config/services/vietnamese.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Tin chính',
     currentPage: 'Current page',
     skipLinkText: 'Bỏ qua để xem nội dung',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/yoruba.js
+++ b/src/app/lib/config/services/yoruba.js
@@ -34,10 +34,11 @@ const yoruba = {
   twitterCreator: '@BBCNews', // to be updated
   twitterSite: '@BBCNews', // to be updated
   translations: {
+    seeAll: 'Wo gbogbo ẹ̀',
     home: 'Ìròyìn',
     currentPage: 'Ojú ewé to wà yìí',
     skipLinkText: 'Fò kọjá sí nnkan tí ó wà nínú rẹ̀',
-    seeAll: 'Wo gbogbo ẹ̀',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',

--- a/src/app/lib/config/services/zhongwen.js
+++ b/src/app/lib/config/services/zhongwen.js
@@ -38,6 +38,7 @@ const service = {
     home: 'Home',
     currentPage: 'Current page',
     skipLinkText: 'Skip to content',
+    relatedContent: 'Related content',
     error: {
       404: {
         statusCode: '404',


### PR DESCRIPTION
Resolves #3612

**Overall change:** 
Add the `Related content` string to each service config, so it is no longer hardcoded in the Index Alsos.

**Code changes:**

- Add `relatedContent` key to the service configs in **English**
- Update the Index Alsos to use the value coming from config
- Update snapshot

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [X] This PR requires manual testing
