### PR TITLE
Escape double quote marks in text values

### DIFF
--- a/data/pidgin/cpsAssets/23248703.json
+++ b/data/pidgin/cpsAssets/23248703.json
@@ -1,334 +1,387 @@
 {
     "metadata": {
-        "id": "urn:bbc:ares::asset:pidgin/23248703",
-        "locators": {
-            "assetUri": "/pidgin/23248703",
-            "cpsUrn": "urn:bbc:content:assetUri:pidgin/23248703",
-            "curie": "http://www.bbc.co.uk/asset/5679389a-3ea6-0b40-9de4-f4d33d6bcd9f"
+      "id": "urn:bbc:ares::asset:pidgin/23248703",
+      "locators": {
+        "assetUri": "/pidgin/23248703",
+        "cpsUrn": "urn:bbc:content:assetUri:pidgin/23248703",
+        "curie": "http://www.bbc.co.uk/asset/5679389a-3ea6-0b40-9de4-f4d33d6bcd9f"
+      },
+      "type": "MAP",
+      "createdBy": "pidgin-v6",
+      "language": "pcm",
+      "lastUpdated": 1571911736305,
+      "firstPublished": 1568388704000,
+      "lastPublished": 1571911727000,
+      "options": {
+        "isIgorSeoTagsEnabled": false,
+        "includeComments": false,
+        "allowRightHandSide": true,
+        "isFactCheck": false,
+        "allowDateStamp": true,
+        "hasNewsTracker": false,
+        "allowRelatedStoriesBox": true,
+        "isKeyContent": false,
+        "allowHeadline": false,
+        "isBreakingNews": false,
+        "allowPrintingSharingLinks": true
+      },
+      "analyticsLabels": {
+        "cps_asset_type": "map",
+        "counterName": "pidgin.media_asset.23248703.page",
+        "cps_asset_id": "23248703"
+      },
+      "passport": {
+        "category": {
+          "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/Opinion",
+          "categoryName": "Opinion"
         },
-        "type": "MAP",
-        "createdBy": "pidgin-v6",
-        "language": "pcm",
-        "lastUpdated": 1568825343680,
-        "firstPublished": 1568388704000,
-        "lastPublished": 1568825334000,
-        "options": {
-            "isIgorSeoTagsEnabled": false,
-            "includeComments": false,
-            "allowRightHandSide": true,
-            "isFactCheck": false,
-            "allowDateStamp": true,
-            "hasNewsTracker": false,
-            "allowRelatedStoriesBox": true,
-            "isKeyContent": false,
-            "allowHeadline": true,
-            "isBreakingNews": false,
-            "allowPrintingSharingLinks": true
-        },
-        "analyticsLabels": {
-            "cps_asset_type": "map",
-            "counterName": "pidgin.media_asset.23248703.page",
-            "cps_asset_id": "23248703"
-        },
-        "tags": {},
-        "version": "v1.1.2",
-        "blockTypes": [
-            "media",
-            "paragraph",
-            "heading",
-            "crosshead",
-            "list",
-            "image"
-        ],
-        "includeComments": false
+        "campaigns": [
+          {
+            "campaignId": "5ad8625ac93a9f000eecb253",
+            "campaignName": "Inspire me"
+          },
+          {
+            "campaignId": "5ad86285c93a9f000eecb256",
+            "campaignName": "Give me perspective"
+          },
+          {
+            "campaignId": "5ad86291c93a9f000eecb257",
+            "campaignName": "Keep me on trend"
+          }
+        ]
+      },
+      "tags": {
+        
+      },
+      "version": "v1.1.2",
+      "blockTypes": [
+        "media",
+        "paragraph",
+        "heading",
+        "crosshead",
+        "list",
+        "image"
+      ],
+      "includeComments": false
     },
     "content": {
-        "blocks": [
+      "blocks": [
+        {
+          "id": "p01kx42s",
+          "subType": "clip",
+          "format": "video",
+          "title": "alt-text world service clip",
+          "synopses": {
+            "short": "short"
+          },
+          "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kx435.jpg",
+          "embedding": true,
+          "advertising": true,
+          "caption": "short",
+          "versions": [
             {
-                "id": "p01kx42s",
-                "subType": "clip",
-                "format": "video",
-                "title": "alt-text world service clip",
-                "synopses": {
-                    "short": "short"
-                },
-                "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kx435.jpg",
-                "embedding": true,
-                "advertising": true,
-                "caption": "short",
-                "versions": [
-                    {
-                        "versionId": "p01kx42v",
-                        "types": [
-                            "Original"
-                        ],
-                        "duration": 5,
-                        "durationISO8601": "PT5S",
-                        "warnings": {},
-                        "availableTerritories": {
-                            "uk": true,
-                            "nonUk": true
-                        },
-                        "availableFrom": 1545304011000
-                    }
-                ],
-                "type": "media"
-            },
-            {
-                "text": "This is an introduction ",
-                "role": "introduction",
-                "markupType": "plain_text",
-                "type": "paragraph"
-            },
-            {
-                "text": "This is a heading ",
-                "markupType": "plain_text",
-                "type": "heading"
-            },
-            {
-                "text": "This is a subheading ",
-                "markupType": "plain_text",
-                "type": "heading"
-            },
-            {
-                "text": "This is a crosshead ",
-                "markupType": "plain_text",
-                "type": "crosshead"
-            },
-            {
-                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-                "markupType": "plain_text",
-                "type": "paragraph"
-            },
-            {
-                "numbered": false,
-                "items": [
-                    {
-                        "text": "<itemMeta>afrique/23248423</itemMeta>",
-                        "meta": [
-                            {
-                                "headlines": {
-                                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "headline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "overtyped": "<Media Asset Page>"
-                                },
-                                "locators": {
-                                    "href": "http://www.bbc.com/afrique/23248423"
-                                },
-                                "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                                "timestamp": 1568218735000,
-                                "passport": {
-                                    "category": {
-                                        "categoryId": "",
-                                        "categoryName": ""
-                                    }
-                                },
-                                "id": "urn:bbc:ares::asset:afrique/23248423",
-                                "type": "cps"
-                            }
-                        ],
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "<itemMeta>afrique/23248423</itemMeta>",
-                        "meta": [
-                            {
-                                "headlines": {
-                                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "headline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "overtyped": "<Media Asset Page>"
-                                },
-                                "locators": {
-                                    "href": "http://www.bbc.com/afrique/23248423"
-                                },
-                                "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                                "timestamp": 1568218735000,
-                                "passport": {
-                                    "category": {
-                                        "categoryId": "",
-                                        "categoryName": ""
-                                    }
-                                },
-                                "id": "urn:bbc:ares::asset:afrique/23248423",
-                                "type": "cps"
-                            }
-                        ],
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "<itemMeta>afrique/23248423</itemMeta>",
-                        "meta": [
-                            {
-                                "headlines": {
-                                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "headline": "Lorem ipsum dolor sit amet, consectetur",
-                                    "overtyped": "<Media Asset Page>"
-                                },
-                                "locators": {
-                                    "href": "http://www.bbc.com/afrique/23248423"
-                                },
-                                "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-                                "timestamp": 1568218735000,
-                                "passport": {
-                                    "category": {
-                                        "categoryId": "",
-                                        "categoryName": ""
-                                    }
-                                },
-                                "id": "urn:bbc:ares::asset:afrique/23248423",
-                                "type": "cps"
-                            }
-                        ],
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
-                        "markupType": "candy_xml",
-                        "type": "listItem"
-                    }
-                ],
-                "type": "list"
-            },
-            {
-                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-                "markupType": "plain_text",
-                "type": "paragraph"
-            },
-            {
-                "text": "Lorem ipsum<link><caption> dolor sit amet</caption><altText>dolor sit amet poop poop </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/></link>, consectetur adipiscing elit",
-                "markupType": "candy_xml",
-                "type": "paragraph"
-            },
-            {
-                "id": "63721686",
-                "subType": "body",
-                "href": "http://b.files.bbci.co.uk/10C04/test/_63721686_testimage.jpg",
-                "path": "/cpsdevpb/10C04/test/_63721686_testimage.jpg",
-                "height": 360,
-                "width": 640,
-                "altText": "test",
-                "copyrightHolder": "BBC",
-                "positionHint": "full-width",
-                "type": "image"
-            },
-            {
-                "numbered": false,
-                "items": [
-                    {
-                        "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
-                        "markupType": "plain_text",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
-                        "markupType": "plain_text",
-                        "type": "listItem"
-                    },
-                    {
-                        "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
-                        "markupType": "plain_text",
-                        "type": "listItem"
-                    }
-                ],
-                "type": "list"
-            },
-            {
-                "text": "This is transmission info ",
-                "role": "transmission-info",
-                "markupType": "plain_text",
-                "type": "paragraph"
-            },
-            {
-                "text": "This is the footer ",
-                "role": "footer",
-                "markupType": "plain_text",
-                "type": "paragraph"
+              "versionId": "p01kx42v",
+              "types": [
+                "Original"
+              ],
+              "duration": 5,
+              "durationISO8601": "PT5S",
+              "warnings": {
+                
+              },
+              "availableTerritories": {
+                "uk": true,
+                "nonUk": true
+              },
+              "availableFrom": 1545304011000
             }
-        ]
+          ],
+          "type": "media"
+        },
+        {
+          "text": "This is an introduction ",
+          "role": "introduction",
+          "markupType": "plain_text",
+          "type": "paragraph"
+        },
+        {
+          "text": "This is a heading ",
+          "markupType": "plain_text",
+          "type": "heading"
+        },
+        {
+          "text": "This is a subheading ",
+          "markupType": "plain_text",
+          "type": "heading"
+        },
+        {
+          "text": "This is a crosshead ",
+          "markupType": "plain_text",
+          "type": "crosshead"
+        },
+        {
+          "text": "This is regular paragraph text. &quot;Lorem ipsum dolor sit amet&quot;, 'consectetur adipiscing elit', sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+          "markupType": "plain_text",
+          "type": "paragraph"
+        },
+        {
+          "numbered": false,
+          "items": [
+            {
+              "text": "<itemMeta>afrique/23248423</itemMeta>",
+              "meta": [
+                {
+                  "headlines": {
+                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
+                    "headline": "Lorem ipsum dolor sit amet, consectetur",
+                    "overtyped": "<Media Asset Page>"
+                  },
+                  "locators": {
+                    "href": "http://www.bbc.com/afrique/23248423"
+                  },
+                  "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                  "timestamp": 1568218735000,
+                  "passport": {
+                    "category": {
+                      "categoryId": "",
+                      "categoryName": ""
+                    }
+                  },
+                  "id": "urn:bbc:ares::asset:afrique/23248423",
+                  "type": "cps"
+                }
+              ],
+              "markupType": "candy_xml",
+              "type": "listItem"
+            },
+            {
+              "text": "<itemMeta>afrique/23248423</itemMeta>",
+              "meta": [
+                {
+                  "headlines": {
+                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
+                    "headline": "Lorem ipsum dolor sit amet, consectetur",
+                    "overtyped": "<Media Asset Page>"
+                  },
+                  "locators": {
+                    "href": "http://www.bbc.com/afrique/23248423"
+                  },
+                  "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                  "timestamp": 1568218735000,
+                  "passport": {
+                    "category": {
+                      "categoryId": "",
+                      "categoryName": ""
+                    }
+                  },
+                  "id": "urn:bbc:ares::asset:afrique/23248423",
+                  "type": "cps"
+                }
+              ],
+              "markupType": "candy_xml",
+              "type": "listItem"
+            },
+            {
+              "text": "<itemMeta>afrique/23248423</itemMeta>",
+              "meta": [
+                {
+                  "headlines": {
+                    "shortHeadline": "Lorem ipsum dolor sit amet, consectetur",
+                    "headline": "Lorem ipsum dolor sit amet, consectetur",
+                    "overtyped": "<Media Asset Page>"
+                  },
+                  "locators": {
+                    "href": "http://www.bbc.com/afrique/23248423"
+                  },
+                  "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                  "timestamp": 1568218735000,
+                  "passport": {
+                    "category": {
+                      "categoryId": "",
+                      "categoryName": ""
+                    }
+                  },
+                  "id": "urn:bbc:ares::asset:afrique/23248423",
+                  "type": "cps"
+                }
+              ],
+              "markupType": "candy_xml",
+              "type": "listItem"
+            },
+            {
+              "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
+              "markupType": "candy_xml",
+              "type": "listItem"
+            },
+            {
+              "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
+              "markupType": "candy_xml",
+              "type": "listItem"
+            },
+            {
+              "text": "<link><caption>this is the link text</caption><altText>this is the alt text </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/><url href=\"https://bbc.com/pidgin\" platform=\"enhancedmobile\"/></link>",
+              "markupType": "candy_xml",
+              "type": "listItem"
+            }
+          ],
+          "type": "list"
+        },
+        {
+          "text": "Lorem ipsum dolor sit amet, <bold>consectetur</bold> adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation<bold> ullamco laboris nisi ut aliquip </bold>ex ea commodo consequat. Duis aute irure dolor in reprehenderit<italic> in voluptate velit esse cillum </italic>dolore &quot;eu fugiat nulla&quot; pariatur. <link><caption>Excepteur</caption><altText>this is a link</altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/></link> sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+          "role": "transmission-info",
+          "markupType": "candy_xml",
+          "type": "paragraph"
+        },
+        {
+          "text": "Lorem ipsum<link><caption> dolor sit amet</caption><altText>dolor sit amet poop poop </altText><url href=\"https://bbc.com/pidgin\" platform=\"highweb\"/></link>, consectetur adipiscing elit",
+          "markupType": "candy_xml",
+          "type": "paragraph"
+        },
+        {
+          "id": "63721686",
+          "subType": "body",
+          "href": "http://b.files.bbci.co.uk/10C04/test/_63721686_testimage.jpg",
+          "path": "/cpsdevpb/10C04/test/_63721686_testimage.jpg",
+          "height": 360,
+          "width": 640,
+          "altText": "test",
+          "copyrightHolder": "BBC",
+          "positionHint": "full-width",
+          "type": "image"
+        },
+        {
+          "numbered": false,
+          "items": [
+            {
+              "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
+              "markupType": "plain_text",
+              "type": "listItem"
+            },
+            {
+              "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
+              "markupType": "plain_text",
+              "type": "listItem"
+            },
+            {
+              "text": "sunt in culpa qui officia deserunt mollit anim id est laborum",
+              "markupType": "plain_text",
+              "type": "listItem"
+            },
+            {
+              "text": "v3 draft",
+              "markupType": "plain_text",
+              "type": "listItem"
+            }
+          ],
+          "type": "list"
+        },
+        {
+          "text": "This is transmission info ",
+          "role": "transmission-info",
+          "markupType": "plain_text",
+          "type": "paragraph"
+        },
+        {
+          "text": "This is the footer ",
+          "role": "footer",
+          "markupType": "plain_text",
+          "type": "paragraph"
+        }
+      ]
     },
     "promo": {
-        "headlines": {
-            "shortHeadline": "WSMEDIA TEST - Lorem ipsum dolor sit amet,",
-            "headline": "Lorem ipsum dolor sit amet, consectetur Lorem ipsum dolor sit amet, consectetur Lorem ipsum dolor sit amet, consectetur Lorem ipsum dolor sit amet, consectetur"
+      "headlines": {
+        "shortHeadline": "Media Pod and Drew Build First Media Asset Page",
+        "headline": "Media Pod Build \"First\" CPS Media Asset Page in Simorgh with the Help of \"Drew\""
+      },
+      "locators": {
+        "assetUri": "/pidgin/23248703",
+        "cpsUrn": "urn:bbc:content:assetUri:pidgin/23248703",
+        "curie": "http://www.bbc.co.uk/asset/5679389a-3ea6-0b40-9de4-f4d33d6bcd9f"
+      },
+      "summary": "The pages were built out in a matter of weeks using existing Psammead Components",
+      "timestamp": 1571911736305,
+      "passport": {
+        "category": {
+          "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/Opinion",
+          "categoryName": "Opinion"
         },
-        "locators": {
-            "assetUri": "/pidgin/23248703",
-            "cpsUrn": "urn:bbc:content:assetUri:pidgin/23248703",
-            "curie": "http://www.bbc.co.uk/asset/5679389a-3ea6-0b40-9de4-f4d33d6bcd9f"
+        "campaigns": [
+          {
+            "campaignId": "5ad8625ac93a9f000eecb253",
+            "campaignName": "Inspire me"
+          },
+          {
+            "campaignId": "5ad86285c93a9f000eecb256",
+            "campaignName": "Give me perspective"
+          },
+          {
+            "campaignId": "5ad86291c93a9f000eecb257",
+            "campaignName": "Keep me on trend"
+          }
+        ]
+      },
+      "media": {
+        "id": "p01kx42s",
+        "subType": "clip",
+        "format": "video",
+        "title": "alt-text world service clip",
+        "synopses": {
+          "short": "short"
         },
-        "summary": "Lorem ipsum dolor sit amet, consectetur",
-        "timestamp": 1568825343680,
-        "passport": {},
-        "media": {
-            "id": "p01kx42s",
-            "subType": "clip",
-            "format": "video",
-            "title": "alt-text world service clip",
-            "synopses": {
-                "short": "short"
-            },
-            "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kx435.jpg",
-            "embedding": true,
-            "advertising": true,
-            "caption": "short",
-            "versions": [
-                {
-                    "versionId": "p01kx42v",
-                    "types": [
-                        "Original"
-                    ],
-                    "duration": 5,
-                    "durationISO8601": "PT5S",
-                    "warnings": {},
-                    "availableTerritories": {
-                        "uk": true,
-                        "nonUk": true
-                    },
-                    "availableFrom": 1545304011000
-                }
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kx435.jpg",
+        "embedding": true,
+        "advertising": true,
+        "caption": "short",
+        "versions": [
+          {
+            "versionId": "p01kx42v",
+            "types": [
+              "Original"
             ],
-            "type": "media"
-        },
-        "indexImage": {
-            "id": "63721682",
-            "subType": "index",
-            "href": "http://b.files.bbci.co.uk/6FC4/test/_63721682_p01kx435.jpg",
-            "path": "/cpsdevpb/6FC4/test/_63721682_p01kx435.jpg",
-            "height": 360,
-            "width": 640,
-            "altText": "connectionAltText",
-            "copyrightHolder": "BBC",
-            "type": "image"
-        },
-        "id": "urn:bbc:ares::asset:pidgin/23248703",
-        "type": "cps"
+            "duration": 5,
+            "durationISO8601": "PT5S",
+            "warnings": {
+              
+            },
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true
+            },
+            "availableFrom": 1545304011000
+          }
+        ],
+        "type": "media"
+      },
+      "indexImage": {
+        "id": "63721682",
+        "subType": "index",
+        "href": "http://b.files.bbci.co.uk/6FC4/test/_63721682_p01kx435.jpg",
+        "path": "/cpsdevpb/6FC4/test/_63721682_p01kx435.jpg",
+        "height": 360,
+        "width": 640,
+        "altText": "connectionAltText",
+        "copyrightHolder": "BBC",
+        "type": "image"
+      },
+      "id": "urn:bbc:ares::asset:pidgin/23248703",
+      "type": "cps"
     },
     "relatedContent": {
-        "section": {
-            "subType": "index",
-            "name": "Domot",
-            "uri": "/pidgin/front_page",
-            "type": "simple"
-        },
-        "site": {
-            "subType": "site",
-            "name": "BBC Pidgin",
-            "uri": "/pidgin",
-            "type": "simple"
-        },
-        "groups": []
+      "section": {
+        "subType": "index",
+        "name": "Domot",
+        "uri": "/pidgin/front_page",
+        "type": "simple"
+      },
+      "site": {
+        "subType": "site",
+        "name": "BBC Pidgin",
+        "uri": "/pidgin",
+        "type": "simple"
+      },
+      "groups": [
+        
+      ]
     }
-}
+  }

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
@@ -13,6 +13,11 @@ const parseBlockByType = block => {
 
   const { type } = block;
 
+  // if the block has text handle escaped quotes
+  if (path(['text'], block)) {
+    block.text = block.text.replace(/&quot;/g, '"'); // eslint-disable-line no-param-reassign
+  }
+
   const parsedBlock = (typesToConvert[type] || handleMissingType)(block);
 
   if (!parsedBlock) {

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
@@ -1,5 +1,6 @@
 import { clone, pathOr, path } from 'ramda';
 import paragraph from './blocks/paragraph';
+import { escapeDoubleQuotes } from './utils/helpers';
 
 const handleMissingType = block =>
   console.log(`Missing type field on block ${block.type}`); // eslint-disable-line no-console
@@ -13,12 +14,17 @@ const parseBlockByType = block => {
 
   const { type } = block;
 
+  let cleanBlock = block;
+
   // if the block has text handle escaped quotes
-  if (path(['text'], block)) {
-    block.text = block.text.replace(/&quot;/g, '"'); // eslint-disable-line no-param-reassign
+  if (path(['text'], cleanBlock)) {
+    cleanBlock = {
+      ...cleanBlock,
+      text: escapeDoubleQuotes(cleanBlock.text),
+    };
   }
 
-  const parsedBlock = (typesToConvert[type] || handleMissingType)(block);
+  const parsedBlock = (typesToConvert[type] || handleMissingType)(cleanBlock);
 
   if (!parsedBlock) {
     return null;

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
@@ -58,6 +58,80 @@ describe('convertToOptimoBlocks', () => {
     expect(await convertToOptimoBlocks(input)).toEqual(expected);
   });
 
+  it('should handle escaped quotes in a plain_text block', async () => {
+    const input = {
+      content: {
+        blocks: [
+          {
+            text: 'Paragraph containing &quot;quote marks&quot;',
+            markupType: 'plain_text',
+            type: 'paragraph',
+          },
+        ],
+      },
+    };
+    const expected = {
+      content: {
+        model: {
+          blocks: [
+            optimoText([
+              {
+                fragments: [
+                  {
+                    fragment: 'Paragraph containing "quote marks"',
+                    attributes: [],
+                  },
+                ],
+                text: 'Paragraph containing "quote marks"',
+              },
+            ]),
+          ],
+        },
+      },
+    };
+
+    expect(await convertToOptimoBlocks(input)).toEqual(expected);
+  });
+
+  it('should handle escaped quotes in a candy_xml block', async () => {
+    const input = {
+      content: {
+        blocks: [
+          {
+            text: 'Paragraph containing <bold>&quot;quote marks&quot;</bold>',
+            markupType: 'candy_xml',
+            type: 'paragraph',
+          },
+        ],
+      },
+    };
+    const expected = {
+      content: {
+        model: {
+          blocks: [
+            optimoText([
+              {
+                fragments: [
+                  {
+                    fragment: 'Paragraph containing ',
+                    attributes: [],
+                  },
+                  {
+                    fragment: '"quote marks"',
+                    attributes: ['bold'],
+                  },
+                ],
+                text: 'Paragraph containing "quote marks"',
+              },
+            ]),
+          ],
+        },
+      },
+    };
+
+    expect(await convertToOptimoBlocks(input)).toEqual(expected);
+  });
+
   it('should return an empty array if blocks is an empty array', async () => {
     const input = {
       content: {

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/utils/helpers.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/utils/helpers.js
@@ -20,3 +20,5 @@ export const optimoText = paragraphs => ({
     blocks: paragraphs.map(optimoParagraph),
   },
 });
+
+export const escapeDoubleQuotes = text => text.replace(/&quot;/g, '"');


### PR DESCRIPTION
Resolves #4146

**Overall change:** Adds a helper function to turn `&quot;` into `"`.

**Code changes:**

- Makes a helper function for escaping double quotes
- Uses the helper function when mapping over CPS blocks that contain a `text` field. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- ~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~
- ~[ ] This PR requires manual testing~

http://localhost.bbc.com:7080/pidgin/23248703 - quotes in the first paragraph. 

NB: Headline works out the box, see issue description for more details. 