### PR TITLE
Bump psammead media player for valid amp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1424,9 +1424,9 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "1.1.1-alpha.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-1.1.1-alpha.2.tgz",
-      "integrity": "sha512-syMkdkuNFvYQRT46qCwJHXvUhFOfh0m0Vpy0KXlpwusshVK/0CeDNLnl80s7roIGw9ymmBOo9e/5+p3n134wWQ==",
+      "version": "1.1.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-1.1.1-alpha.6.tgz",
+      "integrity": "sha512-UM/0mQt6jEWzreBheREgrk70y7HV0BAnC/20S1nEiYIPwwsnSYPp407VW/DC5H6nucVrznmeFO1FQ08INRhX7g==",
       "requires": {
         "@bbc/psammead-image": "^1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@bbc/psammead-inline-link": "^1.3.9",
     "@bbc/psammead-locales": "^2.19.0",
     "@bbc/psammead-media-indicator": "^2.6.2",
-    "@bbc/psammead-media-player": "^1.1.1-alpha.2",
+    "@bbc/psammead-media-player": "^1.1.1-alpha.6",
     "@bbc/psammead-navigation": "^2.3.3",
     "@bbc/psammead-paragraph": "^2.2.11",
     "@bbc/psammead-section-label": "^2.3.15",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simorgh",
   "main": "./src/client.js",
   "scripts": {
-    "amp:validate": "wait-on http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po.amp && amphtml-validator http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po.amp && amphtml-validator http://localhost.bbc.com:7080/igbo.amp",
+    "amp:validate": "wait-on http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po.amp && amphtml-validator http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po.amp && amphtml-validator http://localhost.bbc.com:7080/igbo.amp && amphtml-validator http://localhost.bbc.com:7080/korean/bbc_korean_radio/liveradio.amp",
     "bbcA11y": "wait-on -t 20000 http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po && bbc-a11y",
     "bbcA11y:ci": "wait-on -t 20000 http://localhost.bbc.com:7080/news/articles/c6v11qzyv8po && xvfb-run -a bbc-a11y",
     "build": "rm -rf build && cp envConfig/local.env .env && NODE_ENV=production webpack && node ./scripts/bundleSize.js",

--- a/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`MediaPlayer is called correctly Calls the AMP player when platform is A
           class="c1"
         >
           <amp-iframe
-            allowfullscreen="true"
+            allowfullscreen="allowfullscreen"
             frameborder="0"
             layout="fill"
             sandbox="allow-scripts allow-same-origin"

--- a/src/app/containers/RadioPageBlocks/Blocks/LiveRadio/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/LiveRadio/__snapshots__/index.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`MediaPageBlocks LiveRadio should render correctly for amp 1`] = `
             class="c2"
           >
             <amp-iframe
-              allowfullscreen="true"
+              allowfullscreen="allowfullscreen"
               frameborder="0"
               layout="fill"
               sandbox="allow-scripts allow-same-origin"
@@ -119,7 +119,6 @@ exports[`MediaPageBlocks LiveRadio should render correctly for canonical 1`] = `
         allow="autoplay; fullscreen"
         allowfullscreen=""
         class="c3"
-        scrolling="no"
         src="https://www.test.bbc.co.uk/ws/av-embeds/media/externalId/id"
       />
     </div>
@@ -175,7 +174,7 @@ exports[`MediaPageBlocks LiveRadio when externalId is bbc_oromo_radio it is over
             class="c2"
           >
             <amp-iframe
-              allowfullscreen="true"
+              allowfullscreen="allowfullscreen"
               frameborder="0"
               layout="fill"
               sandbox="allow-scripts allow-same-origin"
@@ -246,7 +245,6 @@ exports[`MediaPageBlocks LiveRadio when externalId is bbc_oromo_radio it is over
         allow="autoplay; fullscreen"
         allowfullscreen=""
         class="c3"
-        scrolling="no"
         src="https://www.test.bbc.co.uk/ws/av-embeds/media/bbc_afaanoromoo_radio/id"
       />
     </div>

--- a/src/app/containers/RadioPageBlocks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/__snapshots__/index.test.jsx.snap
@@ -120,7 +120,6 @@ exports[`Radio Page Blocks should match snapshot 1`] = `
           allow="autoplay; fullscreen"
           allowfullscreen=""
           class="c5"
-          scrolling="no"
           src="https://www.test.bbc.co.uk/ws/av-embeds/media/bbc_amharic_radio/liveradio"
         />
       </div>

--- a/src/app/containers/RadioPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageMain/__snapshots__/index.test.jsx.snap
@@ -436,7 +436,6 @@ exports[`Radio Page Main should match snapshot 1`] = `
                   allow="autoplay; fullscreen"
                   allowfullscreen=""
                   class="c7"
-                  scrolling="no"
                   src="https://www.test.bbc.co.uk/ws/av-embeds/media/bbc_amharic_radio/liveradio"
                 />
               </div>


### PR DESCRIPTION
Resolves #4078 4078

**Overall change:** Bumps psammead media player to include changes to make the player AMP valid. Also updates the `amp:validate` command to check the live radio URL.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- ~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~
- ~[ ] This PR requires manual testing~

**Before this PR** 
![image](https://user-images.githubusercontent.com/7791726/66065040-81cdec00-e53e-11e9-943b-af99f838f8c2.png)

**After this PR** 
![image](https://user-images.githubusercontent.com/7791726/66065095-97431600-e53e-11e9-92ba-c48acbcd22d0.png)
