### PR TITLE
Use psammead test helper snapshots for front page and media page

### DIFF
--- a/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
@@ -1,1744 +1,3566 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FrontPageMain snapshots should render a pidgin frontpage correctly 1`] = `
-<RequestContextProvider
-  bbcOrigin={null}
-  id={null}
-  isAmp={false}
-  pageType="frontPage"
-  pathname="/pathname"
-  previousPath={null}
-  service="igbo"
-  statusCode={200}
-  variant={null}
+.c0 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c1 {
+  margin: 0 auto;
+  padding-bottom: 2rem;
+}
+
+.c2 {
+  margin-top: 0.5rem;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c41 {
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c41:focus,
+.c41:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c42 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c8 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c43 {
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  margin: 1rem 0;
+  color: #222222;
+  background-color: #FFFFFF;
+  white-space: nowrap;
+  padding-left: 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c3 {
+  position: relative;
+  margin-top: 2rem;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+.c38 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+}
+
+.c11 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c11:first-child {
+  padding-top: 0;
+}
+
+.c11:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c10 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c13 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.c29 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c14 {
+  position: relative;
+}
+
+.c17 {
+  position: absolute;
+  bottom: 0;
+}
+
+.c19 {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c36 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c22 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c37 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.c35 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c20 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c20:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c20:hover,
+.c20:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c20:visited {
+  color: #6E6E73;
+}
+
+.c21 {
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #B80000;
+  display: inline-block;
+  margin-right: 0.5rem;
+}
+
+.c23 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c15 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c40 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.22895622895623%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c16 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.c44 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.c33 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c45 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c31 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c32 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c34 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c24 {
+  position: relative;
+  z-index: 2;
+  padding: 1rem 0 0;
+}
+
+.c26 {
+  border-top: 1px solid #F2F2F2;
+  padding: 0.5rem 0;
+}
+
+.c25 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.c28 {
+  display: inline;
+  vertical-align: middle;
+}
+
+.c27 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c27:hover,
+.c27:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c27:visited {
+  color: #6E6E73;
+}
+
+.c39 {
+  margin-top: 0.5rem;
+}
+
+@media (max-width:37.4375rem) {
+  .c1 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c1 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c1 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c1 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (max-width:63rem) {
+  .c2 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c2 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c2 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c2 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c2 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c2 {
+    margin-top: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c42 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c8 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    padding-right: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c43 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c43 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c43 {
+    margin: 0;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c4 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c38 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c11 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c11:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c11:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c12 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c13 {
+    width: 50%;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:80rem) {
+  .c13 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c13 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c29 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c29 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c30 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 1.375rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c36 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c36 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c36 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c22 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c22 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c22 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c37 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c37 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c37 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    width: 50%;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c18 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c18 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c35 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c35 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c35 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c23 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c23 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c31 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c27 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c27 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    margin-top: 0.5rem;
+  }
+}
+
+<html
+  dir="ltr"
+  lang="pcm"
 >
-  <ServiceContextProvider
-    service="igbo"
-    variant="default"
-  >
-    <FrontPageMain
-      frontPageData={
-        Object {
-          "content": Object {
-            "groups": Array [
-              Object {
-                "items": Array [
-                  Object {
-                    "commentary": Object {
-                      "assetUUID": "A8F17B8D05CD9549B2905B8C4E2C5019",
-                      "channels": Object {
-                        "desktop": "bbc.cps.asset.48591365_HighWeb",
-                        "enhancedmobile": "bbc.cps.asset.48591365_EnhancedMobile",
-                        "highweb": "bbc.cps.asset.48591365_HighWeb",
-                        "mobile": "bbc.cps.asset.48591365_EnhancedMobile",
-                      },
-                      "order": "descending",
-                    },
-                    "cpsType": "LIV",
-                    "headlines": Object {
-                      "headline": "Senators don begin vote for Senate President",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/live/tori-48591362",
-                    "imageThumbnail": Object {
-                      "altText": "Senator Ahmad Lawan and Ali Ndume",
-                      "caption": "Senator Ahmad Lawan and Senator Ali Ndume dey contest to become di senate president",
-                      "copyrightHolder": "Other",
-                      "height": 180,
-                      "href": "http://c.files.bbci.co.uk/9D00/production/_107329104_ninthnationalassemblypidgin_senate_reps_1080.jpg",
-                      "id": "107329104",
-                      "path": "/cpsprodpb/9D00/production/_107329104_ninthnationalassemblypidgin_senate_reps_1080.jpg",
-                      "subType": "index-thumbnail",
-                      "width": 320,
-                    },
-                    "indexImage": Object {
-                      "altText": "Senator Ahmad Lawan and Ali Ndume",
-                      "caption": "Senator Ahmad Lawan and Senator Ali Ndume dey contest to become di senate president",
-                      "copyrightHolder": "Other",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg",
-                      "id": "107328539",
-                      "path": "/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "isLive": true,
-                    "locators": Object {
-                      "assetUri": "/pidgin/live/tori-48591362",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/live/tori-48591362",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "prominence": "standard",
-                    "relatedItems": Array [
-                      Object {
-                        "cpsType": "STY",
-                        "headlines": Object {
-                          "headline": "Who go lead di Ninth National Assembly?",
-                        },
-                        "id": "urn:bbc:ares::asset:pidgin/tori-48591361",
-                        "locators": Object {
-                          "assetUri": "/pidgin/tori-48591361",
-                          "cpsUrn": "urn:bbc:content:assetUri:/pidgin/tori-48591361",
-                        },
-                        "summary": "Nigeria go do inauguration to welcome im tear rubber lawmakers into di Ninth Assembly.",
-                        "timestamp": 1560229039000,
-                        "type": "cps",
-                      },
-                      Object {
-                        "cpsType": "STY",
-                        "headlines": Object {
-                          "headline": "4 tins wey go determine who become di next Senate President, Speaker",
-                        },
-                        "id": "urn:bbc:ares::asset:pidgin/tori-47603701",
-                        "locators": Object {
-                          "assetUri": "/pidgin/tori-47603701",
-                          "cpsUrn": "urn:bbc:content:assetUri:/pidgin/tori-47603701",
-                        },
-                        "summary": "Efritin don set for di battle for di leadership battle of di kontri National Assembly during dia 9th assembly.",
-                        "timestamp": 1552922728000,
-                        "type": "cps",
-                      },
-                    ],
-                    "summary": "Nigeria dey do inauguration to welcome im tear rubber lawmakers into di Ninth National Assembly.",
-                    "timestamp": 1560234412000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "BBC Pidgin Minute",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/media-44221514",
-                    "indexImage": Object {
-                      "altText": "BBC Pidgin Minute",
-                      "copyrightHolder": "BBC",
-                      "height": 576,
-                      "href": "http://c.files.bbci.co.uk/4F7F/production/_107315302_p07cr6sy.jpg",
-                      "id": "107315302",
-                      "path": "/cpsprodpb/4F7F/production/_107315302_p07cr6sy.jpg",
-                      "subType": "index",
-                      "width": 1024,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/media-44221514",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/media-44221514",
-                    },
-                    "media": Object {
-                      "advertising": false,
-                      "caption": "BBC Pidgin Minute",
-                      "embedding": false,
-                      "format": "audio",
-                      "id": "p07ct6cd",
-                      "imageCopyright": "BBC",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07ct6pt.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "medium": "All di local and world tori wey you suppose know in 60 seconds!",
-                        "short": "BBC Pidgin Minute",
-                      },
-                      "title": "BBC Pidgin Minute",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1560243610,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "availableUntil": 1560330010,
-                          "duration": 59,
-                          "durationISO8601": "PT59S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07ct6cg",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e2939461b000e9dabf8",
-                          "campaignName": "WS - Educate me",
-                        },
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "prominence": "standard",
-                    "summary": "All di local and world tori wey you suppose know in 60 seconds!",
-                    "timestamp": 1560244488000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Majid Waris no get ‘sɛlɛ’ for Coach Kwesi Appiah en Black Stars Afcon squad",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48591366",
-                    "indexImage": Object {
-                      "altText": "Di Black Stars",
-                      "copyrightHolder": "Facebook/Ghana Football Association",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/0585/production/_107331410_ghana2019afconsquad.jpg",
-                      "id": "107331410",
-                      "path": "/cpsprodpb/0585/production/_107331410_ghana2019afconsquad.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48591366",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48591366",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "prominence": "standard",
-                    "summary": "Major shocker wey come out be sey dem drop striker, Majeed Waris who dem replace plus U-23 striker, Kwabena Owusu.",
-                    "timestamp": 1560248900000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Woman write exam 30 minutes afta she born",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48579283",
-                    "indexImage": Object {
-                      "altText": "New mama dey write exam",
-                      "caption": "Di 21 year old mama get plan to go university",
-                      "copyrightHolder": "Ilu Abba Bor Zone communication office",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/2FA0/production/_107329121_34ba0903-191f-4410-a575-16ca72c6ce2c.jpg",
-                      "id": "107329121",
-                      "path": "/cpsprodpb/2FA0/production/_107329121_34ba0903-191f-4410-a575-16ca72c6ce2c.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48579283",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48579283",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "prominence": "standard",
-                    "summary": "Di 21-year-old Ethiopian woman don take one of her secondary school leaving exams 30 minutes afta she born.",
-                    "timestamp": 1560247904000,
-                    "type": "cps",
-                  },
-                ],
-                "maxRelatedLinks": 3,
-                "semanticGroupName": "Top Stories",
-                "strapline": Object {
-                  "name": "Top tori",
-                },
-                "title": "Top Stories",
-                "type": "responsive-top-stories",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "byline": Object {
-                      "name": "Karina Igonikon",
-                      "persons": Array [
-                        Object {
-                          "function": "BBC News Pidgin, Port Harcourt",
-                          "name": "Karina Igonikon",
-                          "thumbnail": "http://c.files.bbci.co.uk/172D8/production/_99963949_karina.jpg",
-                        },
-                      ],
-                      "title": "BBC News Pidgin, Port Harcourt",
-                    },
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "'Police need to use technology fight crime for Rivers'",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48578550",
-                    "indexImage": Object {
-                      "altText": "Nigeria Police",
-                      "copyrightHolder": "YASUYOSHI CHIBA",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/4660/production/_106261081_gettyimages-1125065202.jpg",
-                      "id": "106261081",
-                      "path": "/cpsprodpb/4660/production/_106261081_gettyimages-1125065202.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48578550",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48578550",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Di oil rich Rivers state for south south Nigeria dey battle insecurity including kidnappings, armed robbery and cultism.",
-                    "timestamp": 1560169438000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "\\"I laik wen deh treat me as journalist and not blind man\\" - Somb Lingom",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48560300",
-                    "indexImage": Object {
-                      "altText": "Jean Pascal Somb Lingom",
-                      "caption": "Jean Pascal Somb Lingom blind wen e be eight years old",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/E91F/production/_107297695_jeanpascalsomblingom.jpg",
-                      "id": "107297695",
-                      "path": "/cpsprodpb/E91F/production/_107297695_jeanpascalsomblingom.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48560300",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48560300",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e2139461b000e9dabf7",
-                          "campaignName": "WS - Inspire me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Somb Lingom na tori pesin wey dey visually impaired for Cameroon wey dey helep oda pipo laik e for go school.",
-                    "timestamp": 1559972055000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "One million new sex infections dey appear evri day - WHO",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/world-48553140",
-                    "indexImage": Object {
-                      "altText": "gonorrhoea alert",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/CB82/production/_107289025_gono2.jpg",
-                      "id": "107289025",
-                      "path": "/cpsprodpb/CB82/production/_107289025_gono2.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/world-48553140",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/world-48553140",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "WHO say safe sex especially through condom and correct testing dey important to reduce di spread.",
-                    "timestamp": 1559903540000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Why Kano State goment cancel popular traditional event",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48538424",
-                    "indexImage": Object {
-                      "altText": "Sarki Sanusi",
-                      "copyrightHolder": "Getty Images",
-                      "height": 334,
-                      "href": "http://c.files.bbci.co.uk/12011/production/_107254737_gettyimages-869453732-594x594.jpg",
-                      "id": "107254737",
-                      "path": "/cpsprodpb/12011/production/_107254737_gettyimages-869453732-594x594.jpg",
-                      "subType": "index",
-                      "width": 594,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48538424",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48538424",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Di 'Hawan Nassarawa' na popular annual event wey dem dey do for four days during di Salah, but dis year own don get k-leg.",
-                    "timestamp": 1559810010000,
-                    "type": "cps",
-                  },
-                ],
-                "semanticGroupName": "Cluster 1",
-                "strapline": Object {
-                  "name": "Yarn Me Tori",
-                },
-                "title": "Cluster 1",
-                "type": "responsive-cluster",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Cameroon di lock horn wit Canada for first ever game",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/sport-48578548",
-                    "indexImage": Object {
-                      "altText": "Di Indomitable Lionesses",
-                      "copyrightHolder": "Fecafoot",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/0AB5/production/_107314720_22358df2-692e-4640-9c19-04f8242cef56.jpg",
-                      "id": "107314720",
-                      "path": "/cpsprodpb/0AB5/production/_107314720_22358df2-692e-4640-9c19-04f8242cef56.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/sport-48578548",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/sport-48578548",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Na de first taim weh Canada and Cameroon go jam for top international game for 2019 Fifa Women’s World Cup.",
-                    "timestamp": 1560161642000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Nadal don win number 12 French Open title",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/sport-48574594",
-                    "indexImage": Object {
-                      "altText": "Nadal brings the trophy to his forehead",
-                      "copyrightHolder": "Clive Brunskill",
-                      "height": 1152,
-                      "href": "http://c.files.bbci.co.uk/18453/production/_107311499_gettyimages-1154811588.jpg",
-                      "id": "107311499",
-                      "path": "/cpsprodpb/18453/production/_107311499_gettyimages-1154811588.jpg",
-                      "subType": "index",
-                      "width": 2048,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/sport-48574594",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/sport-48574594",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Nadal win for di third straight year for Roland Garros wit 6-3 5-7 6-1 6-1 victory for di final.",
-                    "timestamp": 1560101482000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Kelechi Iheanacho no follow as Nigeria release Afcon list",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/sport-48574590",
-                    "indexImage": Object {
-                      "altText": "Super Eagles",
-                      "copyrightHolder": "NFF",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/15A0E/production/_107309588_d8nrcmjxkaeekro.jpg",
-                      "id": "107309588",
-                      "path": "/cpsprodpb/15A0E/production/_107309588_d8nrcmjxkaeekro.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/sport-48574590",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/sport-48574590",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Leicester City forward Kelechi Iheanacho and Semi Ajayi na di two players wey dem drop from di team.",
-                    "timestamp": 1560085284000,
-                    "type": "cps",
-                  },
-                ],
-                "semanticGroupName": "Section 1",
-                "strapline": Object {
-                  "links": Object {
-                    "desktop": "https://www.bbc.com/pidgin/sport",
-                    "enhancedmobile": "https://www.bbc.com/pidgin/sport",
-                    "highweb": "https://www.bbc.com/pidgin/sport",
-                    "mobile": "https://www.bbc.com/pidgin/sport",
-                  },
-                  "name": "Sport (click for more tori) ",
-                  "type": "LINK",
-                },
-                "title": "Section 1",
-                "type": "responsive-must-see",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "“If di spoon attract me, most times na to carry am enta studio” – Collins",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48591363",
-                    "indexImage": Object {
-                      "altText": "Abiniro Collins na spoon artist",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/10DE4/production/_107329096_p07csxwm.jpg",
-                      "id": "107329096",
-                      "path": "/cpsprodpb/10DE4/production/_107329096_p07csxwm.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48591363",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48591363",
-                    },
-                    "media": Object {
-                      "advertising": true,
-                      "caption": "“If di spoon attract me, most times na to carry am enta studio” – Collins",
-                      "embedding": true,
-                      "format": "video",
-                      "id": "p07csxg6",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07csxwm.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "long": "Almost every wia pesin turn you go see art of different kinds but dis one get as e be, unto say na spoon dis pesin take dey do im own work.
-
-Abiniro Collins na Artist for Lagos, south west Nigeria, wey no dey use eye see spoon.
-
-Collins tok say na wen im dey school di idea come, as im bin dey find sometin wey pipo neva too use do art work 
-
-Collins say im dream na to create place wey young artists for Nigeria go fit go to get mentor for dia work.
-
-Producers: Usifo Omozokpea & Sarah Tiamiyu",
-                        "medium": "Dis artist no dey take eye see spoon, as no be to chop food be di only tin him dey use am do.",
-                        "short": "“If di spoon attract me, most times na to carry am enta studio” – Collins",
-                      },
-                      "title": "“If di spoon attract me, most times na to carry am enta studio” – Collins",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1560232614,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "duration": 111,
-                          "durationISO8601": "PT1M51S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07csxg8",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "summary": "Dis artist no dey take eye see spoon, as no be to chop food be di only tin him dey use am do.",
-                    "timestamp": 1560233405000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "I realise my World Cup dream afta 14 years",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/media-48519295",
-                    "indexImage": Object {
-                      "altText": "Janine van Wyk",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/C34D/production/_107279994_p07cfs3f.jpg",
-                      "id": "107279994",
-                      "path": "/cpsprodpb/C34D/production/_107279994_p07cfs3f.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/media-48519295",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/media-48519295",
-                    },
-                    "media": Object {
-                      "advertising": false,
-                      "caption": "Janine van Wyk go lead South Africa go di Women's World Cup for di first time.",
-                      "embedding": true,
-                      "format": "video",
-                      "id": "p07cfpl4",
-                      "imageCopyright": "BBC",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07cfs3f.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "long": "Janine van Wyk don play for South Africa Women's team for 14 years. 
-
-But dis summer, for di first di captain go lead di Banyana Banyana go France 2019 World Cup. 
-
-She discuss her dreams, determination and development wit BBC Sport Africa inside dis BBC Africa one minute tori.
-
-Dis na behind dis scenes wit South Africa captain wey dey lead di Bayana Bayana to go husle for di Women’s World Cup for di first time ever!",
-                        "medium": "Dis na behind dis scenes wit South Africa captain wey dey lead di Bayana Bayana to go husle for di Women’s World Cup for difirst time ever!",
-                        "short": "France 2019 Women's World Cup: Janine van Wyk go lead South Africa compete for first time",
-                      },
-                      "title": "I dey realise my World Cup Dream afta 14 years",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1559844782,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "duration": 100,
-                          "durationISO8601": "PT1M40S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07cfpl6",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "South Africa captain Janine van Wyk dey lead di Bayana Bayana to go hustle for di Women’s World Cup for di first time ever!",
-                    "timestamp": 1559845332000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "Henna Design di natural tattoo",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/media-48516777",
-                    "indexImage": Object {
-                      "altText": "Keyframe #1",
-                      "copyrightHolder": "BBC",
-                      "height": 576,
-                      "href": "http://c.files.bbci.co.uk/14F84/production/_107229858_p07c6v9f.jpg",
-                      "id": "107229858",
-                      "path": "/cpsprodpb/14F84/production/_107229858_p07c6v9f.jpg",
-                      "subType": "index",
-                      "width": 1024,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/media-48516777",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/media-48516777",
-                    },
-                    "media": Object {
-                      "advertising": false,
-                      "caption": "Henna Design di natural tattoo",
-                      "embedding": true,
-                      "format": "video",
-                      "id": "p07c6tx3",
-                      "imageCopyright": "BBC",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07c6v9f.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "long": "Henna, di natural tattoo wey dey important to religion and to fashion don dey exist for many centuries.
-Many, many years back for dis part of Africa, pipo believe say na only Muslims fit do henna designs for dia bodi.
-Back in dos days women dey do di design especially during Eid celebrations, wedding and naming ceremonies plus oda special occasions. E still be di same reach today.
-Islam religion also believe say na only women suppose do henna tattoo for dia bodi as dis go separate dem from di men.
-But all dat one don change as henna tattoo don turn fashion and more pipo wey no be Muslims, plus including men sef dey use am make dem sef beautiful.
-For most of dis pipo dem prefer to do henna design dan to do oyibo kain tattoo wey dey permanent and no dey eva commot.
-
-Production by Onyinye Chime and Abdulmalik Fahd Abdulmalik, Camera man Gift Ufuoma.",
-                        "medium": "Weda na for religion or fashion, henna design na natural way to tattoo bodi witout any wahala.",
-                        "short": "Henna Design di natural tattoo",
-                      },
-                      "title": "Henna Design di natural tattoo",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1559659746,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "duration": 146,
-                          "durationISO8601": "PT2M26S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07c6txg",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/Explainer",
-                        "categoryName": "Explainer",
-                      },
-                    },
-                    "summary": "Weda na for religion or fashion, henna design na natural way to tattoo bodi witout any wahala.",
-                    "timestamp": 1559661792000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "Di codeine investigation wey change Nigeria",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48567846",
-                    "indexImage": Object {
-                      "altText": "Keyframe #2",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/A3CB/production/_101113914_p065w1bn.jpg",
-                      "id": "101113914",
-                      "path": "/cpsprodpb/A3CB/production/_101113914_p065w1bn.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48567846",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48567846",
-                    },
-                    "media": Object {
-                      "advertising": true,
-                      "caption": "Africa Eye: How one codeine investigation change Nigeria",
-                      "embedding": true,
-                      "format": "video",
-                      "id": "p07cmp1m",
-                      "imageCopyright": "BBC",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07cms03.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "long": "BBC Africa Eye tear rubber for April 2018 with Sweet Sweet Codeine, one feem wey Nigerian investigative journalist Ruona Meyer present.
-
-E show di abuse of di cough syrup medicine with codeine wey pipo suppose take afta prescription. Codeine cough syrup bin dey make pipo dey addicted -  millions of young pipo wey dey expose to am na im sabi pipo bin say dey addicted to di syrup.
-
-BBC Africa Eye tori pesin Zuhura Yunus continue di tori of how di codeine story shine light ontop how dem bin dey sell am for black market.",
-                        "medium": "Africa Eye chook eye inside di abuse of codeine cough syrup wey turn many Nigerians to addict.",
-                        "short": "Africa Eye: How one codeine investigation change Nigeria",
-                      },
-                      "title": "Di codeine investigation wey change Nigeria",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1560015439,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "duration": 445,
-                          "durationISO8601": "PT7M25S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07cmp1p",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e2939461b000e9dabf8",
-                          "campaignName": "WS - Educate me",
-                        },
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Africa Eye chook eye inside di abuse of codeine cough syrup wey turn many Nigerians to addict.",
-                    "timestamp": 1560015970000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "MAP",
-                    "headlines": Object {
-                      "headline": "\\"Dance big pass how pipo dey take see am\\"",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/media-48519287",
-                    "indexImage": Object {
-                      "altText": "Kaffy di Nigerian dancer",
-                      "copyrightHolder": "Kelechi Amadi-Obi",
-                      "height": 576,
-                      "href": "http://c.files.bbci.co.uk/C885/production/_107233315_p07c70mp.jpg",
-                      "id": "107233315",
-                      "path": "/cpsprodpb/C885/production/_107233315_p07c70mp.jpg",
-                      "subType": "index",
-                      "width": 1024,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/media-48519287",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/media-48519287",
-                    },
-                    "media": Object {
-                      "advertising": true,
-                      "caption": "Kaffy say if di goment know di importance of dance sef dem go put am for our curriculum",
-                      "embedding": false,
-                      "format": "video",
-                      "id": "p07c700k",
-                      "imageCopyright": "Kelechi Amadi-Obi",
-                      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07c70mp.jpg",
-                      "subType": "clip",
-                      "synopses": Object {
-                        "long": "E don tey wey Kafayat Oluwatoyin aka Kaffy don dey dance sotey she don turn am to business.
-
-Kaffy follow BBC pidgin tok ontop how she take choose dance even though na pesin wey dey fly and repair plane she bin wan become for life before. 
-
-She tok how dance take help her many times for her life “as adult di period of my life wey I tackle depression based on tins wey dey happen for me for inside house, wit di use of dance and di work wey I dey do as dancer, e continue to dey help me to remind me say make you no let your problem to define you” – as she tok.
-
-She feel say pipo suppose dey appreciate dance for Nigeria pass as e dey now and pipo suppose get place wia dem fit go to learn dance if dem wan take am as work just as doctors and lawyers dem too get, “dat na why we say make we create platform like ‘The dance workshop Africa’ wey go empower, train and deal wit di problems wey we dey deal wit as pipo wey dey creative industry” she tok.
-
-Kaffy bin win Guinness world record for “Longest Dance Party\\" for 2006, she dey married and she get two children wey she say be di biggest achievement for her life.",
-                        "medium": "Kaffy say if di goment know di importance of dance sef dem go put am for our curriculum.",
-                        "short": "Kaffy say if di goment know di importance of dance sef dem go put am for our curriculum",
-                      },
-                      "title": "\\"Dance big pass how pipo dey take see am\\"",
-                      "versions": Array [
-                        Object {
-                          "availableFrom": 1559663402,
-                          "availableTerritories": Object {
-                            "nonUk": true,
-                            "uk": true,
-                          },
-                          "duration": 139,
-                          "durationISO8601": "PT2M19S",
-                          "types": Array [
-                            "Original",
-                          ],
-                          "versionId": "p07c700r",
-                          "warnings": Object {},
-                        },
-                      ],
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/Explainer",
-                        "categoryName": "Explainer",
-                      },
-                    },
-                    "summary": "Kaffy say if di goment know di importance of dance sef dem go put am for our curriculum.",
-                    "timestamp": 1559663812000,
-                    "type": "cps",
-                  },
-                ],
-                "semanticGroupName": "Section 2",
-                "strapline": Object {
-                  "name": "Ginger me",
-                },
-                "title": "Section 2",
-                "type": "responsive-inspire",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Bandits for Nigeria north-west different from killer herdsmen - Police",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48586697",
-                    "indexImage": Object {
-                      "altText": "Herdsmen",
-                      "copyrightHolder": "The Washington Post",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/F386/production/_107324326_herdsmen.jpg",
-                      "id": "107324326",
-                      "path": "/cpsprodpb/F386/production/_107324326_herdsmen.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48586697",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48586697",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "On Monday, tori come out say bandits kill at least 25 pipo for Sokoto State, north-west Nigeria wia many attack don dey happun.",
-                    "timestamp": 1560182619000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Justin Bieber wan fight Tom Cruise",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/world-48585358",
-                    "indexImage": Object {
-                      "altText": "Justin Bieber and Tom Cruise",
-                      "caption": "Na 31 years Tom Cruise use senior Justin Bieber wey dey 25 years",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/3018/production/_107321321_untitleddesign.jpg",
-                      "id": "107321321",
-                      "path": "/cpsprodpb/3018/production/_107321321_untitleddesign.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/world-48585358",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/world-48585358",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Di Canadian singer say if Tom Cruise no accept im challenge e go mean say im dey \\"fear am.\\"",
-                    "timestamp": 1560178604000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Jaguda pipo kill 100 pipo for one village for Mali",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48585917",
-                    "indexImage": Object {
-                      "altText": "Mali",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/15F38/production/_107321998__107320905_gettyimages-492754509.jpg",
-                      "id": "107321998",
-                      "path": "/cpsprodpb/15F38/production/_107321998__107320905_gettyimages-492754509.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48585917",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48585917",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                    },
-                    "summary": "Di killing happun for one village for central Mali wia fight-fight between hunters and Fulani herders dey common.",
-                    "timestamp": 1560175187000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "UK, Canada alert nationals over kidnapping den terror threats for Ghana",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48578549",
-                    "indexImage": Object {
-                      "altText": "Ghana flag",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/17148/production/_105063549_gettyimages-80391721-594x594.jpg",
-                      "id": "105063549",
-                      "path": "/cpsprodpb/17148/production/_105063549_gettyimages-80391721-594x594.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48578549",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48578549",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Ghana no record any attacks, but UK government advice dema nationals sey make dem make vigilant, especially for de northern border areas.",
-                    "timestamp": 1560153973000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Buhari don accept Onnoghen retirement",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48578547",
-                    "indexImage": Object {
-                      "altText": "Justice Walter Onnoghen",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/4831/production/_106518481_gettyimages-1137872968.jpg",
-                      "id": "106518481",
-                      "path": "/cpsprodpb/4831/production/_106518481_gettyimages-1137872968.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48578547",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48578547",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "summary": "Di former Chief Justice of Nigeria Walter Onnoghen enter kasala ontop accuse say im no declare im complete asset wen im enta office.",
-                    "timestamp": 1560142191000,
-                    "type": "cps",
-                  },
-                ],
-                "semanticGroupName": "Section 3",
-                "strapline": Object {
-                  "name": "Informate me",
-                },
-                "title": "Section 3",
-                "type": "responsive-in-depth",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "byline": Object {
-                      "name": "Daniel Semeniworima",
-                      "persons": Array [
-                        Object {
-                          "function": "BBC Pidgin, Lagos",
-                          "name": "Daniel Semeniworima",
-                          "thumbnail": "http://c.files.bbci.co.uk/81E3/production/_98115233_danielsppsoftcopyonly.jpg",
-                        },
-                      ],
-                      "title": "BBC Pidgin, Lagos",
-                    },
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Buhari no give speech afta e take oath",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-48421890",
-                    "indexImage": Object {
-                      "altText": "Buhari, Osinbajo take 'Next Level' oath",
-                      "copyrightHolder": "Bashir Ahmad",
-                      "height": 675,
-                      "href": "http://c.files.bbci.co.uk/51E4/production/_107146902_d7ubgzgxyaeqyof.jpg",
-                      "id": "107146902",
-                      "path": "/cpsprodpb/51E4/production/_107146902_d7ubgzgxyaeqyof.jpg",
-                      "subType": "index",
-                      "width": 1200,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-48421890",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-48421890",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e2939461b000e9dabf8",
-                          "campaignName": "WS - Educate me",
-                        },
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Dis go be di first time since 1999 wey any Nigerian leader no go give speech after im inauguration.",
-                    "timestamp": 1559133171000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "PDP candidate Bala Muhammed dey lead wit 6376 votes for Bauchi state",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-47685579",
-                    "indexImage": Object {
-                      "altText": "Bala Mohammed and Govnor Mohammed Abubakar",
-                      "caption": "Bala Mohammed and Govnor Mohammed Abubakar",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/15B3F/production/_106159888_030edd7b-b5e5-4572-8570-5fbd4f9b96cd.jpg",
-                      "id": "106159888",
-                      "path": "/cpsprodpb/15B3F/production/_106159888_030edd7b-b5e5-4572-8570-5fbd4f9b96cd.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-47685579",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-47685579",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Afta collation of results for Bauchi state, North East Nigeria, di ruling All Progressive Congress candidate dey back.",
-                    "timestamp": 1553429821000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "INEC declare Ganduje winner of Kano govnorship election",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-47685581",
-                    "indexImage": Object {
-                      "altText": "Governor Ganduje",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/9F8B/production/_106134804_ganduje1.jpg",
-                      "id": "106134804",
-                      "path": "/cpsprodpb/9F8B/production/_106134804_ganduje1.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-47685581",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-47685581",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Small drama bin happun for di collation centre before dem announce di winner as some party agents and observers condemn di election process say wuru-wuru full inside.",
-                    "timestamp": 1553457177000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "PDP dey ask INEC to cancel Kano rerun",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-47674110",
-                    "indexImage": Object {
-                      "altText": "PDP chairmo for Kano Rabiu Bichi (na im dey middle dey tok to tori pipo)",
-                      "caption": "PDP chairmo for Kano Rabiu Bichi (na im dey middle dey tok to tori pipo)",
-                      "copyrightHolder": "BBC",
-                      "height": 576,
-                      "href": "http://c.files.bbci.co.uk/5496/production/_106145612_pdp.jpg",
-                      "id": "106145612",
-                      "path": "/cpsprodpb/5496/production/_106145612_pdp.jpg",
-                      "subType": "index",
-                      "width": 1024,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-47674110",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-47674110",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e3739461b000e9dabfa",
-                          "campaignName": "WS - Give me perspective",
-                        },
-                        Object {
-                          "campaignId": "5a988e3e39461b000e9dabfb",
-                          "campaignName": "WS - Keep me on trend",
-                        },
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "PDP chairmo for Kano Engr Rabiu Bichi tok say e dey necessary for INEC to cancel Saturday rerun.",
-                    "timestamp": 1553343407000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "'I ready to jam APC for appeal court'",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-47654477",
-                    "imageThumbnail": Object {
-                      "altText": "Ademola Adeleke",
-                      "copyrightHolder": "PDP",
-                      "height": 180,
-                      "href": "http://c.files.bbci.co.uk/9ECE/production/_106145604_d2r-rakw0au3mdy.jpg",
-                      "id": "106145604",
-                      "path": "/cpsprodpb/9ECE/production/_106145604_d2r-rakw0au3mdy.jpg",
-                      "subType": "index-thumbnail",
-                      "width": 320,
-                    },
-                    "indexImage": Object {
-                      "altText": "Ademola Adeleke",
-                      "copyrightHolder": "PDP",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/5C3E/production/_106141632_d2r-rakw0au3mdy.jpg",
-                      "id": "106141632",
-                      "path": "/cpsprodpb/5C3E/production/_106141632_d2r-rakw0au3mdy.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-47654477",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-47654477",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Osun Govnorship Election Tribunal on Friday declare PDP candidate Senator Ademola Adeleke winner.",
-                    "timestamp": 1553283824000,
-                    "type": "cps",
-                  },
-                  Object {
-                    "cpsType": "STY",
-                    "headlines": Object {
-                      "headline": "Kano elections get k-leg, reports of katakata everywia",
-                    },
-                    "id": "urn:bbc:ares::asset:pidgin/tori-47655879",
-                    "indexImage": Object {
-                      "altText": "Kano",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/12B8C/production/_106148667_whatsappimage2019-03-23at9.53.03am.jpg",
-                      "id": "106148667",
-                      "path": "/cpsprodpb/12B8C/production/_106148667_whatsappimage2019-03-23at9.53.03am.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "locators": Object {
-                      "assetUri": "/pidgin/tori-47655879",
-                      "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-47655879",
-                    },
-                    "options": Object {
-                      "isBreakingNews": false,
-                      "isFactCheck": false,
-                    },
-                    "passport": Object {
-                      "campaigns": Array [
-                        Object {
-                          "campaignId": "5a988e4739461b000e9dabfc",
-                          "campaignName": "WS - Update me",
-                        },
-                      ],
-                      "category": Object {
-                        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                        "categoryName": "News",
-                      },
-                    },
-                    "summary": "Areas for Kano State wey INEC don plan supplementary elections for never begin, and e no look like say e go happun at all because of kasala.",
-                    "timestamp": 1553334998000,
-                    "type": "cps",
-                  },
-                ],
-                "semanticGroupName": "Special reports 2",
-                "strapline": Object {
-                  "name": "Special reports 2",
-                },
-                "title": "Special reports 2",
-                "type": "special-reports",
-              },
-              Object {
-                "items": Array [
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Text",
-                    "id": "mockid-2",
-                    "indexImage": Object {
-                      "altText": "Messi, Iwobi, Ronaldo",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/F617/production/_101999926_messiiwobironaldo.jpg",
-                      "id": "101999926",
-                      "path": "/cpsprodpb/F617/production/_101999926_messiiwobironaldo.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Take dis predictor choose who go reach World Cup final",
-                    "timestamp": 1528968307000,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44416820",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Audio",
-                    "id": "mockid-3",
-                    "indexImage": Object {
-                      "altText": "A lone Koala perches in a eucalyptus tree",
-                      "caption": "Koalas are from Australia",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://b.files.bbci.co.uk/14A31/test/_63692548_000327537-1.jpg",
-                      "id": "63692548",
-                      "path": "/cpsdevpb/14A31/test/_63692548_000327537-1.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Audio promo",
-                    "summary": "Summary",
-                    "timestamp": 1565097889000,
-                    "type": "link",
-                    "uri": "http://www.bbc.com/pidgin",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Text",
-                    "id": "mockid-4",
-                    "indexImage": Object {
-                      "altText": "Rashidi",
-                      "caption": "Rashidi Yekini na im score Nigeria first goal for World Cup",
-                      "copyrightHolder": "David Cannon",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/1820B/production/_101972889_gettyimages-227910.jpg",
-                      "id": "101972889",
-                      "path": "/cpsprodpb/1820B/production/_101972889_gettyimages-227910.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?",
-                    "timestamp": 1528975335000,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44439411",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Text",
-                    "id": "mockid-5",
-                    "indexImage": Object {
-                      "altText": "all-time African XI promo image",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/CEBD/production/_101952925_wcbanner-2.png",
-                      "id": "101952925",
-                      "path": "/cpsprodpb/CEBD/production/_101952925_wcbanner-2.png",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Select your best ever African 11 players for World Cup",
-                    "timestamp": 1528978068000,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44425543",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Feature",
-                    "id": "mockid-6",
-                    "indexImage": Object {
-                      "altText": "all-time African XI promo image",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/CEBD/production/_101952925_wcbanner-2.png",
-                      "id": "101952925",
-                      "path": "/cpsprodpb/CEBD/production/_101952925_wcbanner-2.png",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Select your best ever African 11 players for World Cup as a feature",
-                    "timestamp": 1528978068001,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44425543",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Video",
-                    "id": "mockid-7",
-                    "indexImage": Object {
-                      "altText": "all-time African XI promo image",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/CEBD/production/_101952925_wcbanner-2.png",
-                      "id": "101952925",
-                      "path": "/cpsprodpb/CEBD/production/_101952925_wcbanner-2.png",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Select your best ever African 11 players for World Cup - Video",
-                    "timestamp": 1528978068000,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44425543",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Text",
-                    "id": "mockid-8",
-                    "indexImage": Object {
-                      "altText": "Sane",
-                      "copyrightHolder": "Getty Images",
-                      "height": 549,
-                      "href": "http://c.files.bbci.co.uk/0775/production/_101890910_gettyimages-964924372.jpg",
-                      "id": "101890910",
-                      "path": "/cpsprodpb/0775/production/_101890910_gettyimages-964924372.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "World Cup 2018: Di top stars wey no dey go World Cup",
-                    "timestamp": 1528978790000,
-                    "type": "link",
-                    "uri": "https://www.bbc.com/pidgin/sport-44214129",
-                  },
-                  Object {
-                    "assetTypeCode": "PRO",
-                    "contentType": "Gallery",
-                    "id": "mockid-9",
-                    "indexImage": Object {
-                      "altText": "A lone Koala perches in a eucalyptus tree",
-                      "caption": "Koalas are from Australia",
-                      "copyrightHolder": "BBC",
-                      "height": 549,
-                      "href": "http://b.files.bbci.co.uk/14A31/test/_63692548_000327537-1.jpg",
-                      "id": "63692548",
-                      "path": "/cpsdevpb/14A31/test/_63692548_000327537-1.jpg",
-                      "subType": "index",
-                      "width": 976,
-                    },
-                    "name": "Gallery promo",
-                    "timestamp": 1565192199000,
-                    "type": "link",
-                    "uri": "http://www.bbc.com/azeri",
-                  },
-                ],
-                "semanticGroupName": "Frequency info",
-                "strapline": Object {
-                  "name": "2018 World Cup",
-                },
-                "title": "Frequency info",
-                "type": "featured-site-top-stories",
-              },
-            ],
-          },
-          "metadata": Object {
-            "analyticsLabels": Object {
-              "counterName": "pidgin.page",
-              "cps_asset_id": "40423314",
-              "cps_asset_type": "idx",
-            },
-            "blockTypes": Array [
-              "responsive-top-stories",
-              "responsive-cluster",
-              "responsive-must-see",
-              "responsive-inspire",
-              "responsive-in-depth",
-              "special-reports",
-              "featured-site-top-stories",
-            ],
-            "createdBy": "pidgin-v6",
-            "firstPublished": 1499440608,
-            "id": "urn:bbc:ares::index:pidgin/front_page/desktop/domestic",
-            "language": "pcm",
-            "lastPublished": 1560249011,
-            "lastUpdated": 1560249022470,
-            "locators": Object {
-              "assetUri": "/pidgin/front_page",
-              "cpsUrn": "urn:bbc:content:assetUri:pidgin/front_page",
-              "curie": "http://www.bbc.co.uk/asset/52f3c7b1-83ed-2338-e050-17ac8045cd94/desktop/domestic",
-            },
-            "options": Object {
-              "allowAdvertising": true,
-            },
-            "summary": "We dey give una latest tori on top politics, environment, business, sports, entertainment, health, fashion and all di oda things wey dey happen for West and Central Africa come add di rest of di world join. For better informate plus explanation of all di ogbonge tori wey pipo never hear about for inside West and Central Africa, BBC Pidgin dey serve am with video, audio, maps and oda graphics join.",
-            "tags": Object {},
-            "title": "Domot",
-            "type": "IDX",
-            "version": "v1.0.10",
-          },
-          "promo": Object {
-            "id": "urn:bbc:ares::index:pidgin/front_page/desktop/domestic",
-            "name": "Domot",
-            "subType": "IDX",
-            "type": "simple",
-            "uri": "/pidgin/front_page",
-          },
-          "relatedContent": Object {
-            "groups": Array [],
-            "section": Object {
-              "name": "Domot",
-              "subType": "index",
-              "type": "simple",
-              "uri": "/pidgin/front_page",
-            },
-            "site": Object {
-              "name": "BBC Pidgin",
-              "subType": "site",
-              "type": "simple",
-              "uri": "/pidgin",
-            },
-          },
-        }
-      }
+  <head>
+    <title>
+      Ogbako - BBC News Ìgbò
+    </title>
+    <link
+      href="http://localhost/pathname"
+      rel="canonical"
     />
-  </ServiceContextProvider>
-</RequestContextProvider>
+    <link
+      href="http://localhost/pathname"
+      hreflang="ig"
+      rel="alternate"
+    />
+    <link
+      href="http://localhost/pathname.amp"
+      rel="amphtml"
+    />
+    <link
+      href="/igbo/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
+      rel="apple-touch-icon"
+      sizes="72x72"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
+      rel="apple-touch-icon"
+      sizes="96x96"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-128x128.png"
+      rel="apple-touch-icon"
+      sizes="128x128"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-144x144.png"
+      rel="apple-touch-icon"
+      sizes="144x144"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-152x152.png"
+      rel="apple-touch-icon"
+      sizes="152x152"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+      sizes="192x192"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-384x384.png"
+      rel="apple-touch-icon"
+      sizes="384x384"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
+      rel="apple-touch-icon"
+      sizes="512x512"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
+      rel="icon"
+      sizes="72x72"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
+      rel="icon"
+      sizes="96x96"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
+      rel="icon"
+      sizes="192x192"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
+      rel="apple-touch-startup-image"
+    />
+    <link
+      href="/favicon.ico"
+      rel="shortcut icon"
+      type="image/x-icon"
+    />
+    <meta
+      content="IE=edge"
+      http-equiv="X-UA-Compatible"
+    />
+    <meta
+      charset="utf-8"
+    />
+    <meta
+      content="noodp,noydir"
+      name="robots"
+    />
+    <meta
+      content="#B80000"
+      name="theme-color"
+    />
+    <meta
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+      name="viewport"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="apple-mobile-web-app-title"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="application-name"
+    />
+    <meta
+      content="We dey give una latest tori on top politics, environment, business, sports, entertainment, health, fashion and all di oda things wey dey happen for West and Central Africa come add di rest of di world join. For better informate plus explanation of all di ogbonge tori wey pipo never hear about for inside West and Central Africa, BBC Pidgin dey serve am with video, audio, maps and oda graphics join."
+      name="description"
+    />
+    <meta
+      content="100004154058350"
+      name="fb:admins"
+    />
+    <meta
+      content="1609039196070050"
+      name="fb:app_id"
+    />
+    <meta
+      content="yes"
+      name="mobile-web-app-capable"
+    />
+    <meta
+      content="#B80000"
+      name="msapplication-TileColor"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-144x144.png"
+      name="msapplication-TileImage"
+    />
+    <meta
+      content="We dey give una latest tori on top politics, environment, business, sports, entertainment, health, fashion and all di oda things wey dey happen for West and Central Africa come add di rest of di world join. For better informate plus explanation of all di ogbonge tori wey pipo never hear about for inside West and Central Africa, BBC Pidgin dey serve am with video, audio, maps and oda graphics join."
+      name="og:description"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
+      name="og:image"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="og:image:alt"
+    />
+    <meta
+      content="ig"
+      name="og:locale"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="og:site_name"
+    />
+    <meta
+      content="Ogbako - BBC News Ìgbò"
+      name="og:title"
+    />
+    <meta
+      content="website"
+      name="og:type"
+    />
+    <meta
+      content="http://localhost/pathname"
+      name="og:url"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:creator"
+    />
+    <meta
+      content="We dey give una latest tori on top politics, environment, business, sports, entertainment, health, fashion and all di oda things wey dey happen for West and Central Africa come add di rest of di world join. For better informate plus explanation of all di ogbonge tori wey pipo never hear about for inside West and Central Africa, BBC Pidgin dey serve am with video, audio, maps and oda graphics join."
+      name="twitter:description"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="twitter:image:alt"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
+      name="twitter:image:src"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:site"
+    />
+    <meta
+      content="Ogbako - BBC News Ìgbò"
+      name="twitter:title"
+    />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"WebPage","url":"http://localhost/pathname","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"http://localhost/pathname","name":"Domot"}}
+    </script>
+  </head>
+  <body>
+    <div>
+      <noscript />
+      <div>
+        chartbeat
+      </div>
+      <main
+        role="main"
+      >
+        <h1
+          class="c0"
+          id="content"
+          tabindex="-1"
+        >
+          <span
+            role="text"
+          >
+            <span
+              lang="en-GB"
+            >
+              BBC News
+            </span>
+            , 
+            Ìgbò
+             - 
+            Akụkọ
+          </span>
+        </h1>
+        <div
+          class="c1"
+        >
+          <div
+            class="c2"
+          >
+            <section
+              aria-labelledby="Top-Stories"
+              role="region"
+            >
+              <div
+                class="c3"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Top-Stories"
+                      >
+                        Top tori
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c9 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c13"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <img
+                            alt="Senator Ahmad Lawan and Ali Ndume"
+                            class="c16"
+                            sizes="(max-width: 600px) 100vw, (max-width: 1008px) 33vw, 237px"
+                            src="https://ichef.bbci.co.uk/news/660/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg"
+                            srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 624w"
+                            width="976"
+                          />
+                        </div>
+                        <div
+                          class="c17"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c18"
+                    >
+                      <h3
+                        class="c19"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/live/tori-48591362"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              aria-hidden="true"
+                              class="c21"
+                              dir="ltr"
+                            >
+                              LIVE
+                            </span>
+                            <span
+                              class="c0"
+                              lang="en-GB"
+                            >
+                              Live, 
+                            </span>
+                            Senators don begin vote for Senate President
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c22"
+                      >
+                        Nigeria dey do inauguration to welcome im tear rubber lawmakers into di Ninth National Assembly.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-11"
+                      >
+                        11 Juun 2019
+                      </time>
+                      <div
+                        class="c24"
+                      >
+                        <h4
+                          class="c0"
+                        >
+                          Related content
+                        </h4>
+                        <ul
+                          class="c25"
+                          role="list"
+                        >
+                          <li
+                            class="c26"
+                            role="listitem"
+                          >
+                            <a
+                              class="c27"
+                              href="/pidgin/tori-48591361"
+                            >
+                              <span
+                                class="c28"
+                              >
+                                Who go lead di Ninth National Assembly?
+                              </span>
+                            </a>
+                          </li>
+                          <li
+                            class="c26"
+                            role="listitem"
+                          >
+                            <a
+                              class="c27"
+                              href="/pidgin/tori-47603701"
+                            >
+                              <span
+                                class="c28"
+                              >
+                                4 tins wey go determine who become di next Senate President, Speaker
+                              </span>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c33"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 13 12"
+                                width="13px"
+                              >
+                                <path
+                                  d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                                />
+                                <path
+                                  d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT59S"
+                              >
+                                0:59
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/media-44221514"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Ọdịyo
+                              , 
+                            </span>
+                            <span>
+                              BBC Pidgin Minute
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 0,59
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        All di local and world tori wey you suppose know in 60 seconds!
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-11"
+                      >
+                        11 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48591366"
+                        >
+                          Majid Waris no get ‘sɛlɛ’ for Coach Kwesi Appiah en Black Stars Afcon squad
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Major shocker wey come out be sey dem drop striker, Majeed Waris who dem replace plus U-23 striker, Kwabena Owusu.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-11"
+                      >
+                        11 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48579283"
+                        >
+                          Woman write exam 30 minutes afta she born
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di 21-year-old Ethiopian woman don take one of her secondary school leaving exams 30 minutes afta she born.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-11"
+                      >
+                        11 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Cluster-1"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Cluster-1"
+                      >
+                        Yarn Me Tori
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48578550"
+                        >
+                          'Police need to use technology fight crime for Rivers'
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di oil rich Rivers state for south south Nigeria dey battle insecurity including kidnappings, armed robbery and cultism.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48560300"
+                        >
+                          "I laik wen deh treat me as journalist and not blind man" - Somb Lingom
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Somb Lingom na tori pesin wey dey visually impaired for Cameroon wey dey helep oda pipo laik e for go school.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-08"
+                      >
+                        8 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/world-48553140"
+                        >
+                          One million new sex infections dey appear evri day - WHO
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        WHO say safe sex especially through condom and correct testing dey important to reduce di spread.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-07"
+                      >
+                        7 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48538424"
+                        >
+                          Why Kano State goment cancel popular traditional event
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di 'Hawan Nassarawa' na popular annual event wey dem dey do for four days during di Salah, but dis year own don get k-leg.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-06"
+                      >
+                        6 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Section-1"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <a
+                    aria-labelledby="Section-1"
+                    class="c41"
+                    href="https://www.bbc.com/pidgin/sport"
+                  >
+                    <div
+                      class="c6"
+                    >
+                      <span
+                        class="c42"
+                        role="text"
+                      >
+                        <span
+                          class="c8"
+                          dir="ltr"
+                          id="Section-1"
+                        >
+                          Sport (click for more tori) 
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="c43"
+                          dir="ltr"
+                        >
+                          Lee ha niile
+                        </span>
+                      </span>
+                    </div>
+                  </a>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/sport-48578548"
+                        >
+                          Cameroon di lock horn wit Canada for first ever game
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Na de first taim weh Canada and Cameroon go jam for top international game for 2019 Fifa Women’s World Cup.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/sport-48574594"
+                        >
+                          Nadal don win number 12 French Open title
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Nadal win for di third straight year for Roland Garros wit 6-3 5-7 6-1 6-1 victory for di final.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-09"
+                      >
+                        9 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/sport-48574590"
+                        >
+                          Kelechi Iheanacho no follow as Nigeria release Afcon list
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Leicester City forward Kelechi Iheanacho and Semi Ajayi na di two players wey dem drop from di team.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-09"
+                      >
+                        9 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Section-2"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Section-2"
+                      >
+                        Ginger me
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT1M51S"
+                              >
+                                1:51
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48591363"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Vidio
+                              , 
+                            </span>
+                            <span>
+                              “If di spoon attract me, most times na to carry am enta studio” – Collins
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 1,51
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Dis artist no dey take eye see spoon, as no be to chop food be di only tin him dey use am do.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-11"
+                      >
+                        11 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT1M40S"
+                              >
+                                1:40
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/media-48519295"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Vidio
+                              , 
+                            </span>
+                            <span>
+                              I realise my World Cup dream afta 14 years
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 1,40
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        South Africa captain Janine van Wyk dey lead di Bayana Bayana to go hustle for di Women’s World Cup for di first time ever!
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-06"
+                      >
+                        6 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT2M26S"
+                              >
+                                2:26
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/media-48516777"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Vidio
+                              , 
+                            </span>
+                            <span>
+                              Henna Design di natural tattoo
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 2,26
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Weda na for religion or fashion, henna design na natural way to tattoo bodi witout any wahala.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-04"
+                      >
+                        4 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT7M25S"
+                              >
+                                7:25
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48567846"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Vidio
+                              , 
+                            </span>
+                            <span>
+                              Di codeine investigation wey change Nigeria
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 7,25
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Africa Eye chook eye inside di abuse of codeine cough syrup wey turn many Nigerians to addict.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-08"
+                      >
+                        8 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                              <time
+                                class="c34"
+                                datetime="PT2M19S"
+                              >
+                                2:19
+                              </time>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/media-48519287"
+                        >
+                          <span
+                            role="text"
+                          >
+                            <span
+                              class="c0"
+                            >
+                              Vidio
+                              , 
+                            </span>
+                            <span>
+                              "Dance big pass how pipo dey take see am"
+                            </span>
+                            <span
+                              class="c0"
+                            >
+                              , 2,19
+                            </span>
+                          </span>
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Kaffy say if di goment know di importance of dance sef dem go put am for our curriculum.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-04"
+                      >
+                        4 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Section-3"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Section-3"
+                      >
+                        Informate me
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48586697"
+                        >
+                          Bandits for Nigeria north-west different from killer herdsmen - Police
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        On Monday, tori come out say bandits kill at least 25 pipo for Sokoto State, north-west Nigeria wia many attack don dey happun.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/world-48585358"
+                        >
+                          Justin Bieber wan fight Tom Cruise
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di Canadian singer say if Tom Cruise no accept im challenge e go mean say im dey "fear am."
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48585917"
+                        >
+                          Jaguda pipo kill 100 pipo for one village for Mali
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di killing happun for one village for central Mali wia fight-fight between hunters and Fulani herders dey common.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48578549"
+                        >
+                          UK, Canada alert nationals over kidnapping den terror threats for Ghana
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Ghana no record any attacks, but UK government advice dema nationals sey make dem make vigilant, especially for de northern border areas.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48578547"
+                        >
+                          Buhari don accept Onnoghen retirement
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Di former Chief Justice of Nigeria Walter Onnoghen enter kasala ontop accuse say im no declare im complete asset wen im enta office.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-06-10"
+                      >
+                        10 Juun 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Special-reports-2"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Special-reports-2"
+                      >
+                        Special reports 2
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-48421890"
+                        >
+                          Buhari no give speech afta e take oath
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Dis go be di first time since 1999 wey any Nigerian leader no go give speech after im inauguration.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-05-29"
+                      >
+                        29 Mee 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-47685579"
+                        >
+                          PDP candidate Bala Muhammed dey lead wit 6376 votes for Bauchi state
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Afta collation of results for Bauchi state, North East Nigeria, di ruling All Progressive Congress candidate dey back.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-03-24"
+                      >
+                        24 Maachị 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-47685581"
+                        >
+                          INEC declare Ganduje winner of Kano govnorship election
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Small drama bin happun for di collation centre before dem announce di winner as some party agents and observers condemn di election process say wuru-wuru full inside.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-03-24"
+                      >
+                        24 Maachị 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-47674110"
+                        >
+                          PDP dey ask INEC to cancel Kano rerun
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        PDP chairmo for Kano Engr Rabiu Bichi tok say e dey necessary for INEC to cancel Saturday rerun.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-03-23"
+                      >
+                        23 Maachị 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-47654477"
+                        >
+                          'I ready to jam APC for appeal court'
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Osun Govnorship Election Tribunal on Friday declare PDP candidate Senator Ademola Adeleke winner.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-03-22"
+                      >
+                        22 Maachị 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="/pidgin/tori-47655879"
+                        >
+                          Kano elections get k-leg, reports of katakata everywia
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Areas for Kano State wey INEC don plan supplementary elections for never begin, and e no look like say e go happun at all because of kasala.
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-03-23"
+                      >
+                        23 Maachị 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <section
+              aria-labelledby="Frequency-info"
+              role="region"
+            >
+              <div
+                class="c38"
+              >
+                <div
+                  class="c4"
+                />
+                <h2
+                  class="c5"
+                >
+                  <div
+                    class="c6"
+                  >
+                    <span
+                      class="c7"
+                    >
+                      <span
+                        class="c8"
+                        dir="ltr"
+                        id="Frequency-info"
+                      >
+                        2018 World Cup
+                      </span>
+                    </span>
+                  </div>
+                </h2>
+              </div>
+              <ul
+                class="c39 c10"
+                role="list"
+              >
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44416820"
+                        >
+                          Take dis predictor choose who go reach World Cup final
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c33"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 13 12"
+                                width="13px"
+                              >
+                                <path
+                                  d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                                />
+                                <path
+                                  d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="http://www.bbc.com/pidgin"
+                        >
+                          Audio promo
+                        </a>
+                      </h3>
+                      <p
+                        class="c37"
+                      >
+                        Summary
+                      </p>
+                      <time
+                        class="c23"
+                        datetime="2019-08-06"
+                      >
+                        6 Ọgọọst 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44439411"
+                        >
+                          World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44425543"
+                        >
+                          Select your best ever African 11 players for World Cup
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44425543"
+                        >
+                          Select your best ever African 11 players for World Cup as a feature
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c44"
+                                focusable="false"
+                                height="12px"
+                                viewBox="0 0 32 32"
+                                width="12px"
+                              >
+                                <polygon
+                                  points="3,32 29,16 3,0"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44425543"
+                        >
+                          Select your best ever African 11 players for World Cup - Video
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="https://www.bbc.com/pidgin/sport-44214129"
+                        >
+                          World Cup 2018: Di top stars wey no dey go World Cup
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2018-06-14"
+                      >
+                        14 Juun 2018
+                      </time>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  class="c11"
+                  role="listitem"
+                >
+                  <div
+                    class="c12"
+                  >
+                    <div
+                      class="c29"
+                    >
+                      <div
+                        class="c14"
+                      >
+                        <div
+                          class="c15"
+                        >
+                          <div
+                            class="lazyload-placeholder"
+                          />
+                        </div>
+                        <div
+                          class="c30"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="c31"
+                          >
+                            <div
+                              class="c32"
+                            >
+                              <svg
+                                class="c45"
+                                focusable="false"
+                                height="13px"
+                                viewBox="0 0 32 26"
+                                width="16px"
+                              >
+                                <path
+                                  d="M9,2V0H4V2H0V26H32V2ZM6.5,10A2.5,2.5,0,1,1,9,7.52,2.5,2.5,0,0,1,6.5,10ZM20,23a9,9,0,1,1,9-9A9,9,0,0,1,20,23Z"
+                                />
+                                <circle
+                                  cx="20"
+                                  cy="14.02"
+                                  r="5.5"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c35"
+                    >
+                      <h3
+                        class="c36"
+                      >
+                        <a
+                          class="c20"
+                          href="http://www.bbc.com/azeri"
+                        >
+                          Gallery promo
+                        </a>
+                      </h3>
+                      <time
+                        class="c23"
+                        datetime="2019-08-07"
+                      >
+                        7 Ọgọọst 2019
+                      </time>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+          </div>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>
 `;

--- a/src/app/containers/FrontPageMain/index.test.jsx
+++ b/src/app/containers/FrontPageMain/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
+import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import FrontPageMain from '.';
-import { shouldShallowMatchSnapshot } from '#testHelpers';
 import frontPageDataPidgin from '#data/pidgin/frontpage';
 import preprocessor from '#lib/utilities/preprocessor';
 import addIdsToItems from '#lib/utilities/preprocessor/rules/addIdsToItems';
@@ -43,7 +43,7 @@ const FrontPageMainWithContext = props => (
 
 describe('FrontPageMain', () => {
   describe('snapshots', () => {
-    shouldShallowMatchSnapshot(
+    shouldMatchSnapshot(
       'should render a pidgin frontpage correctly',
       <FrontPageMainWithContext frontPageData={processedPidgin} />,
     );

--- a/src/app/containers/MediaPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPageMain/__snapshots__/index.test.jsx.snap
@@ -182,52 +182,271 @@ exports[`Media Page Main should match snapshot 1`] = `
   }
 }
 
-<div>
-  <noscript />
-  <div
-    id="metadata"
-  />
-  <main
-    role="main"
-  >
-    <div
-      class="c0"
+<html
+  dir="ltr"
+  lang="am"
+>
+  <head>
+    <title>
+      ያድምጡ - BBC News
+    </title>
+    <link
+      href="https://www.test.bbc.com/pathname"
+      rel="canonical"
+    />
+    <link
+      href="https://www.test.bbc.com/pathname"
+      hreflang="x-default"
+      rel="alternate"
+    />
+    <link
+      href="https://www.test.bbc.com/pathname"
+      hreflang="en"
+      rel="alternate"
+    />
+    <link
+      href="https://www.test.bbc.co.uk/pathname"
+      hreflang="en-gb"
+      rel="alternate"
+    />
+    <link
+      href="https://www.test.bbc.co.uk/pathname.amp"
+      rel="amphtml"
+    />
+    <link
+      href="/news/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
+      rel="apple-touch-icon"
+      sizes="72x72"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
+      rel="apple-touch-icon"
+      sizes="96x96"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png"
+      rel="apple-touch-icon"
+      sizes="128x128"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
+      rel="apple-touch-icon"
+      sizes="144x144"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png"
+      rel="apple-touch-icon"
+      sizes="152x152"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+      sizes="192x192"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png"
+      rel="apple-touch-icon"
+      sizes="384x384"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
+      rel="apple-touch-icon"
+      sizes="512x512"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
+      rel="icon"
+      sizes="72x72"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
+      rel="icon"
+      sizes="96x96"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
+      rel="icon"
+      sizes="192x192"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
+      rel="apple-touch-startup-image"
+    />
+    <link
+      href="/favicon.ico"
+      rel="shortcut icon"
+      type="image/x-icon"
+    />
+    <meta
+      content="IE=edge"
+      http-equiv="X-UA-Compatible"
+    />
+    <meta
+      charset="utf-8"
+    />
+    <meta
+      content="noodp,noydir"
+      name="robots"
+    />
+    <meta
+      content="#B80000"
+      name="theme-color"
+    />
+    <meta
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+      name="viewport"
+    />
+    <meta
+      content="BBC News"
+      name="apple-mobile-web-app-title"
+    />
+    <meta
+      content="BBC News"
+      name="application-name"
+    />
+    <meta
+      content="ዝግጅቶቻችንን"
+      name="description"
+    />
+    <meta
+      content="100004154058350"
+      name="fb:admins"
+    />
+    <meta
+      content="1609039196070050"
+      name="fb:app_id"
+    />
+    <meta
+      content="yes"
+      name="mobile-web-app-capable"
+    />
+    <meta
+      content="#B80000"
+      name="msapplication-TileColor"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
+      name="msapplication-TileImage"
+    />
+    <meta
+      content="ዝግጅቶቻችንን"
+      name="og:description"
+    />
+    <meta
+      content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
+      name="og:image"
+    />
+    <meta
+      content="BBC News"
+      name="og:image:alt"
+    />
+    <meta
+      content="en_GB"
+      name="og:locale"
+    />
+    <meta
+      content="BBC News"
+      name="og:site_name"
+    />
+    <meta
+      content="ያድምጡ - BBC News"
+      name="og:title"
+    />
+    <meta
+      content="website"
+      name="og:type"
+    />
+    <meta
+      content="https://www.test.bbc.com/pathname"
+      name="og:url"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:creator"
+    />
+    <meta
+      content="ዝግጅቶቻችንን"
+      name="twitter:description"
+    />
+    <meta
+      content="BBC News"
+      name="twitter:image:alt"
+    />
+    <meta
+      content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
+      name="twitter:image:src"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:site"
+    />
+    <meta
+      content="ያድምጡ - BBC News"
+      name="twitter:title"
+    />
+    <script
+      type="application/ld+json"
     >
-      <div
-        class="c1"
+      {"@context":"http://schema.org","@type":"RadioChannel","url":"https://www.test.bbc.com/pathname","publisher":{"@type":"NewsMediaOrganization","name":"BBC News","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"thumbnailUrl":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.test.bbc.com/pathname","name":"ያድምጡ"}}
+    </script>
+  </head>
+  <body>
+    <div>
+      <noscript />
+      <main
+        role="main"
       >
-        <h1
-          class="c2"
-          id="content"
-        >
-          ያድምጡ
-        </h1>
-        <p
-          class="c3"
-        >
-          ዝግጅቶቻችንን
-        </p>
         <div
-          class="c4"
+          class="c0"
         >
           <div
-            class="c5"
+            class="c1"
           >
-            <div
-              class="c6"
+            <h1
+              class="c2"
+              id="content"
             >
-              <iframe
-                allow="autoplay; fullscreen"
-                allowfullscreen=""
-                class="c7"
-                scrolling="no"
-                src="/ws/av-embeds/media/bbc_amharic_radio/liveradio"
-              />
+              ያድምጡ
+            </h1>
+            <p
+              class="c3"
+            >
+              ዝግጅቶቻችንን
+            </p>
+            <div
+              class="c4"
+            >
+              <div
+                class="c5"
+              >
+                <div
+                  class="c6"
+                >
+                  <iframe
+                    allow="autoplay; fullscreen"
+                    allowfullscreen=""
+                    class="c7"
+                    scrolling="no"
+                    src="/ws/av-embeds/media/bbc_amharic_radio/liveradio"
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </main>
     </div>
-  </main>
-</div>
+  </body>
+</html>
 `;

--- a/src/app/containers/MediaPageMain/index.test.jsx
+++ b/src/app/containers/MediaPageMain/index.test.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
-import { latin } from '@bbc/gel-foundations/scripts';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
-import { ServiceContext } from '../../contexts/ServiceContext';
-import { RequestContext } from '../../contexts/RequestContext';
+import { ServiceContextProvider } from '../../contexts/ServiceContext';
+import { RequestContextProvider } from '../../contexts/RequestContext';
 import MediaPageMain from '.';
 import amharicPageData from '#data/amharic/bbc_amharic_radio/liveradio';
 import addIdsToBlocks from '../../routes/getInitialData/mediapage/addIdsToBlocks';
-
-jest.mock('../Metadata', () => () => <div id="metadata" />);
 
 const pageData = addIdsToBlocks(amharicPageData);
 
 describe('Media Page Main', () => {
   shouldMatchSnapshot(
     'should match snapshot',
-    <ServiceContext.Provider value={{ script: latin }}>
-      <RequestContext.Provider
-        value={{ platform: 'canonical', pageType: 'media' }}
+    <ServiceContextProvider service="news">
+      <RequestContextProvider
+        bbcOrigin="https://www.test.bbc.co.uk"
+        isAmp={false}
+        pageType="media"
+        pathname="/pathname"
+        service="news"
+        statusCode={200}
       >
         <MediaPageMain service="amharic" pageData={pageData} />
-      </RequestContext.Provider>
-    </ServiceContext.Provider>,
+      </RequestContextProvider>
+    </ServiceContextProvider>,
   );
 });


### PR DESCRIPTION
Partially resolves https://github.com/bbc/simorgh/issues/3598

**Overall change:** Uses `psammead-test-helpers` to produce more readable snapshot for front page main and media page main.

**Code changes:**

- imports `@bbc/psammead-test-helpers` in `FrontPageMain/index.test.jsx` to replace `shouldShallowMatchSnapshot`
- Removes metadata component mock from `MediaPageMain/index.test.jsx`
- Uses `ServiceContextProvider` and `RequestContextProvider` to enable a deep snapshot of media page with metadata

---

**Testing notes**
No testing required because changes only affect unit tests.

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
