### PR TITLE
Add brands for Cymru Fyw and Naidheachdan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1302,9 +1302,9 @@
       "integrity": "sha512-Jjkk9ieEa0WXK4Wvw82YVvMhP4yi0pBOftwNhQGOVLx1Av8KSHFHacFxHEiVcVxoXCPpdeWaLYrKm0fcyoxlKA=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.4.1.tgz",
-      "integrity": "sha512-ARJodaVdDkRUTf5FmK34J/FbpstPiQl6innPsaUKxQ6YiLWm9uzhywJNpH6yRYAPkjpG0bfkXLNfVftr/S9Zew=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.5.0.tgz",
+      "integrity": "sha512-eO8DFPM7cJ0aNk3z534gxcvsmyumxEfaf6C3ED2N6NNUxPlic6mM8RQOha7wa9P+9WbPQp/OpTEEybHK6P7jPw=="
     },
     "@bbc/psammead-brand": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@bbc/gel-foundations": "^3.4.0",
     "@bbc/moment-timezone-include": "^1.1.2",
     "@bbc/psammead-amp-geo": "^1.1.2",
-    "@bbc/psammead-assets": "^2.4.1",
+    "@bbc/psammead-assets": "^2.5.0",
     "@bbc/psammead-brand": "^5.0.5",
     "@bbc/psammead-caption": "^2.2.13",
     "@bbc/psammead-consent-banner": "^2.3.14",

--- a/src/app/lib/config/services/cymrufyw.js
+++ b/src/app/lib/config/services/cymrufyw.js
@@ -8,7 +8,7 @@ import {
   F_REITH_SERIF_MEDIUM,
   F_REITH_SERIF_MEDIUM_ITALIC,
 } from '@bbc/psammead-styles/fonts';
-import { news as brandSVG } from '@bbc/psammead-assets/svgs';
+import { cymrufyw as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Europe/London';
 import withContext from '../../../contexts/utils/withContext';
 import 'moment/locale/cy';

--- a/src/app/lib/config/services/naidheachdan.js
+++ b/src/app/lib/config/services/naidheachdan.js
@@ -8,7 +8,7 @@ import {
   F_REITH_SERIF_MEDIUM,
   F_REITH_SERIF_MEDIUM_ITALIC,
 } from '@bbc/psammead-styles/fonts';
-import { news as brandSVG } from '@bbc/psammead-assets/svgs';
+import { naidheachdan as brandSVG } from '@bbc/psammead-assets/svgs';
 import '@bbc/moment-timezone-include/tz/Europe/London';
 import withContext from '../../../contexts/utils/withContext';
 import 'moment/locale/gd';


### PR DESCRIPTION
Resolves #4154 

**Overall change:**
- Makes the branding right on Cymru Fyw and Naidheachdan

**Code changes:**

- Bumps version of psammead-assets
- Updates two configs to use the correct SVGs

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
