### PR TITLE
rewrite metadata tests using react testing library

### DIFF
--- a/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Metadata Container LinkedData and Metadata components called with correct props should match snapshot for AMP News & UK origin 1`] = `
+exports[`should match for AMP News & UK origin 1`] = `
 <html
   amp=""
   dir="ltr"
@@ -10,21 +10,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <title>
       Article Headline for SEO - BBC News
     </title>
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o"
-      hreflang="en-gb"
-      rel="alternate"
-    />
     <link
       href="https://www.bbc.com/news/articles/c0000000001o"
       rel="canonical"
@@ -262,7 +247,7 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
 </html>
 `;
 
-exports[`Metadata Container LinkedData and Metadata components called with correct props should match snapshot for Canonical News & international origin 1`] = `
+exports[`should match for Canonical News & international origin 1`] = `
 <html
   dir="ltr"
   lang="en-gb"
@@ -512,7 +497,7 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
 </html>
 `;
 
-exports[`Metadata Container LinkedData and Metadata components called with correct props should match snapshot for Persian News & UK origin 1`] = `
+exports[`should match for Persian News & UK origin 1`] = `
 <html
   amp=""
   dir="rtl"
@@ -522,106 +507,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <title>
       سرصفحه مقاله - BBC News فارسی
     </title>
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o.amp"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://foo.com/static/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
-    <link
-      href="https://www.bbc.com/persian/articles/c4vlle3q337o.amp"
-      rel="amphtml"
-    />
     <link
       href="https://www.bbc.com/persian/articles/c4vlle3q337o"
       rel="canonical"
@@ -696,18 +581,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
       href="/favicon.ico"
       rel="shortcut icon"
       type="image/x-icon"
-    />
-    <meta
-      content="Royal Wedding 2018"
-      name="article:tag"
-    />
-    <meta
-      content="Duchess of Sussex"
-      name="article:tag"
-    />
-    <meta
-      content="Queen Victoria"
-      name="article:tag"
     />
     <meta
       content="IE=edge"
@@ -835,11 +708,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/news/articles/c0000000001o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"thumbnailUrl":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/news/articles/c0000000001o","name":"Article Headline for SEO"},"headline":"Article Headline for SEO","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"},"about":[{"@type":"Thing","name":"Royal Wedding 2018","sameAs":["http://dbpedia.org/resource/Queen_Victoria"]},{"@type":"Person","name":"Duchess of Sussex"}]}
-    </script>
-    <script
-      type="application/ld+json"
-    >
       {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/persian/articles/c4vlle3q337o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/persian/articles/c4vlle3q337o","name":"سرصفحه مقاله"},"headline":"سرصفحه مقاله","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"}}
     </script>
   </head>
@@ -849,7 +717,7 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
 </html>
 `;
 
-exports[`Metadata Container LinkedData and Metadata components called with correct props should match snapshot for Persian News & international origin 1`] = `
+exports[`should match for Persian News & international origin 1`] = `
 <html
   amp=""
   dir="rtl"
@@ -859,102 +727,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <title>
       سرصفحه مقاله - BBC News فارسی
     </title>
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o.amp"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://foo.com/static/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
     <link
       href="https://www.bbc.com/persian/articles/c4vlle3q337o"
       rel="canonical"
@@ -1033,18 +805,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
       href="/favicon.ico"
       rel="shortcut icon"
       type="image/x-icon"
-    />
-    <meta
-      content="Royal Wedding 2018"
-      name="article:tag"
-    />
-    <meta
-      content="Duchess of Sussex"
-      name="article:tag"
-    />
-    <meta
-      content="Queen Victoria"
-      name="article:tag"
     />
     <meta
       content="IE=edge"
