### PR TITLE
remove japanese rugby nav item

### DIFF
--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -183,11 +183,6 @@ export const service = {
         url: '/japanese',
       },
       {
-        title: 'ラグビーW杯',
-        url:
-          'https://www.bbc.com/japanese/topics/ef55ff8e-8d36-4473-9f11-3ba9fa9ac787',
-      },
-      {
         title: '日本',
         url:
           'https://www.bbc.com/japanese/topics/3f53c272-5b8f-4a4f-99de-a857d6726c5b',


### PR DESCRIPTION
Resolves #4520

**Overall change:** _Remove rugby world cup link from Japanese link as the tournament has finished_

**Code changes:**

- _update japanese config_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
