### PR TITLE
Ensure Error page regex includes variant as a parameter

### DIFF
--- a/src/app/routes/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/regex/utils/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`regex utils snapshots should create expected regex from getArticleSwReg
 
 exports[`regex utils snapshots should create expected regex from getCpsAssetRegex 1`] = `"/:service(news|persian|igbo)/:assetUri([a-z-_]{0,}[0-9]{8,}):variant(/simp|/trad|/cyr|/lat)?:amp(.amp)?"`;
 
-exports[`regex utils snapshots should create expected regex from getErrorPageRegex 1`] = `"/:service(news|persian|igbo)/:errorCode(404|500)"`;
+exports[`regex utils snapshots should create expected regex from getErrorPageRegex 1`] = `"/:service(news|persian|igbo)/:errorCode(404|500):variant(/simp|/trad|/cyr|/lat)?"`;
 
 exports[`regex utils snapshots should create expected regex from getFrontPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?:amp(.amp)?"`;
 

--- a/src/app/routes/regex/utils/index.js
+++ b/src/app/routes/regex/utils/index.js
@@ -51,5 +51,5 @@ export const getRadioAndTVRegex = services => {
 
 export const getErrorPageRegex = services => {
   const serviceRegex = getServiceRegex(services);
-  return `/:service(${serviceRegex})/:errorCode(${errorCodeRegex})`;
+  return `/:service(${serviceRegex})/:errorCode(${errorCodeRegex}):variant(${variantRegex})?`;
 };


### PR DESCRIPTION
Resolves #4648

**Overall change:** Ensures error pages with variants show the correct variant, e.g. 
http://localhost:7080/zhongwen/404/trad
http://localhost:7080/ukchina/404/trad
http://localhost:7080/serbian/404/cyr
We can check the right variant by looking at the `lang` attribute on the html element.

**Code changes:**

- Update the ErrorPage regex to allow variants

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
