### PR TITLE
Do not run local tests as part of live e2es

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -54,14 +54,10 @@ node {
                         '3rd Party E2Es': {
                             sh script: 'sleep 5', label: 'Sleeping, waiting for launch of Xvfb'
                             Simorgh.runThirdPartyE2Es()
-                        },
-                        'Local Prod Tests': {
-                            sh script: 'sleep 5', label: 'Sleeping, waiting for launch of Xvfb'
-                            Simorgh.runLocalAndProductionTests()
                         }
                     )
                 } finally {
-                    Simorgh.e2esPostBuildSteps('local & production')
+                    Simorgh.e2esPostBuildSteps('live')
                 }
             }
         }


### PR DESCRIPTION
[no issue]

**Overall change:** _Stops the 'local and production' tests from being run at the end of the live (cron) e2es because they take 4+ minutes and are redundant_

Rationale:

- NB the code being tested here is whatever is on `latest`
- The Jenkinsfile calls `Simorgh.runLocalAndProductionTests()` (smoke 
- That runs `CYPRESS_SMOKE=false npm run build && npm run test:ci`
- This installs some npm packages and runs the following against localhost:
  - `cypress:ci` (calls `cypress run`)
  - `test:puppeteer` (jest)
  - `bbcA11y:ci` (`bbc-a11y`)
  - `lighthouse`
  - `audit-ci` (i.e. `npm audit`)
- These should already have been run [here](https://github.com/bbc/simorgh/blob/remove-e2e-local/Jenkinsfile#L29) during the _Test Production_ (CI) and _Test Production and Zip Production_ (CD) stages in the main `Jenkinsfile`

**Code changes:**

- Remove local and production tests as not necessary
- Update environment name used in Slack notification to be more accurate

---

- [x] I have assigned myself to this PR and the corresponding issues
- [no] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
