### PR TITLE
Temporarily disable Lighthouse locally/on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cypress:interactive": "export NO_PROXY=localhost,localhost.bbc.com && cypress open",
     "cypress:3rdParty": "npm run cypress -- --project ./3rdPartyCypress/.",
     "dev": "rm -rf build && cp envConfig/local.env .env && run-p webpack:dev:client webpack:dev:server",
-    "lighthouse": "./scripts/lighthouseRun.sh",
+    "lighthouse": "echo '*** Lighthouse temporarily disabled due to https://github.com/GoogleChrome/lighthouse/issues/9860'; true || ./scripts/lighthouseRun.sh",
     "postshrinkwrap": "test -z $CI && ./scripts/packagelockHttps.sh; git update-index --assume-unchanged .env",
     "start": "NODE_ENV=production node build/server.js",
     "storybook": "start-storybook -p 9001 -s .storybook/static -c .storybook -h localhost.bbc.com",


### PR DESCRIPTION
Due to https://github.com/GoogleChrome/lighthouse/issues/9860

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [NA] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
