### PR TITLE
Amending copyright cypress tests

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -122,15 +122,19 @@ export const testsThatFollowSmokeTestConfig = ({
               cy.get('figure')
                 .eq(0)
                 .then($fig => {
-                  if ($fig.find('p').length > 0) {
-                    cy.get('figure p')
-                      .eq(0)
-                      .should('contain', copyrightHolder);
+                  if (copyrightHolder === 'BBC') {
+                    cy.get($fig).within(() => {
+                      cy.get('p[class^="Copyright"]').should('not.be.visible');
+                    });
                   } else {
                     // If an image has a BBC copyright, the copyright holder (<p>) does not appear on images.
                     // This is why we're asserting the value. If the copyright does not appear and is not
                     // 'BBC' then it is clear there is an error with this component.
-                    expect(copyrightHolder).to.eq('BBC');
+                    cy.get($fig).within(() => {
+                      cy.get('p[class^="Copyright"]')
+                        .should('be.visible')
+                        .contains(copyrightHolder);
+                    });
                   }
                 });
             },


### PR DESCRIPTION
**Overall change:** _Amending existing copyright Cypress tests._

**Code changes:**

- _Changed the condition as to whether we're returning `BBC` from the copyright data._
- _Changed the component to look specifically for the copyright component, rather than `<p>` as this would sometimes look for the caption rather than the copyright._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
