### PR TITLE
Fix Scotland e2es for live

### DIFF
--- a/cypress/integration/application/index.js
+++ b/cypress/integration/application/index.js
@@ -8,16 +8,17 @@ const servicesUsingArticlePaths = ['news', 'scotland'];
 
 describe('Application', () => {
   Object.keys(config)
-    .filter(service => !servicesUsingArticlePaths.includes(service))
     .filter(service =>
       Object.keys(config[service].pageTypes).some(pageType =>
         serviceHasPageType(service, pageType),
       ),
     )
     .forEach(service => {
+      const usesArticlePath = servicesUsingArticlePaths.includes(service);
+
       it(`should return a 200 status code for ${service}'s service worker`, () => {
         cy.testResponseCodeAndType(
-          `/${service}/sw.js`,
+          usesArticlePath ? `/${service}/articles/sw.js` : `/${service}/sw.js`,
           200,
           'application/javascript',
         );
@@ -25,32 +26,14 @@ describe('Application', () => {
 
       it(`should return a 200 status code for ${service} manifest file`, () => {
         cy.testResponseCodeAndType(
-          `/${service}/manifest.json`,
+          usesArticlePath
+            ? `/${service}/articles/manifest.json`
+            : `/${service}/manifest.json`,
           200,
           'application/json',
         );
       });
     });
-});
-
-describe('Application', () => {
-  servicesUsingArticlePaths.forEach(service => {
-    it(`should return a 200 status code for the ${service} service worker`, () => {
-      cy.testResponseCodeAndType(
-        `/${service}/articles/sw.js`,
-        200,
-        'application/javascript',
-      );
-    });
-
-    it(`should return a 200 status code for ${service} manifest file`, () => {
-      cy.testResponseCodeAndType(
-        `/${service}/articles/manifest.json`,
-        200,
-        'application/json',
-      );
-    });
-  });
 });
 
 describe('Application unknown route error pages', () => {


### PR DESCRIPTION
**Overall change:** Fix Scotland e2es for live

**Code changes:**

- Ensures scotland application tests respect env

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
