### PR TITLE
bump psammead components 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,13 +1398,13 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.10.tgz",
-      "integrity": "sha512-R2fkn9EJBr5WMHl8Sy/IbZVyVQ++pCg2rrjPjv+PnHzUmnj9o5MMRb4Dv3SgXrjDPmb09yrwSYv8AsBdSKKcjw==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.11.tgz",
+      "integrity": "sha512-Tr1Qup3vP47qYrq/eDExUflEcUgkt1bbrNNyBX2F9uO38aOBsK5VXwgXgZ9TRvQfbNgRer2xOYK5suLFQu7x2Q==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.1",
         "@bbc/psammead-assets": "^2.6.0",
-        "@bbc/psammead-styles": "^4.0.4"
+        "@bbc/psammead-styles": "^4.1.0"
       }
     },
     "@bbc/psammead-media-player": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1523,12 +1523,12 @@
       }
     },
     "@bbc/psammead-useful-links": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-useful-links/-/psammead-useful-links-1.0.6.tgz",
-      "integrity": "sha512-4WTOZCI/geGffpqRIUeZO5INNDsjkh6pF9Ywui7RWAxbnZ//2K51UCQ0vehShz3xvR6LEFbtzlnlGbVQXsbsMA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-useful-links/-/psammead-useful-links-1.0.7.tgz",
+      "integrity": "sha512-g2mgCZmjuaMGQ2yIyiKW7jgQIHiKS5Z/RfrTAbLvi39yGGLbX2a5zaKFDgWsXTogUcNJAR3mZZEzf/Jv4etq9Q==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.1",
-        "@bbc/psammead-styles": "^4.0.4"
+        "@bbc/psammead-styles": "^4.1.0"
       }
     },
     "@bbc/psammead-visually-hidden-text": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@bbc/psammead-image-placeholder": "^1.2.20",
     "@bbc/psammead-inline-link": "^1.3.15",
     "@bbc/psammead-locales": "^3.0.0",
-    "@bbc/psammead-media-indicator": "^2.6.10",
+    "@bbc/psammead-media-indicator": "^2.6.11",
     "@bbc/psammead-media-player": "^2.0.0",
     "@bbc/psammead-navigation": "^3.0.5",
     "@bbc/psammead-paragraph": "^2.2.18",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@bbc/psammead-story-promo-list": "^2.1.20",
     "@bbc/psammead-styles": "^4.1.0",
     "@bbc/psammead-timestamp-container": "^2.6.7",
-    "@bbc/psammead-useful-links": "^1.0.6",
+    "@bbc/psammead-useful-links": "^1.0.7",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@loadable/component": "^5.10.3",
     "@loadable/server": "^5.10.3",


### PR DESCRIPTION
Not sure how I missed this bump in my previous PR and the `npm run build` script didn't shout about duplication dependency with psammead-styles 🤷‍♂ 

**Overall change:** _bump useful links to use latest_


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
