### PR TITLE
add descriptive names for page types

### DIFF
--- a/src/app/routes/getInitialData/utils/getPreprocessorRules/index.js
+++ b/src/app/routes/getInitialData/utils/getPreprocessorRules/index.js
@@ -5,21 +5,29 @@ import {
   radioPagePreprocessorRules,
 } from '../preprocessorRulesConfig';
 
-const getPreprocessorRules = type => {
-  switch (type) {
-    case 'article':
+const ARTICLE_PAGE = 'article';
+const LIVE_RADIO_PAGE = 'WS-LIVE';
+const INDEX_PAGE = 'IDX';
+const FEATURE_INDEX_PAGE = 'FIX';
+const MEDIA_ASSET_PAGE = 'MAP';
+const BASIC_STORY_PAGE = 'STY';
+const PHOTO_GALLERY_PAGE = 'PGL';
+
+const getPreprocessorRules = pageType => {
+  switch (pageType) {
+    case ARTICLE_PAGE:
       return articlesPreprocessorRules;
-    case 'WS-LIVE':
+    case LIVE_RADIO_PAGE:
       return radioPagePreprocessorRules;
-    case 'IDX':
+    case INDEX_PAGE:
       return indexPreprocessorRules;
-    case 'FIX':
+    case FEATURE_INDEX_PAGE:
       return indexPreprocessorRules;
-    case 'MAP':
+    case MEDIA_ASSET_PAGE:
       return cpsAssetPreprocessorRules;
-    case 'STY':
+    case BASIC_STORY_PAGE:
       return cpsAssetPreprocessorRules;
-    case 'PGL':
+    case PHOTO_GALLERY_PAGE:
       return cpsAssetPreprocessorRules;
     default:
       return [];


### PR DESCRIPTION
**Overall change:** Refactors getPreprocessorRules by adding descriptive variable names for the different page types.

- changes made in `src/app/routes/getInitialData/utils/getPreprocessorRules/index.js`

**Testing notes**
Low risk refactor and unit tests pass so manual testing likely not required.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
