### PR TITLE
Run Chartbeat e2es on AMP dependent on toggle

### DIFF
--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -19,13 +19,15 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   pageType,
 }) =>
   describe(`Running testsForAMPOnly for ${service} ${pageType}`, () => {
-    describe('Chartbeat', () => {
-      if (envConfig.chartbeatEnabled) {
-        it('should have chartbeat config UID', () => {
-          cy.hasAmpChartbeatConfigUid();
-        });
-      }
-    });
+    if (appToggles.chartbeatAnalytics.enabled) {
+      describe('Chartbeat', () => {
+        if (envConfig.chartbeatEnabled) {
+          it('should have chartbeat config UID', () => {
+            cy.hasAmpChartbeatConfigUid();
+          });
+        }
+      });
+    }
 
     it('should contain an amp-img', () => {
       if (serviceHasFigure(service)) {


### PR DESCRIPTION
[no issue]

**Overall change:** _Make Chartbeat AMP article tests dependent on toggle state_

Related to https://github.com/bbc/simorgh/pull/4602

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
