### PR TITLE
Disable fallback checks for local e2es

### DIFF
--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -1,19 +1,22 @@
 import './application';
 import './analytics';
+import envConfig from '../config/envs';
 
 // Overwriting Cypress Commands should very rarely be done.
-Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
-  cy.request({ url, failOnStatusCode: false }).then(({ headers }) => {
-    // Always ensure we're not seeing the Mozart fallback
-    if (
-      expect(
-        headers,
-        `Mozart fallback response detected for ${url}`,
-      ).not.to.have.property('x-mfa')
-    ) {
-      return originalFn(url, options);
-    }
+if (envConfig.alwaysCheckForFallback) {
+  Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+    cy.request({ url, failOnStatusCode: false }).then(({ headers }) => {
+      // Always ensure we're not seeing the Mozart fallback
+      if (
+        expect(
+          headers,
+          `Mozart fallback response detected for ${url}`,
+        ).not.to.have.property('x-mfa')
+      ) {
+        return originalFn(url, options);
+      }
 
-    return false;
+      return false;
+    });
   });
-});
+}

--- a/cypress/support/config/envs.js
+++ b/cypress/support/config/envs.js
@@ -8,6 +8,7 @@ const config = {
     chartbeatEnabled: false,
     avEmbedBaseUrl: 'https://www.bbc.com',
     standaloneErrorPages: false,
+    alwaysCheckForFallback: true,
   },
   test: {
     baseUrl: 'https://www.test.bbc.com',
@@ -18,6 +19,7 @@ const config = {
     chartbeatEnabled: true,
     avEmbedBaseUrl: 'https://www.test.bbc.com',
     standaloneErrorPages: false,
+    alwaysCheckForFallback: true,
   },
   local: {
     baseUrl: 'http://localhost:7080',
@@ -28,6 +30,7 @@ const config = {
     chartbeatEnabled: false,
     avEmbedBaseUrl: 'https://www.test.bbc.com',
     standaloneErrorPages: true,
+    alwaysCheckForFallback: false,
   },
 };
 


### PR DESCRIPTION
[no issue]

**Overall change:** _Stops automatic checks for Mozart fallback headers when running e2e tests locally_

Currently every time we request a URL via Cypress we make an additional HTTP request via `cy.request` to check for the `x-mfa` header. As we do not typically run Mozart locally this check is redundant, makes the tests take longer to run, and somtimes times out.

**Code changes:**

- Add `alwaysCheckForFallback` option to envConfig (off in local env, on in test/live)
- Make overwriting of `cy.visit` command conditional on option

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
