### PR TITLE
Swallow AMP same-origin console errors in e2es

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -7,16 +7,8 @@ import describeForEuOnly from '../../../support/helpers/describeForEuOnly';
 const serviceFilter = service =>
   Cypress.env('SMOKE') ? ['news', 'thai'].includes(service) : service;
 
-const filterPageTypes = (service, pageType) => {
-  // Note, AMP is currently broken for media embeds
-  // TODO: Re-enable once issue is resolved
-  // https://github.com/bbc/simorgh/issues/3970
-  if (['liveRadio', 'mediaAssetPage'].includes(pageType)) {
-    return false;
-  }
-
-  return config[service].pageTypes[pageType].path !== undefined;
-};
+const filterPageTypes = (service, pageType) =>
+  config[service].pageTypes[pageType].path !== undefined;
 
 const getPrivacyBanner = (service, variant) =>
   cy.contains(

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -77,14 +77,7 @@ const runTestsForPage = ({
         }
       });
 
-      // Switch to AMP page URL
-      // Note, AMP is currently broken for media embeds
-      // TODO: Re-enable once issue is resolved
-      // https://github.com/bbc/simorgh/issues/3970
-      if (['liveRadio', 'mediaAssetPage'].includes(pageType)) {
-        return;
-      }
-
+      // Switch to AMP page URL (NB all our pages have AMP variants)
       describe(`${pageType} - ${service} - Amp`, () => {
         before(() => {
           cy.visit(`${config[service].pageTypes[pageType].path}.amp`, {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -10,3 +10,16 @@ Cypress.on(`window:before:load`, win => {
     throw new Error(msg);
   });
 });
+
+// Workaround for AMP same-origin errors
+// Can be removed when https://github.com/bbc/simorgh/issues/3970 is resolved
+// eslint-disable-next-line consistent-return
+Cypress.on('uncaught:exception', err => {
+  // returning false here prevents Cypress from failing the test
+  if (
+    err.message &&
+    err.message.match(/Origin of <amp-iframe> must not be equal to container/)
+  ) {
+    return false;
+  }
+});


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/4638

**Overall change:** _Prevents AMP tests from failing due to same-origin errors by swallowing these errors but allowing other errors to continue to fail_

**Code changes:**

- Reverts https://github.com/bbc/simorgh/pull/4591
- Reverts https://github.com/bbc/simorgh/pull/4599
- Adds Cypress exclusion for AMP same-origin error based on https://docs.cypress.io/api/events/catalog-of-events.html#cy

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
