### PR TITLE
Live storybook font paths fix

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -15,17 +15,17 @@ function loadStories() {
 }
 
 const fontPathMap = [
-  { prefix: 'F_REITH', path: '/fonts/Reith/' },
-  { prefix: 'F_NASSIM_ARABIC', path: '/fonts/Nassim/Arabic/' },
-  { prefix: 'F_NASSIM_PASHTO', path: '/fonts/Nassim/Pashto/' },
-  { prefix: 'F_NASSIM_PERSIAN', path: '/fonts/Nassim/Persian/' },
-  { prefix: 'F_NASSIM_URDU', path: '/fonts/Nassim/Urdu/' },
-  { prefix: 'F_ISKOOLA_POTA_BBC', path: '/fonts/IskoolaPota/' },
-  { prefix: 'F_LATHA', path: '/fonts/Latha/' },
-  { prefix: 'F_MALLANNA', path: '/fonts/Mallanna/' },
-  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: '/fonts/NotoSansEthiopic/' },
-  { prefix: 'F_PADAUK', path: '/fonts/Padauk/' },
-  { prefix: 'F_SHONAR_BANGLA', path: '/fonts/ShonarBangla/' },
+  { prefix: 'F_REITH', path: 'fonts/Reith/' },
+  { prefix: 'F_NASSIM_ARABIC', path: 'fonts/Nassim/Arabic/' },
+  { prefix: 'F_NASSIM_PASHTO', path: 'fonts/Nassim/Pashto/' },
+  { prefix: 'F_NASSIM_PERSIAN', path: 'fonts/Nassim/Persian/' },
+  { prefix: 'F_NASSIM_URDU', path: 'fonts/Nassim/Urdu/' },
+  { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
+  { prefix: 'F_LATHA', path: 'fonts/Latha/' },
+  { prefix: 'F_MALLANNA', path: 'fonts/Mallanna/' },
+  { prefix: 'F_NOTO_SANS_ETHIOPIC', path: 'fonts/NotoSansEthiopic/' },
+  { prefix: 'F_PADAUK', path: 'fonts/Padauk/' },
+  { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
 ];
 
 addDecorator(story => (


### PR DESCRIPTION
Resolves #4259 

**Overall change:** 
Fixes font 404s on live storybook

**Code changes:**
- Removed extra ' / ' in font paths in `.storybook/config.js`

**Quick Manual Test**
- Run `npm run build:storybook`
- Open the `index.html` in the newly generated `storybook_dist` folder
- See if fonts appear.
- Run `npm run storybook`
- See if fonts appear on a story like Headings

---
- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
