### PR TITLE
Add AV player to CPS pages

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -55,19 +55,6 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
         },
       );
     });
-
-    it('should render a media player', () => {
-      cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
-        ({ body }) => {
-          const { assetUri } = body.metadata.locators;
-          const { versionId } = body.content.blocks[0].versions[0];
-          const { language } = body.metadata;
-          cy.get(
-            `[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
-          ).should('be.visible');
-        },
-      );
-    });
   });
 };
 

--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -63,7 +63,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
           const { versionId } = body.content.blocks[0].versions[0];
           const { language } = body.metadata;
           cy.get(
-            `[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps/${assetUri}/${versionId}/${language}"]`,
+            `[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
           ).should('be.visible');
         },
       );

--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -1,6 +1,5 @@
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
-import envConfig from '../../../support/config/envs';
 
 const getParagraphText = blocks =>
   blocks.find(el => el.type === 'paragraph' && el.markupType === 'plain_text')

--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -1,5 +1,6 @@
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
+import envConfig from '../../../support/config/envs';
 
 const getParagraphText = blocks =>
   blocks.find(el => el.type === 'paragraph' && el.markupType === 'plain_text')
@@ -51,6 +52,19 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
                 appConfig[service].default.articleTimestampPrefix,
               );
           }
+        },
+      );
+    });
+
+    it('should render a media player', () => {
+      cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
+        ({ body }) => {
+          const { assetUri } = body.metadata.locators;
+          const { versionId } = body.content.blocks[0].versions[0];
+          const { language } = body.metadata;
+          cy.get(
+            `[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps/${assetUri}/${versionId}/${language}"]`,
+          ).should('be.visible');
         },
       );
     });

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -20,7 +20,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
           const { versionId } = body.content.blocks[0].versions[0];
           const { language } = body.metadata;
           cy.get(
-            `amp-iframe[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+            `amp-iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
           ).should('be.visible');
         },
       );

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -12,7 +12,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   service,
   pageType,
 }) =>
-  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
+  describe(`testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
     it('should render a media player', () => {
       cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
         ({ body }) => {

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -1,3 +1,6 @@
+import config from '../../../support/config/services';
+import envConfig from '../../../support/config/envs';
+
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
 export const testsThatAlwaysRunForAMPOnly = ({ service, pageType }) => {
@@ -9,7 +12,20 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   service,
   pageType,
 }) =>
-  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {});
+  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
+    it('should render a media player', () => {
+      cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
+        ({ body }) => {
+          const { assetUri } = body.metadata.locators;
+          const { versionId } = body.content.blocks[0].versions[0];
+          const { language } = body.metadata;
+          cy.get(
+            `amp-iframe[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+          ).should('be.visible');
+        },
+      );
+    });
+  });
 
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.
 export const testsThatNeverRunDuringSmokeTestingForAMPOnly = ({

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -12,7 +12,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   service,
   pageType,
 }) =>
