### PR TITLE
Fix 3rd-party errorPage test failing due to config structure change

### DIFF
--- a/3rdPartyCypress/cypress/integration/errorPageNews.js
+++ b/3rdPartyCypress/cypress/integration/errorPageNews.js
@@ -1,4 +1,4 @@
-import news from '../../../src/app/lib/config/services/news';
+import { service as news } from '../../../src/app/lib/config/services/news';
 
 // This is a 3rd party test, but if it fails we should arrange for it to be fixed.
 describe('Test the mozart 404 page', () => {


### PR DESCRIPTION
[no issue]

**Overall change:** _Update 3rd-party test to reflect new service config structure introduced in https://github.com/bbc/simorgh/pull/3680 that is causing the News errorPage test to fail._

Error output:
```
  1) Test the mozart 404 page should display a relevant error message on screen:
     TypeError: Cannot read property 'translations' of undefined
      at Context.<anonymous> (https://www.bbc.com/__cypress/tests?p=cypress/integration/errorPageNews.js-286:215:68)

  2) Test the mozart 404 page should have an inline link on the page that is linked to the home page:
     TypeError: Cannot read property 'translations' of undefined
      at Context.<anonymous> (https://www.bbc.com/__cypress/tests?p=cypress/integration/errorPageNews.js-286:219:79)

  3) Test the mozart 404 page should have a relevant error title in the head:
     TypeError: Cannot read property 'translations' of undefined
      at Context.<anonymous> (https://www.bbc.com/__cypress/tests?p=cypress/integration/errorPageNews.js-286:223:61)
```

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] This PR requires manual testing
