### PR TITLE
Bump Timestamp Container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,21 +1496,28 @@
       }
     },
     "@bbc/psammead-timestamp": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.8.tgz",
-      "integrity": "sha512-Wv5IKWexW8O1A9gsUcJNJA7VzizFJH+3nolydiBiKVkGt4+S8pF4RJwjEG7rqopxGAbewpe4fSlRhdrfGII4UQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp/-/psammead-timestamp-2.2.10.tgz",
+      "integrity": "sha512-UwcvCAqC7k3VBuXE8x0KZf5YByUA4s7d1FgB3H0eaGo4b+sjxWFX3gSDUTZmUjRHVGu0UkxGIdlSBMyduwoLEA==",
       "requires": {
-        "@bbc/gel-foundations": "^3.3.3",
-        "@bbc/psammead-styles": "^2.3.0"
+        "@bbc/gel-foundations": "^3.4.0",
+        "@bbc/psammead-styles": "^3.0.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-styles": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-3.0.0.tgz",
+          "integrity": "sha512-6v+G1wF4Hc3kvm6fH7EZRUSSy9wzByXs0KgxseXrHIK7ps2RxuZRgnykA+4ofXgLwpNg4G+Nznx5oLkeK3kheA=="
+        }
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.4.15.tgz",
-      "integrity": "sha512-H/z1XGSa/Ntym5TC5AhchE2c2dZBPsxWnUJiPrHUvW4tBvLjm18dsNY9qkHjhmThWtpBpPtX5feCvQUXbSH5wQ==",
+      "version": "2.4.19",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-2.4.19.tgz",
+      "integrity": "sha512-k3lIYCAutkgR7zRXNp2ad/XFSu6YrUU1uT+IylCKkqM2E5FMQ8d4DZqSiNQDsUbGwWjzmca6jbk/gN5WstqUvg==",
       "requires": {
-        "@bbc/gel-foundations": "^3.3.3",
-        "@bbc/psammead-timestamp": "^2.2.8",
+        "@bbc/gel-foundations": "^3.4.0",
+        "@bbc/psammead-timestamp": "^2.2.10",
         "moment-timezone": "^0.5.26"
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@bbc/psammead-story-promo": "^2.7.12",
         "@bbc/psammead-story-promo-list": "^2.1.11",
         "@bbc/psammead-styles": "^2.3.0",
-        "@bbc/psammead-timestamp-container": "^2.4.15",
+        "@bbc/psammead-timestamp-container": "^2.4.19",
         "@bbc/psammead-visually-hidden-text": "^1.2.2",
         "@loadable/component": "^5.10.2",
         "@loadable/server": "^5.10.2",


### PR DESCRIPTION
**Overall change:** Brings in changes made in https://github.com/bbc/psammead/pull/2240.

**Code changes:**

- Bump Timestamp Container to version 2.4.19
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
