### PR TITLE
Disable afaanoromoo liveRadio e2e tests on test

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -24,7 +24,7 @@ module.exports = {
       },
       liveRadio: {
         path:
-          Cypress.env('APP_ENV') === 'live'
+          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/afaanoromoo/bbc_afaanoromoo_radio/liveradio',
         smoke: false,


### PR DESCRIPTION
Disables tests while investigating #3976

**Overall change:** _Prevent tests running on test due to Orbit appearing in iframe and breaking cookie banner._

We were seeing test failures such as:
```
Canonical Cookie Banner Test for afaanoromoo liveRadio should have a privacy & cookie banner, which disappears once "accepted" :
AssertionError: expected { Object (name, value, ...) } to have a property 'value' of '111', but got '000'

Canonical Cookie Banner Test for afaanoromoo liveRadio should not override the user's default cookie policy:
AssertionError: expected { Object (name, value, ...) } to have a property 'value' of 'made_up_value', but got '111'
```

This is because of Orbit appearing in the middle of the page:

<img width="1452" alt="Screenshot 2019-09-26 at 08 32 55" src="https://user-images.githubusercontent.com/11161809/65668145-0d281880-e039-11e9-85ca-7b84dcca61be.png">

--

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] This PR requires manual testing
