### PR TITLE
Remove flakey puppeteer tests 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:e2e": "./scripts/killApp.sh && npm run build && run-p --race start cypress",
     "test:e2e:interactive": "./scripts/killApp.sh && npm run build && run-p --race start cypress:interactive",
     "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook ./webpack** && swagger-cli validate data/schema.yaml && stylelint 'src/**/*.js' 'src/**/*.jsx'",
-    "test:puppeteer": "jest --env=jsdom --colors ./puppeteer/bundleRequests.test.js",
+    "test:puppeteer": "jest --env=jsdom --colors --testPathIgnorePatterns=\"puppeteer/rich-text-transforms.test.js\" ./puppeteer",
     "test:unit": "jest --env=jsdom --coverage --colors --testPathIgnorePatterns=\"puppeteer\"",
     "test:unit:watch": "npm run test:unit -- --watch",
     "webpack:dev:client": "NODE_ENV=development webpack-dev-server --inline --hot --env.config='client'",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:e2e": "./scripts/killApp.sh && npm run build && run-p --race start cypress",
     "test:e2e:interactive": "./scripts/killApp.sh && npm run build && run-p --race start cypress:interactive",
     "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook ./webpack** && swagger-cli validate data/schema.yaml && stylelint 'src/**/*.js' 'src/**/*.jsx'",
-    "test:puppeteer": "jest --env=jsdom --colors ./puppeteer",
+    "test:puppeteer": "jest --env=jsdom --colors ./puppeteer/bundleRequests.test.js",
     "test:unit": "jest --env=jsdom --coverage --colors --testPathIgnorePatterns=\"puppeteer\"",
     "test:unit:watch": "npm run test:unit -- --watch",
     "webpack:dev:client": "NODE_ENV=development webpack-dev-server --inline --hot --env.config='client'",


### PR DESCRIPTION
**Overall change:** Changing the test puppeteer route so it only runs the one test

**Code changes:**

- test:puppeteer script amended so it only runs bundleRequests.test.js and not rich-text-transforms.test.js
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing