### PR TITLE
CPS Asset Bold intro

### DIFF
--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -503,7 +503,9 @@ exports[`CpsAssetPageMain should match snapshot 1`] = `
           <p
             class="c6"
           >
-            As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
+            <b>
+              As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
+            </b>
           </p>
         </div>
         <div

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.js
@@ -13,7 +13,7 @@ export const processBlock = _block => {
     block.text = escapeDoubleQuotes(block.text);
 
     // make introductions bold
-    if (block.type === 'paragraph' && block.role === 'introduction') {
+    if (block.role === 'introduction') {
       block.text = boldWrap(block.text);
       block.markupType = 'candy_xml';
     }

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.js
@@ -1,0 +1,23 @@
+/* eslint-disable import/prefer-default-export */
+import path from 'ramda/src/path';
+
+const boldWrap = text => `<bold>${text}</bold>`;
+
+const escapeDoubleQuotes = text => text.replace(/&quot;/g, '"');
+
+export const processBlock = _block => {
+  const block = _block;
+
+  if (path(['text'], block)) {
+    // escape quotes in all text
+    block.text = escapeDoubleQuotes(block.text);
+
+    // make introductions bold
+    if (block.type === 'paragraph' && block.role === 'introduction') {
+      block.text = boldWrap(block.text);
+      block.markupType = 'candy_xml';
+    }
+  }
+
+  return block;
+};

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.test.js
@@ -1,0 +1,71 @@
+import { processBlock } from './helpers';
+
+describe('processBlock', () => {
+  it('should make the introduction paragraph bold', () => {
+    const input = {
+      text: 'paragraph one',
+      role: 'introduction',
+      markupType: 'plain_text',
+      type: 'paragraph',
+    };
+
+    const expected = {
+      text: '<bold>paragraph one</bold>',
+      role: 'introduction',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+
+    expect(processBlock(input)).toEqual(expected);
+  });
+
+  it('should make the introduction paragraph bold even if its already candy xml', () => {
+    const input = {
+      text: '<italic>paragraph one</italic>',
+      role: 'introduction',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+
+    const expected = {
+      text: '<bold><italic>paragraph one</italic></bold>',
+      role: 'introduction',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+
+    expect(processBlock(input)).toEqual(expected);
+  });
+
+  it('should escape quotes', () => {
+    const input = {
+      text: 'Paragraph containing &quot;quote marks&quot;',
+      markupType: 'plain_text',
+      type: 'paragraph',
+    };
+
+    const expected = {
+      text: 'Paragraph containing "quote marks"',
+      markupType: 'plain_text',
+      type: 'paragraph',
+    };
+
+    expect(processBlock(input)).toEqual(expected);
+  });
+
+  it('should escape quotes', () => {
+    const input = {
+      text: 'Paragraph containing <bold>&quot;quote marks&quot;</bold>',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+
+    const expected = {
+      text: 'Paragraph containing <bold>"quote marks"</bold>',
+      markupType: 'candy_xml',
+      type: 'paragraph',
+    };
+
+    expect(processBlock(input)).toEqual(expected);
+  });
+});

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/helpers.test.js
@@ -37,7 +37,7 @@ describe('processBlock', () => {
     expect(processBlock(input)).toEqual(expected);
   });
 
-  it('should escape quotes', () => {
+  it('should escape quotes for plain_text', () => {
     const input = {
       text: 'Paragraph containing &quot;quote marks&quot;',
       markupType: 'plain_text',
@@ -53,7 +53,7 @@ describe('processBlock', () => {
     expect(processBlock(input)).toEqual(expected);
   });
 
-  it('should escape quotes', () => {
+  it('should escape quotes for candy_xml', () => {
     const input = {
       text: 'Paragraph containing <bold>&quot;quote marks&quot;</bold>',
       markupType: 'candy_xml',

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.js
@@ -1,4 +1,5 @@
 import loadable from '@loadable/component';
+import { processBlock } from './helpers';
 
 const richTextTransforms = loadable(() =>
   import(
@@ -15,9 +16,11 @@ const convertParagraph = async block => {
   const xmlWrapper = innerXML =>
     `<body><paragraph>${innerXML}</paragraph></body>`;
 
-  return block.markupType === 'candy_xml'
-    ? candyXmlToRichText(xmlWrapper(block.text))
-    : stringToRichText(block.text);
+  const proccessedBlock = processBlock(block);
+
+  return proccessedBlock.markupType === 'candy_xml'
+    ? candyXmlToRichText(xmlWrapper(proccessedBlock.text))
+    : stringToRichText(proccessedBlock.text);
 };
 
 export default convertParagraph;

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.test.js
@@ -47,25 +47,4 @@ describe('convertParagraph', () => {
 
     expect(await convertParagraph(input)).toEqual(expected);
   });
-
-  it('should convert a plain_text paragraph to Optimo format', async () => {
-    const input = {
-      text: 'A plain text paragraph',
-      markupType: 'plain_text',
-      type: 'paragraph',
-    };
-    const expected = optimoText([
-      {
-        fragments: [
-          {
-            fragment: 'A plain text paragraph',
-            attributes: [],
-          },
-        ],
-        text: 'A plain text paragraph',
-      },
-    ]);
-
-    expect(await convertParagraph(input)).toEqual(expected);
-  });
 });

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/paragraph/index.test.js
@@ -47,4 +47,25 @@ describe('convertParagraph', () => {
 
     expect(await convertParagraph(input)).toEqual(expected);
   });
+
+  it('should convert a plain_text paragraph to Optimo format', async () => {
+    const input = {
+      text: 'A plain text paragraph',
+      markupType: 'plain_text',
+      type: 'paragraph',
+    };
+    const expected = optimoText([
+      {
+        fragments: [
+          {
+            fragment: 'A plain text paragraph',
+            attributes: [],
+          },
+        ],
+        text: 'A plain text paragraph',
+      },
+    ]);
+
+    expect(await convertParagraph(input)).toEqual(expected);
+  });
 });

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.js
@@ -1,6 +1,5 @@
 import { clone, pathOr, path } from 'ramda';
 import paragraph from './blocks/paragraph';
-import { escapeDoubleQuotes } from './utils/helpers';
 import media from './blocks/media';
 
 const handleMissingType = block =>
@@ -16,17 +15,7 @@ const parseBlockByType = block => {
 
   const { type } = block;
 
-  let cleanBlock = block;
-
-  // if the block has text handle escaped quotes
-  if (path(['text'], cleanBlock)) {
-    cleanBlock = {
-      ...cleanBlock,
-      text: escapeDoubleQuotes(cleanBlock.text),
-    };
-  }
-
-  const parsedBlock = (typesToConvert[type] || handleMissingType)(cleanBlock);
+  const parsedBlock = (typesToConvert[type] || handleMissingType)(block);
 
   if (!parsedBlock) {
     return null;

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
@@ -1,3 +1,4 @@
+import { clone } from 'ramda';
 import { CPSMediaBlock, optimoVideoBlock } from './blocks/media/fixtures';
 import convertToOptimoBlocks from '.';
 import { optimoText } from './utils/helpers';
@@ -172,5 +173,32 @@ describe('convertToOptimoBlocks', () => {
     };
 
     expect(await convertToOptimoBlocks(input)).toEqual(expected);
+  });
+
+  it('should make the introduction paragraph bold', async () => {
+    const input = {
+      content: {
+        blocks: [
+          {
+            text: 'paragraph two',
+            markupType: 'candy_xml',
+            type: 'paragraph',
+          },
+          {
+            text: 'paragraph one',
+            role: 'introduction',
+            markupType: 'plain_text',
+            type: 'paragraph',
+          },
+        ],
+      },
+    };
+
+    const output = await convertToOptimoBlocks(input);
+
+    expect(
+      output.content.model.blocks[1].model.blocks[0].model.blocks[0].model
+        .attributes,
+    ).toEqual(['bold']);
   });
 });

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/index.test.js
@@ -1,4 +1,3 @@
-import { clone } from 'ramda';
 import { CPSMediaBlock, optimoVideoBlock } from './blocks/media/fixtures';
 import convertToOptimoBlocks from '.';
 import { optimoText } from './utils/helpers';

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/utils/helpers.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/utils/helpers.js
@@ -20,5 +20,3 @@ export const optimoText = paragraphs => ({
     blocks: paragraphs.map(optimoParagraph),
   },
 });
-
-export const escapeDoubleQuotes = text => text.replace(/&quot;/g, '"');


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/4099

**Overall change:** Make introductions bold

**Code changes:**

- Adds preprocessor logic to handle bold intros and moves the quote escaping

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
