### PR TITLE
Add live e2es for MBT

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -671,7 +671,7 @@ const services = {
       articles: {
         path:
           Cypress.env('APP_ENV') === 'live'
-            ? undefined
+            ? '/mundo/articles/cdwrpl7qwqqo'
             : '/mundo/articles/ce42wzqr2mko',
         smoke: false,
       },
@@ -906,7 +906,7 @@ const services = {
       articles: {
         path:
           Cypress.env('APP_ENV') === 'live'
-            ? undefined
+            ? '/portuguese/articles/cpg5prg95lmo'
             : '/portuguese/articles/cd61pm8gzmpo',
         smoke: false,
       },
@@ -1340,7 +1340,7 @@ const services = {
       articles: {
         path:
           Cypress.env('APP_ENV') === 'live'
-            ? undefined
+            ? '/turkce/articles/cpgzpzjl3pdo'
             : '/turkce/articles/c8q1ze59n25o',
         smoke: false,
       },


### PR DESCRIPTION
Part of #4276 

**Overall change:**
- Enables e2e tests on live for Mundo, Brasil, and Turkish

**Code changes:**

- Adds an asset on the live env for cypress tests for each of Mundo, Brasil (portuguese) and Turkish (turkce)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
