### PR TITLE
Fix double notification of test alarms and send all failures to alarm…

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -60,7 +60,6 @@ node {
               ]
 
               if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, channels.liveAlarms)
                 stageHasFailed = true
               }
@@ -82,7 +81,6 @@ node {
               ]
 
               if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, channels.liveAlarms)
                 stageHasFailed = true
               }
@@ -121,7 +119,6 @@ node {
                   colour: 'danger',
                   emoji: '😱',
                 ]
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, channels.liveAlarms)
                 break
               case 'ABORTED':
@@ -132,7 +129,6 @@ node {
                   colour: 'warning',
                   emoji: '🙀',
                 ]
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, channels.liveAlarms)
                 break
               default:
@@ -144,7 +140,6 @@ node {
                     colour: 'danger',
                     emoji: '😱',
                   ]
-                  notifySlack(messageParameters, channels.simorgh)
                   notifySlack(messageParameters, channels.liveAlarms)
                 }
                 break

--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -100,7 +100,7 @@ node {
                   colour: 'danger',
                   emoji: '😱',
                 ]
-                notifySlack(messageParameters, simorgh.testAlarms)
+                notifySlack(messageParameters, channels.testAlarms)
                 break
               case 'ABORTED':
                 def messageParameters = [
@@ -110,7 +110,7 @@ node {
                   colour: 'warning',
                   emoji: '🙀',
                 ]
-                notifySlack(messageParameters, simorgh.testAlarms)
+                notifySlack(messageParameters, channels.testAlarms)
                 break
               default:
                 if (stageHasFailed == false) {
@@ -121,7 +121,7 @@ node {
                     colour: 'danger',
                     emoji: '😱',
                   ]
-                  notifySlack(messageParameters, simorgh.testAlarms)
+                  notifySlack(messageParameters, channels.testAlarms)
                 }
                 break
             }

--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -61,8 +61,7 @@ node {
               ]
 
               if (env.BRANCH_NAME == 'latest') {
-                notifySlack(messageParameters, channels.simorgh)
-                notifySlack(messageParameters, simorgh.testAlarms)
+                notifySlack(messageParameters, channels.testAlarms)
                 stageHasFailed = true
               }
 
@@ -73,6 +72,7 @@ node {
         } catch (Throwable e) {
           echo "The pipeline has failed with the error: ${e}"
           currentBuild.result = 'FAILURE'
+
           throw e
         } finally {
           def buildResult = currentBuild.result ?: 'SUCCESS'
@@ -100,7 +100,6 @@ node {
                   colour: 'danger',
                   emoji: '😱',
                 ]
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, simorgh.testAlarms)
                 break
               case 'ABORTED':
@@ -111,7 +110,6 @@ node {
                   colour: 'warning',
                   emoji: '🙀',
                 ]
-                notifySlack(messageParameters, channels.simorgh)
                 notifySlack(messageParameters, simorgh.testAlarms)
                 break
               default:
@@ -123,7 +121,6 @@ node {
                     colour: 'danger',
                     emoji: '😱',
                   ]
-                  notifySlack(messageParameters, channels.simorgh)
                   notifySlack(messageParameters, simorgh.testAlarms)
                 }
                 break


### PR DESCRIPTION
…s channels

Resolves N/A

**Overall change:**

- Fixes the issue where the test pipeline fails and we get double notifications.
- Ensures all failures only get sent to the test/live alarms clack channels 
- Only success messages are sent to the #si_repo_simorgh channel