### PR TITLE
Optimisation: stop minifying the `server.js`

### DIFF
--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -6,9 +6,14 @@ module.exports = ({ resolvePath, START_DEV_SERVER }) => {
   const serverConfig = {
     target: 'node', // compile for server environment
     entry: START_DEV_SERVER ? ['webpack/hot/poll?100', './src'] : ['./src'],
+    devtool: false,
     output: {
       path: resolvePath('build'),
       filename: 'server.js',
+    },
+    optimization: {
+      // We no not want to minimize our code.
+      minimize: false,
     },
     externals: [
       /**

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -12,7 +12,6 @@ module.exports = ({ resolvePath, START_DEV_SERVER }) => {
       filename: 'server.js',
     },
     optimization: {
-      // We no not want to minimize our code.
       minimize: false,
     },
     externals: [


### PR DESCRIPTION
Resolves #1415

**Overall change:** _Stopped minifying the server and producing a map file._

**Code changes:**

- _Added `optimization` object._
- _Set [`devtool`](https://webpack.js.org/configuration/devtool/) to false._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing