### PR TITLE
Fix cypress link tests

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -370,8 +370,9 @@ export const testsThatNeverRunDuringSmokeTestingForAllPageTypes = ({
           cy.get('a')
             .not('[href="#*"]')
             .each(element => {
-              const href = element.attr('href');
-              cy.request(href, {
+              const url = element.attr('href');
+              cy.request({
+                url,
                 failOnStatusCode: false,
               }).then(resp => {
                 expect(resp.status).to.not.equal(404);


### PR DESCRIPTION
**Overall change:** Fix cypress link tests which are using the cypress request api wrong 🙈 

**Code changes:**

- Moves `url` inside the options object in request
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing
