### PR TITLE
Fix embed endpoint on github storybook

### DIFF
--- a/src/app/containers/MediaPlayer/helpers/embedUrl.js
+++ b/src/app/containers/MediaPlayer/helpers/embedUrl.js
@@ -1,11 +1,11 @@
+// Local embeds do not work, therefore, we use the test server when running locally or in storybook
 const buildBaseUrl = origin => {
-  if (!origin.includes('local')) {
-    return origin;
+  if (origin.includes('local') || origin.includes('bbc.github.io')) {
+    const tld = origin.includes('.co.uk') ? '.co.uk' : '.com';
+    return `https://www.test.bbc${tld}`;
   }
 
-  const tld = origin.includes('.co.uk') ? '.co.uk' : '.com';
-
-  return `https://www.test.bbc${tld}`;
+  return origin;
 };
 
 const embedUrl = ({ origin, type, requestUrl, isAmp = false }) => {

--- a/src/app/containers/MediaPlayer/helpers/embedUrl.test.js
+++ b/src/app/containers/MediaPlayer/helpers/embedUrl.test.js
@@ -95,6 +95,18 @@ const testCases = [
       type: 'media',
     },
   },
+  {
+    description:
+      'CANONICAL: builds a URL for GITHUB environment that has a base of test.bbc.co.uk',
+    expected: `https://www.test.bbc.com/ws/av-embeds/media/bbc_korean_radio/liveradio`,
+    embedObject: {
+      origin:
+        'https://bbc.github.io/simorgh/iframe.html?id=main-radio-page--default',
+      isAmp: false,
+      requestUrl: 'bbc_korean_radio/liveradio',
+      type: 'media',
+    },
+  },
 ];
 
 describe('Media Player: Embed URL', () =>

--- a/src/app/containers/MediaPlayer/helpers/embedUrl.test.js
+++ b/src/app/containers/MediaPlayer/helpers/embedUrl.test.js
@@ -98,7 +98,8 @@ const testCases = [
   {
     description:
       'CANONICAL: builds a URL for GITHUB environment that has a base of test.bbc.co.uk',
-    expected: `https://www.test.bbc.com/ws/av-embeds/media/bbc_korean_radio/liveradio`,
+    expected:
+      'https://www.test.bbc.com/ws/av-embeds/media/bbc_korean_radio/liveradio',
     embedObject: {
       origin:
         'https://bbc.github.io/simorgh/iframe.html?id=main-radio-page--default',


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/4011

**Overall change:** _Fixes embed endpoint on storybook._

**Code changes:**

- _Update embed path to use test server if accessed through github storybook_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
