### PR TITLE
Thai frontpage timestamps Cypress fix

### DIFF
--- a/cypress/integration/pages/frontPage/tests.js
+++ b/cypress/integration/pages/frontPage/tests.js
@@ -24,7 +24,9 @@ export const testsThatAlwaysRun = ({ service, pageType }) => {
             cy.get('section')
               .eq(0)
               .within(() => {
-                cy.get('time').should('contain', formattedTimestamp);
+                cy.get('time')
+                  .eq(0)
+                  .should('contain', formattedTimestamp);
               });
           },
         );


### PR DESCRIPTION
The front page timestamp test added in https://github.com/bbc/simorgh/pull/3562 was selecting multiple time elements (one for each story) and causing test failures of the form

```
CypressError: Timed out retrying: expected '[ <time.StyledTimestamp-um718p-0.eKyewn>, 11 more... ]' to contain '10 กันยายน 2019'
```

<img width="425" alt="Screenshot 2019-09-10 at 08 39 10" src="https://user-images.githubusercontent.com/11161809/64593754-828fba00-d3a6-11e9-8228-1300148862f3.png">


**Code changes:**

- Only look at first `time` element within Top Stories section

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] This PR requires manual testing
