### PR TITLE
Allow branch override on e2e pipelines

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -1,8 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh'
-
-def nodeImageVersion = "12.13.0"
-def nodeImage = "329802642264.dkr.ecr.eu-west-1.amazonaws.com/bbc-news/node-12-lts:${nodeImageVersion}"
+library 'Simorgh/simorgh-clean'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""
@@ -29,21 +26,18 @@ node {
     timeout(time: 240, unit: 'MINUTES') {
         withEnv([
             'CI=true',
-            'APP_DIR=simorgh'
         ]) {
             cleanWs() // Clean the workspace
 
-            Simorgh.checkoutAndBuild("${params.BRANCH}")
-            dir ("${env.APP_DIR}") {
-                docker.image("${nodeImage}").inside('--ipc host') {
-                    try {
-                        stage ('Localhost Tests') {
-                            sh 'ls -l'
-                            Simorgh.runLocalAndProductionTests()
-                        }
-                    } finally {
-                        Simorgh.e2esPostBuildSteps('local')
+            docker.image(Simorgh.nodeDockerImage()).inside('--ipc host') {
+                try {
+                    Simorgh.checkout("${params.BRANCH}", 'simorgh')
+                    Simorgh.installNodeModules()
+                    stage ('Localhost Tests') {
+                        Simorgh.runLocalAndProductionTests()
                     }
+                } finally {
+                    Simorgh.e2esPostBuildSteps('local')
                 }
             }
         }

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh/simorgh-clean'
+library 'Simorgh'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -18,24 +18,32 @@ node {
                     artifactDaysToKeepStr: '10'
                 )
             ),
-            pipelineTriggers([cron(cron_string)])
+            pipelineTriggers([cron(cron_string)]),
+            parameters(
+                [
+                    string(defaultValue: 'latest', name: 'BRANCH')
+                ]
+            )
         ]
     )
     timeout(time: 240, unit: 'MINUTES') {
         withEnv([
-            'CI=true'
+            'CI=true',
+            'APP_DIR=simorgh'
         ]) {
             cleanWs() // Clean the workspace
-            checkout scm // Checkout from git
 
-            docker.image("${nodeImage}").inside('--ipc host') {
-                try {
-                    Simorgh.installNodeModules()
-                    stage ('Live E2Es') {
-                        Simorgh.runE2Es('live', false)
+            Simorgh.checkoutAndBuild("${params.BRANCH}")
+            dir ("${env.APP_DIR}") {
+                docker.image("${nodeImage}").inside('--ipc host') {
+                    try {
+                        stage ('Localhost Tests') {
+                            sh 'ls -l'
+                            Simorgh.runLocalAndProductionTests()
+                        }
+                    } finally {
+                        Simorgh.e2esPostBuildSteps('local')
                     }
-                } finally {
-                    Simorgh.e2esPostBuildSteps('live')
                 }
             }
         }

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -33,11 +33,11 @@ node {
                 try {
                     Simorgh.checkout("${params.BRANCH}", 'simorgh')
                     Simorgh.installNodeModules()
-                    stage ('Localhost Tests') {
-                        Simorgh.runLocalAndProductionTests()
+                    stage ('Live E2Es') {
+                        Simorgh.runE2Es('live', false)
                     }
                 } finally {
-                    Simorgh.e2esPostBuildSteps('local')
+                    Simorgh.e2esPostBuildSteps('live')
                 }
             }
         }

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -25,7 +25,7 @@ node {
     )
     timeout(time: 240, unit: 'MINUTES') {
         withEnv([
-            'CI=true',
+            'CI=true'
         ]) {
             cleanWs() // Clean the workspace
 

--- a/Jenkinsfile-e2e-local
+++ b/Jenkinsfile-e2e-local
@@ -18,7 +18,12 @@ node {
                     artifactDaysToKeepStr: '10'
                 )
             ),
-            pipelineTriggers([cron(cron_string)])
+            pipelineTriggers([cron(cron_string)]),
+            parameters(
+                [
+                    string(defaultValue: 'latest', name: 'BRANCH')
+                ]
+            )
         ]
     )
     timeout(time: 240, unit: 'MINUTES') {
@@ -26,16 +31,18 @@ node {
             'CI=true'
         ]) {
             cleanWs() // Clean the workspace
-            checkout scm // Checkout from git
 
-            docker.image("${nodeImage}").inside('--ipc host') {
-                try {
-                    Simorgh.installNodeModules()
-                    stage ('Localhost Tests') {
-                        Simorgh.runLocalAndProductionTests()
+            Simorgh.checkoutAndBuild("${params.BRANCH}")
+            dir ("${env.APP_DIR}") {
+                docker.image("${nodeImage}").inside('--ipc host') {
+                    try {
+                        Simorgh.installNodeModules()
+                        stage ('Localhost Tests') {
+                            Simorgh.runLocalAndProductionTests()
+                        }
+                    } finally {
+                        Simorgh.e2esPostBuildSteps('local')
                     }
-                } finally {
-                    Simorgh.e2esPostBuildSteps('local')
                 }
             }
         }

--- a/Jenkinsfile-e2e-local
+++ b/Jenkinsfile-e2e-local
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh@simorgh-clean'
+library 'Simorgh'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""

--- a/Jenkinsfile-e2e-local
+++ b/Jenkinsfile-e2e-local
@@ -1,8 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh'
-
-def nodeImageVersion = "12.13.0"
-def nodeImage = "329802642264.dkr.ecr.eu-west-1.amazonaws.com/bbc-news/node-12-lts:${nodeImageVersion}"
+library 'Simorgh@simorgh-clean'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""
@@ -32,17 +29,15 @@ node {
         ]) {
             cleanWs() // Clean the workspace
 
-            Simorgh.checkoutAndBuild("${params.BRANCH}")
-            dir ("${env.APP_DIR}") {
-                docker.image("${nodeImage}").inside('--ipc host') {
-                    try {
-                        Simorgh.installNodeModules()
-                        stage ('Localhost Tests') {
-                            Simorgh.runLocalAndProductionTests()
-                        }
-                    } finally {
-                        Simorgh.e2esPostBuildSteps('local')
+            docker.image(Simorgh.nodeDockerImage()).inside('--ipc host') {
+                try {
+                    Simorgh.checkout("${params.BRANCH}", 'simorgh')
+                    Simorgh.installNodeModules()
+                    stage ('Localhost Tests') {
+                        Simorgh.runLocalAndProductionTests()
                     }
+                } finally {
+                    Simorgh.e2esPostBuildSteps('local')
                 }
             }
         }

--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh@simorgh-clean'
+library 'Simorgh'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""

--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -18,7 +18,12 @@ node {
                     artifactDaysToKeepStr: '10'
                 )
             ),
-            pipelineTriggers([cron(cron_string)])
+            pipelineTriggers([cron(cron_string)]),
+            parameters(
+                [
+                    string(defaultValue: 'latest', name: 'BRANCH')
+                ]
+            )
         ]
     )
     timeout(time: 240, unit: 'MINUTES') {
@@ -26,16 +31,18 @@ node {
             'CI=true'
         ]) {
             cleanWs() // Clean the workspace
-            checkout scm // Checkout from git
-            
-            docker.image("${nodeImage}").inside('--ipc host') {
-                try {
-                    Simorgh.installNodeModules()
-                    stage ('Test E2Es') {
-                        Simorgh.runE2Es('test', false)
+
+            Simorgh.checkoutAndBuild("${params.BRANCH}")
+            dir ("${env.APP_DIR}") {
+                docker.image("${nodeImage}").inside('--ipc host') {
+                    try {
+                        Simorgh.installNodeModules()
+                        stage ('Test E2Es') {
+                            Simorgh.runE2Es('test', false)
+                        }
+                    } finally {
+                        Simorgh.e2esPostBuildSteps('test')
                     }
-                } finally {
-                    Simorgh.e2esPostBuildSteps('test')
                 }
             }
         }

--- a/Jenkinsfile-e2e-test
+++ b/Jenkinsfile-e2e-test
@@ -1,8 +1,5 @@
 #!/usr/bin/env groovy
-library 'Simorgh'
-
-def nodeImageVersion = "12.13.0"
-def nodeImage = "329802642264.dkr.ecr.eu-west-1.amazonaws.com/bbc-news/node-12-lts:${nodeImageVersion}"
+library 'Simorgh@simorgh-clean'
 
 // Run latest every 3 hours
 def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""
@@ -32,17 +29,15 @@ node {
         ]) {
             cleanWs() // Clean the workspace
 
-            Simorgh.checkoutAndBuild("${params.BRANCH}")
-            dir ("${env.APP_DIR}") {
-                docker.image("${nodeImage}").inside('--ipc host') {
-                    try {
-                        Simorgh.installNodeModules()
-                        stage ('Test E2Es') {
-                            Simorgh.runE2Es('test', false)
-                        }
-                    } finally {
-                        Simorgh.e2esPostBuildSteps('test')
+            docker.image(Simorgh.nodeDockerImage()).inside('--ipc host') {
+                try {
+                    Simorgh.checkout("${params.BRANCH}", 'simorgh')
+                    Simorgh.installNodeModules()
+                    stage ('Test E2Es') {
+                        Simorgh.runE2Es('test', false)
                     }
+                } finally {
+                    Simorgh.e2esPostBuildSteps('test')
                 }
             }
         }


### PR DESCRIPTION
Resolves #3438

**Overall change:** Jenkins doesn't provide optional step functionality. Thus the easiest way to allow developers to perform a non smoke test is to allow them to run the e2e test suite with a different branch. 

**Code changes:**
- For all the 3 e2e pipelines
  - Added the simorgh checkout and build step
  - Added the branch override parameter defaulting to `latest`
  - Localized the directory to `simorgh`

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
