### PR TITLE
STY POC - Cps images

### DIFF
--- a/src/app/containers/MediaPageMain/blocks/image.jsx
+++ b/src/app/containers/MediaPageMain/blocks/image.jsx
@@ -7,6 +7,6 @@ const ImageContainer = ({ uuid, path, height, width }) => {
     return (
         <StoryPromoImage key={uuid} topStory="false" imageValues={imageValues} lazyLoad="true"/>
     )
-    };
+};
 
 export default HeadingContainer;

--- a/src/app/containers/MediaPageMain/blocks/image.jsx
+++ b/src/app/containers/MediaPageMain/blocks/image.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StoryPromoImage } from '../../StoryPromo/index.jsx'
 
 // eslint-disable-next-line react/prop-types
-const HeadingContainer = ({ uuid, path, height, width }) => {
+const ImageContainer = ({ uuid, path, height, width }) => {
     const imageValues = {height, width, path}
     return (
         <StoryPromoImage key={uuid} topStory="false" imageValues={imageValues} lazyLoad="true"/>

--- a/src/app/containers/MediaPageMain/blocks/image.jsx
+++ b/src/app/containers/MediaPageMain/blocks/image.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StoryPromoImage } from '../../StoryPromo/index.jsx'
+
+// eslint-disable-next-line react/prop-types
+const HeadingContainer = ({ uuid, path, height, width }) => {
+    const imageValues = {height, width, path}
+    return (
+        <StoryPromoImage key={uuid} topStory="false" imageValues={imageValues} lazyLoad="true"/>
+    )
+    };
+
+export default HeadingContainer;

--- a/src/app/containers/MediaPageMain/index.jsx
+++ b/src/app/containers/MediaPageMain/index.jsx
@@ -9,11 +9,13 @@ import { ServiceContext } from '../../contexts/ServiceContext';
 import HeadingBlock from './blocks/heading';
 import LiveRadioBlock from './blocks/liveradio';
 import ParagraphBlock from './blocks/paragraph';
+import Image from './blocks/image'
 
 const blockMap = {
   heading: HeadingBlock,
   paragraph: ParagraphBlock,
   liveradio: LiveRadioBlock,
+  image: Image,
 };
 
 const LIVE_RADIO_BLOCK = 'liveradio';

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -194,4 +194,4 @@ StoryPromo.defaultProps = {
   topStory: false,
 };
 
-export default StoryPromo;
+export {StoryPromo, StoryPromoImage};


### PR DESCRIPTION
**Overall change:** 

Creates a new images block in mediaContainer.

Imports and uses the story promo image for now as the main image container is tightly coupled with optimo blocks

![image](https://user-images.githubusercontent.com/14273378/64853191-cedf3200-d612-11e9-9563-81fd81c00f4c.png)