### PR TITLE
Remove references to Cosmos dial

### DIFF
--- a/src/app/containers/Error/index.test.jsx
+++ b/src/app/containers/Error/index.test.jsx
@@ -8,7 +8,6 @@ global.console.log = jest.fn();
 const defaultProps = {
   isAmp: false,
   pageType: 'error',
-  dials: {},
   status: 404,
   service: 'news',
 };

--- a/src/app/containers/PageHandlers/withData/index.test.jsx
+++ b/src/app/containers/PageHandlers/withData/index.test.jsx
@@ -51,7 +51,6 @@ describe('withData HOC', () => {
   };
 
   describe('with no data', () => {
-    suppressPropWarnings(['data.dials', 'undefined']);
     shouldMatchSnapshot(
       'should return the errorMain component and 500 status',
       <WithDataHOC {...noDataProps} />,


### PR DESCRIPTION
Resolves #3150

**Overall change:** Removes references to `dial`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
