### PR TITLE
Fetch error handling refactor

### DIFF
--- a/src/app/containers/App/App.jsx
+++ b/src/app/containers/App/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { renderRoutes } from 'react-router-config';
 import { withRouter } from 'react-router-dom';
+import path from 'ramda/src/path';
 import getRouteProps from '../../routes/getInitialData/utils/getRouteProps';
 import usePrevious from '#lib/utilities/usePrevious';
 
@@ -13,7 +14,7 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
     route: { pageType },
   } = getRouteProps(routes, location.pathname);
 
-  const { pageData, status } = initialData;
+  const { pageData, status, error } = initialData;
 
   const [state, setState] = useState({
     pageData,
@@ -23,8 +24,8 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
     id,
     isAmp,
     pageType,
+    error,
     loading: false,
-    error: null,
   });
 
   const isInitialMount = useRef(true);
@@ -55,28 +56,15 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
         error: null,
       });
 
-      const fetchData = async () => {
-        try {
-          const {
-            pageData: _pageData,
-            status: _status,
-          } = await route.getInitialData(match.params);
-
-          setState(prevState => ({
-            ...prevState,
-            pageData: _pageData,
-            status: _status,
-            loading: false,
-          }));
-        } catch (error) {
-          setState(prevState => ({
-            ...prevState,
-            error,
-            loading: false,
-          }));
-        }
-      };
-      fetchData();
+      route.getInitialData(match.params).then(data =>
+        setState(prevState => ({
+          ...prevState,
+          loading: false,
+          pageData: path(['pageData'], data),
+          status: path(['status'], data),
+          error: path(['error'], data),
+        })),
+      );
     }
   }, [routes, location.pathname]);
 

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -47,7 +47,7 @@ describe('App', () => {
     expect(reactRouterConfig.renderRoutes).toHaveBeenCalledWith([], {
       bbcOrigin: 'https://www.bbc.co.uk',
       pageData: initialData.pageData,
-      error: null,
+      error: undefined,
       isAmp: false,
       loading: false,
       pageType: 'article',
@@ -84,7 +84,9 @@ describe('App', () => {
       });
       describe('rejected loadInitialData', () => {
         it('should set state to the error', async () => {
-          route.getInitialData.mockImplementation(() => Promise.reject(error));
+          route.getInitialData.mockImplementation(() =>
+            Promise.resolve({ pageData: null, status: null, error }),
+          );
 
           await act(async () => {
             wrapper.setProps({ location: { pathname: 'pathnameTwo' } });
@@ -179,7 +181,7 @@ describe('App', () => {
               bbcOrigin: 'https://www.bbc.co.uk',
               pageData: data.pageData,
               status: data.status,
-              error: null,
+              error: undefined,
               id: undefined,
               isAmp: false,
               loading: false,

--- a/src/app/routes/getInitialData/utils/fetchData/index.js
+++ b/src/app/routes/getInitialData/utils/fetchData/index.js
@@ -3,32 +3,45 @@ import nodeLogger from '#lib/logger.node';
 import preprocess from '#lib/utilities/preprocessor';
 
 const logger = nodeLogger(__filename);
-const upstreamStatusCodesToPropagate = [200, 404];
+const STATUS_CODE_OK = 200;
+const STATUS_CODE_BAD_GATEWAY = 502;
+const STATUS_CODE_NOT_FOUND = 404;
+const upstreamStatusCodesToPropagate = [STATUS_CODE_OK, STATUS_CODE_NOT_FOUND];
 
-const fetchData = async ({ url, preprocessorRules }) => {
-  let pageData;
-  let status;
+const handleResponse = preprocessorRules => async response => {
+  const { status } = response;
 
-  try {
-    const response = await fetch(url);
-
-    status = response.status; // eslint-disable-line prefer-destructuring
-
-    if (status === 200) {
-      pageData = await response.json();
-      pageData = preprocess(pageData, preprocessorRules);
-    } else if (!upstreamStatusCodesToPropagate.includes(status)) {
-      logger.warn(
-        `Unexpected upstream response (HTTP status code ${status}) when requesting ${url}`,
-      );
-      status = 502;
-    }
-  } catch (error) {
-    logger.error(error);
-    status = 502;
-  }
-
-  return { pageData, status };
+  return {
+    status,
+    ...(status === STATUS_CODE_OK && {
+      pageData: preprocess(await response.json(), preprocessorRules),
+    }),
+  };
 };
+
+const checkForError = url => ({ status, pageData }) => {
+  const isHandledStatus = upstreamStatusCodesToPropagate.includes(status);
+
+  if (isHandledStatus) {
+    return { status, pageData };
+  }
+  logger.warn(
+    `Unexpected upstream response (HTTP status code ${status}) when requesting ${url}`,
+  );
+  throw new Error();
+};
+
+const handleError = error => {
+  if (error.message) {
+    logger.error(error.message);
+  }
+  return { error, status: STATUS_CODE_BAD_GATEWAY };
+};
+
+const fetchData = ({ url, preprocessorRules }) =>
+  fetch(url)
+    .then(handleResponse(preprocessorRules))
+    .then(checkForError(url))
+    .catch(handleError);
 
 export default fetchData;

--- a/src/app/routes/getInitialData/utils/fetchData/index.test.js
+++ b/src/app/routes/getInitialData/utils/fetchData/index.test.js
@@ -12,11 +12,9 @@ describe('fetchData', () => {
   const mockFetchSuccess = () =>
     fetch.mockResponseOnce(JSON.stringify(mockSuccessfulResponse));
 
-  const mockFetchFailure = () =>
-    fetch.mockReject(JSON.stringify({ error: true }));
+  const mockFetchFailure = () => fetch.mockReject(true);
 
-  const mockFetchInvalidJSON = () =>
-    fetch.mockResponseOnce('Some Invalid: { JSON');
+  const mockFetchInvalidJSON = () => fetch.mockReject('Some Invalid: { JSON');
 
   const mockFetchNotFoundStatus = () =>
     fetch.mockResponseOnce(JSON.stringify({}), { status: 404 });
@@ -85,8 +83,8 @@ describe('fetchData', () => {
       expect(preprocess).not.toHaveBeenCalled();
 
       expect(response).toEqual({
-        data: undefined,
         status: 502,
+        error: true,
       });
     });
   });
@@ -98,8 +96,8 @@ describe('fetchData', () => {
       expect(preprocess).not.toHaveBeenCalled();
 
       expect(response).toEqual({
-        data: undefined,
         status: 502,
+        error: 'Some Invalid: { JSON',
       });
     });
   });
@@ -113,7 +111,6 @@ describe('fetchData', () => {
       expect(preprocess).not.toHaveBeenCalled();
 
       expect(response).toEqual({
-        data: undefined,
         status: 404,
       });
     });
@@ -132,8 +129,8 @@ describe('fetchData', () => {
       );
 
       expect(response).toEqual({
-        data: undefined,
         status: 502,
+        error: Error(),
       });
     });
   });


### PR DESCRIPTION
## this is a copy of https://github.com/bbc/simorgh/pull/4171 with a gpg signed commit

Resolves https://github.com/bbc/simorgh/issues/3815

**Overall change:** Fixes error page not being shown in most cases.

Removes error handling from `fetchData` call in `App.jsx` and does error handling inside of `fetchData` which now also returns an error object that we can pass to the error HOC to detect any errors and show the relevant error page to the user.

**Code changes:**

- Removes error handling from `fetchData` call in `App.jsx`
- Refactors `fetchData` to make it easier to reason about
- `fetchData` now returns error which can be passed to error HOC

**Testing notes**
It's possible to simulate 500 and 404 errors by changing the code in `src/app/routes/getInitialData/utils/fetchData/index.js`:

404 - change the line with `fetch(url)` to `fetch(url + 'blah')`
500 - after the `handleResponse` function definition (line 11) add `throw new Error();` to the next line (line 12)

By doing this you should see the relevant error pages.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
