### PR TITLE
Remove duplicate test that was looking at the incorrect value

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -92,11 +92,6 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
               'content',
               appConfig[service][variant].locale,
             );
-            cy.get('meta[name="og:site_name"]').should(
-              'have.attr',
-              'content',
-              appConfig[service][variant].defaultImageAltText,
-            );
             cy.get('meta[name="og:type"]').should(
               'have.attr',
               'content',


### PR DESCRIPTION
Resolves N/A

**Overall change:**

There were two tests that were looking at the OG site_name meta tag. One test asserted that the value should be equal to the brand name (which is correct) and the other asserted that the value should be equal to the defaultImageAltText which is wrong.

This is most likely just a copy paste error when setting up the tests however was only spotted now as for most services the site name is the same value as the defaultImageAltText

**Code changes:**

- Remove incorrect duplicate test

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
