### PR TITLE
Use psammead rich text transforms with signed commits

### DIFF
--- a/src/app/containers/CpsAssetPage/index.test.jsx
+++ b/src/app/containers/CpsAssetPage/index.test.jsx
@@ -7,7 +7,7 @@ const cpsAssetScaffoldProps = {
   isAmp: false,
   pageType: 'MAP',
   service: 'pidgin',
-  pathname: '/pathname',
+  pathname: '/pidgin/tori-49450859',
   match: {
     params: {
       assetUri: 'tori-49450859',

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -89,16 +89,225 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   }
 }
 
-<main
-  class="c0"
-  role="main"
+<html
+  dir="ltr"
+  lang="pcm"
 >
-  <div
-    class="c1"
-  >
-    <h1>
-       Placeholder content for MAP page skeleton
-    </h1>
-  </div>
-</main>
+  <head>
+    <title>
+      Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Pidgin
+    </title>
+    <link
+      href="https://www.test.bbc.com/pidgin/tori-49450859"
+      rel="canonical"
+    />
+    <link
+      href="https://www.test.bbc.co.uk/pidgin/tori-49450859.amp"
+      rel="amphtml"
+    />
+    <link
+      href="/pidgin/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-72x72.png"
+      rel="apple-touch-icon"
+      sizes="72x72"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-96x96.png"
+      rel="apple-touch-icon"
+      sizes="96x96"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-128x128.png"
+      rel="apple-touch-icon"
+      sizes="128x128"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-144x144.png"
+      rel="apple-touch-icon"
+      sizes="144x144"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-152x152.png"
+      rel="apple-touch-icon"
+      sizes="152x152"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+      sizes="192x192"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png"
+      rel="apple-touch-icon"
+      sizes="384x384"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png"
+      rel="apple-touch-icon"
+      sizes="512x512"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-72x72.png"
+      rel="icon"
+      sizes="72x72"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-96x96.png"
+      rel="icon"
+      sizes="96x96"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png"
+      rel="icon"
+      sizes="192x192"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png"
+      rel="apple-touch-startup-image"
+    />
+    <link
+      href="/favicon.ico"
+      rel="shortcut icon"
+      type="image/x-icon"
+    />
+    <meta
+      content="IE=edge"
+      http-equiv="X-UA-Compatible"
+    />
+    <meta
+      charset="utf-8"
+    />
+    <meta
+      content="noodp,noydir"
+      name="robots"
+    />
+    <meta
+      content="#B80000"
+      name="theme-color"
+    />
+    <meta
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+      name="viewport"
+    />
+    <meta
+      content="BBC News Pidgin"
+      name="apple-mobile-web-app-title"
+    />
+    <meta
+      content="BBC News Pidgin"
+      name="application-name"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="description"
+    />
+    <meta
+      content="100004154058350"
+      name="fb:admins"
+    />
+    <meta
+      content="1609039196070050"
+      name="fb:app_id"
+    />
+    <meta
+      content="yes"
+      name="mobile-web-app-capable"
+    />
+    <meta
+      content="#B80000"
+      name="msapplication-TileColor"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-144x144.png"
+      name="msapplication-TileImage"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="og:description"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"
+      name="og:image"
+    />
+    <meta
+      content="BBC News Pidgin"
+      name="og:image:alt"
+    />
+    <meta
+      content="pcm"
+      name="og:locale"
+    />
+    <meta
+      content="BBC News Pidgin"
+      name="og:site_name"
+    />
+    <meta
+      content="Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Pidgin"
+      name="og:title"
+    />
+    <meta
+      content="website"
+      name="og:type"
+    />
+    <meta
+      content="https://www.test.bbc.com/pidgin/tori-49450859"
+      name="og:url"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:creator"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="twitter:description"
+    />
+    <meta
+      content="BBC News Pidgin"
+      name="twitter:image:alt"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"
+      name="twitter:image:src"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:site"
+    />
+    <meta
+      content="Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Pidgin"
+      name="twitter:title"
+    />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"Article","url":"https://www.test.bbc.com/pidgin/tori-49450859","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Pidgin","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.test.bbc.com/pidgin/tori-49450859","name":"Nigerian man Emeka Nelson don produce generator wey dey use only water"}}
+    </script>
+  </head>
+  <body>
+    <div>
+      <main
+        class="c0"
+        role="main"
+      >
+        <div
+          class="c1"
+        >
+          <h1>
+             Placeholder content for MAP page skeleton
+          </h1>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>
 `;

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -1,14 +1,31 @@
 import React from 'react';
 import { string, shape, object, arrayOf } from 'prop-types';
-import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';
+import path from 'ramda/src/path';
 
-const CpsAssetPageMain = () => {
+import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';
+import MetadataContainer from '../Metadata';
+import LinkedData from '../LinkedData';
+
+const CpsAssetPageMain = ({ pageData }) => {
+  const title = path(['promo', 'headlines', 'headline'], pageData);
+  const summary = path(['promo', 'summary'], pageData);
+  const metadata = path(['metadata'], pageData);
+
   return (
-    <Grid as="main" role="main">
-      <GridItemConstrainedMedium>
-        <h1> Placeholder content for MAP page skeleton</h1>
-      </GridItemConstrainedMedium>
-    </Grid>
+    <>
+      <MetadataContainer
+        title={title}
+        lang={metadata.language}
+        description={summary}
+        openGraphType="website"
+      />
+      <LinkedData type="Article" seoTitle={title} />
+      <Grid as="main" role="main">
+        <GridItemConstrainedMedium>
+          <h1> Placeholder content for MAP page skeleton</h1>
+        </GridItemConstrainedMedium>
+      </Grid>
+    </>
   );
 };
 

--- a/src/app/containers/CpsAssetPageMain/index.test.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.test.jsx
@@ -13,7 +13,7 @@ describe('CpsAssetPageMain', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         isAmp={false}
         pageType="MAP"
-        pathname="/pathname"
+        pathname="/pidgin/tori-49450859"
         service="pidgin"
         statusCode={200}
       >

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertParagraph.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertParagraph.js
@@ -1,0 +1,14 @@
+import {
+  candyXmlToRichText,
+  stringToRichText,
+} from '@bbc/psammead-rich-text-transforms';
+
+const xmlWrapper = innerXML =>
+  `<body><paragraph>${innerXML}</paragraph></body>`;
+
+const convertParagraph = block =>
+  block.markupType === 'candy_xml'
+    ? candyXmlToRichText(xmlWrapper(block.text))
+    : stringToRichText(block.text);
+
+export default convertParagraph;

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertParagraph.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertParagraph.test.js
@@ -1,0 +1,50 @@
+import convertParagraph from './convertParagraph';
+import { optimoText } from './helpers';
+
+describe('convertParagraph', () => {
+  it('should convert a plain_text paragraph to Optimo format', () => {
+    const input = {
+      text: 'A plain text paragraph',
+      markupType: 'plain_text',
+      type: 'paragraph',
+    };
+    const expected = optimoText([
+      {
+        fragments: [
+          {
+            fragment: 'A plain text paragraph',
+            attributes: [],
+          },
+        ],
+        text: 'A plain text paragraph',
+      },
+    ]);
+
+    expect(convertParagraph(input)).toEqual(expected);
+  });
+
+  it('should convert a candy_xml paragraph to Optimo format', () => {
+    const input = {
+      text: 'A paragraph with <bold>bold text</bold>',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+    const expected = optimoText([
+      {
+        fragments: [
+          {
+            fragment: 'A paragraph with ',
+            attributes: [],
+          },
+          {
+            fragment: 'bold text',
+            attributes: ['bold'],
+          },
+        ],
+        text: 'A paragraph with bold text',
+      },
+    ]);
+
+    expect(convertParagraph(input)).toEqual(expected);
+  });
+});

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks.js
@@ -1,0 +1,38 @@
+import { clone, pathOr } from 'ramda';
+import convertParagraph from './convertParagraph';
+
+const handleMissingType = block =>
+  console.log(`Missing type field on block ${block.type}`); // eslint-disable-line no-console
+
+const typesToConvert = {
+  paragraph: convertParagraph,
+};
+
+const parseBlockByType = block => {
+  if (!block || !block.type) {
+    return null;
+  }
+  const { type } = block;
+
+  const parsedBlock = (typesToConvert[type] || handleMissingType)(block);
+
+  return parsedBlock;
+};
+
+const convertToOptimoBlocks = jsonRaw => {
+  const json = clone(jsonRaw);
+  const blocks = pathOr([], ['content', 'blocks'], json);
+
+  const parsedBlocks = blocks.map(parseBlockByType).filter(Boolean);
+
+  return {
+    ...json,
+    content: {
+      model: {
+        blocks: parsedBlocks,
+      },
+    },
+  };
+};
+
+export default convertToOptimoBlocks;

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks.test.js
@@ -1,0 +1,99 @@
+import convertToOptimoBlocks from './convertToOptimoBlocks';
+import { optimoText } from './helpers';
+
+describe('convertToOptimoBlocks', () => {
+  it('should convert CPS data into Optimo format', () => {
+    const input = {
+      content: {
+        blocks: [
+          {
+            text: 'Paragraph containing <bold>bold text</bold>',
+            markupType: 'candy_xml',
+            type: 'paragraph',
+          },
+          {
+            text: 'A plain text paragraph',
+            markupType: 'plain_text',
+            type: 'paragraph',
+          },
+        ],
+      },
+    };
+
+    const expected = {
+      content: {
+        model: {
+          blocks: [
+            optimoText([
+              {
+                fragments: [
+                  {
+                    fragment: 'Paragraph containing ',
+                    attributes: [],
+                  },
+                  {
+                    fragment: 'bold text',
+                    attributes: ['bold'],
+                  },
+                ],
+                text: 'Paragraph containing bold text',
+              },
+            ]),
+            optimoText([
+              {
+                fragments: [
+                  {
+                    fragment: 'A plain text paragraph',
+                    attributes: [],
+                  },
+                ],
+                text: 'A plain text paragraph',
+              },
+            ]),
+          ],
+        },
+      },
+    };
+
+    expect(convertToOptimoBlocks(input)).toEqual(expected);
+  });
+
+  it('should return an empty array if blocks is an empty array', () => {
+    const input = {
+      content: {
+        blocks: [],
+      },
+    };
+    const expected = {
+      content: {
+        model: {
+          blocks: [],
+        },
+      },
+    };
+
+    expect(convertToOptimoBlocks(input)).toEqual(expected);
+  });
+
+  it('should return an empty array if block does not have a type', () => {
+    const input = {
+      content: {
+        blocks: [
+          {
+            text: 'Paragraph containing <bold>bold text</bold>',
+            markupType: 'candy_xml',
+          },
+        ],
+      },
+    };
+    const expected = {
+      content: {
+        model: {
+          blocks: [],
+        },
+      },
+    };
+
+    expect(convertToOptimoBlocks(input)).toEqual(expected);
+  });
+});

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/helpers.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/helpers.js
@@ -1,0 +1,22 @@
+export const optimoFragment = ({ fragment, attributes }) => ({
+  type: 'fragment',
+  model: {
+    text: fragment,
+    attributes,
+  },
+});
+
+export const optimoParagraph = ({ fragments, text }) => ({
+  type: 'paragraph',
+  model: {
+    text,
+    blocks: fragments.map(optimoFragment),
+  },
+});
+
+export const optimoText = paragraphs => ({
+  type: 'text',
+  model: {
+    blocks: paragraphs.map(optimoParagraph),
+  },
+});

--- a/src/app/models/propTypes/cpsAssetPage/index.js
+++ b/src/app/models/propTypes/cpsAssetPage/index.js
@@ -1,0 +1,22 @@
+import { bool, shape, string, number, any } from 'prop-types';
+import mainContentPropTypes from '../mainContent';
+import cpsAssetPagePromoPropTypes from '../cpsAssetPagePromo';
+import relatedContentPropTypes from '../frontPageRelatedContent'; // TODO: check is relatedContent is consistent on frontpage and CpsAsset
+
+export const cpsAssetPageDataPropTypes = shape({
+  metadata: any, // TODO: define metadata props for CPS Asset
+  content: shape({
+    model: shape(mainContentPropTypes).isRequired,
+  }).isRequired,
+  promo: cpsAssetPagePromoPropTypes,
+  relatedContent: shape(relatedContentPropTypes).isRequired,
+});
+
+const cpsAssetPagePropTypes = {
+  isAmp: bool,
+  data: cpsAssetPageDataPropTypes,
+  service: string,
+  status: number,
+};
+
+export default cpsAssetPagePropTypes;

--- a/src/app/models/propTypes/cpsAssetPagePromo/index.js
+++ b/src/app/models/propTypes/cpsAssetPagePromo/index.js
@@ -1,0 +1,7 @@
+import { any } from 'prop-types';
+
+// this should be extended to include any values required by the page.
+// EG: promo.headlines.headline is required to create for the Headline block so should be added here during that PR
+const cpsAssetPagePromoPropTypes = any;
+
+export default cpsAssetPagePromoPropTypes;

--- a/src/app/models/propTypes/data/index.js
+++ b/src/app/models/propTypes/data/index.js
@@ -2,11 +2,13 @@ import { shape, oneOfType, number } from 'prop-types';
 import { frontPageDataPropTypes } from '../frontPage';
 import { articleDataPropTypes } from '../article';
 import { radioPageDataPropTypes } from '../radioPage';
+import { cpsAssetPageDataPropTypes } from '../cpsAssetPage';
 
 export const pageDataPropType = oneOfType([
   articleDataPropTypes,
   frontPageDataPropTypes,
   radioPageDataPropTypes,
+  cpsAssetPageDataPropTypes,
 ]);
 
 export const dataPropType = shape({

--- a/src/app/routes/getInitialData/cpsAsset/index.js
+++ b/src/app/routes/getInitialData/cpsAsset/index.js
@@ -2,6 +2,9 @@ import onClient from '../../../lib/utilities/onClient';
 import getBaseUrl from '../utils/getBaseUrl';
 import fetchData from '../utils/fetchData';
 import { variantSanitiser } from '../../../lib/utilities/variantHandler';
+import convertToOptimoBlocks from '#lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks';
+
+const preprocessorRules = [convertToOptimoBlocks];
 
 const getCpsAssetInitialData = async ({ service, variant, assetUri }) => {
   const baseUrl = onClient()
@@ -14,7 +17,10 @@ const getCpsAssetInitialData = async ({ service, variant, assetUri }) => {
     ? `${baseUrl}/${service}/${assetUri}/${processedVariant}.json`
     : `${baseUrl}/${service}/${assetUri}.json`;
 
-  return fetchData({ url });
+  return fetchData({
+    url,
+    preprocessorRules,
+  });
 };
 
 export default getCpsAssetInitialData;

--- a/src/app/routes/getInitialData/cpsAsset/index.test.js
+++ b/src/app/routes/getInitialData/cpsAsset/index.test.js
@@ -1,6 +1,7 @@
 import baseUrl from '../utils/getBaseUrl';
 import fetchData from '../utils/fetchData';
 import getCpsAssetInitialData from '.';
+import convertToOptimoBlocks from '#lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks';
 
 const mockData = { service: 'pidgin', status: 200, pageData: {} };
 
@@ -16,6 +17,8 @@ const defaultServiceParam = 'pidgin';
 const defaultAssetUri = 'tori-49450859';
 const defaultAmpParam = '';
 let defaultContext;
+
+const preprocessorRules = [convertToOptimoBlocks];
 
 describe('getCpsAssetInitialData', () => {
   beforeEach(() => {
@@ -33,6 +36,7 @@ describe('getCpsAssetInitialData', () => {
 
     expect(fetchData).toBeCalledWith({
       url: `${mockBaseUrl}/pidgin/tori-49450859.json`,
+      preprocessorRules,
     });
   });
 
@@ -50,6 +54,7 @@ describe('getCpsAssetInitialData', () => {
 
     expect(fetchData).toHaveBeenCalledWith({
       url: 'https://www.SIMORGH_BASE_URL.com/pidgin/tori-49450859/variant.json',
+      preprocessorRules,
     });
   });
 
@@ -61,6 +66,7 @@ describe('getCpsAssetInitialData', () => {
 
     expect(fetchData).toHaveBeenCalledWith({
       url: 'https://www.SIMORGH_BASE_URL.com/pidgin/tori-49450859/variant.json',
+      preprocessorRules,
     });
   });
 });


### PR DESCRIPTION
PLEASE ERAD THROUGH https://github.com/bbc/simorgh/pull/4184 before this PR. Especially https://github.com/bbc/simorgh/pull/4184/files#r334420000.

This is a repeat of the branch `use-psammead-rich-text-transforms` now that signed commits are enforced in Simorgh. 

Resolves #4087 

**Overall change:** Adds the package `@bbc/psammead-rich-text-transforms` and uses it in a new preprocessor rule `convertToOptimoBlocks`.

**Code changes:**

- The new preprocessor rule takes the CPS data from Ares, looping over each of the blocks and has a callback function for each type in `typesToConvert`
- Handles paragraph conversion to prove the rich-text-transforms library is working as expected

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- ~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~
- ~[] This PR requires manual testing~
