### PR TITLE
Allow dirAlias.js to be used on jenkins

### DIFF
--- a/scripts/jenkinsProductionFiles.sh
+++ b/scripts/jenkinsProductionFiles.sh
@@ -32,6 +32,7 @@ cp Jenkinsfile ./pack
 cp Makefile ./pack
 cp a11y.js ./pack
 cp excludeFromPublicBuild.txt ./pack
+cp dirAlias.js ./pack
 
 # Copy the webpack configs
 cp webpack.config.js ./pack


### PR DESCRIPTION
**Overall change:** Allow dirAlias.js to be used on jenkins
**Code changes:**

- Add `dirAlias.js` to the prod files whitelist

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