-  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
+  describe(`testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
     it('should render a media player', () => {
       cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
         ({ body }) => {

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -20,7 +20,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
           const { versionId } = body.content.blocks[0].versions[0];
           const { language } = body.metadata;
           cy.get(
-            `iframe[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+            `iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
           ).should('be.visible');
         },
       );

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -1,3 +1,6 @@
+import config from '../../../support/config/services';
+import envConfig from '../../../support/config/envs';
+
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
 export const testsThatAlwaysRunForCanonicalOnly = ({ service, pageType }) => {
@@ -9,7 +12,20 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   service,
   pageType,
 }) =>
-  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {});
+  describe(`No testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
+    it('should render a media player', () => {
+      cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
+        ({ body }) => {
+          const { assetUri } = body.metadata.locators;
+          const { versionId } = body.content.blocks[0].versions[0];
+          const { language } = body.metadata;
+          cy.get(
+            `iframe[src*="${envConfig.liveRadioIframeBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+          ).should('be.visible');
+        },
+      );
+    });
+  });
 
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.
 export const testsThatNeverRunDuringSmokeTestingForCanonicalOnly = ({

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CPSVideoBlock no placeholder 1`] = `<div />`;
+exports[`CPSVideoBlock no placeholder 1`] = `
+.c2 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
 
-exports[`CPSVideoBlock with placeholder 1`] = `<div />`;
+.c1 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0 {
+  padding-bottom: 1.5rem;
+}
+
+@media (max-width:63rem) {
+  .c0 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <iframe
+      allow="autoplay; fullscreen"
+      allowfullscreen=""
+      class="c2"
+      src="https://www.test.bbc.co.uk/ws/av-embeds/cps//pidgin/12345678/p07jl3lx/ig"
+    />
+  </div>
+</div>
+`;
+
+exports[`CPSVideoBlock with placeholder 1`] = `
+.c3 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.c2 {
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c1 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0 {
+  padding-bottom: 1.5rem;
+}
+
+@media (max-width:63rem) {
+  .c0 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <img
+        alt="Image Alt"
+        class="c3"
+        src="https://ichef.bbci.co.uk/images/ic/$recipe/p07jl8g4.jpg"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
@@ -51,24 +51,46 @@ exports[`CPSVideoBlock no placeholder 1`] = `
   }
 }
 
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <iframe
-      allow="autoplay; fullscreen"
-      allowfullscreen=""
-      class="c2"
-      src="https://www.test.bbc.co.uk/ws/av-embeds/cps//pidgin/12345678/p07jl3lx/ig"
-    />
-  </div>
-</div>
+<html>
+  <head>
+    <script
+      type="application/ld+json"
+    >
+      {"video":{"@list":[{"@type":"VideoObject","name":"Why dis pikin get fish skin","description":"Short Synopsis","duration":101,"thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p07jl8g4.jpg","uploadDate":1564740166}]}}
+    </script>
+  </head>
+  <body>
+    <div>
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <iframe
+            allow="autoplay; fullscreen"
+            allowfullscreen=""
+            class="c2"
+            src="https://www.test.bbc.co.uk/ws/av-embeds/cps//pidgin/12345678/p07jl3lx/ig"
+          />
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
 `;
 
 exports[`CPSVideoBlock with placeholder 1`] = `
-.c3 {
+<html>
+  <head>
+    <script
+      type="application/ld+json"
+    >
+      {"video":{"@list":[{"@type":"VideoObject","name":"Why dis pikin get fish skin","description":"Short Synopsis","duration":101,"thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p07jl8g4.jpg","uploadDate":1564740166}]}}
+    </script>
+  </head>
+  <body>
+    .c3 {
   display: block;
   width: 100%;
   visibility: visible;
@@ -123,21 +145,26 @@ exports[`CPSVideoBlock with placeholder 1`] = `
   }
 }
 
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <img
-        alt="Image Alt"
-        class="c3"
-        src="https://ichef.bbci.co.uk/images/ic/$recipe/p07jl8g4.jpg"
-      />
+<div>
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <div
+            class="c2"
+          >
+            <img
+              alt="Image Alt"
+              class="c3"
+              src="https://ichef.bbci.co.uk/images/ic/$recipe/p07jl8g4.jpg"
+            />
+          </div>
+        </div>
+      </div>
+      ,
     </div>
-  </div>
-</div>
+  </body>
+</html>
 `;

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CPSVideoBlock no placeholder 1`] = `<div />`;
+
+exports[`CPSVideoBlock with placeholder 1`] = `<div />`;

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
@@ -5,13 +5,14 @@ import { GridItemConstrainedLarge } from '#lib/styledGrid';
 
 import MediaPlayer from '../../../MediaPlayer';
 
-const CPSVideoBlock = ({ showPlaceholder, assetUri }) => {
-  return props => (
+const CPSVideoBlock = props => {
+  const { showPlaceholder, assetUri } = props;
+  return (
     <MediaPlayer
       {...props}
       embedOverrides={{
         type: 'cps',
-        id: assetUri.substr(1),
+        id: assetUri,
         showPlaceholder,
         wrapper: styled(GridItemConstrainedLarge)`
           padding-bottom: 1.5rem;
@@ -19,6 +20,10 @@ const CPSVideoBlock = ({ showPlaceholder, assetUri }) => {
       }}
     />
   );
+};
+
+CPSVideoBlock.defaultProps = {
+  showPlaceholder: true,
 };
 
 CPSVideoBlock.propTypes = {

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { bool, string } from 'prop-types';
+import styled from 'styled-components';
+import { GridItemConstrainedLarge } from '#lib/styledGrid';
+
+import MediaPlayer from '../../../MediaPlayer';
+
+const CPSVideoBlock = ({ showPlaceholder, assetUri }) => {
+  return props => (
+    <MediaPlayer
+      {...props}
+      embedOverrides={{
+        type: 'cps',
+        id: assetUri.substr(1),
+        showPlaceholder,
+        wrapper: styled(GridItemConstrainedLarge)`
+          padding-bottom: 1.5rem;
+        `,
+      }}
+    />
+  );
+};
+
+CPSVideoBlock.propTypes = {
+  showPlaceholder: bool,
+  assetUri: string.isRequired,
+};
+
+export default CPSVideoBlock;

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { bool, string } from 'prop-types';
 import styled from 'styled-components';
 import { GridItemConstrainedLarge } from '#lib/styledGrid';
-
 import MediaPlayer from '../../../MediaPlayer';
 
 const CPSVideoBlock = props => {

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/index.test.jsx
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/index.test.jsx
@@ -1,14 +1,51 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { RequestContextProvider } from '#contexts/RequestContext';
+import { ToggleContextProvider } from '#contexts/ToggleContext';
+
+import { optimoVideoBlock } from '#lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/media/fixtures';
+
 import CPSVideoBlock from '.';
+
+// eslint-disable-next-line react/prop-types
+const Contexts = ({ children }) => (
+  <ToggleContextProvider>
+    <ServiceContextProvider service="igbo">
+      <RequestContextProvider
+        bbcOrigin="https://www.test.bbc.co.uk"
+        isAmp={false}
+        pageType="STY"
+        pathname="/igbo/afirika-23252735"
+        service="igbo"
+        statusCode={200}
+      >
+        {children}
+      </RequestContextProvider>
+    </ServiceContextProvider>
+  </ToggleContextProvider>
+);
 
 describe('CPSVideoBlock', () => {
   shouldMatchSnapshot(
     'no placeholder',
-    <CPSVideoBlock assetUri="/pidgin/12345678" />,
+    <Contexts>
+      <CPSVideoBlock
+        {...optimoVideoBlock.model}
+        assetUri="/pidgin/12345678"
+        showPlaceholder={false}
+      />
+    </Contexts>,
   );
   shouldMatchSnapshot(
     'with placeholder',
-    <CPSVideoBlock assetUri="/pidgin/12345678" showPlaceholder />,
+    <Contexts>
+      <CPSVideoBlock
+        {...optimoVideoBlock.model}
+        assetUri="/pidgin/12345678"
+        showPlaceholder
+      />
+      ,
+    </Contexts>,
   );
 });

--- a/src/app/containers/CpsAssetPageMain/Blocks/Video/index.test.jsx
+++ b/src/app/containers/CpsAssetPageMain/Blocks/Video/index.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import CPSVideoBlock from '.';
+
+describe('CPSVideoBlock', () => {
+  shouldMatchSnapshot(
+    'no placeholder',
+    <CPSVideoBlock assetUri="/pidgin/12345678" />,
+  );
+  shouldMatchSnapshot(
+    'with placeholder',
+    <CPSVideoBlock assetUri="/pidgin/12345678" showPlaceholder />,
+  );
+});

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -217,7 +217,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 2rem;
 }
 
-.c5 {
+.c8 {
   grid-column: 1 / span 6;
 }
 
@@ -251,7 +251,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 1rem;
 }
 
-.c6 {
+.c9 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -260,6 +260,26 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   color: #3F3F42;
   padding-bottom: 1.5rem;
   margin: 0;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  padding-bottom: 1.5rem;
 }
 
 @media (max-width:37.4375rem) {
@@ -303,40 +323,40 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (max-width:25rem) {
-  .c5 {
+  .c8 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c5 {
+  .c8 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 {
+  .c8 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c5 {
+  .c8 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c5 {
+  .c8 {
     grid-column: 6 / span 10;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c5 {
+  .c8 {
     max-width: initial;
   }
 }
@@ -445,16 +465,46 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
+  }
+}
+
+@media (max-width:63rem) {
+  .c5 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c5 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c5 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c5 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c5 {
+    padding: 0 1rem;
   }
 }
 
@@ -495,98 +545,112 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
         <div
           class="c5"
         >
-          <p
+          <div
             class="c6"
+          >
+            <iframe
+              allow="autoplay; fullscreen"
+              allowfullscreen=""
+              class="c7"
+              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
+            />
+          </div>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
           >
             As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Wetin ginger Emeka na im friend wey smoke from generator kill.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Most of di material wey Nelson take arrange im generator na from  scrap.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
           </p>
         </div>
         <div
-          class="c5"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
           </p>
@@ -763,6 +827,26 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
   animation: eMLfYp 0.2s linear;
   -webkit-transition: visibility 0.2s linear;
   transition: visibility 0.2s linear;
+}
+
+.c21 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
+
+.c20 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c19 {
+  padding-bottom: 1.5rem;
 }
 
 @media (max-width:37.4375rem) {
@@ -1062,6 +1146,36 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
 @media (min-width:63rem) {
   .c12 {
     padding: 0.5rem 0 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c19 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c19 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c19 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c19 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c19 {
+    padding: 0 1rem;
   }
 }
 
@@ -1519,6 +1633,20 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
           >
             Cauliflower cheese bocconcini hard cheese. Port-salut ricotta rubber cheese pecorino queso say cheese danish fontina parmesan. Port-salut lancashire pecorino say cheese stilton jarlsberg when the cheese comes out everybody's happy chalk and cheese. Squirty cheese cheese triangles swiss blue castello fromage mozzarella macaroni cheese cottage cheese. Chalk and cheese parmesan lancashire fondue.
           </p>
+        </div>
+        <div
+          class="c19"
+        >
+          <div
+            class="c20"
+          >
+            <iframe
+              allow="autoplay; fullscreen"
+              allowfullscreen=""
+              class="c21"
+              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/ig"
+            />
+          </div>
         </div>
         <div
           class="c15"

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -547,7 +547,7 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
               allow="autoplay; fullscreen"
               allowfullscreen=""
               class="c7"
-              src="https://www.test.bbc.co.uk/ws/av-embeds/cps//pidgin/tori-49450859/p07lg239/pcm"
+              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/pcm"
             />
           </div>
         </div>
@@ -650,6 +650,12 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
             Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
           </p>
         </div>
+        <a
+          data-e2e="cpsAssetDummyLink"
+          href="/pidgin/23248703"
+          style="pointer-events: none;"
+          tabindex="-1"
+        />
       </main>
     </div>
   </body>

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -217,7 +217,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 2rem;
 }
 
-.c8 {
+.c5 {
   grid-column: 1 / span 6;
 }
 
@@ -251,7 +251,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 1rem;
 }
 
-.c9 {
+.c6 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -260,26 +260,6 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   color: #3F3F42;
   padding-bottom: 1.5rem;
   margin: 0;
-}
-
-.c7 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  overflow: hidden;
-}
-
-.c6 {
-  padding-top: 56.25%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c5 {
-  padding-bottom: 1.5rem;
 }
 
 @media (max-width:37.4375rem) {
@@ -323,40 +303,40 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (max-width:25rem) {
-  .c8 {
+  .c5 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c8 {
+  .c5 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c5 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c8 {
+  .c5 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c8 {
+  .c5 {
     grid-column: 6 / span 10;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c5 {
     max-width: initial;
   }
 }
@@ -465,46 +445,16 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c6 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c6 {
     font-size: 1rem;
     line-height: 1.375rem;
-  }
-}
-
-@media (max-width:63rem) {
-  .c5 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c5 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c5 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c5 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c5 {
-    padding: 0 1rem;
   }
 }
 
@@ -545,112 +495,98 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
         <div
           class="c5"
         >
-          <div
-            class="c6"
-          >
-            <iframe
-              allow="autoplay; fullscreen"
-              allowfullscreen=""
-              class="c7"
-              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
-            />
-          </div>
-        </div>
-        <div
-          class="c8"
-        >
           <p
-            class="c9"
+            class="c6"
           >
             As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Wetin ginger Emeka na im friend wey smoke from generator kill.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Most of di material wey Nelson take arrange im generator na from  scrap.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
           </p>
         </div>
         <div
-          class="c8"
+          class="c5"
         >
           <p
-            class="c9"
+            class="c6"
           >
             Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
           </p>
@@ -658,9 +594,9 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
         <a
           data-e2e="cpsAssetDummyLink"
           href="/pidgin/23248703"
-          style="pointer-events: none;"
-          tabindex="-1"
-        />
+        >
+          _
+        </a>
       </main>
     </div>
   </body>
@@ -827,26 +763,6 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
   animation: eMLfYp 0.2s linear;
   -webkit-transition: visibility 0.2s linear;
   transition: visibility 0.2s linear;
-}
-
-.c21 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
-  overflow: hidden;
-}
-
-.c20 {
-  padding-top: 56.25%;
-  position: relative;
-  overflow: hidden;
-}
-
-.c19 {
-  padding-bottom: 1.5rem;
 }
 
 @media (max-width:37.4375rem) {
@@ -1146,36 +1062,6 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
 @media (min-width:63rem) {
   .c12 {
     padding: 0.5rem 0 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c19 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c19 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c19 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c19 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c19 {
-    padding: 0 1rem;
   }
 }
 
@@ -1635,20 +1521,6 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
           </p>
         </div>
         <div
-          class="c19"
-        >
-          <div
-            class="c20"
-          >
-            <iframe
-              allow="autoplay; fullscreen"
-              allowfullscreen=""
-              class="c21"
-              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/ig"
-            />
-          </div>
-        </div>
-        <div
           class="c15"
         >
           <p
@@ -1692,9 +1564,9 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
         <a
           data-e2e="cpsAssetDummyLink"
           href="/pidgin/23248703"
-          style="pointer-events: none;"
-          tabindex="-1"
-        />
+        >
+          _
+        </a>
       </main>
     </div>
   </body>

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -7,15 +7,15 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   padding-bottom: 2rem;
 }
 
-.c1 {
-  grid-column: 1 / span 6;
-}
-
-.c4 {
+.c8 {
   grid-column: 1 / span 6;
 }
 
 .c3 {
+  grid-column: 1 / span 6;
+}
+
+.c2 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -26,7 +26,7 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   padding: 2rem 0;
 }
 
-.c5 {
+.c4 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -37,11 +37,11 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   padding-bottom: 0.25rem;
 }
 
-.c5:last-child {
+.c4:last-child {
   padding-bottom: 1rem;
 }
 
-.c6 {
+.c9 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -50,6 +50,26 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
   color: #3F3F42;
   padding-bottom: 1.5rem;
   margin: 0;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  padding-bottom: 1.5rem;
 }
 
 @media (max-width:37.4375rem) {
@@ -93,158 +113,188 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
 }
 
 @media (max-width:25rem) {
-  .c1 {
+  .c8 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c1 {
+  .c8 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c8 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c1 {
+  .c8 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c1 {
+  .c8 {
     grid-column: 6 / span 10;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c1 {
+  .c8 {
     max-width: initial;
   }
 }
 
 @media (max-width:63rem) {
-  .c2 {
+  .c1 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c2 {
+  .c1 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c1 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c2 {
+  .c1 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c2 {
+  .c1 {
     padding: 0 1rem;
   }
 }
 
 @media (max-width:25rem) {
-  .c4 {
+  .c3 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c4 {
+  .c3 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c4 {
+  .c3 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c4 {
+  .c3 {
     grid-column: 2 / span 4;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c4 {
+  .c3 {
     max-width: initial;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c2 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c2 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c2 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
+  .c4 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 {
+  .c4 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
+  }
+}
+
+@media (max-width:63rem) {
+  .c5 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c5 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c5 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c5 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c5 {
+    padding: 0 1rem;
   }
 }
 
@@ -462,18 +512,8 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
         <div
           class="c1"
         >
-          <a
-            data-e2e="cpsAssetDummyLink"
-            href="/pidgin/23248703"
-          >
-            Test MAP to MAP inline link
-          </a>
-        </div>
-        <div
-          class="c2"
-        >
           <h1
-            class="c3"
+            class="c2"
             id="content"
             tabindex="-1"
           >
@@ -481,16 +521,16 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
           </h1>
         </div>
         <div
-          class="c4"
+          class="c3"
         >
           <time
-            class="c5"
+            class="c4"
             datetime="2019-08-23"
           >
             23 August 2019
           </time>
           <time
-            class="c5"
+            class="c4"
             datetime="2019-08-23"
           >
             New Informate 
@@ -498,100 +538,114 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
           </time>
         </div>
         <div
-          class="c1"
+          class="c5"
+        >
+          <div
+            class="c6"
+          >
+            <iframe
+              allow="autoplay; fullscreen"
+              allowfullscreen=""
+              class="c7"
+              src="https://www.test.bbc.co.uk/ws/av-embeds/cps//pidgin/tori-49450859/p07lg239/pcm"
+            />
+          </div>
+        </div>
+        <div
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Wetin ginger Emeka na im friend wey smoke from generator kill.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Most of di material wey Nelson take arrange im generator na from  scrap.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
           </p>
         </div>
         <div
-          class="c1"
+          class="c8"
         >
           <p
-            class="c6"
+            class="c9"
           >
             Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
           </p>

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -209,6 +209,11 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
     >
       {"@context":"http://schema.org","@type":"Article","url":"https://www.test.bbc.com/pidgin/tori-49450859","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.test.bbc.com/pidgin/tori-49450859","name":"Nigerian man Emeka Nelson don produce generator wey dey use only water"}}
     </script>
+    <script
+      type="application/ld+json"
+    >
+      {"video":{"@list":[{"@type":"VideoObject","name":"Nigerian man produce generator wey dey run on water","description":"Nigerian man produce generator wey dey run on water","duration":139,"thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p07lgnlf.jpg","uploadDate":1566573314}]}}
+    </script>
   </head>
   <body>
     .c0 {
@@ -1386,6 +1391,11 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
       type="application/ld+json"
     >
       {"@context":"http://schema.org","@type":"Article","url":"https://www.test.bbc.com/igbo/afirika-23252735","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.test.bbc.com/igbo/afirika-23252735","name":"STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?"}}
+    </script>
+    <script
+      type="application/ld+json"
+    >
+      {"video":{"@list":[{"@type":"AudioObject","name":"Подкаст \\"Разговоры с арбитром\\": чемпионский парад \\"Ливерпуля\\"","description":"Сева Бойко рассказывает о том, как в Ливерпуле отметили победу в Лиге чемпионов.","duration":1961,"thumbnailUrl":"https://ichef.test.bbci.co.uk/images/ic/1024x576/p01mr7dp.jpg","uploadDate":1559819809000}]}}
     </script>
   </head>
   <body>

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,672 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
+<html
+  dir="ltr"
+  lang="pcm"
+>
+  <head>
+    <title>
+      Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Ìgbò
+    </title>
+    <link
+      href="https://www.test.bbc.com/pidgin/tori-49450859"
+      rel="canonical"
+    />
+    <link
+      href="https://www.test.bbc.co.uk/pidgin/tori-49450859"
+      hreflang="ig"
+      rel="alternate"
+    />
+    <link
+      href="https://www.test.bbc.co.uk/pidgin/tori-49450859.amp"
+      rel="amphtml"
+    />
+    <link
+      href="http://localhost:7080/igbo/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
+      rel="apple-touch-icon"
+      sizes="72x72"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
+      rel="apple-touch-icon"
+      sizes="96x96"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-128x128.png"
+      rel="apple-touch-icon"
+      sizes="128x128"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-144x144.png"
+      rel="apple-touch-icon"
+      sizes="144x144"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-152x152.png"
+      rel="apple-touch-icon"
+      sizes="152x152"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
+      rel="apple-touch-icon"
+      sizes="192x192"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-384x384.png"
+      rel="apple-touch-icon"
+      sizes="384x384"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
+      rel="apple-touch-icon"
+      sizes="512x512"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-72x72.png"
+      rel="icon"
+      sizes="72x72"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-96x96.png"
+      rel="icon"
+      sizes="96x96"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-192x192.png"
+      rel="icon"
+      sizes="192x192"
+      type="image/png"
+    />
+    <link
+      href="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-512x512.png"
+      rel="apple-touch-startup-image"
+    />
+    <link
+      href="/favicon.ico"
+      rel="shortcut icon"
+      type="image/x-icon"
+    />
+    <meta
+      content="IE=edge"
+      http-equiv="X-UA-Compatible"
+    />
+    <meta
+      charset="utf-8"
+    />
+    <meta
+      content="noodp,noydir"
+      name="robots"
+    />
+    <meta
+      content="#B80000"
+      name="theme-color"
+    />
+    <meta
+      content="width=device-width, initial-scale=1, minimum-scale=1"
+      name="viewport"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="apple-mobile-web-app-title"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="application-name"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="description"
+    />
+    <meta
+      content="100004154058350"
+      name="fb:admins"
+    />
+    <meta
+      content="1609039196070050"
+      name="fb:app_id"
+    />
+    <meta
+      content="yes"
+      name="mobile-web-app-capable"
+    />
+    <meta
+      content="#B80000"
+      name="msapplication-TileColor"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/include/articles/public/igbo/images/icons/icon-144x144.png"
+      name="msapplication-TileImage"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="og:description"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
+      name="og:image"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="og:image:alt"
+    />
+    <meta
+      content="ig"
+      name="og:locale"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="og:site_name"
+    />
+    <meta
+      content="Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Ìgbò"
+      name="og:title"
+    />
+    <meta
+      content="website"
+      name="og:type"
+    />
+    <meta
+      content="https://www.test.bbc.com/pidgin/tori-49450859"
+      name="og:url"
+    />
+    <meta
+      content="summary_large_image"
+      name="twitter:card"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:creator"
+    />
+    <meta
+      content="Emeka Nelson don find di solution to di light palava wey dey worry for Nigeria nad oda parts of Africa as im produce generator wey dey run on water."
+      name="twitter:description"
+    />
+    <meta
+      content="BBC News Ìgbò"
+      name="twitter:image:alt"
+    />
+    <meta
+      content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
+      name="twitter:image:src"
+    />
+    <meta
+      content="@BBCNews"
+      name="twitter:site"
+    />
+    <meta
+      content="Nigerian man Emeka Nelson don produce generator wey dey use only water - BBC News Ìgbò"
+      name="twitter:title"
+    />
+    <script
+      type="application/ld+json"
+    >
+      {"@context":"http://schema.org","@type":"Article","url":"https://www.test.bbc.com/pidgin/tori-49450859","publisher":{"@type":"NewsMediaOrganization","name":"BBC News Ìgbò","publishingPrinciples":"https://www.bbc.com/news/help-41670342","logo":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"}},"image":{"@type":"ImageObject","width":1024,"height":576,"url":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"},"thumbnailUrl":"https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.test.bbc.com/pidgin/tori-49450859","name":"Nigerian man Emeka Nelson don produce generator wey dey use only water"}}
+    </script>
+  </head>
+  <body>
+    .c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c8 {
+  grid-column: 1 / span 6;
+}
+
+.c3 {
+  grid-column: 1 / span 6;
+}
+
+.c2 {
+  font-size: 1.75rem;
+  line-height: 2rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding: 2rem 0;
+}
+
+.c4 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  padding-bottom: 0.25rem;
+}
+
+.c4:last-child {
+  padding-bottom: 1rem;
+}
+
+.c9 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  padding-bottom: 1.5rem;
+  margin: 0;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c5 {
+  padding-bottom: 1.5rem;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (max-width:25rem) {
+  .c8 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c8 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c8 {
+    grid-column: 1 / span 5;
+    max-width: 83.33%;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c8 {
+    grid-column: 3 / span 5;
+    max-width: 37.75rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c8 {
+    grid-column: 6 / span 10;
+    max-width: 38.5rem;
+  }
+}
+
+@supports (display:grid) {
+  .c8 {
+    max-width: initial;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width:25rem) {
+  .c3 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c3 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    grid-column: 1 / span 5;
+    max-width: 83.33%;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c3 {
+    grid-column: 3 / span 5;
+    max-width: 37.75rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c3 {
+    grid-column: 2 / span 4;
+    max-width: 38.5rem;
+  }
+}
+
+@supports (display:grid) {
+  .c3 {
+    max-width: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c2 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    font-size: 2.75rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    padding: 2.5rem 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c4 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c4 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c9 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    font-size: 1rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (max-width:63rem) {
+  .c5 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c5 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c5 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c5 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c5 {
+    padding: 0 1rem;
+  }
+}
+
+<div>
+      <noscript />
+      <main
+        class="c0"
+        role="main"
+      >
+        <div
+          class="c1"
+        >
+          <h1
+            class="c2"
+            id="content"
+            tabindex="-1"
+          >
+            Nigerian man Emeka Nelson don produce generator wey dey use only water
+          </h1>
+        </div>
+        <div
+          class="c3"
+        >
+          <time
+            class="c4"
+            datetime="2019-08-23"
+          >
+            23 Ọgọọst 2019
+          </time>
+          <time
+            class="c4"
+            datetime="2019-08-23"
+          >
+            Mgbe ikpeazụ e tinyere ya ozi ọhụrụ 
+            23 Ọgọọst 2019
+          </time>
+        </div>
+        <div
+          class="c5"
+        >
+          <div
+            class="c6"
+          >
+            <iframe
+              allow="autoplay; fullscreen"
+              allowfullscreen=""
+              class="c7"
+              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
+            />
+          </div>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Wetin ginger Emeka na im friend wey smoke from generator kill.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Most of di material wey Nelson take arrange im generator na from  scrap.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
+          </p>
+        </div>
+        <div
+          class="c8"
+        >
+          <p
+            class="c9"
+          >
+            Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
+          </p>
+        </div>
+        <a
+          data-e2e="cpsAssetDummyLink"
+          href="/pidgin/23248703"
+          style="pointer-events: none;"
+          tabindex="-1"
+        />
+      </main>
+    </div>
+  </body>
+</html>
+`;
+
 exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
 .c0 {
   margin: 0 auto;

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -33,7 +33,6 @@ const CpsAssetPageMain = ({ pageData }) => {
     video: props => (
       <MediaPlayer
         {...props}
-        style={{ paddingBottom: 50 }}
         embedOverrides={{
           type: 'cps',
           id: assetUri.substr(1),

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { GhostGrid, GridItemConstrainedLarge } from '#lib/styledGrid';
 import { RequestContext } from '#contexts/RequestContext';
 
@@ -33,7 +34,7 @@ const CpsAssetPageMain = ({ pageData }) => {
         style={{ paddingBottom: 50 }}
         embedOverrides={{
           type: 'cps',
-          id: assetUri,
+          id: assetUri.substr(1),
           showPlaceholder: platform === 'amp',
           wrapper: styled(GridItemConstrainedLarge)`
             padding-bottom: 1.5rem;
@@ -55,6 +56,13 @@ const CpsAssetPageMain = ({ pageData }) => {
       <ATIAnalytics data={pageData} />
       <GhostGrid as="main" role="main">
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
+        {/* this link is temporarily used in a cypress test */}
+        <Link
+          to="/pidgin/23248703"
+          data-e2e="cpsAssetDummyLink"
+          tabIndex={-1}
+          style={{ pointerEvents: 'none' }}
+        />
       </GhostGrid>
     </>
   );

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -1,9 +1,8 @@
 import React, { useContext } from 'react';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
-import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { GhostGrid, GridItemConstrainedLarge } from '#lib/styledGrid';
+import { GhostGrid } from '#lib/styledGrid';
 import { RequestContext } from '#contexts/RequestContext';
 
 import MetadataContainer from '../Metadata';
@@ -13,7 +12,7 @@ import timestamp from '../ArticleTimestamp';
 import text from '../Text';
 import image from '../Image';
 import Blocks from '../Blocks';
-import MediaPlayer from '../MediaPlayer';
+import MediaPlayer from './Blocks/Video';
 import ATIAnalytics from '../ATIAnalytics';
 import cpsAssetPagePropTypes from '../../models/propTypes/cpsAssetPage';
 
@@ -33,14 +32,8 @@ const CpsAssetPageMain = ({ pageData }) => {
     video: props => (
       <MediaPlayer
         {...props}
-        embedOverrides={{
-          type: 'cps',
-          id: assetUri.substr(1),
-          showPlaceholder: platform === 'amp',
-          wrapper: styled(GridItemConstrainedLarge)`
-            padding-bottom: 1.5rem;
-          `,
-        }}
+        assetUri={assetUri.substr(1)}
+        showPlaceholder={platform === 'amp'}
       />
     ),
   };
@@ -58,12 +51,9 @@ const CpsAssetPageMain = ({ pageData }) => {
       <GhostGrid as="main" role="main">
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
         {/* this link is temporarily used in a cypress test */}
-        <Link
-          to="/pidgin/23248703"
-          data-e2e="cpsAssetDummyLink"
-          tabIndex={-1}
-          style={{ pointerEvents: 'none' }}
-        />
+        <Link to="/pidgin/23248703" data-e2e="cpsAssetDummyLink">
+          _
+        </Link>
       </GhostGrid>
     </>
   );

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -1,28 +1,47 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
-import { Link } from 'react-router-dom';
-import { GhostGrid, GridItemConstrainedMedium } from '#lib/styledGrid';
+import styled from 'styled-components';
+import { GhostGrid, GridItemConstrainedLarge } from '#lib/styledGrid';
+import { RequestContext } from '#contexts/RequestContext';
+
 import MetadataContainer from '../Metadata';
 import LinkedData from '../LinkedData';
 import headings from '../Headings';
 import timestamp from '../ArticleTimestamp';
 import text from '../Text';
 import Blocks from '../Blocks';
+import MediaPlayer from '../MediaPlayer';
 import ATIAnalytics from '../ATIAnalytics';
 import cpsAssetPagePropTypes from '../../models/propTypes/cpsAssetPage';
 
-const componentsToRender = {
-  headline: headings,
-  text,
-  timestamp,
-};
-
 const CpsAssetPageMain = ({ pageData }) => {
+  const { platform } = useContext(RequestContext);
   const title = path(['promo', 'headlines', 'headline'], pageData);
   const summary = path(['promo', 'summary'], pageData);
   const metadata = path(['metadata'], pageData);
+  const assetUri = path(['locators', 'assetUri'], metadata);
   const blocks = pathOr([], ['content', 'model', 'blocks'], pageData);
+
+  const componentsToRender = {
+    headline: headings,
+    text,
+    timestamp,
+    video: props => (
+      <MediaPlayer
+        {...props}
+        style={{ paddingBottom: 50 }}
+        embedOverrides={{
+          type: 'cps',
+          id: assetUri,
+          showPlaceholder: platform === 'amp',
+          wrapper: styled(GridItemConstrainedLarge)`
+            padding-bottom: 1.5rem;
+          `,
+        }}
+      />
+    ),
+  };
 
   return (
     <>
@@ -35,11 +54,6 @@ const CpsAssetPageMain = ({ pageData }) => {
       <LinkedData type="Article" seoTitle={title} />
       <ATIAnalytics data={pageData} />
       <GhostGrid as="main" role="main">
-        <GridItemConstrainedMedium>
-          <Link to="/pidgin/23248703" data-e2e="cpsAssetDummyLink">
-            Test MAP to MAP inline link
-          </Link>
-        </GridItemConstrainedMedium>
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
       </GhostGrid>
     </>

--- a/src/app/containers/CpsAssetPageMain/index.test.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.test.jsx
@@ -3,6 +3,7 @@ import { StaticRouter } from 'react-router-dom';
 import { matchSnapshotAsync } from '@bbc/psammead-test-helpers';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
+import { ToggleContextProvider } from '#contexts/ToggleContext';
 import CpsAssetPageMain from '.';
 import preprocessor from '#lib/utilities/preprocessor';
 import pidginPageData from '#data/pidgin/cpsAssets/tori-49450859';
@@ -16,18 +17,20 @@ describe('CpsAssetPageMain', () => {
         for the value it would bring, it is much simpler to wrap a react-router Link in a Router, rather than mock a Router or pass some mocked context.
       */
       <StaticRouter>
-        <ServiceContextProvider service="pidgin">
-          <RequestContextProvider
-            bbcOrigin="https://www.test.bbc.co.uk"
-            isAmp={false}
-            pageType="MAP"
-            pathname="/pidgin/tori-49450859"
-            service="pidgin"
-            statusCode={200}
-          >
-            <CpsAssetPageMain service="pidgin" pageData={pageData} />
-          </RequestContextProvider>
-        </ServiceContextProvider>
+        <ToggleContextProvider>
+          <ServiceContextProvider service="pidgin">
+            <RequestContextProvider
+              bbcOrigin="https://www.test.bbc.co.uk"
+              isAmp={false}
+              pageType="MAP"
+              pathname="/pidgin/tori-49450859"
+              service="pidgin"
+              statusCode={200}
+            >
+              <CpsAssetPageMain service="pidgin" pageData={pageData} />
+            </RequestContextProvider>
+          </ServiceContextProvider>
+        </ToggleContextProvider>
       </StaticRouter>,
     );
   });

--- a/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
@@ -188,6 +188,82 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
 </html>
 `;
 
+exports[`MediaPlayer Calls the canonical placeholder when platform is canonical with CPS overrides 1`] = `
+<html>
+  <head>
+    <script
+      type="application/ld+json"
+    >
+      {"video":{"@list":[{"@type":"VideoObject","name":"Five things ants can teach us about management","description":"They may be tiny, but us humans could learn a thing or two from ants.","duration":191,"thumbnailUrl":"https://ichef.test.bbci.co.uk/images/ic/1024x576/p01k6mtv.jpg","uploadDate":1540218932000}]}}
+    </script>
+  </head>
+  <body>
+    .c2 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  overflow: hidden;
+}
+
+.c1 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+@media (max-width:63rem) {
+  .c0 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c0 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
+<div>
+      <div
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <iframe
+            allow="autoplay; fullscreen"
+            allowfullscreen=""
+            class="c2"
+            src="https://www.test.bbc.com/ws/av-embeds/cps/pidgin/12345678/p01k6msp/en-GB"
+          />
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
+`;
+
 exports[`MediaPlayer Calls the canonical player when platform is canonical and placeholder is false 1`] = `
 <html>
   <head>

--- a/src/app/containers/MediaPlayer/fixtureData.jsx
+++ b/src/app/containers/MediaPlayer/fixtureData.jsx
@@ -5,6 +5,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContext } from '#contexts/ToggleContext';
 import MediaPlayerContainer from '.';
+import { GridItemConstrainedLarge } from '#lib/styledGrid';
 
 const captionBlock = {
   model: {
@@ -320,6 +321,7 @@ const GenerateFixtureData = ({
   toggleState,
   blocks,
   placeholder,
+  embedOverrides,
 }) => (
   <RequestContextProvider
     isAmp={platform === 'amp'}
@@ -334,7 +336,11 @@ const GenerateFixtureData = ({
       <ToggleContext.Provider
         value={{ toggleState, toggleDispatch: jest.fn() }}
       >
-        <MediaPlayerContainer blocks={blocks} placeholder={placeholder} />
+        <MediaPlayerContainer
+          blocks={blocks}
+          placeholder={placeholder}
+          embedOverrides={embedOverrides}
+        />
       </ToggleContext.Provider>
     </ServiceContextProvider>
   </RequestContextProvider>
@@ -345,17 +351,32 @@ GenerateFixtureData.propTypes = {
   toggleState: shape({}),
   blocks: arrayOf(object).isRequired,
   placeholder: bool,
+  embedOverrides: shape({}),
 };
 
 GenerateFixtureData.defaultProps = {
   toggleState: defaultToggles,
   placeholder: true,
+  embedOverrides: {},
 };
 
 export const VideoCanonical = (
   <GenerateFixtureData
     platform="canonical"
     blocks={[validAresMediaVideoBlock]}
+  />
+);
+
+export const VideoCanonicalWithOverrides = (
+  <GenerateFixtureData
+    platform="canonical"
+    blocks={[validAresMediaVideoBlock]}
+    embedOverrides={{
+      type: 'cps',
+      id: 'pidgin/12345678',
+      showPlaceholder: false,
+      wrapper: GridItemConstrainedLarge,
+    }}
   />
 );
 

--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -17,7 +17,7 @@ import {
   emptyBlockArrayDefaultProps,
 } from '#models/propTypes';
 
-const MediaPlayerContainer = ({ blocks, placeholder }) => {
+const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
   const { id, platform, origin } = useContext(RequestContext);
   const { lang } = useContext(ServiceContext);
   const { enabled } = useToggle('mediaPlayer');
@@ -48,27 +48,37 @@ const MediaPlayerContainer = ({ blocks, placeholder }) => {
     return null; // this should be the holding image with an error overlay
   }
 
+  const hidePlaceholder =
+    typeof embedOverrides.showPlaceholder !== 'undefined' &&
+    !embedOverrides.showPlaceholder;
   const placeholderSrc = getPlaceholderSrc(imageUrl);
   const embedSource = embedUrl({
-    requestUrl: `${id}/${versionId}/${lang}`,
-    type: 'articles',
+    requestUrl: `${embedOverrides.id || id}/${versionId}/${lang}`,
+    type: embedOverrides.type || 'articles',
     isAmp,
     origin,
   });
 
+  const Wrapper = embedOverrides.wrapper || GridItemConstrainedMedium;
+
   return (
-    <GridItemConstrainedMedium>
+    <Wrapper>
       <Metadata aresMediaBlock={aresMediaBlock} />
       {isAmp ? (
-        <AmpMediaPlayer src={embedSource} placeholderSrc={placeholderSrc} />
+        <AmpMediaPlayer
+          src={embedSource}
+          showPlaceholder={!hidePlaceholder}
+          placeholderSrc={placeholderSrc}
+        />
       ) : (
         <CanonicalMediaPlayer
           src={embedSource}
+          showPlaceholder={!hidePlaceholder}
           placeholder={placeholder}
           placeholderSrc={placeholder ? placeholderSrc : ''}
         />
       )}
-    </GridItemConstrainedMedium>
+    </Wrapper>
   );
 };
 

--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -24,9 +24,12 @@ const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides }) => {
   const isAmp = platform === 'amp';
 
   // Player settings can be overridden for other page types (eg, CPS)
+  // TODO: Refactor in https://github.com/bbc/simorgh/issues/4418
   const type = embedOverrides.type || 'articles';
   const assetId = embedOverrides.id || id;
   const Wrapper = embedOverrides.wrapper || GridItemConstrainedMedium;
+  const showPlaceholder = type === 'articles' || embedOverrides.showPlaceholder;
+  // End of override logic
 
   if (!enabled || !blocks) {
     return null;
@@ -53,7 +56,6 @@ const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides }) => {
     return null; // this should be the holding image with an error overlay
   }
 
-  const showPlaceholder = type === 'articles' || embedOverrides.showPlaceholder;
   const placeholderSrc = getPlaceholderSrc(imageUrl);
   const embedSource = embedUrl({
     requestUrl: `${assetId}/${versionId}/${lang}`,

--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -17,13 +17,16 @@ import {
   emptyBlockArrayDefaultProps,
 } from '#models/propTypes';
 
-const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
-  // Player has slightly different behavior depending on whether it is on CPS or articles page
-  const type = embedOverrides.type || 'articles';
+const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides }) => {
   const { id, platform, origin } = useContext(RequestContext);
   const { lang } = useContext(ServiceContext);
   const { enabled } = useToggle('mediaPlayer');
   const isAmp = platform === 'amp';
+
+  // Player settings can be overridden for other page types (eg, CPS)
+  const type = embedOverrides.type || 'articles';
+  const assetId = embedOverrides.id || id;
+  const Wrapper = embedOverrides.wrapper || GridItemConstrainedMedium;
 
   if (!enabled || !blocks) {
     return null;
@@ -53,13 +56,11 @@ const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
   const showPlaceholder = type === 'articles' || embedOverrides.showPlaceholder;
   const placeholderSrc = getPlaceholderSrc(imageUrl);
   const embedSource = embedUrl({
-    requestUrl: `${embedOverrides.id || id}/${versionId}/${lang}`,
+    requestUrl: `${assetId}/${versionId}/${lang}`,
     type,
     isAmp,
     origin,
   });
-
-  const Wrapper = embedOverrides.wrapper || GridItemConstrainedMedium;
 
   return (
     <Wrapper>
@@ -86,6 +87,7 @@ MediaPlayerContainer.propTypes = mediaPlayerPropTypes;
 MediaPlayerContainer.defaultProps = {
   ...emptyBlockArrayDefaultProps,
   placeholder: true,
+  embedOverrides: {},
 };
 
 export default MediaPlayerContainer;

--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -18,6 +18,8 @@ import {
 } from '#models/propTypes';
 
 const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
+  // Player has slightly different behavior depending on whether it is on CPS or articles page
+  const type = embedOverrides.type || 'articles';
   const { id, platform, origin } = useContext(RequestContext);
   const { lang } = useContext(ServiceContext);
   const { enabled } = useToggle('mediaPlayer');
@@ -48,13 +50,11 @@ const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
     return null; // this should be the holding image with an error overlay
   }
 
-  const hidePlaceholder =
-    typeof embedOverrides.showPlaceholder !== 'undefined' &&
-    !embedOverrides.showPlaceholder;
+  const showPlaceholder = type === 'articles' || embedOverrides.showPlaceholder;
   const placeholderSrc = getPlaceholderSrc(imageUrl);
   const embedSource = embedUrl({
     requestUrl: `${embedOverrides.id || id}/${versionId}/${lang}`,
-    type: embedOverrides.type || 'articles',
+    type,
     isAmp,
     origin,
   });
@@ -67,13 +67,13 @@ const MediaPlayerContainer = ({ blocks, placeholder, embedOverrides = {} }) => {
       {isAmp ? (
         <AmpMediaPlayer
           src={embedSource}
-          showPlaceholder={!hidePlaceholder}
+          showPlaceholder={showPlaceholder}
           placeholderSrc={placeholderSrc}
         />
       ) : (
         <CanonicalMediaPlayer
           src={embedSource}
-          showPlaceholder={!hidePlaceholder}
+          showPlaceholder={showPlaceholder}
           placeholder={placeholder}
           placeholderSrc={placeholder ? placeholderSrc : ''}
         />

--- a/src/app/containers/MediaPlayer/index.test.jsx
+++ b/src/app/containers/MediaPlayer/index.test.jsx
@@ -2,6 +2,7 @@ import { shouldMatchSnapshot, isNull } from '@bbc/psammead-test-helpers';
 import {
   VideoCanonical,
   VideoAmp,
+  VideoCanonicalWithOverrides,
   VideoCanonicalNoPlaceHolder,
   VideoCanonicalNoVersionId,
   VideoCanonicalToggledOff,
@@ -16,6 +17,11 @@ describe('MediaPlayer', () => {
   shouldMatchSnapshot(
     'Calls the canonical player when platform is canonical and placeholder is false',
     VideoCanonicalNoPlaceHolder,
+  );
+
+  shouldMatchSnapshot(
+    'Calls the canonical placeholder when platform is canonical with CPS overrides',
+    VideoCanonicalWithOverrides,
   );
 
   shouldMatchSnapshot('Calls the AMP player when platform is AMP', VideoAmp);

--- a/src/app/models/propTypes/index.js
+++ b/src/app/models/propTypes/index.js
@@ -1,4 +1,4 @@
-import { arrayOf, bool, shape, string } from 'prop-types';
+import { arrayOf, bool, shape, string, oneOf, elementType } from 'prop-types';
 import { textBlockPropTypes } from './text';
 import { imageBlockPropTypes } from './image';
 
@@ -39,6 +39,11 @@ export const mediaPlayerPropTypes = {
     }),
   ).isRequired,
   placeholder: bool,
+  embedOverrides: shape({
+    type: oneOf(['cps', 'articles']),
+    showPlaceholder: bool,
+    wrapper: elementType,
+  }),
 };
 
 const baseDefaultPropTypes = {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/4097

**Overall change:** _Add the AV block to CPS pages._

**Code changes:**

- _Enable AV rendering on the CPS page_
- _Update API of Media Player container_
- Tests_

Testing notes:
Regression on article video. Video loading and page position and grid location

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