@@ -1172,11 +932,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/news/articles/c0000000001o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"thumbnailUrl":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/news/articles/c0000000001o","name":"Article Headline for SEO"},"headline":"Article Headline for SEO","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"},"about":[{"@type":"Thing","name":"Royal Wedding 2018","sameAs":["http://dbpedia.org/resource/Queen_Victoria"]},{"@type":"Person","name":"Duchess of Sussex"}]}
-    </script>
-    <script
-      type="application/ld+json"
-    >
       {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/persian/articles/c4vlle3q337o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/persian/articles/c4vlle3q337o","name":"سرصفحه مقاله"},"headline":"سرصفحه مقاله","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"}}
     </script>
   </head>
@@ -1186,7 +941,7 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
 </html>
 `;
 
-exports[`Metadata Container LinkedData and Metadata components called with correct props should match snapshot for WS Frontpages 1`] = `
+exports[`should match for WS Frontpages 1`] = `
 <html
   amp=""
   dir="ltr"
@@ -1196,172 +951,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <title>
       Ogbako - BBC News Ìgbò
     </title>
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o.amp"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://foo.com/static/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
-    <link
-      href="https://www.bbc.com/persian/articles/c4vlle3q337o.amp"
-      rel="amphtml"
-    />
-    <link
-      href="https://foo.com/static/persian/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
     <link
       href="https://www.bbc.com/igbo"
       rel="canonical"
@@ -1445,30 +1034,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
       href="/favicon.ico"
       rel="shortcut icon"
       type="image/x-icon"
-    />
-    <meta
-      content="Royal Wedding 2018"
-      name="article:tag"
-    />
-    <meta
-      content="Duchess of Sussex"
-      name="article:tag"
-    />
-    <meta
-      content="Queen Victoria"
-      name="article:tag"
-    />
-    <meta
-      content="https://www.facebook.com/bbcnews"
-      name="article:author"
-    />
-    <meta
-      content="2018-01-01T13:00:00.000Z"
-      name="article:modified_time"
-    />
-    <meta
-      content="2018-01-01T12:01:00.000Z"
-      name="article:published_time"
     />
     <meta
       content="IE=edge"
@@ -1584,16 +1149,6 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/news/articles/c0000000001o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"thumbnailUrl":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/news/articles/c0000000001o","name":"Article Headline for SEO"},"headline":"Article Headline for SEO","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"},"about":[{"@type":"Thing","name":"Royal Wedding 2018","sameAs":["http://dbpedia.org/resource/Queen_Victoria"]},{"@type":"Person","name":"Duchess of Sussex"}]}
-    </script>
-    <script
-      type="application/ld+json"
-    >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/persian/articles/c4vlle3q337o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/persian/articles/c4vlle3q337o","name":"سرصفحه مقاله"},"headline":"سرصفحه مقاله","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"}}
-    </script>
-    <script
-      type="application/ld+json"
-    >
       {"@context":"http://schema.org","@type":"WebPage","url":"https://www.bbc.com/igbo","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/igbo","name":"Ogbako"}}
     </script>
   </head>
@@ -1603,7 +1158,7 @@ exports[`Metadata Container LinkedData and Metadata components called with corre
 </html>
 `;
 
-exports[`Metadata Container should match snapshot for WS Media liveradio 1`] = `
+exports[`should match for WS Media liveradio 1`] = `
 <html
   amp=""
   dir="ltr"
@@ -1613,247 +1168,6 @@ exports[`Metadata Container should match snapshot for WS Media liveradio 1`] = `
     <title>
       BBC News 코리아 라디오 - BBC News 코리아
     </title>
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="x-default"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/news/articles/c0000000001o.amp"
-      hreflang="en"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.co.uk/news/articles/c0000000001o.amp"
-      hreflang="en-gb"
-      rel="alternate"
-    />
-    <link
-      href="https://foo.com/static/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
-    <link
-      href="https://www.bbc.com/persian/articles/c4vlle3q337o.amp"
-      rel="amphtml"
-    />
-    <link
-      href="https://foo.com/static/persian/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
-    <link
-      href="https://www.bbc.com/igbo"
-      hreflang="ig"
-      rel="alternate"
-    />
-    <link
-      href="https://www.bbc.com/igbo.amp"
-      rel="amphtml"
-    />
-    <link
-      href="https://foo.com/static/igbo/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
-      rel="apple-touch-icon"
-      sizes="96x96"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-144x144.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-152x152.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
-      rel="apple-touch-icon"
-      sizes="192x192"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-384x384.png"
-      rel="apple-touch-icon"
-      sizes="384x384"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
-      rel="apple-touch-icon"
-      sizes="512x512"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
-      rel="icon"
-      sizes="96x96"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png"
-    />
-    <link
-      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
-      rel="apple-touch-startup-image"
-    />
     <link
       href="https://www.bbc.com/korean/bbc_korean_radio/liveradio"
       rel="canonical"
@@ -1932,30 +1246,6 @@ exports[`Metadata Container should match snapshot for WS Media liveradio 1`] = `
       href="/favicon.ico"
       rel="shortcut icon"
       type="image/x-icon"
-    />
-    <meta
-      content="Royal Wedding 2018"
-      name="article:tag"
-    />
-    <meta
-      content="Duchess of Sussex"
-      name="article:tag"
-    />
-    <meta
-      content="Queen Victoria"
-      name="article:tag"
-    />
-    <meta
-      content="https://www.facebook.com/bbcnews"
-      name="article:author"
-    />
-    <meta
-      content="2018-01-01T13:00:00.000Z"
-      name="article:modified_time"
-    />
-    <meta
-      content="2018-01-01T12:01:00.000Z"
-      name="article:published_time"
     />
     <meta
       content="IE=edge"
@@ -2068,21 +1358,6 @@ exports[`Metadata Container should match snapshot for WS Media liveradio 1`] = `
       content="BBC News 코리아 라디오 - BBC News 코리아"
       name="twitter:title"
     />
-    <script
-      type="application/ld+json"
-    >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/news/articles/c0000000001o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"thumbnailUrl":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/news/articles/c0000000001o","name":"Article Headline for SEO"},"headline":"Article Headline for SEO","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"},"about":[{"@type":"Thing","name":"Royal Wedding 2018","sameAs":["http://dbpedia.org/resource/Queen_Victoria"]},{"@type":"Person","name":"Duchess of Sussex"}]}
-    </script>
-    <script
-      type="application/ld+json"
-    >
-      {"@context":"http://schema.org","@type":"Article","url":"https://www.bbc.com/persian/articles/c4vlle3q337o","publisher":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/persian/articles/c4vlle3q337o","name":"سرصفحه مقاله"},"headline":"سرصفحه مقاله","datePublished":"2018-01-01T12:01:00.000Z","dateModified":"2018-01-01T13:00:00.000Z","author":{"@type":"NewsMediaOrganization","name":"BBC News فارسی","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"},"noBylinesPolicy":"https://www.bbc.com/news/help-41670342#authorexpertise"}}
-    </script>
-    <script
-      type="application/ld+json"
-    >
-      {"@context":"http://schema.org","@type":"WebPage","url":"https://www.bbc.com/igbo","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.bbc.com/igbo","name":"Ogbako"}}
-    </script>
     <script
       type="application/ld+json"
     >

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, waitForDomChange } from '@testing-library/react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import MetadataContainer from './index';
-import LinkedData from '../../components/LinkedData';
-import Metadata from '../../components/Metadata';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { articleDataNews, articleDataPersian } from '../Article/fixtureData';
 import services from '#testHelpers/serviceConfigs';
