### PR TITLE
Removing Persian from serviceHasTimestamp config

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -28,7 +28,7 @@ const serviceHasCaption = service => service === 'news';
 const serviceHasCorrectlyRenderedParagraphs = service => service !== 'sinhala';
 
 const serviceHasTimestamp = service =>
-  ['news', 'urdu', 'persian'].includes(service);
+  ['news', 'urdu'].includes(service);
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -27,8 +27,7 @@ const serviceHasCaption = service => service === 'news';
 // TODO: Remove after https://github.com/bbc/simorgh/issues/2962
 const serviceHasCorrectlyRenderedParagraphs = service => service !== 'sinhala';
 
-const serviceHasTimestamp = service =>
-  ['news', 'urdu'].includes(service);
+const serviceHasTimestamp = service => ['news', 'urdu'].includes(service);
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.


### PR DESCRIPTION
**Overall change:** _Removing `Persian` from `serviceHasTimestamp` config due to failing test._

**Code changes:**

- _Removing `Persian` from `serviceHasTimestamp` config due to failing test._
- _Will reinstate once cause of failure has been isolated._

---

