### PR TITLE
Rename CpsPage to CpsAssetPage

### DIFF
--- a/src/app/containers/ATIAnalytics/index.jsx
+++ b/src/app/containers/ATIAnalytics/index.jsx
@@ -6,7 +6,7 @@ import AmpATIAnalytics from './amp';
 import { buildArticleATIUrl } from './params/article/buildParams';
 import { buildFrontPageATIUrl } from './params/frontpage/buildParams';
 import { buildRadioATIUrl } from './params/radioPage/buildParams';
-import { buildCPSATIUrl } from './params/cpsAssetPage/buildParams';
+import { buildCpsAssetATIUrl } from './params/cpsAssetPage/buildParams';
 import { pageDataPropType } from '#models/propTypes/data';
 
 const ATIAnalytics = ({ data }) => {
@@ -18,7 +18,7 @@ const ATIAnalytics = ({ data }) => {
     article: buildArticleATIUrl,
     frontPage: buildFrontPageATIUrl,
     media: buildRadioATIUrl,
-    MAP: buildCPSATIUrl,
+    MAP: buildCpsAssetATIUrl,
   };
 
   const isValidPageType = Object.keys(pageTypeHandlers).includes(pageType);

--- a/src/app/containers/ATIAnalytics/index.jsx
+++ b/src/app/containers/ATIAnalytics/index.jsx
@@ -6,7 +6,7 @@ import AmpATIAnalytics from './amp';
 import { buildArticleATIUrl } from './params/article/buildParams';
 import { buildFrontPageATIUrl } from './params/frontpage/buildParams';
 import { buildRadioATIUrl } from './params/radioPage/buildParams';
-import { buildCpsAssetATIUrl } from './params/cpsAssetPage/buildParams';
+import { buildCpsAssetPageATIUrl } from './params/cpsAssetPage/buildParams';
 import { pageDataPropType } from '#models/propTypes/data';
 
 const ATIAnalytics = ({ data }) => {
@@ -18,7 +18,7 @@ const ATIAnalytics = ({ data }) => {
     article: buildArticleATIUrl,
     frontPage: buildFrontPageATIUrl,
     media: buildRadioATIUrl,
-    MAP: buildCpsAssetATIUrl,
+    MAP: buildCpsAssetPageATIUrl,
   };
 
   const isValidPageType = Object.keys(pageTypeHandlers).includes(pageType);

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -2,7 +2,7 @@ import path from 'ramda/src/path';
 import { buildATIPageTrackPath } from '../../atiUrl';
 import { getPublishedDatetime } from '../../../../lib/analyticsUtils';
 
-export const buildCpsAssetATIParams = (
+export const buildCpsAssetPageATIParams = (
   pageData,
   requestContext,
   serviceContext,
@@ -41,12 +41,12 @@ export const buildCpsAssetATIParams = (
   };
 };
 
-export const buildCpsAssetATIUrl = (
+export const buildCpsAssetPageATIUrl = (
   pageData,
   requestContext,
   serviceContext,
 ) => {
   return buildATIPageTrackPath(
-    buildCpsAssetATIParams(pageData, requestContext, serviceContext),
+    buildCpsAssetPageATIParams(pageData, requestContext, serviceContext),
   );
 };

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -2,7 +2,11 @@ import path from 'ramda/src/path';
 import { buildATIPageTrackPath } from '../../atiUrl';
 import { getPublishedDatetime } from '../../../../lib/analyticsUtils';
 
-export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
+export const buildCpsAssetATIParams = (
+  pageData,
+  requestContext,
+  serviceContext,
+) => {
   const { platform, statsDestination } = requestContext;
   const {
     atiAnalyticsAppName,
@@ -37,8 +41,12 @@ export const buildCPSATIParams = (pageData, requestContext, serviceContext) => {
   };
 };
 
-export const buildCPSATIUrl = (pageData, requestContext, serviceContext) => {
+export const buildCpsAssetATIUrl = (
+  pageData,
+  requestContext,
+  serviceContext,
+) => {
   return buildATIPageTrackPath(
-    buildCPSATIParams(pageData, requestContext, serviceContext),
+    buildCpsAssetATIParams(pageData, requestContext, serviceContext),
   );
 };

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -1,4 +1,4 @@
-import { buildCPSATIParams, buildCPSATIUrl } from './buildParams';
+import { buildCpsAssetATIParams, buildCpsAssetATIUrl } from './buildParams';
 import * as analyticsUtils from '#lib/analyticsUtils';
 import payload from '#data/pidgin/cpsAssets/tori-49450859.json';
 
@@ -42,14 +42,18 @@ const expectation = {
 
 describe('buildRadioATIParams', () => {
   it('should return the right object', () => {
-    const result = buildCPSATIParams(payload, requestContext, serviceContext);
+    const result = buildCpsAssetATIParams(
+      payload,
+      requestContext,
+      serviceContext,
+    );
     expect(result).toEqual(expectation);
   });
 });
 
-describe('buildCPSATIUrl', () => {
+describe('buildCpsAssetATIUrl', () => {
   it('should return the right url', () => {
-    const result = buildCPSATIUrl(payload, requestContext, serviceContext);
+    const result = buildCpsAssetATIUrl(payload, requestContext, serviceContext);
     const campaignString = expectation.campaigns
       .filter(
         campaign =>

--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.test.js
@@ -1,4 +1,7 @@
-import { buildCpsAssetATIParams, buildCpsAssetATIUrl } from './buildParams';
+import {
+  buildCpsAssetPageATIParams,
+  buildCpsAssetPageATIUrl,
+} from './buildParams';
 import * as analyticsUtils from '#lib/analyticsUtils';
 import payload from '#data/pidgin/cpsAssets/tori-49450859.json';
 
@@ -40,9 +43,9 @@ const expectation = {
   timeUpdated: analyticsUtils.getPublishedDatetime(),
 };
 
-describe('buildRadioATIParams', () => {
+describe('buildCpsAssetPageATIParams', () => {
   it('should return the right object', () => {
-    const result = buildCpsAssetATIParams(
+    const result = buildCpsAssetPageATIParams(
       payload,
       requestContext,
       serviceContext,
@@ -51,9 +54,13 @@ describe('buildRadioATIParams', () => {
   });
 });
 
-describe('buildCpsAssetATIUrl', () => {
+describe('buildCpsAssetPageATIUrl', () => {
   it('should return the right url', () => {
-    const result = buildCpsAssetATIUrl(payload, requestContext, serviceContext);
+    const result = buildCpsAssetPageATIUrl(
+      payload,
+      requestContext,
+      serviceContext,
+    );
     const campaignString = expectation.campaigns
       .filter(
         campaign =>

--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -8,22 +8,22 @@ import {
 } from './frontpage/buildParams';
 import { buildRadioATIParams, buildRadioATIUrl } from './radioPage/buildParams';
 import {
-  buildCpsAssetATIParams,
-  buildCpsAssetATIUrl,
+  buildCpsAssetPageATIParams,
+  buildCpsAssetPageATIUrl,
 } from './cpsAssetPage/buildParams';
 
 const pageTypeUrlBuilders = {
   article: buildArticleATIUrl,
   frontPage: buildFrontPageATIUrl,
   media: buildRadioATIUrl,
-  MAP: buildCpsAssetATIUrl,
+  MAP: buildCpsAssetPageATIUrl,
 };
 
 const pageTypeParamBuilders = {
   article: buildArticleATIParams,
   frontPage: buildFrontPageATIParams,
   media: buildRadioATIParams,
-  MAP: buildCpsAssetATIParams,
+  MAP: buildCpsAssetPageATIParams,
 };
 
 const createBuilderFactory = (requestContext, pageTypeHandlers = {}) => {

--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -7,20 +7,23 @@ import {
   buildFrontPageATIUrl,
 } from './frontpage/buildParams';
 import { buildRadioATIParams, buildRadioATIUrl } from './radioPage/buildParams';
-import { buildCPSATIParams, buildCPSATIUrl } from './cpsAssetPage/buildParams';
+import {
+  buildCpsAssetATIParams,
+  buildCpsAssetATIUrl,
+} from './cpsAssetPage/buildParams';
 
 const pageTypeUrlBuilders = {
   article: buildArticleATIUrl,
   frontPage: buildFrontPageATIUrl,
   media: buildRadioATIUrl,
-  MAP: buildCPSATIUrl,
+  MAP: buildCpsAssetATIUrl,
 };
 
 const pageTypeParamBuilders = {
   article: buildArticleATIParams,
   frontPage: buildFrontPageATIParams,
   media: buildRadioATIParams,
-  MAP: buildCPSATIParams,
+  MAP: buildCpsAssetATIParams,
 };
 
 const createBuilderFactory = (requestContext, pageTypeHandlers = {}) => {

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -5,7 +5,7 @@ import { Grid, GridItemConstrainedMedium } from '#lib/styledGrid';
 import MetadataContainer from '../Metadata';
 import LinkedData from '../LinkedData';
 import ATIAnalytics from '../ATIAnalytics';
-import cpsPagePropTypes from '../../models/propTypes/cpsPage';
+import cpsAssetPagePropTypes from '../../models/propTypes/cpsAssetPage';
 
 const CpsAssetPageMain = ({ pageData }) => {
   const title = path(['promo', 'headlines', 'headline'], pageData);
@@ -31,6 +31,6 @@ const CpsAssetPageMain = ({ pageData }) => {
   );
 };
 
-CpsAssetPageMain.propTypes = cpsPagePropTypes;
+CpsAssetPageMain.propTypes = cpsAssetPagePropTypes;
 
 export default CpsAssetPageMain;

--- a/src/app/models/propTypes/cpsAssetPage/index.js
+++ b/src/app/models/propTypes/cpsAssetPage/index.js
@@ -1,6 +1,6 @@
 import { bool, shape, string, number, object, arrayOf } from 'prop-types';
 
-export const cpsPageDataPropTypes = shape({
+export const cpsAssetPageDataPropTypes = shape({
   metadata: shape({
     id: string,
     tags: object,
@@ -22,11 +22,11 @@ export const cpsPageDataPropTypes = shape({
   }),
 });
 
-const cpsPagePropTypes = {
+const cpsAssetPagePropTypes = {
   isAmp: bool,
-  data: cpsPageDataPropTypes,
+  data: cpsAssetPageDataPropTypes,
   service: string,
   status: number,
 };
 
-export default cpsPagePropTypes;
+export default cpsAssetPagePropTypes;

--- a/src/app/models/propTypes/data/index.js
+++ b/src/app/models/propTypes/data/index.js
@@ -2,13 +2,13 @@ import { shape, oneOfType, number } from 'prop-types';
 import { frontPageDataPropTypes } from '../frontPage';
 import { articleDataPropTypes } from '../article';
 import { radioPageDataPropTypes } from '../radioPage';
-import { cpsPageDataPropTypes } from '../cpsPage';
+import { cpsAssetPageDataPropTypes } from '../cpsAssetPage';
 
 export const pageDataPropType = oneOfType([
   articleDataPropTypes,
   frontPageDataPropTypes,
   radioPageDataPropTypes,
-  cpsPageDataPropTypes,
+  cpsAssetPageDataPropTypes,
 ]);
 
 export const dataPropType = shape({


### PR DESCRIPTION
**Overall change:** Corrects misnaming added by https://github.com/bbc/simorgh/pull/4281

**Code changes:**

- renames `CpsPage` to `CpsAssetPage` to be consistent with existing code

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
