### PR TITLE
Rename MediaAssetPage to CpsAssetPage in server tests

### DIFF
--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -326,7 +326,7 @@ const testArticles = ({ platform, service, variant }) => {
   });
 };
 
-const testMediaAssetPages = ({ platform, service, assetUri, variant }) => {
+const testCpsAssetPages = ({ platform, service, assetUri, variant }) => {
   const isAmp = platform === 'amp';
   const extension = isAmp ? '.amp' : '';
 
@@ -681,7 +681,7 @@ describe('Server', () => {
         });
       });
     });
-    describe('for media asset pages', () => {
+    describe('for cps asset pages', () => {
       it('should respond with JSON', async () => {
         const { body } = await makeRequest('/pidgin/tori-49450859.json');
         expect(body).toEqual(
@@ -726,23 +726,23 @@ describe('Server', () => {
     mediaId: 'liveradio',
   });
 
-  testMediaAssetPages({
+  testCpsAssetPages({
     platform: 'amp',
     service: 'pidgin',
     assetUri: 'tori-49450859',
   });
-  testMediaAssetPages({
+  testCpsAssetPages({
     platform: 'canonical',
     service: 'pidgin',
     assetUri: 'tori-49450859',
   });
-  testMediaAssetPages({
+  testCpsAssetPages({
     platform: 'amp',
     service: 'serbian',
     assetUri: 'srbija-49427344',
     variant: 'cyr',
   });
-  testMediaAssetPages({
+  testCpsAssetPages({
     platform: 'canonical',
     service: 'serbian',
     assetUri: 'srbija-49427344',


### PR DESCRIPTION
**Overall change:** Rename MediaAssetPage to CpsAssetPage in server tests

**Code changes:**

- Rename MediaAssetPage to CpsAssetPage in server tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
