### PR TITLE
Fix MAP e2es

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -1,5 +1,6 @@
 import config from '../../../support/config/services';
 import envConfig from '../../../support/config/envs';
+import appConfig from '../../../../src/server/utilities/serviceConfigs';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -11,6 +12,7 @@ export const testsThatAlwaysRunForAMPOnly = ({ service, pageType }) => {
 export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   service,
   pageType,
+  variant,
 }) =>
   describe(`testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
     it('should render a media player', () => {
@@ -18,7 +20,8 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         ({ body }) => {
           const { assetUri } = body.metadata.locators;
           const { versionId } = body.content.blocks[0].versions[0];
-          const { language } = body.metadata;
+          const language = appConfig[service][variant].lang;
+
           cy.get(
             `amp-iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
           ).should('be.visible');

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -1,5 +1,6 @@
 import config from '../../../support/config/services';
 import envConfig from '../../../support/config/envs';
+import appConfig from '../../../../src/server/utilities/serviceConfigs';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -11,6 +12,7 @@ export const testsThatAlwaysRunForCanonicalOnly = ({ service, pageType }) => {
 export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   service,
   pageType,
+  variant,
 }) =>
   describe(`testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
     it('should render a media player', () => {
@@ -18,7 +20,8 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
         ({ body }) => {
           const { assetUri } = body.metadata.locators;
           const { versionId } = body.content.blocks[0].versions[0];
-          const { language } = body.metadata;
+          const language = appConfig[service][variant].lang;
+
           cy.get(
             `iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
           ).should('be.visible');


### PR DESCRIPTION
**Overall change:** Tests used the cps language which isnt lowercase

**Code changes:**

- use app service env lang

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
