### PR TITLE
Updating story promo and snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1455,12 +1455,12 @@
       }
     },
     "@bbc/psammead-story-promo": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-2.7.8.tgz",
-      "integrity": "sha512-73PSzWz5I0AGoaoyPDoG+9wuFMmNGAVx1Q12tyePTaDc2hbz2S6OHmMwEHQ4/UysvWyV6Y21Wnev9U/moK/90A==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo/-/psammead-story-promo-2.7.10.tgz",
+      "integrity": "sha512-QNfFksMMPtLwgC20L4V97l2vcOgq+pYNBQNUll4xellecT3V990YjoG23KX8S5fZBhRjvOvhV7ezu++Fltqq7w==",
       "requires": {
         "@bbc/gel-foundations": "^3.3.3",
-        "@bbc/psammead-styles": "^2.1.3"
+        "@bbc/psammead-styles": "^2.1.4"
       }
     },
     "@bbc/psammead-story-promo-list": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@bbc/psammead-paragraph": "^2.2.7",
     "@bbc/psammead-section-label": "^2.3.11",
     "@bbc/psammead-sitewide-links": "^3.1.6",
-    "@bbc/psammead-story-promo": "^2.7.8",
+    "@bbc/psammead-story-promo": "^2.7.10",
     "@bbc/psammead-story-promo-list": "^2.1.8",
     "@bbc/psammead-styles": "^2.1.4",
     "@bbc/psammead-timestamp-container": "^2.4.11",

--- a/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -2249,7 +2249,7 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
   }
 }
 
-@media (max-width:62.9375rem) {
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
   .c8 {
     display: none;
     visibility: hidden;


### PR DESCRIPTION
**Overall change:** 
Pulls in latest version of story promo to enable the summary to display in the mobile breakpoint https://github.com/bbc/psammead/pull/2040
 
As per Zeplin documentation:
0-599 has summary
600-1007 hide summary [due to height of component]
1008+ has summary

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
