### PR TITLE
Switch isUK logic to isInternational

### DIFF
--- a/cypress/support/config/envs.js
+++ b/cypress/support/config/envs.js
@@ -37,8 +37,8 @@ const config = {
   },
 };
 
-const geoLocate = (conf, isUk = false) => {
-  if (!isUk) return conf;
+const geoLocate = (conf, isInternational = true) => {
+  if (isInternational) return conf;
 
   // eslint-disable-next-line no-param-reassign
   conf.baseUrl = conf.baseUrl.replace('.com', '.co.uk');
@@ -50,5 +50,5 @@ const geoLocate = (conf, isUk = false) => {
 
 module.exports =
   typeof Cypress !== 'undefined'
-    ? geoLocate(config[Cypress.env('APP_ENV')], Cypress.env('UK'))
-    : (env, uk) => geoLocate(config[env], uk);
+    ? geoLocate(config[Cypress.env('APP_ENV')], Cypress.env('INTERNATIONAL'))
+    : (env, isInternational) => geoLocate(config[env], isInternational);


### PR DESCRIPTION
Resolves #3510

**Overall change:**
Switch `isUK` logic to `isInternational` to have the default behaviour assume users are in the UK

**Code changes:**
- Switch `isUK` to `isInternational`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
