### PR TITLE
Readme update so non-smoke tests will run on correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ CYPRESS_SKIP_EU=true npm run cypress:interactive
 The following command runs both simorgh and cypress:
 
 ```
-CYPRESS_APP_ENV=local CYPRESS_UK=true CYPRESS_SMOKE=true npm run build && npm run test:e2e
+CYPRESS_APP_ENV=local CYPRESS_UK=true CYPRESS_SMOKE=true npm run test:e2e
 ```
 
 CYPRESS_APP_ENV can also be set equal to 'test' and 'live'.


### PR DESCRIPTION
**Overall change:** Changing readme to remove build command for e2e tests

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
