### PR TITLE
Moment locale import fix

### DIFF
--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -4,6 +4,7 @@ import { burmese as brandSVG } from '@bbc/psammead-assets/svgs';
 import { F_PADAUK_BOLD, F_PADAUK_REGULAR } from '@bbc/psammead-styles/fonts';
 import '@bbc/moment-timezone-include/tz/GMT';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/my';
 
 export const service = {
   default: {

--- a/src/app/lib/config/services/cymrufyw.js
+++ b/src/app/lib/config/services/cymrufyw.js
@@ -11,6 +11,7 @@ import {
 import { news as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Europe/London';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/cy';
 
 export const service = {
   default: {

--- a/src/app/lib/config/services/korean.js
+++ b/src/app/lib/config/services/korean.js
@@ -3,6 +3,7 @@ import { noAscendersOrDescenders } from '@bbc/gel-foundations/scripts';
 import { korean as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Asia/Seoul';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/ko';
 
 export const service = {
   default: {

--- a/src/app/lib/config/services/naidheachdan.js
+++ b/src/app/lib/config/services/naidheachdan.js
@@ -11,6 +11,7 @@ import {
 import { news as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Europe/London';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/gd';
 
 export const service = {
   default: {

--- a/src/app/lib/config/services/telugu.js
+++ b/src/app/lib/config/services/telugu.js
@@ -4,6 +4,7 @@ import { news as brandSVG } from '@bbc/psammead-assets/svgs';
 import { F_MALLANNA_REGULAR } from '@bbc/psammead-styles/fonts';
 import '@bbc/moment-timezone-include/tz/Asia/Kolkata';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/te';
 
 export const service = {
   default: {

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -11,6 +11,7 @@ import {
 import { turkce as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Asia/Istanbul';
 import withContext from '../../../contexts/utils/withContext';
+import 'moment/locale/tr';
 
 export const service = {
   default: {


### PR DESCRIPTION
Resolves #4075

**Overall change:** _Added import statement for the moment locales._

**Code changes:**

- _Added import 'my' locale into Burmese config._
- _Added import 'cy' locale into Cymrufyw config._
- _Added import 'ko' locale into Korean config._
- _Added import 'gd' locale into Naidheachdan config._
- _Added import 'te' locale into Telugu config._
- _Added import 'tr' locale into Turkce config._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] This PR requires manual testing