### PR TITLE
Skip cookie banner tests for live radio and MAP AMP pages

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -7,8 +7,16 @@ import describeForEuOnly from '../../../support/helpers/describeForEuOnly';
 const serviceFilter = service =>
   Cypress.env('SMOKE') ? ['news', 'thai'].includes(service) : service;
 
-const filterPageTypes = (service, pageType) =>
-  config[service].pageTypes[pageType].path !== undefined;
+const filterPageTypes = (service, pageType) => {
+  // Note, AMP is currently broken for media embeds
+  // TODO: Re-enable once issue is resolved
+  // https://github.com/bbc/simorgh/issues/3970
+  if (['liveRadio', 'mediaAssetPage'].includes(pageType)) {
+    return false;
+  }
+
+  return config[service].pageTypes[pageType].path !== undefined;
+};
 
 const getPrivacyBanner = (service, variant) =>
   cy.contains(


### PR DESCRIPTION
Resolves [No Ticket]

**Overall change:** Temporarily disables cookie banner tests until associated issue (https://github.com/bbc/simorgh/issues/3970) is resolved
