### PR TITLE
fix: the passportHomesOverride does not matter when checking.

### DIFF
--- a/src/app/lib/utilities/passport/index.js
+++ b/src/app/lib/utilities/passport/index.js
@@ -23,7 +23,7 @@ export const isValidPassportHome = (
   const passportHomesOverrideArray = passportHomesOverride || [];
   const passportHomeLower = (passportHome || '').toLowerCase();
 
-  if (!passportHome && !passportHomesOverrideArray.length) return true;
+  if (!passportHome) return true;
 
   return (
     passportHomeLower === service ||

--- a/src/app/lib/utilities/passport/index.test.js
+++ b/src/app/lib/utilities/passport/index.test.js
@@ -54,4 +54,8 @@ describe('isValidPassportHome', () => {
   it('should give true for null passportHome', () => {
     expect(isValidPassportHome(null, 'portuguese')).toEqual(true);
   });
+
+  it('should give true for null service', () => {
+    expect(isValidPassportHome('brasil', null, ['brasil'])).toEqual(true);
+  });
 });

--- a/src/app/lib/utilities/passport/index.test.js
+++ b/src/app/lib/utilities/passport/index.test.js
@@ -58,4 +58,8 @@ describe('isValidPassportHome', () => {
   it('should give true for null service', () => {
     expect(isValidPassportHome('brasil', null, ['brasil'])).toEqual(true);
   });
+
+  it('should give true for null passportHome with overrides', () => {
+    expect(isValidPassportHome(null, 'portuguest', ['brasil'])).toEqual(true);
+  });
 });

--- a/src/app/lib/utilities/passport/index.test.js
+++ b/src/app/lib/utilities/passport/index.test.js
@@ -60,6 +60,6 @@ describe('isValidPassportHome', () => {
   });
 
   it('should give true for null passportHome with overrides', () => {
-    expect(isValidPassportHome(null, 'portuguest', ['brasil'])).toEqual(true);
+    expect(isValidPassportHome(null, 'portuguese', ['brasil'])).toEqual(true);
   });
 });


### PR DESCRIPTION
Related to #2574

**Issue:** _The isValidPassportHome method is returning false when on the frontpage. CPS assets i.e. front pages do not have a passport, can the passport step be skipped for front pages?_

**Overall change:** _the passportHomesOverride array does not matter, if `passportHome` is null or undefined._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
