### PR TITLE
Revert "Cypress tests multiple variants "

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # On running the 'build' commands this file is replaced by the files in `env-config/`
 # To ignore and keep this file we have a command in `postshrinkwrap` which assumes this file is not changing
-# The command is `git update-index --assume-unchanged .env`
+# The command is `git update-index --assume-unchanged .env` 
 # Source: https://wildlyinaccurate.com/git-ignore-changes-in-already-tracked-files/

--- a/cypress/integration/application/index.js
+++ b/cypress/integration/application/index.js
@@ -1,43 +1,39 @@
 import config from '../../support/config/services';
 import appConfig from '../../../src/server/utilities/serviceConfigs';
 
-const serviceHasPageType = (serviceName, pageType) =>
-  config[serviceName].pageTypes[pageType].path !== undefined;
+const serviceHasPageType = (service, pageType) =>
+  config[service].pageTypes[pageType].path !== undefined;
 
 const servicesUsingArticlePaths = ['news', 'scotland'];
 
-const services = Object.keys(config);
-
-const serviceHasAtLeastOnePageType = service => {
-  const pageTypes = Object.keys(config[service].pageTypes);
-
-  return pageTypes.some(pageType => serviceHasPageType(service, pageType));
-};
-
 describe('Application', () => {
-  services.filter(serviceHasAtLeastOnePageType).forEach(service => {
-    const usesArticlePath = servicesUsingArticlePaths.includes(service);
+  Object.keys(config)
+    .filter(service =>
+      Object.keys(config[service].pageTypes).some(pageType =>
+        serviceHasPageType(service, pageType),
+      ),
+    )
+    .forEach(service => {
+      const usesArticlePath = servicesUsingArticlePaths.includes(service);
 
-    it(`should return a 200 status code for ${service}'s service worker`, () => {
-      cy.testResponseCodeAndType(
-        usesArticlePath
-          ? `/${config[service].name}/articles/sw.js`
-          : `/${config[service].name}/sw.js`,
-        200,
-        'application/javascript',
-      );
-    });
+      it(`should return a 200 status code for ${service}'s service worker`, () => {
+        cy.testResponseCodeAndType(
+          usesArticlePath ? `/${service}/articles/sw.js` : `/${service}/sw.js`,
+          200,
+          'application/javascript',
+        );
+      });
 
-    it(`should return a 200 status code for ${service} manifest file`, () => {
-      cy.testResponseCodeAndType(
-        usesArticlePath
-          ? `/${config[service].name}/articles/manifest.json`
-          : `/${config[service].name}/manifest.json`,
-        200,
-        'application/json',
-      );
+      it(`should return a 200 status code for ${service} manifest file`, () => {
+        cy.testResponseCodeAndType(
+          usesArticlePath
+            ? `/${service}/articles/manifest.json`
+            : `/${service}/manifest.json`,
+          200,
+          'application/json',
+        );
+      });
     });
-  });
 });
 
 describe('Application unknown route error pages', () => {
@@ -55,10 +51,7 @@ describe('Application unknown route error pages', () => {
         const service = url.includes('igbo') ? 'igbo' : 'news';
         cy.get('h1').should(
           'contain',
-          `${
-            appConfig[config[service].name].default.translations.error[404]
-              .title
-          }`,
+          `${appConfig[service].default.translations.error[404].title}`,
         );
       });
     });

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -35,7 +35,7 @@ export const testsThatFollowSmokeTestConfig = ({
         cy.get('meta[name="article:author"]').should(
           'have.attr',
           'content',
-          appConfig[config[service].name][variant].articleAuthor,
+          appConfig[service][variant].articleAuthor,
         );
       });
 
@@ -75,7 +75,7 @@ export const testsThatFollowSmokeTestConfig = ({
       });
 
       it('should render a paragraph, which contains/displays styled text', () => {
-        if (serviceHasCorrectlyRenderedParagraphs(config[service].name)) {
+        if (serviceHasCorrectlyRenderedParagraphs(service)) {
           cy.request(`${config[service].pageTypes.articles.path}.json`).then(
             ({ body }) => {
               const paragraphData = getBlockData('text', body);
@@ -87,7 +87,7 @@ export const testsThatFollowSmokeTestConfig = ({
         }
       });
 
-      if (serviceHasFigure(config[service].name)) {
+      if (serviceHasFigure(service)) {
         it('should have a placeholder image', () => {
           cy.get('figure div div div')
             .eq(0)
@@ -99,7 +99,7 @@ export const testsThatFollowSmokeTestConfig = ({
             });
         });
 
-        if (serviceHasCaption(config[service].name)) {
+        if (serviceHasCaption(service)) {
           it('should have a visible image with a caption, and also not be lazyloaded', () => {
             cy.get('figure')
               .eq(0)
@@ -150,7 +150,7 @@ export const testsThatFollowSmokeTestConfig = ({
       });
 
       if (
-        serviceHasInlineLink(config[service].name) &&
+        serviceHasInlineLink(service) &&
         (Cypress.env('APP_ENV') === 'local' ||
           Cypress.env('APP_ENV') === 'test')
       ) {
@@ -169,7 +169,7 @@ export const testsThatFollowSmokeTestConfig = ({
         });
       }
 
-      if (serviceHasTimestamp(config[service].name)) {
+      if (serviceHasTimestamp(service)) {
         it('should render a timestamp', () => {
           cy.request(`${config[service].pageTypes.articles.path}.json`).then(
             ({ body }) => {

--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -43,7 +43,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       );
     });
 
-    if (serviceHasCaption(config[service].name)) {
+    if (serviceHasCaption(service)) {
       it('should have a visible image without a caption that is lazyloaded and has a noscript fallback image', () => {
         cy.get('figure')
           .eq(1)

--- a/cypress/integration/pages/errorPage404/tests.js
+++ b/cypress/integration/pages/errorPage404/tests.js
@@ -42,14 +42,10 @@ export const testsThatFollowSmokeTestConfig = ({
         });
       });
 
-      const variantService = appConfig[service]
-        ? appConfig[service][variant]
-        : appConfig[config[service].name][variant];
-
-      it(`should display a ${variantService.translations.error[404].statusCode} error message on screen`, () => {
+      it(`should display a ${appConfig[service][variant].translations.error[404].statusCode} error message on screen`, () => {
         cy.get('h1').should(
           'contain',
-          `${variantService.translations.error[404].title}`,
+          `${appConfig[service][variant].translations.error[404].title}`,
         );
       });
 
@@ -58,7 +54,7 @@ export const testsThatFollowSmokeTestConfig = ({
           cy.get('a').should(
             'have.attr',
             'href',
-            `${variantService.translations.error[404].callToActionLinkUrl}`,
+            `${appConfig[service][variant].translations.error[404].callToActionLinkUrl}`,
           );
         });
       });
@@ -66,14 +62,9 @@ export const testsThatFollowSmokeTestConfig = ({
       it('should have correct title & description metadata', () => {
         /* Note that description & title tests for all other page types are in /pages/testsForAllPages.js */
         const description =
-          appConfig[config[service].name][variant].translations.error[404]
-            .title;
-        const { title } = appConfig[config[service].name][
-          variant
-        ].translations.error[404];
-        const pageTitle = `${title} - ${
-          appConfig[config[service].name][variant].brandName
-        }`;
+          appConfig[service][variant].translations.error[404].title;
+        const { title } = appConfig[service][variant].translations.error[404];
+        const pageTitle = `${title} - ${appConfig[service][variant].brandName}`;
 
         cy.get('head').within(() => {
           cy.title().should('eq', pageTitle);
@@ -104,38 +95,28 @@ export const testsThatFollowSmokeTestConfig = ({
         cy.get('html').should(
           'have.attr',
           'lang',
-          appConfig[config[service].name][variant].lang,
+          appConfig[service][variant].lang,
         );
       });
     });
     if (envConfig.standaloneErrorPages) {
       describe(`${service} error page routes`, () => {
         it(`/${service}/404 should have response code 200`, () => {
-          cy.testResponseCodeAndType(
-            `/${config[service].name}/404`,
-            200,
-            'text/html',
-          );
-          cy.visit(`${config[service].name}/404`)
+          cy.testResponseCodeAndType(`/${service}/404`, 200, 'text/html');
+          cy.visit(`${service}/404`)
             .get('[class^="StatusCode"]')
             .should(
               'contain',
-              appConfig[config[service].name][variant].translations.error[404]
-                .statusCode,
+              appConfig[service][variant].translations.error[404].statusCode,
             );
         });
         it(`/${service}/500 should have response code 200`, () => {
-          cy.testResponseCodeAndType(
-            `/${config[service].name}/500`,
-            200,
-            'text/html',
-          );
-          cy.visit(`${config[service].name}/500`)
+          cy.testResponseCodeAndType(`/${service}/500`, 200, 'text/html');
+          cy.visit(`${service}/500`)
             .get('[class^="StatusCode"]')
             .should(
               'contain',
-              appConfig[config[service].name][variant].translations.error[500]
-                .statusCode,
+              appConfig[service][variant].translations.error[500].statusCode,
             );
         });
       });

--- a/cypress/integration/pages/frontPage/tests.js
+++ b/cypress/integration/pages/frontPage/tests.js
@@ -95,7 +95,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
         });
 
         if (
-          serviceHasPublishedPromo(config[service].name) &&
+          serviceHasPublishedPromo(service) &&
           Cypress.env('APP_ENV') !== 'local'
         ) {
           it('individual promo should link to corresponding article pages and back navigation should link to frontpage', () => {
@@ -132,10 +132,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
               const topstories = body.content.groups[0].items[0];
               const relatedItemsExists = 'relatedItems' in topstories;
 
-              if (
-                relatedItemsExists &&
-                serviceHasIndexAlsos(config[service].name)
-              ) {
+              if (relatedItemsExists && serviceHasIndexAlsos(service)) {
                 cy.get('[aria-labelledby="Top-stories"]')
                   .eq(0)
                   .within(() => {
@@ -146,10 +143,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
                           .eq(0)
                           .then($el => {
                             expect($el.text()).includes(
-                              `${
-                                appConfig[config[service].name].default
-                                  .translations.relatedContent
-                              }`,
+                              `${appConfig[service].default.translations.relatedContent}`,
                             );
                           });
 

--- a/cypress/integration/pages/testsForAllCanonicalPages.js
+++ b/cypress/integration/pages/testsForAllCanonicalPages.js
@@ -1,5 +1,4 @@
 import envConfig from '../../support/config/envs';
-import config from '../../support/config/services';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -29,7 +28,7 @@ export const testsThatFollowSmokeTestConfigForAllCanonicalPages = ({
           if ($p.attr('src').includes(envConfig.assetOrigin)) {
             return expect($p.attr('src')).to.match(
               new RegExp(
-                `(\\/static\\/js\\/(main|vendor|${config[service].name})-\\w+\\.\\w+\\.js)`,
+                `(\\/static\\/js\\/(main|vendor|${service})-\\w+\\.\\w+\\.js)`,
                 'g',
               ),
             );
@@ -47,7 +46,7 @@ export const testsThatFollowSmokeTestConfigForAllCanonicalPages = ({
               .attr('src')
               .match(
                 new RegExp(
-                  `(\\/static\\/js\\/${config[service].name}-\\w+\\.\\w+\\.js)`,
+                  `(\\/static\\/js\\/${service}-\\w+\\.\\w+\\.js)`,
                   'g',
                 ),
               );

--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -20,7 +20,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
     describe(`Metadata`, () => {
       it('should have resource hints', () => {
         const resources = [envConfig.assetOrigin, 'https://ichef.bbci.co.uk'];
-        const serviceConfig = appConfig[config[service].name];
+        const serviceConfig = appConfig[service];
         const { fonts } = serviceConfig[variant || 'default'];
         if (fonts && fonts.length > 0) {
           resources.push(
@@ -90,17 +90,17 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
             cy.get('meta[name="og:image"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].defaultImage,
+              appConfig[service][variant].defaultImage,
             );
             cy.get('meta[name="og:image:alt"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].defaultImageAltText,
+              appConfig[service][variant].defaultImageAltText,
             );
             cy.get('meta[name="og:locale"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].locale,
+              appConfig[service][variant].locale,
             );
             cy.get('meta[name="og:type"]').should(
               'have.attr',
@@ -115,7 +115,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
             cy.get('meta[name="og:site_name"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].brandName,
+              appConfig[service][variant].brandName,
             );
             cy.get('meta[name="twitter:card"]').should(
               'have.attr',
@@ -125,22 +125,22 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
             cy.get('meta[name="twitter:creator"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].twitterCreator,
+              appConfig[service][variant].twitterCreator,
             );
             cy.get('meta[name="twitter:image:alt"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].defaultImageAltText,
+              appConfig[service][variant].defaultImageAltText,
             );
             cy.get('meta[name="twitter:image:src"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].defaultImage,
+              appConfig[service][variant].defaultImage,
             );
             cy.get('meta[name="twitter:site"]').should(
               'have.attr',
               'content',
-              appConfig[config[service].name][variant].twitterSite,
+              appConfig[service][variant].twitterSite,
             );
             cy.get('link[rel="apple-touch-icon"]').each(link => {
               const url = link.attr('href');
@@ -177,8 +177,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
                     break;
                   case 'frontPage':
                     description = body.metadata.summary;
-                    title =
-                      appConfig[config[service].name][variant].frontPageTitle;
+                    title = appConfig[service][variant].frontPageTitle;
                     break;
                   case 'liveRadio':
                     description = body.promo.summary;
@@ -193,9 +192,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
                     title = '';
                 }
                 /* Note that if updating these, also do the same for errorPage404/tests.js */
-                const pageTitle = `${title} - ${
-                  appConfig[config[service].name][variant].brandName
-                }`;
+                const pageTitle = `${title} - ${appConfig[service][variant].brandName}`;
 
                 cy.get('head').within(() => {
                   cy.title().should('eq', pageTitle);
@@ -228,57 +225,43 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
       /* End of block (pageType !== 'errorPage404') */
 
       it('should have dir matching service config', () => {
-        cy.get('html').and(
-          'have.attr',
-          'dir',
-          appConfig[config[service].name][variant].dir,
-        );
+        cy.get('html').and('have.attr', 'dir', appConfig[service][variant].dir);
       });
     });
 
     describeForEuOnly('Consent Banners', () => {
       it('have correct translations', () => {
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .privacy.title,
+          appConfig[service][variant].translations.consentBanner.privacy.title,
         );
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .privacy.reject,
+          appConfig[service][variant].translations.consentBanner.privacy.reject,
         );
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .privacy.accept,
+          appConfig[service][variant].translations.consentBanner.privacy.accept,
         ).click();
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .cookie.title,
+          appConfig[service][variant].translations.consentBanner.cookie.title,
         );
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .cookie.reject,
+          appConfig[service][variant].translations.consentBanner.cookie.reject,
         );
         cy.contains(
-          appConfig[config[service].name][variant].translations.consentBanner
-            .cookie.accept,
+          appConfig[service][variant].translations.consentBanner.cookie.accept,
         );
       });
     });
 
     describe('Header Tests', () => {
-      const hasLocalisedName = appConfig[service]
-        ? appConfig[service][variant].serviceLocalizedName !== undefined
-        : appConfig[config[service].name][variant].serviceLocalizedName !==
-          undefined;
+      const hasLocalisedName =
+        appConfig[service][variant].serviceLocalizedName !== undefined;
 
       it('should render the BBC News branding', () => {
         cy.get('header a').should(
           'contain',
           hasLocalisedName
-            ? `${appConfig[config[service].name][variant].product}, ${
-                appConfig[config[service].name][variant].serviceLocalizedName
-              }`
-            : appConfig[config[service].name][variant].product,
+            ? `${appConfig[service][variant].product}, ${appConfig[service][variant].serviceLocalizedName}`
+            : appConfig[service][variant].product,
         );
       });
 
@@ -311,16 +294,12 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
           .children()
           .should('have.lengthOf', 1)
           .children()
-          .should('have.attr', 'href', `/${config[service].name}`)
+          .should('have.attr', 'href', `/${service}`)
           .find('svg')
           .should('be.visible');
       });
 
-      const navigation = appConfig[service]
-        ? appConfig[service][variant].navigation
-        : appConfig[config[service].name][variant].navigation;
-
-      if (navigation) {
+      if (appConfig[service][variant].navigation) {
         if (
           pageType !== 'articles' ||
           (pageType === 'articles' && useAppToggles.navOnArticles.enabled)
@@ -336,11 +315,11 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
               .should(
                 'have.attr',
                 'href',
-                appConfig[config[service].name][variant].navigation[0].url,
+                appConfig[service][variant].navigation[0].url,
               )
               .should(
                 'contain',
-                appConfig[config[service].name][variant].navigation[0].title,
+                appConfig[service][variant].navigation[0].title,
               );
             cy.get('h1')
               .should('have.lengthOf', 1)
@@ -357,7 +336,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
             .should('have.length', 1)
             .should('have.attr', 'role', 'contentinfo')
             .find('a')
-            .should('have.attr', 'href', `/${config[service].name}`)
+            .should('have.attr', 'href', `/${service}`)
             .find('svg')
             .should('be.visible');
         });
@@ -368,19 +347,16 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
           .eq(0)
           .should(
             'contain',
-            appConfig[config[service].name][variant].serviceLocalizedName !==
-              undefined
-              ? `${appConfig[config[service].name][variant].product}, ${
-                  appConfig[config[service].name][variant].serviceLocalizedName
-                }`
-              : appConfig[config[service].name][variant].product,
+            appConfig[service][variant].serviceLocalizedName !== undefined
+              ? `${appConfig[service][variant].product}, ${appConfig[service][variant].serviceLocalizedName}`
+              : appConfig[service][variant].product,
           );
       });
 
       it('should contain copyright text', () => {
         cy.get('footer p').should(
           'contain',
-          appConfig[config[service].name][variant].footer.copyrightText,
+          appConfig[service][variant].footer.copyrightText,
         );
       });
 
@@ -392,10 +368,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
         cy.get('footer p')
           .children('a')
           .should('have.attr', 'href')
-          .and(
-            'contain',
-            appConfig[config[service].name][variant].footer.externalLink.href,
-          );
+          .and('contain', appConfig[service][variant].footer.externalLink.href);
       });
     });
   });

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -1,6 +1,5 @@
 const services = {
   afaanoromoo: {
-    name: 'afaanoromoo',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -37,7 +36,6 @@ const services = {
     },
   },
   afrique: {
-    name: 'afrique',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -79,7 +77,6 @@ const services = {
     },
   },
   amharic: {
-    name: 'amharic',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -116,7 +113,6 @@ const services = {
     },
   },
   arabic: {
-    name: 'arabic',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -158,7 +154,6 @@ const services = {
     },
   },
   azeri: {
-    name: 'azeri',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -192,7 +187,6 @@ const services = {
     },
   },
   bengali: {
-    name: 'bengali',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -234,7 +228,6 @@ const services = {
     },
   },
   burmese: {
-    name: 'burmese',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -276,7 +269,6 @@ const services = {
     },
   },
   cymrufyw: {
-    name: 'cymrufyw',
     font: 'Reith',
     isWorldService: false,
     variant: 'default',
@@ -307,7 +299,6 @@ const services = {
     },
   },
   gahuza: {
-    name: 'gahuza',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -349,7 +340,6 @@ const services = {
     },
   },
   gujarati: {
-    name: 'gujarati',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -383,7 +373,6 @@ const services = {
     },
   },
   hausa: {
-    name: 'hausa',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -425,7 +414,6 @@ const services = {
     },
   },
   hindi: {
-    name: 'hindi',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -467,7 +455,6 @@ const services = {
     },
   },
   igbo: {
-    name: 'igbo',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -498,7 +485,6 @@ const services = {
     },
   },
   indonesia: {
-    name: 'indonesia',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -535,7 +521,6 @@ const services = {
     },
   },
   japanese: {
-    name: 'japanese',
     font: undefined,
     isWorldService: false,
     variant: 'default',
@@ -569,7 +554,6 @@ const services = {
     },
   },
   korean: {
-    name: 'korean',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -606,7 +590,6 @@ const services = {
     },
   },
   kyrgyz: {
-    name: 'kyrgyz',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -648,7 +631,6 @@ const services = {
     },
   },
   marathi: {
-    name: 'marathi',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -682,7 +664,6 @@ const services = {
     },
   },
   mundo: {
-    name: 'mundo',
     font: 'Reith',
     isWorldService: true,
     variant: 'default',
@@ -716,7 +697,6 @@ const services = {
     },
   },
   naidheachdan: {
-    name: 'naidheachdan',
     font: 'Reith',
     isWorldService: false,
     variant: 'default',
@@ -744,7 +724,6 @@ const services = {
     },
   },
   nepali: {
-    name: 'nepali',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -786,7 +765,6 @@ const services = {
     },
   },
   news: {
-    name: 'news',
     font: 'Reith',
     isWorldService: false,
     variant: 'default',
@@ -811,7 +789,6 @@ const services = {
     },
   },
   pashto: {
-    name: 'pashto',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -853,7 +830,6 @@ const services = {
     },
   },
   persian: {
-    name: 'persian',
     font: 'Nassim',
     isWorldService: true,
     variant: 'default',
@@ -893,7 +869,6 @@ const services = {
     },
   },
   pidgin: {
-    name: 'pidgin',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -924,7 +899,6 @@ const services = {
     },
   },
   portuguese: {
-    name: 'portuguese',
     font: 'Reith',
     isWorldService: true,
     variant: 'default',
@@ -958,7 +932,6 @@ const services = {
     },
   },
   punjabi: {
-    name: 'punjabi',
     font: undefined,
     variant: 'default',
     pageTypes: {
@@ -991,7 +964,6 @@ const services = {
     },
   },
   russian: {
-    name: 'russian',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1025,7 +997,6 @@ const services = {
     },
   },
   scotland: {
-    name: 'scotland',
     font: undefined,
     isWorldService: false,
     variant: 'default',
@@ -1049,45 +1020,7 @@ const services = {
       mediaAssetPage: { path: undefined, smoke: false },
     },
   },
-  serbianCyr: {
-    name: 'serbian',
-    font: undefined,
-    isWorldService: true,
-    variant: 'cyr',
-    pageTypes: {
-      articles: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/serbian/articles/c805k05kr73o/cyr',
-        smoke: true,
-      },
-      errorPage404: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/serbian/articles/cabcdefghijo/cyr',
-        smoke: true,
-      },
-      frontPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/serbian/cyr',
-        smoke: true,
-      },
-      liveRadio: { path: undefined, smoke: false },
-      mediaAssetPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/serbian/srbija-49427344/cyr',
-        smoke: false,
-      },
-    },
-  },
-  serbianLat: {
-    name: 'serbian',
+  serbian: {
     font: undefined,
     isWorldService: true,
     variant: 'lat',
@@ -1124,7 +1057,6 @@ const services = {
     },
   },
   sinhala: {
-    name: 'sinhala',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1166,7 +1098,6 @@ const services = {
     },
   },
   somali: {
-    name: 'somali',
     font: undefined,
     variant: 'default',
     pageTypes: {
@@ -1207,7 +1138,6 @@ const services = {
     },
   },
   sport: {
-    name: 'sport',
     font: undefined,
     variant: 'default',
     pageTypes: {
@@ -1219,7 +1149,6 @@ const services = {
     },
   },
   swahili: {
-    name: 'swahili',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1261,7 +1190,6 @@ const services = {
     },
   },
   tamil: {
-    name: 'tamil',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1303,7 +1231,6 @@ const services = {
     },
   },
   telugu: {
-    name: 'telugu',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1337,7 +1264,6 @@ const services = {
     },
   },
   thai: {
-    name: 'thai',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1371,7 +1297,6 @@ const services = {
     },
   },
   tigrinya: {
-    name: 'tigrinya',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1408,7 +1333,6 @@ const services = {
     },
   },
   turkce: {
-    name: 'turkce',
     font: 'Reith',
     isWorldService: true,
     variant: 'default',
@@ -1441,8 +1365,7 @@ const services = {
       },
     },
   },
-  ukchinaSimp: {
-    name: 'ukchina',
+  ukchina: {
     font: undefined,
     isWorldService: true,
     variant: 'simp',
@@ -1478,45 +1401,7 @@ const services = {
       },
     },
   },
-  ukchinaTrad: {
-    name: 'ukchina',
-    font: undefined,
-    isWorldService: true,
-    variant: 'trad',
-    pageTypes: {
-      articles: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/ukchina/articles/c0e8weny66ko/trad',
-        smoke: true,
-      },
-      errorPage404: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/ukchina/articles/cabcdefghijo/trad',
-        smoke: true,
-      },
-      frontPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/ukchina/trad',
-        smoke: true,
-      },
-      liveRadio: { path: undefined, smoke: false },
-      mediaAssetPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/ukchina/49375846/trad',
-        smoke: false,
-      },
-    },
-  },
   ukrainian: {
-    name: 'ukrainian',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1550,7 +1435,6 @@ const services = {
     },
   },
   urdu: {
-    name: 'urdu',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1592,7 +1476,6 @@ const services = {
     },
   },
   uzbek: {
-    name: 'uzbek',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1634,7 +1517,6 @@ const services = {
     },
   },
   vietnamese: {
-    name: 'vietnamese',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1668,7 +1550,6 @@ const services = {
     },
   },
   yoruba: {
-    name: 'yoruba',
     font: undefined,
     isWorldService: true,
     variant: 'default',
@@ -1698,8 +1579,7 @@ const services = {
       },
     },
   },
-  zhongwenSimp: {
-    name: 'zhongwen',
+  zhongwen: {
     font: undefined,
     isWorldService: true,
     variant: 'simp',
@@ -1731,43 +1611,6 @@ const services = {
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
             : '/zhongwen/chinese-news-49631219/simp',
-        smoke: false,
-      },
-    },
-  },
-  zhongwenTrad: {
-    name: 'zhongwen',
-    font: undefined,
-    isWorldService: true,
-    variant: 'trad',
-    pageTypes: {
-      articles: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/zhongwen/articles/c3xd4x9prgyo/trad',
-        smoke: true,
-      },
-      errorPage404: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/zhongwen/articles/cabcdefghijo/trad',
-        smoke: true,
-      },
-      frontPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/zhongwen/trad',
-        smoke: true,
-      },
-      liveRadio: { path: undefined, smoke: false },
-      mediaAssetPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/zhongwen/chinese-news-49631219/trad',
         smoke: false,
       },
     },

--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -35,7 +35,7 @@ describe('Js bundle requests', () => {
     Object.keys(config[service].pageTypes)
       .filter(
         pageType =>
-          shouldSmokeTest(pageType, config[service].name) &&
+          shouldSmokeTest(pageType, service) &&
           config[service].pageTypes[pageType].path !== undefined,
       )
       .forEach(pageType => {
@@ -59,7 +59,7 @@ describe('Js bundle requests', () => {
               .forEach(url => {
                 expect(url).toMatch(
                   new RegExp(
-                    `(\\/static\\/js\\/(main|vendor|${config[service].name})-\\w+\\.\\w+\\.js)`,
+                    `(\\/static\\/js\\/(main|vendor|${service})-\\w+\\.\\w+\\.js)`,
                     'g',
                   ),
                 );
@@ -70,7 +70,7 @@ describe('Js bundle requests', () => {
             const serviceMatches = requests.filter(url =>
               url.match(
                 new RegExp(
-                  `(\\/static\\/js\\/${config[service].name}-\\w+\\.\\w+\\.js)`,
+                  `(\\/static\\/js\\/${service}-\\w+\\.\\w+\\.js)`,
                   'g',
                 ),
               ),


### PR DESCRIPTION
Reverts bbc/simorgh#4546

failing on CI with

```
Canonical Cookie Banner Test for serbianLat articles should show cookie banner (and NOT privacy banner) if user has visited the page before and didn't explicitly 'accept' cookies:

TypeError: Cannot read property 'lat' of undefined
```