### PR TITLE
Fix MAP E2Es (Live Streams)

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -19,11 +19,15 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
       cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
         ({ body }) => {
           const { assetUri } = body.metadata.locators;
-          const { versionId } = body.content.blocks[0].versions[0];
+          const mediaBlock = body.content.blocks[0];
+          const isLiveStream = mediaBlock.type === 'version';
+          const serviceId = isLiveStream
+            ? mediaBlock.externalId
+            : mediaBlock.versions[0].versionId;
           const language = appConfig[service][variant].lang;
 
           cy.get(
-            `amp-iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+            `amp-iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${serviceId}/${language}"]`,
           ).should('be.visible');
         },
       );

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -19,11 +19,15 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
         ({ body }) => {
           const { assetUri } = body.metadata.locators;
-          const { versionId } = body.content.blocks[0].versions[0];
+          const mediaBlock = body.content.blocks[0];
+          const isLiveStream = mediaBlock.type === 'version';
+          const serviceId = isLiveStream
+            ? mediaBlock.externalId
+            : mediaBlock.versions[0].versionId;
           const language = appConfig[service][variant].lang;
 
           cy.get(
-            `iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${versionId}/${language}"]`,
+            `iframe[src*="${envConfig.avEmbedBaseUrl}/ws/av-embeds/cps${assetUri}/${serviceId}/${language}"]`,
           ).should('be.visible');
         },
       );


### PR DESCRIPTION
Resolves N/A

**Overall change:** _Fix cypress tests that are failing when the MAP is using a live stream._

**Code changes:**

- Update Cypress test to change where it gets version IDs depending on whether the MAP is using a livestream or on-demand clip

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
