### PR TITLE
Add some nav items for /news

### DIFF
--- a/src/app/lib/config/services/news.js
+++ b/src/app/lib/config/services/news.js
@@ -191,6 +191,32 @@ const news = {
       F_REITH_SERIF_MEDIUM_ITALIC,
     ],
     timezone: 'Europe/London',
+    navigation: [
+      {
+        title: 'Home',
+        url: '/news',
+      },
+      {
+        title: 'UK',
+        url: '/news/uk',
+      },
+      {
+        title: 'World',
+        url: '/news/world',
+      },
+      {
+        title: 'Business',
+        url: '/news/business',
+      },
+      {
+        title: 'Politics',
+        url: '/news/politics',
+      },
+      {
+        title: 'Tech',
+        url: '/news/technology',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
Resolves #3887

**Overall change:**
Adds a nav to /news (on test)

**Code changes:**

- Updates the config for /news to add six nav items

<img width="420" alt="Screen Shot 2019-09-20 at 10 26 33" src="https://user-images.githubusercontent.com/8124899/65321082-2d6c5900-db9b-11e9-829f-ac086b1af509.png">
<img width="1416" alt="Screen Shot 2019-09-20 at 10 55 29" src="https://user-images.githubusercontent.com/8124899/65321083-30674980-db9b-11e9-9b3d-ecb30021852c.png">


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
