### PR TITLE
Run chartbeat e2e's if the chartbeat app toggle is enabled

### DIFF
--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -22,16 +22,18 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       cy.get('html').should('not.have.attr', 'amp');
     });
 
-    describe('Chartbeat', () => {
-      if (envConfig.chartbeatEnabled) {
-        it('should have a script with src value set to chartbeat source', () => {
-          cy.hasScriptWithChartbeatSrc();
-        });
-        it('should have chartbeat config set to window object', () => {
-          cy.hasGlobalChartbeatConfig();
-        });
-      }
-    });
+    if (appToggles.chartbeatAnalytics.enabled) {
+      describe('Chartbeat', () => {
+        if (envConfig.chartbeatEnabled) {
+          it('should have a script with src value set to chartbeat source', () => {
+            cy.hasScriptWithChartbeatSrc();
+          });
+          it('should have chartbeat config set to window object', () => {
+            cy.hasGlobalChartbeatConfig();
+          });
+        }
+      });
+    }
 
     it('should include ampHTML tag', () => {
       cy.get('head link[rel="amphtml"]').should(


### PR DESCRIPTION
Resolves N/A

**Overall change:**

In a previous PR ChartbeatAnalytics were disabled on test due to an e2e failure. The PR ensures the e2e tests for Chartbeat only run when when the chartbeat toggle is enabled.

Solving this issue with our e2e's

```
articles - news - Canonical Canonical Tests for news articles Chartbeat should have a script with src value set to chartbeat source:
CypressError: Timed out retrying: Expected to find element: 'script[src="//static.chartbeat.com/js/chartbeat.js"]', but never found it.
```

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
