### PR TITLE
Enable live e2es for Russian and Kyrgyz

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -597,7 +597,7 @@ const services = {
       articles: {
         path:
           Cypress.env('APP_ENV') === 'live'
-            ? undefined
+            ? '/kyrgyz/articles/c414v42gy75o'
             : '/kyrgyz/articles/c3xd4xg3rm9o',
         smoke: false,
       },
@@ -971,7 +971,7 @@ const services = {
       articles: {
         path:
           Cypress.env('APP_ENV') === 'live'
-            ? undefined
+            ? '/russian/articles/c6ygxgl53w9o'
             : '/russian/articles/ck7pz7re3zgo',
         smoke: false,
       },


### PR DESCRIPTION
Part of #4276 

**Overall change:**
* Enables live e2es for Russian and Kyrgyz articles

**Code changes:**

- Adds a live asset to run Cypress tests against for Russian and Kyrgyz articles

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
