### PR TITLE
Fix handlebars DoS vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10208,9 +10208,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
-      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",


### PR DESCRIPTION
[no issue]

**Overall change:** _Fixes medium-severity vuln in handlebars brought in via Chromatic and Jest (devDeps)_

Context: https://npmjs.com/advisories/1300

**Code changes:**

- `package-lock.json` edit

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [NA] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
