### PR TITLE
Revert "Disable afaanoromoo liveRadio e2e tests on test"

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -24,7 +24,7 @@ module.exports = {
       },
       liveRadio: {
         path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
+          Cypress.env('APP_ENV') === 'live'
             ? undefined
             : '/afaanoromoo/bbc_afaanoromoo_radio/liveradio',
         smoke: false,


### PR DESCRIPTION
Reverts bbc/simorgh#3975

Following the merge of https://github.com/bbc/simorgh/pull/3981 the Afaanoromoo TEST live radio pages should be back stable and the E2E will pass again. 