### PR TITLE
Update bbc-a11y package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5083,14 +5083,14 @@
       "dev": true
     },
     "bbc-a11y": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bbc-a11y/-/bbc-a11y-2.3.2.tgz",
-      "integrity": "sha512-o74tA1bU0ViKnY4Gs7YkWwIM06rdGI0RWNoFKO92BIeHVTyr9uddWtt/4y/HnRy/rHoAql+S4GwKV9ww7q4o8g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/bbc-a11y/-/bbc-a11y-2.3.3.tgz",
+      "integrity": "sha512-hFF9pYbdlyD0616iv3NdfCAQrwX8zTWZVkzGFiP9wQ8NjJAhrrhVRnXYC6vQP9KtarMoW9bT6zPHGNV+F0f28w==",
       "dev": true,
       "requires": {
         "commander": "^2.17.1",
         "electron": "^2.0.8",
-        "httpism": "^3.10.0",
+        "httpism": "^3.24.0",
         "jquery": "^3.4.0"
       }
     },
@@ -10585,9 +10585,9 @@
       }
     },
     "home-path": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
-      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.7.tgz",
+      "integrity": "sha512-tM1pVa+u3ZqQwIkXcWfhUlY3HWS3TsnKsfi2OHHvnhkX52s9etyktPyy1rQotkr0euWimChDq+QkQuDe8ngUlQ==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -10805,9 +10805,9 @@
       }
     },
     "httpism": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/httpism/-/httpism-3.24.0.tgz",
-      "integrity": "sha512-q9kSrhi7duVYphQY8I0sh4LPIIUF/J4dqbViDCU5qEiVEPmnvNyDC1P/G/3YXX6wijkaHzu91V0jgawBdjrMfQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/httpism/-/httpism-3.25.0.tgz",
+      "integrity": "sha512-LeSB9/ahbeHotGjq5hHcWgkjamakdPc1ChYFAz9CXERFskKToc9D6ZuK175bQqhkOTYoYhRT8JWjJkqXZ5GGmA==",
       "dev": true,
       "requires": {
         "base-64": "0.1.0",
@@ -16818,6 +16818,12 @@
         "through2": "~0.2.3"
       },
       "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
@@ -16834,14 +16840,6 @@
             "inherits": "~2.0.1",
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            }
           }
         },
         "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-styled-components": "^1.10.6",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "bbc-a11y": "^2.3.2",
+    "bbc-a11y": "^2.3.3",
     "brotli-webpack-plugin": "^1.1.0",
     "chalk": "^2.4.2",
     "chrome-launcher": "^0.12.0",


### PR DESCRIPTION
**Overall change:** Updates to the latest version of the bbc-a11y package which fixes the httpism vulnerability. #4333 

**Code changes:**

- Updates package.json and package-lock.json with the newest bbc-a11y version

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
