### PR TITLE
Fix failing media player caption tests

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -206,14 +206,16 @@ export const testsThatFollowSmokeTestConfig = ({
                   text,
                 } = captionBlock.model.blocks[0].model.blocks[0].model;
 
-                cy.get('figcaption')
-                  .eq(1)
-                  .within(() => {
-                    cy.get('p')
-                      .eq(0)
-                      .should('be.visible')
-                      .should('contain', text);
-                  });
+                if (captionBlock) {
+                  cy.get('figcaption')
+                    .eq(1)
+                    .within(() => {
+                      cy.get('p')
+                        .eq(0)
+                        .should('be.visible')
+                        .should('contain', text);
+                    });
+                }
               },
             );
           });

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -1,6 +1,7 @@
 import { BBC_BLOCKS } from '@bbc/psammead-assets/svgs';
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
+import appToggles from '../../../support/helpers/useAppToggles';
 import { getBlockByType, getBlockData } from './helpers';
 
 // TODO: Remove after https://github.com/bbc/simorgh/issues/2959
@@ -107,30 +108,6 @@ export const testsThatFollowSmokeTestConfig = ({
               .should('to.have.descendants', 'figcaption')
               .within(() => cy.get('noscript').should('not.exist'));
           });
-
-          it('should have a visible caption beneath a mediaplayer', () => {
-            cy.request(`${config[service].pageTypes.articles.path}.json`).then(
-              ({ body }) => {
-                const mediaData = getBlockData('video', body);
-                const captionBlock = getBlockByType(
-                  mediaData.model.blocks,
-                  'caption',
-                );
-                const {
-                  text,
-                } = captionBlock.model.blocks[0].model.blocks[0].model;
-
-                cy.get('figcaption')
-                  .eq(1)
-                  .within(() => {
-                    cy.get('p')
-                      .eq(0)
-                      .should('be.visible')
-                      .should('contain', text);
-                  });
-              },
-            );
-          });
         }
 
         it('should have an image copyright label with styling', () => {
@@ -211,6 +188,35 @@ export const testsThatFollowSmokeTestConfig = ({
               }
             },
           );
+        });
+      }
+
+      // `appToggles` tells us whether a feature is toggled on or off in the current environment.
+      if (appToggles.mediaPlayer.enabled) {
+        describe('Media Player', () => {
+          it('should have a visible caption beneath a mediaplayer', () => {
+            cy.request(`${config[service].pageTypes.articles.path}.json`).then(
+              ({ body }) => {
+                const mediaData = getBlockData('video', body);
+                const captionBlock = getBlockByType(
+                  mediaData.model.blocks,
+                  'caption',
+                );
+                const {
+                  text,
+                } = captionBlock.model.blocks[0].model.blocks[0].model;
+
+                cy.get('figcaption')
+                  .eq(1)
+                  .within(() => {
+                    cy.get('p')
+                      .eq(0)
+                      .should('be.visible')
+                      .should('contain', text);
+                  });
+              },
+            );
+          });
         });
       }
     });

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -197,24 +197,27 @@ export const testsThatFollowSmokeTestConfig = ({
           it('should have a visible caption beneath a mediaplayer', () => {
             cy.request(`${config[service].pageTypes.articles.path}.json`).then(
               ({ body }) => {
-                const mediaData = getBlockData('video', body);
-                const captionBlock = getBlockByType(
-                  mediaData.model.blocks,
-                  'caption',
-                );
-                const {
-                  text,
-                } = captionBlock.model.blocks[0].model.blocks[0].model;
+                const media = getBlockData('video', body);
+                if (media) {
+                  const captionBlock = getBlockByType(
+                    media.model.blocks,
+                    'caption',
+                  );
 
-                if (captionBlock) {
-                  cy.get('figcaption')
-                    .eq(1)
-                    .within(() => {
-                      cy.get('p')
-                        .eq(0)
-                        .should('be.visible')
-                        .should('contain', text);
-                    });
+                  if (captionBlock) {
+                    const {
+                      text,
+                    } = captionBlock.model.blocks[0].model.blocks[0].model;
+
+                    cy.get('figcaption')
+                      .eq(1)
+                      .within(() => {
+                        cy.get('p')
+                          .eq(0)
+                          .should('be.visible')
+                          .should('contain', text);
+                      });
+                  }
                 }
               },
             );


### PR DESCRIPTION
Fix tests that were added in https://github.com/bbc/simorgh/pull/4256 that were failing when smoke testing during live deploy because the media player is not enabled in the live environment.

```
articles - news - Canonical Running tests for news articles Article Body should have a visible caption beneath a mediaplayer:
CypressError: Timed out retrying: Expected to find element: '1', but never found it. Queried from element: <figcaption.Caption-sc-16x70so-0.gDfBZX>
```

Fix verified locally and against test and live.

**Code changes:**

- Make tests dependent on mediaplayer toggle state
- Reorder for consistency

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
