### PR TITLE
Revert "Revert "i18n articles routes""

### DIFF
--- a/src/app/containers/App/App.jsx
+++ b/src/app/containers/App/App.jsx
@@ -40,7 +40,6 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
         id: nextId,
         isAmp: nextIsAmp,
         route,
-        match,
       } = getRouteProps(routes, location.pathname);
 
       setState({
@@ -60,7 +59,7 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
           const {
             pageData: _pageData,
             status: _status,
-          } = await route.getInitialData(match.params);
+          } = await route.getInitialData(location.pathname);
 
           setState(prevState => ({
             ...prevState,

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -149,7 +149,7 @@ describe('App', () => {
 
           expect.assertions(3);
 
-          expect(route.getInitialData).toHaveBeenCalledWith(match.params);
+          expect(route.getInitialData).toHaveBeenCalledWith(pathname);
 
           // start data fetch and set loading to true
           expect(reactRouterConfig.renderRoutes).toHaveBeenNthCalledWith(

--- a/src/app/routes/getInitialData/article/index.js
+++ b/src/app/routes/getInitialData/article/index.js
@@ -1,29 +1,18 @@
-import onClient from '#lib/utilities/onClient';
-import getBaseUrl from '../utils/getBaseUrl';
-import fetchData from '../utils/fetchData';
-import { variantSanitiser } from '#lib/utilities/variantHandler';
 import applyTimestampRules from '#lib/utilities/preprocessor/rules/timestamp';
 import addIdsToBlocks from '#lib/utilities/preprocessor/rules/addIdsToBlocks';
 import applyBlockPositioning from '#lib/utilities/preprocessor/rules/blockPositioning';
+import fetchData from '../utils/fetchData';
 
-const getArticleInitialData = async ({ id, service, variant }) => {
-  const baseUrl = onClient()
-    ? getBaseUrl(window.location.origin)
-    : process.env.SIMORGH_BASE_URL;
+const preprocessorRules = [
+  applyTimestampRules,
+  addIdsToBlocks,
+  applyBlockPositioning,
+];
 
-  const processedVariant = variantSanitiser(variant);
-
-  const url = processedVariant
-    ? `${baseUrl}/${service}/articles/${id}/${processedVariant}.json`
-    : `${baseUrl}/${service}/articles/${id}.json`;
-
+const getArticleInitialData = async pathname => {
   return fetchData({
-    url,
-    preprocessorRules: [
-      applyTimestampRules,
-      addIdsToBlocks,
-      applyBlockPositioning,
-    ],
+    pathname,
+    preprocessorRules,
   });
 };
 

--- a/src/app/routes/getInitialData/article/index.test.js
+++ b/src/app/routes/getInitialData/article/index.test.js
@@ -1,41 +1,15 @@
-import baseUrl from '../utils/getBaseUrl';
-import onClient from '#lib/utilities/onClient';
 import fetchData from '../utils/fetchData';
+import applyTimestampRules from '#lib/utilities/preprocessor/rules/timestamp';
+import addIdsToBlocks from '#lib/utilities/preprocessor/rules/addIdsToBlocks';
+import applyBlockPositioning from '#lib/utilities/preprocessor/rules/blockPositioning';
 
-const mockApplyTimestampRules = jest.fn();
-const mockAddIdsToBlocks = jest.fn();
-const mockApplyBlockPositioning = jest.fn();
-
-jest.mock(
-  '#lib/utilities/preprocessor/rules/timestamp',
-  () => mockApplyTimestampRules,
-);
-
-jest.mock(
-  '#lib/utilities/preprocessor/rules/addIdsToBlocks',
-  () => mockAddIdsToBlocks,
-);
-
-jest.mock(
-  '#lib/utilities/preprocessor/rules/blockPositioning',
-  () => mockApplyBlockPositioning,
-);
+const getArticleInitialData = require('.').default;
 
 const preprocessorRules = [
-  mockApplyTimestampRules,
-  mockAddIdsToBlocks,
-  mockApplyBlockPositioning,
+  applyTimestampRules,
+  addIdsToBlocks,
+  applyBlockPositioning,
 ];
-
-process.env.SIMORGH_BASE_URL = 'https://www.SIMORGH_BASE_URL.com';
-
-const getBaseUrlMockOrigin = 'https://www.getBaseUrl.com';
-jest.mock('../utils/getBaseUrl', () => jest.fn());
-baseUrl.mockImplementation(() => getBaseUrlMockOrigin);
-
-let onClientMockResponse = true;
-jest.mock('#lib/utilities/onClient', () => jest.fn());
-onClient.mockImplementation(() => onClientMockResponse);
 
 const fetchDataMockResponse = {
   pageData: 'foo',
@@ -44,90 +18,21 @@ const fetchDataMockResponse = {
 jest.mock('../utils/fetchData', () => jest.fn());
 fetchData.mockImplementation(() => fetchDataMockResponse);
 
-const getArticleInitialData = require('.').default;
-
-const defaultIdParam = 'c0000000001o';
-const defaultServiceParam = 'news';
-let defaultContext;
+const pathname = `/news/articles/c0000000001o`;
 
 describe('getArticleInitialData', () => {
   beforeEach(() => {
-    defaultContext = {
-      id: defaultIdParam,
-      service: defaultServiceParam,
-    };
-
     jest.clearAllMocks();
   });
 
   it('fetches data and returns expected object', async () => {
-    const response = await getArticleInitialData(defaultContext);
+    const response = await getArticleInitialData(pathname);
 
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news/articles/c0000000001o.json',
-      preprocessorRules,
-    });
+    expect(fetchData).toHaveBeenCalledWith({ pathname, preprocessorRules });
 
     expect(response).toEqual({
       pageData: 'foo',
       status: 123,
-    });
-  });
-
-  it('fetches data and returns expected object with variant', async () => {
-    await getArticleInitialData({
-      ...defaultContext,
-      variant: 'variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news/articles/c0000000001o/variant.json',
-      preprocessorRules,
-    });
-  });
-
-  it('fetches data and returns expected object with variant with leading slash', async () => {
-    await getArticleInitialData({
-      ...defaultContext,
-      variant: '/variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news/articles/c0000000001o/variant.json',
-      preprocessorRules,
-    });
-  });
-
-  describe('When not on client', () => {
-    beforeEach(() => {
-      onClientMockResponse = false;
-    });
-
-    it('fetches data from SIMORGH_BASE_URL enviroment variable origin', async () => {
-      const response = await getArticleInitialData(defaultContext);
-
-      expect(fetchData).toHaveBeenCalledWith({
-        url: 'https://www.SIMORGH_BASE_URL.com/news/articles/c0000000001o.json',
-        preprocessorRules,
-      });
-
-      expect(response).toEqual({
-        pageData: 'foo',
-        status: 123,
-      });
-    });
-
-    it('fetches data from SIMORGH_BASE_URL enviroment variable origin with variant', async () => {
-      await getArticleInitialData({
-        ...defaultContext,
-        variant: 'variant',
-      });
-
-      expect(fetchData).toHaveBeenCalledWith({
-        url:
-          'https://www.SIMORGH_BASE_URL.com/news/articles/c0000000001o/variant.json',
-        preprocessorRules,
-      });
     });
   });
 });

--- a/src/app/routes/getInitialData/cpsAsset/index.js
+++ b/src/app/routes/getInitialData/cpsAsset/index.js
@@ -1,20 +1,7 @@
-import onClient from '../../../lib/utilities/onClient';
-import getBaseUrl from '../utils/getBaseUrl';
 import fetchData from '../utils/fetchData';
-import { variantSanitiser } from '../../../lib/utilities/variantHandler';
 
-const getCpsAssetInitialData = async ({ service, variant, assetUri }) => {
-  const baseUrl = onClient()
-    ? getBaseUrl(window.location.origin)
-    : process.env.SIMORGH_BASE_URL;
-
-  const processedVariant = variantSanitiser(variant);
-
-  const url = processedVariant
-    ? `${baseUrl}/${service}/${assetUri}/${processedVariant}.json`
-    : `${baseUrl}/${service}/${assetUri}.json`;
-
-  return fetchData({ url });
+const getCpsAssetInitialData = async pathname => {
+  return fetchData({ pathname });
 };
 
 export default getCpsAssetInitialData;

--- a/src/app/routes/getInitialData/cpsAsset/index.test.js
+++ b/src/app/routes/getInitialData/cpsAsset/index.test.js
@@ -1,66 +1,23 @@
-import baseUrl from '../utils/getBaseUrl';
 import fetchData from '../utils/fetchData';
 import getCpsAssetInitialData from '.';
 
 const mockData = { service: 'pidgin', status: 200, pageData: {} };
 
-const mockBaseUrl = 'https://www.SIMORGH_BASE_URL.com';
-
-jest.mock('../utils/getBaseUrl', () => jest.fn());
-baseUrl.mockImplementation(() => mockBaseUrl);
-
 jest.mock('../utils/fetchData', () => jest.fn());
 fetchData.mockImplementation(() => mockData);
 
-const defaultServiceParam = 'pidgin';
-const defaultAssetUri = 'tori-49450859';
-const defaultAmpParam = '';
-let defaultContext;
+const pathname = `/pidgin/tori-49450859`;
 
 describe('getCpsAssetInitialData', () => {
   beforeEach(() => {
-    defaultContext = {
-      service: defaultServiceParam,
-      assetUri: defaultAssetUri,
-      amp: defaultAmpParam,
-    };
-
     jest.clearAllMocks();
   });
 
-  it('should match the url for MAPs', async () => {
-    await getCpsAssetInitialData(defaultContext);
+  it('should fetch and return expected data', async () => {
+    const response = await getCpsAssetInitialData(pathname);
 
-    expect(fetchData).toBeCalledWith({
-      url: `${mockBaseUrl}/pidgin/tori-49450859.json`,
-    });
-  });
+    expect(fetchData).toHaveBeenCalledWith({ pathname });
 
-  it('should return the expected page data', async () => {
-    expect(await getCpsAssetInitialData({ service: 'pidgin' })).toEqual(
-      mockData,
-    );
-  });
-
-  it('fetches data and returns expected object with variant', async () => {
-    await getCpsAssetInitialData({
-      ...defaultContext,
-      variant: 'variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.SIMORGH_BASE_URL.com/pidgin/tori-49450859/variant.json',
-    });
-  });
-
-  it('fetches data and returns expected object with variant with leading slash', async () => {
-    await getCpsAssetInitialData({
-      ...defaultContext,
-      variant: '/variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.SIMORGH_BASE_URL.com/pidgin/tori-49450859/variant.json',
-    });
+    expect(response).toEqual(mockData);
   });
 });

--- a/src/app/routes/getInitialData/frontpage/index.js
+++ b/src/app/routes/getInitialData/frontpage/index.js
@@ -1,6 +1,3 @@
-import onClient from '#lib/utilities/onClient';
-import { variantSanitiser } from '#lib/utilities/variantHandler';
-import getBaseUrl from '../utils/getBaseUrl';
 import fetchData from '../utils/fetchData';
 import filterUnknownContentTypes from '#lib/utilities/preprocessor/rules/filterContentType';
 import filterEmptyGroupItems from '#lib/utilities/preprocessor/rules/filterEmptyGroupItems';
@@ -16,18 +13,8 @@ const preprocessorRules = [
   filterGroupsWithoutStraplines,
 ];
 
-const getFrontpageInitialData = async ({ service, variant }) => {
-  const baseUrl = onClient()
-    ? getBaseUrl(window.location.origin)
-    : process.env.SIMORGH_BASE_URL;
-
-  const processedVariant = variantSanitiser(variant);
-
-  const url = processedVariant
-    ? `${baseUrl}/${service}/${processedVariant}.json`
-    : `${baseUrl}/${service}.json`;
-
-  return fetchData({ url, preprocessorRules });
+const getFrontpageInitialData = async pathname => {
+  return fetchData({ pathname, preprocessorRules });
 };
 
 export default getFrontpageInitialData;

--- a/src/app/routes/getInitialData/frontpage/index.test.js
+++ b/src/app/routes/getInitialData/frontpage/index.test.js
@@ -1,5 +1,3 @@
-import baseUrl from '../utils/getBaseUrl';
-import onClient from '#lib/utilities/onClient';
 import fetchData from '../utils/fetchData';
 import filterUnknownContentTypes from '#lib/utilities/preprocessor/rules/filterContentType';
 import filterEmptyGroupItems from '#lib/utilities/preprocessor/rules/filterEmptyGroupItems';
@@ -15,16 +13,6 @@ const preprocessorRules = [
   filterGroupsWithoutStraplines,
 ];
 
-process.env.SIMORGH_BASE_URL = 'https://www.SIMORGH_BASE_URL.com';
-
-const getBaseUrlMockOrigin = 'https://www.getBaseUrl.com';
-jest.mock('../utils/getBaseUrl', () => jest.fn());
-baseUrl.mockImplementation(() => getBaseUrlMockOrigin);
-
-let onClientMockResponse = true;
-jest.mock('#lib/utilities/onClient', () => jest.fn());
-onClient.mockImplementation(() => onClientMockResponse);
-
 const fetchDataMockResponse = {
   pageData: 'foo',
   status: 123,
@@ -34,95 +22,23 @@ fetchData.mockImplementation(() => fetchDataMockResponse);
 
 const getFrontpageInitialData = require('.').default;
 
-const defaultServiceParam = 'news';
-const defaultAmpParam = '';
-let defaultContext;
-
 describe('getFrontpageInitialData', () => {
   beforeEach(() => {
-    defaultContext = {
-      service: defaultServiceParam,
-      amp: defaultAmpParam,
-    };
-
     jest.clearAllMocks();
   });
 
   it('fetches data and returns expected object', async () => {
-    const response = await getFrontpageInitialData(defaultContext);
+    const pathname = '/news';
+    const response = await getFrontpageInitialData(pathname);
 
     expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news.json',
+      pathname,
       preprocessorRules,
     });
 
     expect(response).toEqual({
       pageData: 'foo',
       status: 123,
-    });
-  });
-
-  it('fetches data and returns expected object with variant', async () => {
-    await getFrontpageInitialData({
-      ...defaultContext,
-      variant: 'variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news/variant.json',
-      preprocessorRules,
-    });
-  });
-
-  it('fetches data and returns expected object with variant with leading slash', async () => {
-    await getFrontpageInitialData({
-      ...defaultContext,
-      variant: '/variant',
-    });
-
-    expect(fetchData).toHaveBeenCalledWith({
-      url: 'https://www.getBaseUrl.com/news/variant.json',
-      preprocessorRules,
-    });
-  });
-
-  describe('When on amp', () => {
-    beforeEach(() => {
-      defaultContext.amp = true;
-    });
-
-    it('returns isAmp as true', async () => {
-      const response = await getFrontpageInitialData(defaultContext);
-
-      expect(fetchData).toHaveBeenCalledWith({
-        url: 'https://www.getBaseUrl.com/news.json',
-        preprocessorRules,
-      });
-
-      expect(response).toEqual({
-        pageData: 'foo',
-        status: 123,
-      });
-    });
-  });
-
-  describe('When not on client', () => {
-    beforeEach(() => {
-      onClientMockResponse = false;
-    });
-
-    it('fetches data from SIMORGH_BASE_URL enviroment variable origin', async () => {
-      const response = await getFrontpageInitialData(defaultContext);
-
-      expect(fetchData).toHaveBeenCalledWith({
-        url: 'https://www.SIMORGH_BASE_URL.com/news.json',
-        preprocessorRules,
-      });
-
-      expect(response).toEqual({
-        pageData: 'foo',
-        status: 123,
-      });
     });
   });
 });

--- a/src/app/routes/getInitialData/radioPage/index.js
+++ b/src/app/routes/getInitialData/radioPage/index.js
@@ -1,18 +1,12 @@
 import fetchData from '../utils/fetchData';
 import addIdsToBlocks from './addIdsToBlocks';
-import onClient from '#lib/utilities/onClient';
-import getBaseUrl from '../utils/getBaseUrl';
 
-const getRadioPageInitialData = ({ service, serviceId, mediaId }) => {
-  const baseUrl = onClient()
-    ? getBaseUrl(window.location.origin)
-    : process.env.SIMORGH_BASE_URL;
+const preprocessorRules = [addIdsToBlocks];
 
-  const url = `${baseUrl}/${service}/${serviceId}/${mediaId}.json`;
-
+const getRadioPageInitialData = pathname => {
   return fetchData({
-    url,
-    preprocessorRules: [addIdsToBlocks],
+    pathname,
+    preprocessorRules,
   });
 };
 

--- a/src/app/routes/getInitialData/radioPage/index.test.js
+++ b/src/app/routes/getInitialData/radioPage/index.test.js
@@ -1,46 +1,26 @@
 import fetchData from '../utils/fetchData';
-import baseUrl from '../utils/getBaseUrl';
-import onClient from '#lib/utilities/onClient';
 import getRadioPageInitialData from '.';
 import addIdsToBlocks from './addIdsToBlocks';
 
-jest.mock('./addIdsToBlocks');
-jest.mock('../utils/getBaseUrl');
-jest.mock('#lib/utilities/onClient');
 jest.mock('../utils/fetchData');
 
 const mockData = { service: 'amharic', status: 200, pageData: {} };
-const onClientMockResponse = false;
-const getBaseUrlMockOrigin = 'https://www.getBaseUrl.com';
-
-process.env.SIMORGH_BASE_URL = 'https://www.SIMORGH_BASE_URL.com';
-
-addIdsToBlocks.mockImplementation(() => jest.fn());
-baseUrl.mockImplementation(() => getBaseUrlMockOrigin);
-onClient.mockImplementation(() => onClientMockResponse);
 fetchData.mockImplementation(() => mockData);
 
-const defaultParams = {
-  service: 'amharic',
-  serviceId: 'bbc_amharic_radio',
-  mediaId: 'liveradio',
-};
+const pathname = '/amharic/bbc_amharic_radio/liveradio';
+const preprocessorRules = [addIdsToBlocks];
 
 describe('getRadioPageInitialData', () => {
-  it('returns expected pageData', async () => {
-    expect(await getRadioPageInitialData(defaultParams)).toEqual(mockData);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe('When not on client', () => {
-    it('fetches data from SIMORGH_BASE_URL enviroment variable origin', async () => {
-      const response = await getRadioPageInitialData(defaultParams);
-      expect(response).toEqual(mockData);
+  it('returns expected pageData', async () => {
+    expect(await getRadioPageInitialData(pathname)).toEqual(mockData);
 
-      expect(fetchData).toHaveBeenCalledWith({
-        url:
-          'https://www.SIMORGH_BASE_URL.com/amharic/bbc_amharic_radio/liveradio.json',
-        preprocessorRules: [addIdsToBlocks],
-      });
+    expect(fetchData).toHaveBeenCalledWith({
+      pathname,
+      preprocessorRules,
     });
   });
 });

--- a/src/app/routes/getInitialData/utils/fetchData/index.js
+++ b/src/app/routes/getInitialData/utils/fetchData/index.js
@@ -1,11 +1,22 @@
 import 'isomorphic-fetch';
 import nodeLogger from '#lib/logger.node';
 import preprocess from '#lib/utilities/preprocessor';
+import onClient from '#lib/utilities/onClient';
+import getBaseUrl from '../getBaseUrl';
 
 const logger = nodeLogger(__filename);
 const upstreamStatusCodesToPropagate = [200, 404];
 
-const fetchData = async ({ url, preprocessorRules }) => {
+const ampRegex = /(.amp)$/;
+
+const fetchData = async ({ pathname, preprocessorRules }) => {
+  const baseUrl = onClient()
+    ? getBaseUrl(window.location.origin)
+    : process.env.SIMORGH_BASE_URL;
+
+  // Remove .amp at the end of pathnames for AMP pages.
+  const url = `${baseUrl}${pathname.replace(ampRegex, '')}.json`;
+
   let pageData;
   let status;
 

--- a/src/app/routes/getInitialData/utils/fetchData/index.test.js
+++ b/src/app/routes/getInitialData/utils/fetchData/index.test.js
@@ -24,20 +24,22 @@ describe('fetchData', () => {
   const mockFetchTeapotStatus = () =>
     fetch.mockResponseOnce(JSON.stringify({}), { status: 418 });
 
-  const requestedUrl = 'http://foobar.com/path/to/asset.json';
+  const expectedBaseUrl = 'http://localhost';
+  const requestedPathname = '/path/to/asset';
+  const expectedUrl = `${expectedBaseUrl}${requestedPathname}.json`;
 
-  const callfetchData = async ({ url, preprocessorRules, mockFetch }) => {
+  const callfetchData = async ({
+    pathname = requestedPathname,
+    preprocessorRules,
+    mockFetch,
+  }) => {
     if (mockFetch) {
       mockFetch();
     } else {
       mockFetchSuccess();
     }
 
-    const response = await fetchData({
-      url: url || requestedUrl,
-      preprocessorRules,
-    });
-    return response;
+    return fetchData({ pathname, preprocessorRules });
   };
 
   afterEach(() => {
@@ -46,6 +48,18 @@ describe('fetchData', () => {
   });
 
   describe('Succesful fetch', () => {
+    it('should call fetch with correct url', async () => {
+      await callfetchData({});
+
+      expect(fetch).toHaveBeenCalledWith(expectedUrl);
+    });
+
+    it('should call fetch on amp pages without .amp in pathname', async () => {
+      await callfetchData({ pathname: `${requestedPathname}.amp` });
+
+      expect(fetch).toHaveBeenCalledWith(expectedUrl);
+    });
+
     it('should return an empty object', async () => {
       const response = await callfetchData({});
 
@@ -128,7 +142,7 @@ describe('fetchData', () => {
       expect(preprocess).not.toHaveBeenCalled();
 
       expect(loggerMock.warn).toBeCalledWith(
-        `Unexpected upstream response (HTTP status code 418) when requesting ${requestedUrl}`,
+        `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
       );
 
       expect(response).toEqual({

--- a/src/app/routes/regex/index.js
+++ b/src/app/routes/regex/index.js
@@ -11,13 +11,15 @@ const assetUriRegex = '[a-z-_]{0,}[0-9]{8,}';
 
 const variantRegex = '/simp|/trad|/cyr|/lat';
 
-export const articleRegexPath = `/:service(${serviceRegex})/articles/:id(${idRegex}):variant(${variantRegex})?:amp(${ampRegex})?`;
+const articleLocalRegex = 'articles|erthyglau|sgeulachdan';
+
+export const articleRegexPath = `/:service(${serviceRegex})/:local(${articleLocalRegex})/:id(${idRegex}):variant(${variantRegex})?:amp(${ampRegex})?`;
 
 export const articleDataRegexPath = `${articleRegexPath}.json`;
 
-export const articleSwRegexPath = `/:service(${serviceRegex})/articles/sw.js`;
+export const articleSwRegexPath = `/:service(${serviceRegex})/:local(${articleLocalRegex})/sw.js`;
 
-export const articleManifestRegexPath = `/:service(${serviceRegex})/articles/manifest.json`;
+export const articleManifestRegexPath = `/:service(${serviceRegex})/:local(${articleLocalRegex})/manifest.json`;
 
 export const frontpageRegexPath = `/:service(${serviceRegex}):variant(${variantRegex})?:amp(${ampRegex})?`;
 

--- a/src/app/routes/regex/index.test.js
+++ b/src/app/routes/regex/index.test.js
@@ -48,6 +48,9 @@ describe('articleRegexPath', () => {
     '/news/articles/c5jje4ejkqvo/simp',
     '/news/articles/c5jje4ejkqvo/trad.amp',
     '/persian/articles/c7eel0lmr4do/lat',
+    '/cymrufyw/erthyglau/c7eel0lmr4do',
+    '/cymrufyw/erthyglau/c7eel0lmr4do.amp',
+    '/naidheachdan/sgeulachdan/c7eel0lmr4do',
   ];
   shouldMatchValidRoutes(validRoutes, articleRegexPath);
 
@@ -70,6 +73,7 @@ describe('articleDataRegexPath', () => {
     '/persian/articles/c7eel0lmr4do.json',
     '/news/articles/c5jje4ejkqvo/lat.json',
     '/persian/articles/c7eel0lmr4do/trad.json',
+    '/cymrufyw/erthyglau/c5jje4ejkqvo.json',
   ];
   shouldMatchValidRoutes(validRoutes, articleDataRegexPath);
 
@@ -124,14 +128,19 @@ describe('frontpageDataRegexPath', () => {
   shouldNotMatchInvalidRoutes(invalidRoutes, frontpageDataRegexPath);
 });
 
-describe('swRegexPath', () => {
-  const validRoutes = ['/news/articles/sw.js', '/persian/articles/sw.js'];
+describe('articleSwRegexPath', () => {
+  const validRoutes = [
+    '/news/articles/sw.js',
+    '/persian/articles/sw.js',
+    '/cymrufyw/erthyglau/sw.js',
+  ];
   shouldMatchValidRoutes(validRoutes, articleSwRegexPath);
 
   const invalidRoutes = [
     '/news/sw.js',
     '/persian/articles/sw',
     '/news/trad/sw.js',
+    '/cymrufyw/sw.js',
   ];
   shouldNotMatchInvalidRoutes(invalidRoutes, articleSwRegexPath);
 });
@@ -140,6 +149,7 @@ describe('manifestRegexPath', () => {
   const validRoutes = [
     '/news/articles/manifest.json',
     '/persian/articles/manifest.json',
+    '/naidheachdan/sgeulachdan/manifest.json',
   ];
   shouldMatchValidRoutes(validRoutes, articleManifestRegexPath);
 

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -192,11 +192,8 @@ server
   )
   .get('/*', async ({ url, headers, path: urlPath }, res) => {
     try {
-      const { service, isAmp, route, match, variant } = getRouteProps(
-        routes,
-        url,
-      );
-      const data = await route.getInitialData(match.params);
+      const { service, isAmp, route, variant } = getRouteProps(routes, url);
+      const data = await route.getInitialData(urlPath);
       const { status } = data;
       const bbcOrigin = headers['bbc-origin'];
 


### PR DESCRIPTION
Reverts bbc/simorgh#4223

This restores https://github.com/bbc/simorgh/pull/4185 which resolves #4168 

Resolves #4168

**Overall change:** _cymrufyw_ and _naidheachdan_ articles should route to `/cymrufyw/erthyglau` and `/naidheachdan/sgeulachdan`

**Code changes:**

- Articles route regex now allows matching `/cymrufyw/erthyglau` and `/naidheachdan/sgeulachdan`.
- `getInitialData` in `routes` now fetches from `/cymrufyw/erthyglau` and `/naidheachdan/sgeulachdan`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
