### PR TITLE
Jenkins Cron job - Run Live E2Es and Local tests in parallel

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -47,48 +47,50 @@ node {
           stage ('Install & Setup') {
             sh 'make install'
           }
-          stage ('Live E2Es') {
-            try {
-              sh 'make liveE2Es'
-            } catch (Throwable e) {
-              def messageParameters = [
-                buildStatus: 'Failed',
-                env: 'LIVE',
-                branch: env.BRANCH_NAME,
-                colour: 'danger',
-                emoji: '😱',
-              ]
+          parallel {
+            stage ('Live E2Es') {
+              try {
+                sh 'make liveE2Es'
+              } catch (Throwable e) {
+                def messageParameters = [
+                  buildStatus: 'Failed',
+                  env: 'LIVE',
+                  branch: env.BRANCH_NAME,
+                  colour: 'danger',
+                  emoji: '😱',
+                ]
 
-              if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters, channels.simorgh)
-                notifySlack(messageParameters, channels.liveAlarms)
-                stageHasFailed = true
+                if (env.BRANCH_NAME == 'latest') {
+                  notifySlack(messageParameters, channels.simorgh)
+                  notifySlack(messageParameters, channels.liveAlarms)
+                  stageHasFailed = true
+                }
+
+                currentBuild.result = 'FAILURE'
+                throw e
               }
-
-              currentBuild.result = 'FAILURE'
-              throw e
             }
-          }
-          stage ('Local Prod Tests') {
-            try {
-              sh 'CYPRESS_SMOKE=false npm run build && npm run test:ci;'
-            } catch (Throwable e) {
-              def messageParameters = [
-                buildStatus: 'Failed',
-                env: 'LOCAL',
-                branch: env.BRANCH_NAME,
-                colour: 'danger',
-                emoji: '😱',
-              ]
+            stage ('Local Prod Tests') {
+              try {
+                sh 'CYPRESS_SMOKE=false npm run build && npm run test:ci;'
+              } catch (Throwable e) {
+                def messageParameters = [
+                  buildStatus: 'Failed',
+                  env: 'LOCAL',
+                  branch: env.BRANCH_NAME,
+                  colour: 'danger',
+                  emoji: '😱',
+                ]
 
-              if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters, channels.simorgh)
-                notifySlack(messageParameters, channels.liveAlarms)
-                stageHasFailed = true
+                if (env.BRANCH_NAME == 'latest') {
+                  notifySlack(messageParameters, channels.simorgh)
+                  notifySlack(messageParameters, channels.liveAlarms)
+                  stageHasFailed = true
+                }
+
+                currentBuild.result = 'FAILURE'
+                throw e
               }
-
-              currentBuild.result = 'FAILURE'
-              throw e
             }
           }
         } catch (Throwable e) {

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -43,6 +43,9 @@ node {
       cleanWs() // Clean the workspace
       checkout scm // Checkout from git
       docker.image("${nodeImage}").inside('--ipc host') {
+        parameters {
+          string(name: 'APPLICATION_BRANCH', defaultValue: 'latest', description: 'Which simorgh branch do you want to build?')
+        }
         try {
           stage ('Install & Setup') {
             sh 'make install'


### PR DESCRIPTION
No ticket

**Overall change:** Ensures that E2E test stages run on the Cron job are run in parallel

**Before**: Install & Setup, Live E2Es, Local Prod Tests

<img width="487" alt="Screenshot of stages" src="https://user-images.githubusercontent.com/3028997/64743564-600db600-d4f8-11e9-883d-0c767ac46e2a.png">

**After**: Live E2Es & Local Prod Tests run in parallel:

< image to be added>

**Code changes:**

- Moves two stages into a `parallel` block 


**Testing notes**

- TBC


---

- [x] I have assigned myself to this PR and the corresponding issues
- ~[ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~ N/A
- [x] This PR requires manual testing
