### PR TITLE
Run localhost tests in their own pipeline

### DIFF
--- a/Jenkinsfile-e2e-local
+++ b/Jenkinsfile-e2e-local
@@ -31,11 +31,11 @@ node {
             docker.image("${nodeImage}").inside('--ipc host') {
                 try {
                     Simorgh.installNodeModules()
-                    stage ('Live E2Es') {
-                        Simorgh.runE2Es('live', false)
+                    stage ('Localhost Tests') {
+                        Simorgh.runLocalAndProductionTests()
                     }
                 } finally {
-                    Simorgh.e2esPostBuildSteps('live')
+                    Simorgh.e2esPostBuildSteps('local')
                 }
             }
         }


### PR DESCRIPTION
We are seeing constant failures on a local & prod e2e pipeline, these failures are seemingly random and split between the localhost tests and the actual live e2e's.

In an effort to separate the concerns of these two suites I think it's best to have them running in separate pipelines