@@ -17,15 +15,16 @@ const dotCoDotUKOrigin = 'https://www.bbc.co.uk';
 process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN = 'https://foo.com';
 process.env.SIMORGH_PUBLIC_STATIC_ASSETS_PATH = '/static';
 
-const getContainer = ({
+const MetadataWithContext = ({
   /* eslint-disable react/prop-types */
   service,
   bbcOrigin,
   platform,
-  data,
   id,
   pageType,
   pathname,
+  promo,
+  metadata,
   /* eslint-enable react/prop-types */
 }) => {
   const serviceConfig = services[service].default;
@@ -41,540 +40,491 @@ const getContainer = ({
         service={service}
         statusCode={200}
       >
-        <MetadataContainer {...articleDataNews} {...data} />
+        <MetadataContainer promo={promo} metadata={metadata} />
       </RequestContextProvider>
     </ServiceContextProvider>
   );
 };
 
-const metadataProps = ({
-  isAmp,
-  alternateLinks,
-  ampLink,
-  canonicalLink,
-  description,
-  dir,
-  lang,
-  metaTags,
-  timeFirstPublished,
-  timeLastPublished,
-  title,
-  serviceConfig,
-  type,
-  service,
-  showArticleTags,
-}) => ({
-  isAmp,
-  alternateLinks,
-  ampLink,
-  appleTouchIcon: `https://foo.com/static/${serviceConfig.service}/images/icons/icon-192x192.png`,
-  articleAuthor: serviceConfig.articleAuthor || null,
-  articleSection: null,
-  brandName: serviceConfig.brandName,
-  canonicalLink,
-  defaultImage: serviceConfig.defaultImage,
-  defaultImageAltText: serviceConfig.defaultImageAltText,
-  description,
-  dir,
-  facebookAdmin: 100004154058350,
-  facebookAppID: 1609039196070050,
-  lang,
-  locale: serviceConfig.locale,
-  metaTags,
-  themeColor: serviceConfig.themeColor,
-  timeFirstPublished,
-  timeLastPublished,
-  title,
-  twitterCreator: serviceConfig.twitterCreator,
-  twitterSite: serviceConfig.twitterSite,
-  type,
-  service,
-  showArticleTags,
-  iconSizes: {
-    'apple-touch-icon': [
-      '72x72',
-      '96x96',
-      '128x128',
-      '144x144',
-      '152x152',
-      '192x192',
-      '384x384',
-      '512x512',
-    ],
-    icon: ['72x72', '96x96', '192x192'],
-  },
+const CanonicalNewsInternationalOrigin = () => (
+  <MetadataWithContext
+    service="news"
+    bbcOrigin={dotComOrigin}
+    platform="canonical"
+    id="c0000000001o"
+    pageType="article"
+    pathname="/news/articles/c0000000001o"
+    promo={articleDataNews.promo}
+    metadata={articleDataNews.metadata}
+  />
+);
+
+const renderMetadataToDocument = async () => {
+  render(<CanonicalNewsInternationalOrigin />);
+
+  await waitForDomChange({
+    container: document.querySelector('head'),
+  });
+};
+
+it('should render the dir and lang attribute', async () => {
+  await renderMetadataToDocument();
+  const htmlEl = document.querySelector('html');
+
+  expect(htmlEl.getAttribute('dir')).toEqual('ltr');
+  expect(htmlEl.getAttribute('lang')).toEqual('en-gb');
 });
 
-const linkedDataProps = ({
-  brandName,
-  canonicalLink,
-  firstPublished,
-  lastUpdated,
-  logoUrl,
-  seoHeadline,
-  type,
-  about = undefined,
-}) => ({
-  brandName,
-  canonicalLink,
-  firstPublished,
-  lastUpdated,
-  logoUrl,
-  noBylinesPolicy: 'https://www.bbc.com/news/help-41670342#authorexpertise',
-  publishingPrinciples: 'https://www.bbc.com/news/help-41670342',
-  seoHeadline,
-  type,
-  about,
+it('should render the document title', async () => {
+  await renderMetadataToDocument();
+  const actual = document.querySelector('head > title').innerHTML;
+  const expected = 'Article Headline for SEO - BBC News';
+
+  expect(actual).toEqual(expected);
 });
 
-describe('Metadata Container', () => {
-  describe('LinkedData and Metadata components called with correct props', () => {
-    it('should be correct for Canonical News & international origin', () => {
-      const Wrapper = mount(
-        getContainer({
-          service: 'news',
-          bbcOrigin: dotComOrigin,
-          platform: 'canonical',
-          data: articleDataNews,
-          id: 'c0000000001o',
-          pageType: 'article',
-          pathname: '/news/articles/c0000000001o',
-        }),
-      );
+it('should render the canonical link', async () => {
+  await renderMetadataToDocument();
 
-      expect(
-        Wrapper.containsMatchingElement(
-          <MetadataContainer {...articleDataNews} />,
-        ),
-      ).toEqual(true);
-      expect(Wrapper.find(Metadata).props()).toEqual(
-        metadataProps({
-          isAmp: false,
-          alternateLinks: [
-            {
-              href: 'https://www.bbc.com/news/articles/c0000000001o',
-              hrefLang: 'x-default',
-            },
-            {
-              href: 'https://www.bbc.com/news/articles/c0000000001o',
-              hrefLang: 'en',
-            },
-            {
-              href: 'https://www.bbc.co.uk/news/articles/c0000000001o',
-              hrefLang: 'en-gb',
-            },
-          ],
-          ampLink: 'https://www.bbc.com/news/articles/c0000000001o.amp',
-          canonicalLink: 'https://www.bbc.com/news/articles/c0000000001o',
-          description: 'Article summary.',
-          dir: 'ltr',
-          lang: 'en-gb',
-          metaTags: [
-            'Royal Wedding 2018',
-            'Duchess of Sussex',
-            'Queen Victoria',
-          ],
-          timeFirstPublished: '2018-01-01T12:01:00.000Z',
-          timeLastPublished: '2018-01-01T13:00:00.000Z',
-          title: 'Article Headline for SEO',
-          serviceConfig: services.news.default,
-          type: 'article',
-          service: 'news',
-          showArticleTags: true,
-        }),
-      );
-      expect(Wrapper.find(LinkedData).props()).toEqual(
-        linkedDataProps({
-          brandName: 'BBC News',
-          canonicalLink: 'https://www.bbc.com/news/articles/c0000000001o',
-          firstPublished: '2018-01-01T12:01:00.000Z',
-          lastUpdated: '2018-01-01T13:00:00.000Z',
-          createdBy: 'News',
-          logoUrl:
-            'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
-          seoHeadline: 'Article Headline for SEO',
-          type: 'Article',
-          about: [
-            {
-              '@type': 'Thing',
-              name: 'Royal Wedding 2018',
-              sameAs: ['http://dbpedia.org/resource/Queen_Victoria'],
-            },
-            {
-              '@type': 'Person',
-              name: 'Duchess of Sussex',
-            },
-          ],
-        }),
-      );
-    });
+  const actual = document
+    .querySelector('head > link[rel="canonical"]')
+    .getAttribute('href');
+  const expected = 'https://www.bbc.com/news/articles/c0000000001o';
 
-    shouldMatchSnapshot(
-      'should match snapshot for Canonical News & international origin',
-      getContainer({
-        service: 'news',
-        bbcOrigin: dotComOrigin,
-        platform: 'canonical',
-        data: articleDataNews,
-        id: 'c0000000001o',
-        pageType: 'article',
-        pathname: '/news/articles/c0000000001o',
-      }),
-    );
+  expect(actual).toEqual(expected);
+});
 
-    it('should be correct for AMP News & UK origin', () => {
-      const Wrapper = mount(
-        getContainer({
-          service: 'news',
-          bbcOrigin: dotCoDotUKOrigin,
-          platform: 'amp',
-          data: articleDataNews,
-          id: 'c0000000001o',
-          pageType: 'article',
-          pathname: '/news/articles/c0000000001o.amp',
-        }),
-      );
+it('should render the alternate links', async () => {
+  await renderMetadataToDocument();
+  const actual = Array.from(
+    document.querySelectorAll('head > link[rel="alternate"]'),
+  ).map(tag => ({
+    href: tag.getAttribute('href'),
+    hreflang: tag.getAttribute('hreflang'),
+  }));
+  const expected = [
+    {
+      href: 'https://www.bbc.com/news/articles/c0000000001o',
+      hreflang: 'x-default',
+    },
+    {
+      href: 'https://www.bbc.com/news/articles/c0000000001o',
+      hreflang: 'en',
+    },
+    {
+      href: 'https://www.bbc.co.uk/news/articles/c0000000001o',
+      hreflang: 'en-gb',
+    },
+  ];
 
-      expect(
-        Wrapper.containsMatchingElement(
-          <MetadataContainer {...articleDataNews} />,
-        ),
-      ).toEqual(true);
-      expect(Wrapper.find(Metadata).props()).toEqual(
-        metadataProps({
-          isAmp: true,
-          alternateLinks: [
-            {
-              href: 'https://www.bbc.com/news/articles/c0000000001o.amp',
-              hrefLang: 'x-default',
-            },
-            {
-              href: 'https://www.bbc.com/news/articles/c0000000001o.amp',
-              hrefLang: 'en',
-            },
-            {
-              href: 'https://www.bbc.co.uk/news/articles/c0000000001o.amp',
-              hrefLang: 'en-gb',
-            },
-          ],
-          ampLink: 'https://www.bbc.co.uk/news/articles/c0000000001o.amp',
-          canonicalLink: 'https://www.bbc.com/news/articles/c0000000001o',
-          description: 'Article summary.',
-          dir: 'ltr',
-          lang: 'en-gb',
-          metaTags: [
-            'Royal Wedding 2018',
-            'Duchess of Sussex',
-            'Queen Victoria',
-          ],
-          timeFirstPublished: '2018-01-01T12:01:00.000Z',
-          timeLastPublished: '2018-01-01T13:00:00.000Z',
-          title: 'Article Headline for SEO',
-          serviceConfig: services.news.default,
-          type: 'article',
-          service: 'news',
-          showArticleTags: true,
-        }),
-      );
-      expect(Wrapper.find(LinkedData).props()).toEqual(
-        linkedDataProps({
-          brandName: 'BBC News',
-          canonicalLink: 'https://www.bbc.com/news/articles/c0000000001o',
-          firstPublished: '2018-01-01T12:01:00.000Z',
-          lastUpdated: '2018-01-01T13:00:00.000Z',
-          createdBy: 'News',
-          logoUrl:
-            'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
-          seoHeadline: 'Article Headline for SEO',
-          type: 'Article',
-          about: [
-            {
-              '@type': 'Thing',
-              name: 'Royal Wedding 2018',
-              sameAs: ['http://dbpedia.org/resource/Queen_Victoria'],
-            },
-            {
-              '@type': 'Person',
-              name: 'Duchess of Sussex',
-            },
-          ],
-        }),
-      );
-    });
+  expect(actual).toEqual(expected);
+});
 
-    shouldMatchSnapshot(
-      'should match snapshot for AMP News & UK origin',
-      getContainer({
-        service: 'news',
-        bbcOrigin: dotCoDotUKOrigin,
-        platform: 'amp',
-        data: articleDataNews,
-        id: 'c0000000001o',
-        pageType: 'article',
-        pathname: '/news/articles/c0000000001o.amp',
-      }),
-    );
+it('should render the apple touch icons', async () => {
+  await renderMetadataToDocument();
+  const actual = Array.from(
+    document.querySelectorAll('head > link[rel="apple-touch-icon"]'),
+  ).map(tag => ({
+    href: tag.getAttribute('href'),
+    sizes: tag.getAttribute('sizes'),
+  }));
+  const expected = [
+    {
+      href: 'https://foo.com/static/news/images/icons/icon-192x192.png',
+      sizes: null,
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png',
+      sizes: '72x72',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png',
+      sizes: '96x96',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-128x128.png',
+      sizes: '128x128',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png',
+      sizes: '144x144',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-152x152.png',
+      sizes: '152x152',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png',
+      sizes: '192x192',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png',
+      sizes: '384x384',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png',
+      sizes: '512x512',
+    },
+  ];
 
-    it('should be correct for Persian News & international origin', () => {
-      const Wrapper = mount(
-        getContainer({
-          service: 'persian',
-          bbcOrigin: dotComOrigin,
-          platform: 'canonical',
-          data: articleDataPersian,
-          id: 'c4vlle3q337o',
-          pageType: 'article',
-          pathname: '/persian/articles/c4vlle3q337o',
-        }),
-      );
+  expect(actual).toEqual(expected);
+});
 
-      expect(
-        Wrapper.containsMatchingElement(
-          <MetadataContainer {...articleDataPersian} />,
-        ),
-      ).toEqual(true);
-      expect(Wrapper.find(Metadata).props()).toEqual(
-        metadataProps({
-          isAmp: false,
-          alternateLinks: [],
-          ampLink: 'https://www.bbc.com/persian/articles/c4vlle3q337o.amp',
-          canonicalLink: 'https://www.bbc.com/persian/articles/c4vlle3q337o',
-          description: 'خلاصه مقاله',
-          dir: 'rtl',
-          lang: 'fa',
-          metaTags: [],
-          timeFirstPublished: '2018-01-01T12:01:00.000Z',
-          timeLastPublished: '2018-01-01T13:00:00.000Z',
-          title: 'سرصفحه مقاله',
-          serviceConfig: services.persian.default,
-          type: 'article',
-          service: 'persian',
-          showArticleTags: true,
-        }),
-      );
-      expect(Wrapper.find(LinkedData).props()).toEqual(
-        linkedDataProps({
-          brandName: 'BBC News فارسی',
-          canonicalLink: 'https://www.bbc.com/persian/articles/c4vlle3q337o',
-          firstPublished: '2018-01-01T12:01:00.000Z',
-          lastUpdated: '2018-01-01T13:00:00.000Z',
-          createdBy: 'Persian',
-          logoUrl: 'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
-          seoHeadline: 'سرصفحه مقاله',
-          type: 'Article',
-        }),
-      );
-    });
+it('should render the icons', async () => {
+  await renderMetadataToDocument();
+  const actual = Array.from(
+    document.querySelectorAll('head > link[rel="icon"]'),
+  ).map(tag => ({
+    href: tag.getAttribute('href'),
+    type: tag.getAttribute('type'),
+    sizes: tag.getAttribute('sizes'),
+  }));
+  const expected = [
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-72x72.png',
+      sizes: '72x72',
+      type: 'image/png',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-96x96.png',
+      sizes: '96x96',
+      type: 'image/png',
+    },
+    {
+      href:
+        'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png',
+      sizes: '192x192',
+      type: 'image/png',
+    },
+  ];
 
-    shouldMatchSnapshot(
-      'should match snapshot for Persian News & international origin',
-      getContainer({
-        service: 'persian',
-        bbcOrigin: dotComOrigin,
-        platform: 'canonical',
-        data: articleDataPersian,
-        id: 'c4vlle3q337o',
-        pageType: 'article',
-        pathname: '/persian/articles/c4vlle3q337o',
-      }),
-    );
+  expect(actual).toEqual(expected);
+});
 
-    it('should be correct for Persian News & UK origin', () => {
-      const Wrapper = mount(
-        getContainer({
-          service: 'persian',
-          bbcOrigin: dotCoDotUKOrigin,
-          platform: 'amp',
-          data: articleDataPersian,
-          id: 'c4vlle3q337o',
-          pageType: 'article',
-          pathname: '/persian/articles/c4vlle3q337o.amp',
-        }),
-      );
+it('should render the favicon', async () => {
+  await renderMetadataToDocument();
+  const favicon = document.querySelector('head > link[rel="shortcut icon"]');
 
-      expect(
-        Wrapper.containsMatchingElement(
-          <MetadataContainer {...articleDataPersian} />,
-        ),
-      ).toEqual(true);
-      expect(Wrapper.find(Metadata).props()).toEqual(
-        metadataProps({
-          isAmp: true,
-          alternateLinks: [],
-          ampLink: 'https://www.bbc.co.uk/persian/articles/c4vlle3q337o.amp',
-          canonicalLink: 'https://www.bbc.com/persian/articles/c4vlle3q337o',
-          description: 'خلاصه مقاله',
-          dir: 'rtl',
-          lang: 'fa',
-          metaTags: [],
-          timeFirstPublished: '2018-01-01T12:01:00.000Z',
-          timeLastPublished: '2018-01-01T13:00:00.000Z',
-          title: 'سرصفحه مقاله',
-          serviceConfig: services.persian.default,
-          type: 'article',
-          service: 'persian',
-          showArticleTags: true,
-        }),
-      );
-      expect(Wrapper.find(LinkedData).props()).toEqual(
-        linkedDataProps({
-          brandName: 'BBC News فارسی',
-          canonicalLink: 'https://www.bbc.com/persian/articles/c4vlle3q337o',
-          firstPublished: '2018-01-01T12:01:00.000Z',
-          lastUpdated: '2018-01-01T13:00:00.000Z',
-          createdBy: 'Persian',
-          logoUrl: 'https://news.files.bbci.co.uk/ws/img/logos/og/persian.png',
-          seoHeadline: 'سرصفحه مقاله',
-          type: 'Article',
-        }),
-      );
-    });
+  expect(favicon.getAttribute('href')).toEqual('/favicon.ico');
+  expect(favicon.getAttribute('rel')).toEqual('shortcut icon');
+  expect(favicon.getAttribute('type')).toEqual('image/x-icon');
+});
 
-    shouldMatchSnapshot(
-      'should match snapshot for Persian News & UK origin',
-      getContainer({
-        service: 'persian',
-        bbcOrigin: dotCoDotUKOrigin,
-        platform: 'amp',
-        data: articleDataPersian,
-        id: 'c4vlle3q337o',
-        pageType: 'article',
-        pathname: '/persian/articles/c4vlle3q337o.amp',
-      }),
-    );
+it('should render the IE X-UA-Compatible meta tag', async () => {
+  await renderMetadataToDocument();
 
-    it('should be correct for WS Frontpages', () => {
-      const Wrapper = mount(
-        getContainer({
-          service: 'igbo',
-          bbcOrigin: dotComOrigin,
-          platform: 'canonical',
-          data: frontPageData,
-          id: null,
-          pageType: 'frontPage',
-          pathname: '/igbo',
-        }),
-      );
+  const actual = document
+    .querySelector('head > meta[http-equiv="X-UA-Compatible"]')
+    .getAttribute('content');
+  const expected = 'IE=edge';
 
-      expect(
-        Wrapper.containsMatchingElement(
-          <MetadataContainer {...frontPageData} />,
-        ),
-      ).toEqual(true);
-      expect(Wrapper.find(Metadata).props()).toEqual(
-        metadataProps({
-          isAmp: false,
-          alternateLinks: [
-            {
-              href: 'https://www.bbc.com/igbo',
-              hrefLang: 'ig',
-            },
-          ],
-          ampLink: 'https://www.bbc.com/igbo.amp',
-          canonicalLink: 'https://www.bbc.com/igbo',
-          description:
-            'BBC News Igbo na-agbasa akụkọ sị Naịjirịa, Afịrịka na mba ụwa niile... Ihe na-eme ugbua gbasara akụkọ, egwuregwu, ihe nkiri na ihe na-ewu ewu... BBC Nkeji.',
-          dir: 'ltr',
-          lang: 'ig',
-          metaTags: [],
-          timeFirstPublished: null,
-          timeLastPublished: null,
-          title: 'Ogbako',
-          serviceConfig: services.igbo.default,
-          type: 'website',
-          service: 'igbo',
-          showArticleTags: false,
-        }),
-      );
-      expect(Wrapper.find(LinkedData).props()).toEqual(
-        linkedDataProps({
-          brandName: 'BBC News Ìgbò',
-          canonicalLink: 'https://www.bbc.com/igbo',
-          firstPublished: null,
-          lastUpdated: null,
-          createdBy: 'Igbo',
-          logoUrl: 'https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png',
-          seoHeadline: 'Ogbako',
-          type: 'WebPage',
-        }),
-      );
-    });
+  expect(actual).toEqual(expected);
+});
 
-    shouldMatchSnapshot(
-      'should match snapshot for WS Frontpages',
-      getContainer({
-        service: 'igbo',
-        bbcOrigin: dotComOrigin,
-        platform: 'canonical',
-        data: frontPageData,
-        id: null,
-        pageType: 'frontPage',
-        pathname: '/igbo',
-      }),
-    );
-  });
+it('should render the char set metadata', async () => {
+  await renderMetadataToDocument();
 
-  it('should be correct for WS Media liveradio', () => {
-    const Wrapper = mount(
-      getContainer({
-        service: 'korean',
-        bbcOrigin: dotComOrigin,
-        platform: 'canonical',
-        data: liveRadioPageData,
-        id: null,
-        pageType: 'media',
-        pathname: '/korean/bbc_korean_radio/liveradio',
-      }),
-    );
+  expect(document.querySelector('head > meta[charset="utf-8"]')).toBeTruthy();
+});
 
-    expect(
-      Wrapper.containsMatchingElement(
-        <MetadataContainer {...liveRadioPageData} />,
-      ),
-    ).toEqual(true);
-    expect(Wrapper.find(Metadata).props()).toEqual(
-      metadataProps({
-        isAmp: false,
-        alternateLinks: [],
-        ampLink: 'https://www.bbc.com/korean/bbc_korean_radio/liveradio.amp',
-        canonicalLink: 'https://www.bbc.com/korean/bbc_korean_radio/liveradio',
-        description: '세계와 한반도 뉴스를 공정하고 객관적으로 전달해 드립니다',
-        dir: 'ltr',
-        lang: 'ko',
-        metaTags: [],
-        timeFirstPublished: null,
-        timeLastPublished: null,
-        title: 'BBC News 코리아 라디오',
-        serviceConfig: services.korean.default,
-        type: 'website',
-        service: 'korean',
-        showArticleTags: false,
-      }),
-    );
-    expect(Wrapper.find(LinkedData).props()).toEqual(
-      linkedDataProps({
-        brandName: 'BBC News 코리아',
-        canonicalLink: 'https://www.bbc.com/korean/bbc_korean_radio/liveradio',
-        firstPublished: null,
-        lastUpdated: null,
-        createdBy: 'Korean',
-        logoUrl: 'https://news.files.bbci.co.uk/ws/img/logos/og/korean.png',
-        seoHeadline: 'BBC News 코리아 라디오',
-        type: 'RadioChannel',
-      }),
-    );
-  });
+it('should render the robots meta tag', async () => {
+  await renderMetadataToDocument();
 
-  shouldMatchSnapshot(
-    'should match snapshot for WS Media liveradio',
-    getContainer({
-      service: 'korean',
-      bbcOrigin: dotComOrigin,
-      platform: 'canonical',
-      data: liveRadioPageData,
-      id: null,
-      pageType: 'media',
-      pathname: '/korean/bbc_korean_radio/liveradio',
-    }),
+  const actual = document
+    .querySelector('head > meta[name="robots"]')
+    .getAttribute('content');
+  const expected = 'noodp,noydir';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the theme-colour meta tag', async () => {
+  await renderMetadataToDocument();
+
+  const actual = document
+    .querySelector('head > meta[name="theme-color"]')
+    .getAttribute('content');
+  const expected = '#B80000';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the apple-mobile-web-app-title', async () => {
+  await renderMetadataToDocument();
+
+  const actual = document
+    .querySelector('head > meta[name="apple-mobile-web-app-title"]')
+    .getAttribute('content');
+  const expected = 'BBC News';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the application name meta tag', async () => {
+  await renderMetadataToDocument();
+
+  const actual = document
+    .querySelector('head > meta[name="application-name"]')
+    .getAttribute('content');
+  const expected = 'BBC News';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the description meta tag', async () => {
+  await renderMetadataToDocument();
+
+  const actual = document
+    .querySelector('head > meta[name="description"]')
+    .getAttribute('content');
+  const expected = 'Article summary.';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the facebook metatags', async () => {
+  await renderMetadataToDocument();
+
+  const fbAdminId = document
+    .querySelector('head > meta[name="fb:admins"]')
+    .getAttribute('content');
+  const fbAppId = document
+    .querySelector('head > meta[name="fb:app_id"]')
+    .getAttribute('content');
+
+  expect(fbAdminId).toEqual('100004154058350');
+  expect(fbAppId).toEqual('1609039196070050');
+});
+
+it('should render the mobile-web-app-capable meta tag', async () => {
+  await renderMetadataToDocument();
+
+  const actual = document
+    .querySelector('head > meta[name="mobile-web-app-capable"]')
+    .getAttribute('content');
+  const expected = 'yes';
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the msapplication meta tags', async () => {
+  await renderMetadataToDocument();
+
+  const tileColour = document
+    .querySelector('head > meta[name=msapplication-TileColor]')
+    .getAttribute('content');
+  const tileImage = document
+    .querySelector('head > meta[name=msapplication-TileImage]')
+    .getAttribute('content');
+
+  expect(tileColour).toEqual('#B80000');
+  expect(tileImage).toEqual(
+    'https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-144x144.png',
   );
 });
+
+it('should render the OG metatags', async () => {
+  await renderMetadataToDocument();
+
+  const actual = Array.from(
+    document.querySelectorAll('head > meta[name^="og:"]'),
+  ).map(tag => ({
+    name: tag.getAttribute('name'),
+    content: tag.getAttribute('content'),
+  }));
+  const expected = [
+    { content: 'Article summary.', name: 'og:description' },
+    {
+      content:
+        'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+      name: 'og:image',
+    },
+    { content: 'BBC News', name: 'og:image:alt' },
+    { content: 'en_GB', name: 'og:locale' },
+    { content: 'BBC News', name: 'og:site_name' },
+    { content: 'Article Headline for SEO - BBC News', name: 'og:title' },
+    { content: 'article', name: 'og:type' },
+    {
+      content: 'https://www.bbc.com/news/articles/c0000000001o',
+      name: 'og:url',
+    },
+  ];
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the twitter metatags', async () => {
+  await renderMetadataToDocument();
+
+  const actual = Array.from(
+    document.querySelectorAll('head > meta[name^="twitter"]'),
+  ).map(tag => ({
+    name: tag.getAttribute('name'),
+    content: tag.getAttribute('content'),
+  }));
+  const expected = [
+    { content: 'summary_large_image', name: 'twitter:card' },
+    { content: '@BBCNews', name: 'twitter:creator' },
+    { content: 'Article summary.', name: 'twitter:description' },
+    { content: 'BBC News', name: 'twitter:image:alt' },
+    {
+      content:
+        'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+      name: 'twitter:image:src',
+    },
+    { content: '@BBCNews', name: 'twitter:site' },
+    { content: 'Article Headline for SEO - BBC News', name: 'twitter:title' },
+  ];
+
+  expect(actual).toEqual(expected);
+});
+
+it('should render the linked data', async () => {
+  await renderMetadataToDocument();
+
+  const actual = JSON.parse(
+    document.querySelector('head > script[type="application/ld+json"]')
+      .innerHTML,
+  );
+  const expected = {
+    '@context': 'http://schema.org',
+    '@type': 'Article',
+    about: [
+      {
+        '@type': 'Thing',
+        name: 'Royal Wedding 2018',
+        sameAs: ['http://dbpedia.org/resource/Queen_Victoria'],
+      },
+      { '@type': 'Person', name: 'Duchess of Sussex' },
+    ],
+    author: {
+      '@type': 'NewsMediaOrganization',
+      logo: {
+        '@type': 'ImageObject',
+        height: 576,
+        url:
+          'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+        width: 1024,
+      },
+      name: 'BBC News',
+      noBylinesPolicy: 'https://www.bbc.com/news/help-41670342#authorexpertise',
+    },
+    dateModified: '2018-01-01T13:00:00.000Z',
+    datePublished: '2018-01-01T12:01:00.000Z',
+    headline: 'Article Headline for SEO',
+    image: {
+      '@type': 'ImageObject',
+      height: 576,
+      url:
+        'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+      width: 1024,
+    },
+    mainEntityOfPage: {
+      '@id': 'https://www.bbc.com/news/articles/c0000000001o',
+      '@type': 'WebPage',
+      name: 'Article Headline for SEO',
+    },
+    publisher: {
+      '@type': 'NewsMediaOrganization',
+      logo: {
+        '@type': 'ImageObject',
+        height: 576,
+        url:
+          'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+        width: 1024,
+      },
+      name: 'BBC News',
+      publishingPrinciples: 'https://www.bbc.com/news/help-41670342',
+    },
+    thumbnailUrl:
+      'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
+    url: 'https://www.bbc.com/news/articles/c0000000001o',
+  };
+
+  expect(actual).toEqual(expected);
+});
+
+shouldMatchSnapshot(
+  'should match for Canonical News & international origin',
+  <CanonicalNewsInternationalOrigin />,
+);
+
+shouldMatchSnapshot(
+  'should match for AMP News & UK origin',
+  <MetadataWithContext
+    service="news"
+    bbcOrigin={dotCoDotUKOrigin}
+    platform="amp"
+    id="c0000000001o"
+    pageType="article"
+    pathname="/news/articles/c0000000001o.amp"
+    promo={articleDataNews.promo}
+    metadata={articleDataNews.metadata}
+  />,
+);
+
+shouldMatchSnapshot(
+  'should match for Persian News & international origin',
+  <MetadataWithContext
+    service="persian"
+    bbcOrigin={dotComOrigin}
+    platform="canonical"
+    id="c4vlle3q337o"
+    pageType="article"
+    pathname="/persian/articles/c4vlle3q337o"
+    promo={articleDataPersian.promo}
+    metadata={articleDataPersian.metadata}
+  />,
+);
+
+shouldMatchSnapshot(
+  'should match for Persian News & UK origin',
+  <MetadataWithContext
+    service="persian"
+    bbcOrigin={dotCoDotUKOrigin}
+    platform="amp"
+    id="c4vlle3q337o"
+    pageType="article"
+    pathname="/persian/articles/c4vlle3q337o.amp"
+    promo={articleDataPersian.promo}
+    metadata={articleDataPersian.metadata}
+  />,
+);
+
+shouldMatchSnapshot(
+  'should match for WS Frontpages',
+  <MetadataWithContext
+    service="igbo"
+    bbcOrigin={dotComOrigin}
+    platform="canonical"
+    id={null}
+    pageType="frontPage"
+    pathname="/igbo"
+    promo={frontPageData.promo}
+    metadata={frontPageData.metadata}
+  />,
+);
+
+shouldMatchSnapshot(
+  'should match for WS Media liveradio',
+  <MetadataWithContext
+    service="korean"
+    bbcOrigin={dotComOrigin}
+    platform="canonical"
+    id={null}
+    pageType="media"
+    pathname="/korean/bbc_korean_radio/liveradio"
+    promo={liveRadioPageData.promo}
+    metadata={liveRadioPageData.metadata}
+  />,
+);


### PR DESCRIPTION
Partially resolves #3598

**Overall change:** Removes tests that tested the implementation of metadata with tests that checks that metadata is correctly rendered to the head of the document.

This PR is an effort to break down a bigger PR for the metadata refactor. The reason for these changes - it was difficult to refactor the metadata because the previous tests were so tied to the implementation and whenever I changed the implementation the tests would break. Refactoring will be much easier with these tests.

**Code changes:**

- Removed all previous tests using Enzyme
- Added tests to check for presence of all metadata in the head of the document.
- Updated snapshots. For some reason I haven't found an explanation for yet, the previous snapshots leaked some of their metadata into each other. This can be verified by looking at the alternate links for `should match snapshot for AMP News & UK` you can see that it previously included extra canonical links as well as the amp links. I'll create an issue to investigate why this happened with the previous test set up.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
