### PR TITLE
Add Local route for Most Read json

### DIFF
--- a/src/app/routes/regex/index.js
+++ b/src/app/routes/regex/index.js
@@ -11,6 +11,7 @@ const assetUriRegex = '[a-z-_]{0,}[0-9]{8,}';
 const variantRegex = '/simp|/trad|/cyr|/lat';
 const articleLocalRegex = 'articles|erthyglau|sgeulachdan';
 const errorCodeRegex = '404|500';
+const mostRead = 'most_read';
 
 export const articleRegexPath = `/:service(${serviceRegex})/:local(${articleLocalRegex})/:id(${idRegex}):variant(${variantRegex})?:amp(${ampRegex})?`;
 
@@ -27,6 +28,8 @@ export const frontpageDataRegexPath = `${frontpageRegexPath}.json`;
 export const frontpageManifestRegexPath = `/:service(${serviceRegex})/manifest.json`;
 
 export const frontpageSwRegexPath = `/:service(${serviceRegex})/sw.js`;
+
+export const mostReadDataRegexPath = `/:service(${serviceRegex})/${mostRead}:variant(${variantRegex})?.json`;
 
 export const radioAndTvRegexPathsArray = buildRadioAndTvRoutes(
   servicesWithRadioAndTv,

--- a/src/app/routes/regex/index.test.js
+++ b/src/app/routes/regex/index.test.js
@@ -10,6 +10,7 @@ import {
   frontpageSwRegexPath,
   cpsAssetPageRegexPath,
   cpsAssetPageDataRegexPath,
+  mostReadDataRegexPath,
   radioAndTvRegexPathsArray,
 } from './index';
 
@@ -183,6 +184,19 @@ describe('frontpageManifestRegexPath', () => {
     '/news/trad/sw.js',
   ];
   shouldNotMatchInvalidRoutes(invalidRoutes, frontpageManifestRegexPath);
+});
+
+describe('mostReadDataRegexPath', () => {
+  const validRoutes = ['/news/most_read.json', '/zhongwen/most_read/simp.json'];
+  shouldMatchValidRoutes(validRoutes, mostReadDataRegexPath);
+
+  const invalidRoutes = [
+    '/foobar/most_read.json',
+    '/foobar/most_read',
+    '/foobar/most_read.js',
+    '/news/trad/most_read.json',
+  ];
+  shouldNotMatchInvalidRoutes(invalidRoutes, mostReadDataRegexPath);
 });
 
 jest.mock('../config', () => ({

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -14,6 +14,7 @@ import {
   frontpageManifestRegexPath,
   frontpageSwRegexPath,
   cpsAssetPageDataRegexPath,
+  mostReadDataRegexPath,
   radioAndTvDataRegexPath,
 } from '../app/routes/regex';
 import nodeLogger from '#lib/logger.node';
@@ -48,7 +49,7 @@ class LoggerStream {
 
 const constructDataFilePath = ({ pageType, service, id, variant = '' }) => {
   const dataPath =
-    pageType === 'frontpage'
+    pageType === 'frontpage' || pageType === 'mostRead'
       ? `${variant || 'index'}.json`
       : `${id}${variant}.json`;
 
@@ -131,6 +132,16 @@ if (process.env.APP_ENV === 'local') {
 
       const dataFilePath = constructDataFilePath({
         pageType: 'frontpage',
+        service,
+        variant,
+      });
+
+      sendDataFile(res, dataFilePath, next);
+    })
+    .get(mostReadDataRegexPath, async ({ params }, res, next) => {
+      const { service, variant } = params;
+      const dataFilePath = constructDataFilePath({
+        pageType: 'mostRead',
         service,
         variant,
       });

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -533,6 +533,25 @@ describe('Server', () => {
     });
   });
 
+  describe('Most Read json', () => {
+    it('should serve a file for valid service paths with variants', async () => {
+      const { body } = await makeRequest('/zhongwen/most_read/trad.json');
+      expect(body).toEqual(
+        expect.objectContaining({ records: expect.any(Object) }),
+      );
+    });
+    it('should serve a file for valid service paths without variants', async () => {
+      const { body } = await makeRequest('/news/most_read.json');
+      expect(body).toEqual(
+        expect.objectContaining({ records: expect.any(Object) }),
+      );
+    });
+    it('should respond with a 500 for non-existing services', async () => {
+      const { statusCode } = await makeRequest('/some-service/most_read.json');
+      expect(statusCode).toEqual(500);
+    });
+  });
+
   describe('Data', () => {
     describe('for articles', () => {
       it('should respond with JSON', async () => {


### PR DESCRIPTION
Resolves #4585

**Overall change:** Adds a local route for Most Read json. 

**Code changes:**

- Add regex
- Add route in local server

Testing urls:
http://localhost:7080/news/most_read.json   (without service variant)
http://localhost:7080/zhongwen/most_read/trad.json (with service variant)

Screenshot of JSON output for Zhongwen Trad:
<img width="818" alt="Screenshot of JSON output for Zhongwen Trad:" src="https://user-images.githubusercontent.com/3028997/68403248-8c4e5780-0174-11ea-8c1e-c928b912ae9b.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
