### PR TITLE
ATI Analytics for CPS Pages

### DIFF
--- a/scripts/bundleSizeConfig.js
+++ b/scripts/bundleSizeConfig.js
@@ -2,5 +2,5 @@ module.exports = {
   // Size limit for all bundles used by each service (K)
   // Keep these +/- 5K and update frequently!
   MIN_SIZE: 547,
-  MAX_SIZE: 585,
+  MAX_SIZE: 591,
 };

--- a/scripts/bundleSizeConfig.js
+++ b/scripts/bundleSizeConfig.js
@@ -1,6 +1,6 @@
 module.exports = {
   // Size limit for all bundles used by each service (K)
   // Keep these +/- 5K and update frequently!
-  MIN_SIZE: 547,
+   MIN_SIZE: 550,
   MAX_SIZE: 591,
 };

--- a/scripts/bundleSizeConfig.js
+++ b/scripts/bundleSizeConfig.js
@@ -1,6 +1,6 @@
 module.exports = {
   // Size limit for all bundles used by each service (K)
   // Keep these +/- 5K and update frequently!
-   MIN_SIZE: 550,
+  MIN_SIZE: 550,
   MAX_SIZE: 591,
 };

--- a/src/app/containers/ATIAnalytics/atiUrl/index.js
+++ b/src/app/containers/ATIAnalytics/atiUrl/index.js
@@ -37,7 +37,7 @@ export const buildATIPageTrackPath = ({
   origin,
   previousPath,
   categoryName,
-  campaigns
+  campaigns,
 }) => {
   const pageViewBeaconValues = [
     {

--- a/src/app/containers/ATIAnalytics/atiUrl/index.js
+++ b/src/app/containers/ATIAnalytics/atiUrl/index.js
@@ -15,6 +15,8 @@ import {
   getProducer,
 } from '#lib/analyticsUtils';
 
+const spaceRegex = / /g;
+
 /*
  * For AMP pages, certain browser and device values are determined
  * https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md#device-and-browser
@@ -149,7 +151,7 @@ export const buildATIPageTrackPath = ({
       key: 'x16',
       description: 'campaigns',
       value: (Array.isArray(campaigns) ? campaigns : [])
-        .map(campaign => campaign.campaignName.replace(/ /g, '%20'))
+        .map(campaign => campaign.campaignName.replace(spaceRegex, '%20'))
         .join('~'),
       wrap: true,
     },

--- a/src/app/containers/ATIAnalytics/atiUrl/index.js
+++ b/src/app/containers/ATIAnalytics/atiUrl/index.js
@@ -36,6 +36,8 @@ export const buildATIPageTrackPath = ({
   timeUpdated,
   origin,
   previousPath,
+  categoryName,
+  campaigns
 }) => {
   const pageViewBeaconValues = [
     {
@@ -141,6 +143,20 @@ export const buildATIPageTrackPath = ({
       key: 'x14',
       description: 'ldp things ids',
       value: ldpThingIds,
+      wrap: true,
+    },
+    {
+      key: 'x16',
+      description: 'campaigns',
+      value: (Array.isArray(campaigns) ? campaigns : [])
+        .map(campaign => campaign.campaignName.replace(/ /g, '%20'))
+        .join('~'),
+      wrap: true,
+    },
+    {
+      key: 'x17',
+      description: 'category',
+      value: categoryName,
       wrap: true,
     },
     {

--- a/src/app/containers/ATIAnalytics/index.jsx
+++ b/src/app/containers/ATIAnalytics/index.jsx
@@ -6,6 +6,7 @@ import AmpATIAnalytics from './amp';
 import { buildArticleATIUrl } from './params/article/buildParams';
 import { buildFrontPageATIUrl } from './params/frontpage/buildParams';
 import { buildRadioATIUrl } from './params/radioPage/buildParams';
+import { buildCPSATIUrl } from './params/cpsAssetPage/buildParams';
 import { pageDataPropType } from '#models/propTypes/data';
 
 const ATIAnalytics = ({ data }) => {
@@ -17,6 +18,7 @@ const ATIAnalytics = ({ data }) => {
     article: buildArticleATIUrl,
     frontPage: buildFrontPageATIUrl,
     media: buildRadioATIUrl,
+    MAP: buildCPSATIUrl,
   };
 
   const isValidPageType = Object.keys(pageTypeHandlers).includes(pageType);

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -12,17 +12,18 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
 
   const { metadata, promo } = pageData;
 
-  // ATI gets it's "Chapter 1" value from a prefix to the page identifier
-  // eg embedded_media::pidgin.embedded_media.media_asset.49529724.page
+  const getChapter1 = pageIdentifier => pageIdentifier.split('.')[1];
+
   const page = path(['analyticsLabels', 'counterName'], metadata);
   const isValidPage = page && typeof page === 'string' && page.includes('.');
-  const chapter1 = isValidPage && page.split('.')[1];
+  const chapter1 = isValidPage ? getChapter1(page) : false;
 
   return {
     appName: atiAnalyticsAppName,
-    contentId: metadata.id,
+    contentId: path(['id'], metadata),
     contentType: 'article-media-asset',
-    language: metadata.language,
+    language: path(['language'], metadata),
+    // Example page identifier: embedded_media::pidgin.embedded_media.media_asset.49529724.page
     pageIdentifier: chapter1 ? `${chapter1}::${page}` : page,
     pageTitle: path(['headlines', 'headline'], promo),
     timePublished: getPublishedDatetime('firstPublished', pageData),

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -1,6 +1,7 @@
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
 import { buildATIPageTrackPath } from '../../atiUrl';
+import { getPublishedDatetime } from '../../../../lib/analyticsUtils';
 
 export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
   const { platform, statsDestination } = requestContext;
@@ -19,10 +20,17 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
     language: metadata.language,
     pageIdentifier: path(['analyticsLabels', 'counterName'], metadata),
     pageTitle: path(['headlines', 'headline'], promo),
+
     // Will be second part of counter name, eg 'pidgin.news.media_asset.49529724' -> 'news'
-    chapter1: pathOr('.Unknown', ['analyticsLabels', 'counterName'], metadata).split('.')[1],
-    timePublished: metadata.firstPublished, // TODO - convert from epoch
-    timeUpdated: metadata.lastUpdated, // TODO - convert from epoch
+    // TODO: new url param - what is the URL key?
+    chapter1: pathOr(
+      '.Unknown',
+      ['analyticsLabels', 'counterName'],
+      metadata,
+    ).split('.')[1],
+
+    timePublished: getPublishedDatetime('firstPublished', pageData),
+    timeUpdated: getPublishedDatetime('lastPublished', pageData),
     category: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
     campaign: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
     producerId: atiAnalyticsProducerId,

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -13,26 +13,27 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
 
   const { metadata, promo } = pageData;
 
+  // ATI gets it's "Chapter 1" value from a prefix to the page identifier
+  // eg embedded_media::pidgin.embedded_media.media_asset.49529724.page
+  const pageIdentifierPrefix = pathOr(
+    '.Unknown',
+    ['analyticsLabels', 'counterName'],
+    metadata,
+  ).split('.')[1];
+
+  const page = path(['analyticsLabels', 'counterName'], metadata);
+
   return {
     appName: atiAnalyticsAppName,
     contentId: metadata.id,
     contentType: 'article-media-asset',
     language: metadata.language,
-    pageIdentifier: path(['analyticsLabels', 'counterName'], metadata),
+    pageIdentifier: `${pageIdentifierPrefix}::${page}`,
     pageTitle: path(['headlines', 'headline'], promo),
-
-    // Will be second part of counter name, eg 'pidgin.news.media_asset.49529724' -> 'news'
-    // TODO: new url param - what is the URL key?
-    chapter1: pathOr(
-      '.Unknown',
-      ['analyticsLabels', 'counterName'],
-      metadata,
-    ).split('.')[1],
-
     timePublished: getPublishedDatetime('firstPublished', pageData),
     timeUpdated: getPublishedDatetime('lastPublished', pageData),
-    category: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
-    campaign: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
+    categoryName: path(['passport', 'category', 'categoryName'], metadata),
+    campaigns: path(['passport', 'campaigns'], metadata),
     producerId: atiAnalyticsProducerId,
     statsDestination,
     platform,

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -1,0 +1,40 @@
+import path from 'ramda/src/path';
+import pathOr from 'ramda/src/pathOr';
+import { buildATIPageTrackPath } from '../../atiUrl';
+
+export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
+  const { platform, statsDestination } = requestContext;
+  const {
+    atiAnalyticsAppName,
+    atiAnalyticsProducerId,
+    service,
+  } = serviceContext;
+
+  const { metadata, promo } = pageData;
+
+  return {
+    appName: atiAnalyticsAppName,
+    contentId: metadata.id,
+    contentType: 'article-media-asset',
+    language: metadata.language,
+    pageIdentifier: path(['analyticsLabels', 'counterName'], metadata),
+    pageTitle: path(['headlines', 'headline'], promo),
+    // Will be second part of counter name, eg 'pidgin.news.media_asset.49529724' -> 'news'
+    chapter1: pathOr('.Unknown', ['analyticsLabels', 'counterName'], metadata)
+      .split['.'][1],
+    timePublished: metadata.firstPublished, // TODO - convert from epoch
+    timeUpdated: metadata.lastUpdated, // TODO - convert from epoch
+    category: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
+    campaign: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?
+    producerId: atiAnalyticsProducerId,
+    statsDestination,
+    platform,
+    service,
+  };
+};
+
+export const buildCPSATIUrl = (pageData, requestContext, serviceContext) => {
+  return buildATIPageTrackPath(
+    buildCPSATIParams(pageData, requestContext, serviceContext),
+  );
+};

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -20,8 +20,7 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
     pageIdentifier: path(['analyticsLabels', 'counterName'], metadata),
     pageTitle: path(['headlines', 'headline'], promo),
     // Will be second part of counter name, eg 'pidgin.news.media_asset.49529724' -> 'news'
-    chapter1: pathOr('.Unknown', ['analyticsLabels', 'counterName'], metadata)
-      .split['.'][1],
+    chapter1: pathOr('.Unknown', ['analyticsLabels', 'counterName'], metadata).split('.')[1],
     timePublished: metadata.firstPublished, // TODO - convert from epoch
     timeUpdated: metadata.lastUpdated, // TODO - convert from epoch
     category: '', // TODO - new URL param - needs analysis - what is URL key? can be multiple?

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -1,5 +1,4 @@
 import path from 'ramda/src/path';
-import pathOr from 'ramda/src/pathOr';
 import { buildATIPageTrackPath } from '../../atiUrl';
 import { getPublishedDatetime } from '../../../../lib/analyticsUtils';
 
@@ -15,20 +14,16 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
 
   // ATI gets it's "Chapter 1" value from a prefix to the page identifier
   // eg embedded_media::pidgin.embedded_media.media_asset.49529724.page
-  const pageIdentifierPrefix = pathOr(
-    '.Unknown',
-    ['analyticsLabels', 'counterName'],
-    metadata,
-  ).split('.')[1];
-
   const page = path(['analyticsLabels', 'counterName'], metadata);
+  const isValidPage = page && typeof page === 'string' && page.includes('.');
+  const chapter1 = isValidPage && page.split('.')[1];
 
   return {
     appName: atiAnalyticsAppName,
     contentId: metadata.id,
     contentType: 'article-media-asset',
     language: metadata.language,
-    pageIdentifier: `${pageIdentifierPrefix}::${page}`,
+    pageIdentifier: chapter1 ? `${chapter1}::${page}` : page,
     pageTitle: path(['headlines', 'headline'], promo),
     timePublished: getPublishedDatetime('firstPublished', pageData),
     timeUpdated: getPublishedDatetime('lastPublished', pageData),

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -1,0 +1,68 @@
+import { buildCPSATIParams, buildCPSATIUrl } from './buildParams';
+import * as analyticsUtils from '#lib/analyticsUtils';
+import payload from '#data/pidgin/cpsAssets/tori-49450859.json';
+
+// Mocks
+analyticsUtils.getCurrentTime = jest.fn().mockReturnValue('00-00-00');
+analyticsUtils.getPublishedDatetime = jest
+  .fn()
+  .mockReturnValue('1970-01-01T00:00:00.000Z');
+
+// Fixtures
+const requestContext = {
+  platform: 'platform',
+  isUK: 'isUK',
+  statsDestination: 'statsDestination',
+  previousPath: 'previousPath',
+  origin: 'origin',
+};
+
+const serviceContext = {
+  atiAnalyticsAppName: 'atiAnalyticsAppName',
+  atiAnalyticsProducerId: 'atiAnalyticsProducerId',
+  service: 'service',
+};
+
+const expectation = {
+  appName: serviceContext.atiAnalyticsAppName,
+  contentId: 'id',
+  contentType: 'article-media-asset',
+  language: 'language',
+  pageIdentifier: 'pageIdentifier',
+  pageTitle: 'pageTitle',
+  producerId: serviceContext.atiAnalyticsProducerId,
+  statsDestination: requestContext.statsDestination,
+  platform: requestContext.platform,
+  service: 'service',
+};
+
+describe('buildRadioATIParams', () => {
+  it('should return the right object', () => {
+    const result = buildCPSATIParams(payload, requestContext, serviceContext);
+    expect(result).toEqual(expectation);
+  });
+});
+
+describe('buildRadioATIUrl', () => {
+  it('should return the right url', () => {
+    const result = buildCPSATIUrl(payload, requestContext, serviceContext);
+    expect(result).toEqual(
+      [
+        's=598285',
+        's2=atiAnalyticsProducerId',
+        'p=pageIdentifier',
+        'r=0x0x24x24',
+        're=1024x768',
+        'hl=00-00-00',
+        'lng=en-US',
+        'x1=[id]',
+        'x2=[responsive]',
+        'x3=[atiAnalyticsAppName]',
+        'x4=[language]',
+        'x5=[http://localhost/]',
+        'x7=[article-media-asset]',
+        'x9=[pageTitle]',
+      ].join('&'),
+    );
+  });
+});

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -51,13 +51,17 @@ describe('buildCPSATIUrl', () => {
   it('should return the right url', () => {
     const result = buildCPSATIUrl(payload, requestContext, serviceContext);
     const campaignString = expectation.campaigns
+      .filter(
+        campaign =>
+          campaign.campaignName && typeof campaign.campaignName === 'string',
+      )
       .map(campaign => campaign.campaignName.replace(/ /g, '%20'))
       .join('~');
 
     expect(result).toEqual(
       [
         's=598285',
-        's2=atiAnalyticsProducerId',
+        `s2=${serviceContext.atiAnalyticsProducerId}`,
         `p=${expectation.pageIdentifier}`,
         'r=0x0x24x24',
         're=1024x768',
@@ -65,7 +69,7 @@ describe('buildCPSATIUrl', () => {
         'lng=en-US',
         `x1=[${expectation.contentId}]`,
         'x2=[responsive]',
-        'x3=[atiAnalyticsAppName]',
+        `x3=[${serviceContext.atiAnalyticsAppName}]`,
         `x4=[${expectation.language}]`,
         'x5=[http://localhost/]',
         `x7=[${expectation.contentType}]`,

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -25,15 +25,19 @@ const serviceContext = {
 
 const expectation = {
   appName: serviceContext.atiAnalyticsAppName,
-  contentId: 'id',
+  contentId: payload.metadata.id,
+  campaigns: payload.metadata.passport.campaigns,
   contentType: 'article-media-asset',
-  language: 'language',
-  pageIdentifier: 'pageIdentifier',
-  pageTitle: 'pageTitle',
+  language: payload.metadata.language,
+  pageIdentifier: `news::${payload.metadata.analyticsLabels.counterName}`,
+  pageTitle: payload.promo.headlines.headline,
+  categoryName: 'News',
   producerId: serviceContext.atiAnalyticsProducerId,
   statsDestination: requestContext.statsDestination,
   platform: requestContext.platform,
   service: 'service',
+  timePublished: analyticsUtils.getPublishedDatetime(),
+  timeUpdated: analyticsUtils.getPublishedDatetime(),
 };
 
 describe('buildRadioATIParams', () => {
@@ -46,22 +50,30 @@ describe('buildRadioATIParams', () => {
 describe('buildCPSATIUrl', () => {
   it('should return the right url', () => {
     const result = buildCPSATIUrl(payload, requestContext, serviceContext);
+    const campaignString = expectation.campaigns
+      .map(campaign => campaign.campaignName.replace(/ /g, '%20'))
+      .join('~');
+
     expect(result).toEqual(
       [
         's=598285',
         's2=atiAnalyticsProducerId',
-        'p=pageIdentifier',
+        `p=${expectation.pageIdentifier}`,
         'r=0x0x24x24',
         're=1024x768',
         'hl=00-00-00',
         'lng=en-US',
-        'x1=[id]',
+        `x1=[${expectation.contentId}]`,
         'x2=[responsive]',
         'x3=[atiAnalyticsAppName]',
-        'x4=[language]',
+        `x4=[${expectation.language}]`,
         'x5=[http://localhost/]',
-        'x7=[article-media-asset]',
-        'x9=[pageTitle]',
+        `x7=[${expectation.contentType}]`,
+        `x9=[${expectation.pageTitle.replace(/ /g, '+')}]`,
+        `x11=[${expectation.timePublished}]`,
+        `x12=[${expectation.timeUpdated}]`,
+        `x16=[${campaignString}]`,
+        `x17=[${expectation.categoryName}]`,
       ].join('&'),
     );
   });

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -43,7 +43,7 @@ describe('buildRadioATIParams', () => {
   });
 });
 
-describe('buildRadioATIUrl', () => {
+describe('buildCPSATIUrl', () => {
   it('should return the right url', () => {
     const result = buildCPSATIUrl(payload, requestContext, serviceContext);
     expect(result).toEqual(

--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -13,12 +13,14 @@ const pageTypeUrlBuilders = {
   article: buildArticleATIUrl,
   frontPage: buildFrontPageATIUrl,
   media: buildRadioATIUrl,
+  MAP: buildCPSATIUrl,
 };
 
 const pageTypeParamBuilders = {
   article: buildArticleATIParams,
   frontPage: buildFrontPageATIParams,
   media: buildRadioATIParams,
+  MAP: buildCPSATIParams,
 };
 
 const createBuilderFactory = (requestContext, pageTypeHandlers = {}) => {

--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -7,6 +7,7 @@ import {
   buildFrontPageATIUrl,
 } from './frontpage/buildParams';
 import { buildRadioATIParams, buildRadioATIUrl } from './radioPage/buildParams';
+import { buildCPSATIParams, buildCPSATIUrl } from './cpsAssetPage/buildParams';
 
 const pageTypeUrlBuilders = {
   article: buildArticleATIUrl,

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -295,6 +295,7 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   </head>
   <body>
     <div>
+      <noscript />
       <main
         class="c0"
         role="main"

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { string, shape, object, arrayOf } from 'prop-types';
 import path from 'ramda/src/path';
 
 import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -5,6 +5,7 @@ import path from 'ramda/src/path';
 import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';
 import MetadataContainer from '../Metadata';
 import LinkedData from '../LinkedData';
+import ATIAnalytics from '../ATIAnalytics';
 
 const CpsAssetPageMain = ({ pageData }) => {
   const title = path(['promo', 'headlines', 'headline'], pageData);
@@ -20,6 +21,7 @@ const CpsAssetPageMain = ({ pageData }) => {
         openGraphType="website"
       />
       <LinkedData type="Article" seoTitle={title} />
+      <ATIAnalytics data={pageData} />
       <Grid as="main" role="main">
         <GridItemConstrainedMedium>
           <h1> Placeholder content for MAP page skeleton</h1>

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -6,6 +6,7 @@ import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';
 import MetadataContainer from '../Metadata';
 import LinkedData from '../LinkedData';
 import ATIAnalytics from '../ATIAnalytics';
+import cpsPagePropTypes from '../../models/propTypes/cpsPage';
 
 const CpsAssetPageMain = ({ pageData }) => {
   const title = path(['promo', 'headlines', 'headline'], pageData);
@@ -31,29 +32,6 @@ const CpsAssetPageMain = ({ pageData }) => {
   );
 };
 
-CpsAssetPageMain.propTypes = {
-  /* eslint-disable react/no-unused-prop-types */
-  pageData: shape({
-    metadata: shape({
-      id: string,
-      tags: object,
-      type: string,
-    }),
-    promo: shape({
-      id: string,
-      type: string,
-    }),
-    content: shape({
-      blocks: arrayOf(
-        shape({
-          uuid: string,
-          id: string,
-          text: string,
-          type: string,
-        }),
-      ),
-    }),
-  }).isRequired,
-};
+CpsAssetPageMain.propTypes = cpsPagePropTypes;
 
 export default CpsAssetPageMain;

--- a/src/app/models/propTypes/cpsPage/index.js
+++ b/src/app/models/propTypes/cpsPage/index.js
@@ -1,0 +1,32 @@
+import { bool, shape, string, number, object, arrayOf } from 'prop-types';
+
+export const cpsPageDataPropTypes = shape({
+  metadata: shape({
+    id: string,
+    tags: object,
+    type: string,
+  }),
+  promo: shape({
+    id: string,
+    type: string,
+  }),
+  content: shape({
+    blocks: arrayOf(
+      shape({
+        uuid: string,
+        id: string,
+        text: string,
+        type: string,
+      }),
+    ),
+  }),
+});
+
+const cpsPagePropTypes = {
+  isAmp: bool,
+  data: cpsPageDataPropTypes,
+  service: string,
+  status: number,
+};
+
+export default cpsPagePropTypes;

--- a/src/app/models/propTypes/data/index.js
+++ b/src/app/models/propTypes/data/index.js
@@ -2,11 +2,13 @@ import { shape, oneOfType, number } from 'prop-types';
 import { frontPageDataPropTypes } from '../frontPage';
 import { articleDataPropTypes } from '../article';
 import { radioPageDataPropTypes } from '../radioPage';
+import { cpsPageDataPropTypes } from '../cpsPage';
 
 export const pageDataPropType = oneOfType([
   articleDataPropTypes,
   frontPageDataPropTypes,
   radioPageDataPropTypes,
+  cpsPageDataPropTypes,
 ]);
 
 export const dataPropType = shape({


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/3454

**Overall change:** Add ATI analytics tracking to the CPS page

**Code changes:**

- Add ATI analytics container and set up its data dependencies
- Add unit tests
- Bump bundle size (hit Persian threshold - 586KB)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
