### PR TITLE
Use BBC Scotland SVG for scotland service pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1311,9 +1311,9 @@
       "integrity": "sha512-Jjkk9ieEa0WXK4Wvw82YVvMhP4yi0pBOftwNhQGOVLx1Av8KSHFHacFxHEiVcVxoXCPpdeWaLYrKm0fcyoxlKA=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.2.4.tgz",
-      "integrity": "sha512-kw/KrqkFbL99psjzl5OifENBL5vWi2OCPI/VMvMN53OfydOQxMryfwdxOkg60oRfsuGYvBvBUayYB9Tu8Ar7AA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.4.0.tgz",
+      "integrity": "sha512-glFrzt67rve6z/8JuNkNTdImw3LlmmANzD+O6P6EKm9mY8AlYtWc4LQDFRb4t9xeeYWejwPGOKz0tX756nA+bA=="
     },
     "@bbc/psammead-brand": {
       "version": "5.0.1",
@@ -9554,18 +9554,21 @@
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "ms": {
@@ -9574,7 +9577,8 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -9582,7 +9586,8 @@
           }
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@bbc/gel-foundations": "^3.4.0",
     "@bbc/moment-timezone-include": "^1.1.2",
     "@bbc/psammead-amp-geo": "^1.1.2",
-    "@bbc/psammead-assets": "^2.2.4",
+    "@bbc/psammead-assets": "^2.4.0",
     "@bbc/psammead-brand": "^5.0.1",
     "@bbc/psammead-caption": "^2.2.9",
     "@bbc/psammead-consent-banner": "^2.3.10",

--- a/src/app/lib/config/services/scotland.js
+++ b/src/app/lib/config/services/scotland.js
@@ -1,5 +1,5 @@
 import { C_DARK_SALTIRE, C_WHITE } from '@bbc/psammead-styles/colours';
-import { news as brandSVG } from '@bbc/psammead-assets/svgs';
+import { scotland as brandSVG } from '@bbc/psammead-assets/svgs';
 import { cyrillicAndLatin } from '@bbc/gel-foundations/scripts';
 import {
   F_REITH_SANS_BOLD,


### PR DESCRIPTION
Resolves #3885
Desktop breakpoint:
<img width="1201" alt="Screenshot BBC Scotland article with relevant SVG" src="https://user-images.githubusercontent.com/3028997/65313506-5df8c680-db8c-11e9-9532-b6badc30b6bb.png">

Mobile breakpoint:
<img width="329" alt="Screenshot BBC Scotland svg at mobile breakpoint" src="https://user-images.githubusercontent.com/3028997/65318944-8685be00-db96-11e9-9518-f0d44a39c09d.png">

Page URL used for testing: http://localhost.bbc.com:7080/scotland/articles/czwj5l0n210o

**Overall change:** Use BBC Scotland SVG for scotland service pages

**Code changes:**

- Use BBC Scotland SVG for scotland service pages

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] This PR requires manual testing
