### PR TITLE
Add figure HTML to media player && padding to the bottom of the media player

### DIFF
--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -46,7 +46,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
     if (serviceHasCaption(service)) {
       it('should have a visible image without a caption that is lazyloaded and has a noscript fallback image', () => {
         cy.get('figure')
-          .eq(1)
+          .eq(2)
           .within(() => {
             cy.get('div div div div').should(
               'have.class',
@@ -56,7 +56,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
           .scrollIntoView();
 
         cy.get('figure')
-          .eq(1)
+          .eq(2)
           .should('be.visible')
           .should('to.have.descendants', 'img')
           .should('not.to.have.descendants', 'figcaption')

--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -43,10 +43,16 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       );
     });
 
+    // Have the test toggle between if mediaPlayer is enabled on live on not
+    let imageIndex = 1;
+    if (appToggles.mediaPlayer.enabled) {
+      imageIndex = 2;
+    }
+
     if (serviceHasCaption(service)) {
       it('should have a visible image without a caption that is lazyloaded and has a noscript fallback image', () => {
         cy.get('figure')
-          .eq(2)
+          .eq(imageIndex)
           .within(() => {
             cy.get('div div div div').should(
               'have.class',
@@ -56,7 +62,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
           .scrollIntoView();
 
         cy.get('figure')
-          .eq(2)
+          .eq(imageIndex)
           .should('be.visible')
           .should('to.have.descendants', 'img')
           .should('not.to.have.descendants', 'figcaption')

--- a/data/news/articles/cjn0qpz3jjvo.json
+++ b/data/news/articles/cjn0qpz3jjvo.json
@@ -1,0 +1,2645 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares::article:cjn0qpz3jjvo",
+    "locators": {
+      "optimoUrn": "urn:bbc:optimo:asset:cjn0qpz3jjvo",
+      "canonicalUrl": "https://www.bbc.com/news/articles/cjn0qpz3jjvo"
+    },
+    "type": "article",
+    "createdBy": "News",
+    "language": "en-gb",
+    "lastUpdated": 1571155538091,
+    "firstPublished": 1571146595887,
+    "lastPublished": 1571149356325,
+    "options": {},
+    "analyticsLabels": {},
+    "passport": {
+      "language": "en-gb",
+      "home": "http://www.bbc.co.uk/ontologies/passport/home/News"
+    },
+    "tags": {},
+    "version": "v1.1.2",
+    "blockTypes": [
+      "headline",
+      "text",
+      "paragraph",
+      "fragment",
+      "video",
+      "caption",
+      "image",
+      "altText",
+      "rawImage",
+      "subheadline"
+    ]
+  },
+  "content": {
+    "model": {
+      "blocks": [
+        {
+          "type": "headline",
+          "model": {
+            "blocks": [
+              {
+                "type": "text",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "paragraph",
+                      "model": {
+                        "text": "AV test article ",
+                        "blocks": [
+                          {
+                            "type": "fragment",
+                            "model": {
+                              "text": "AV test article ",
+                              "attributes": []
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "model": {
+            "blocks": [
+              {
+                "type": "paragraph",
+                "model": {
+                  "text": "Text block before a media block",
+                  "blocks": [
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "Text block before a media block",
+                        "attributes": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "model": {
+            "blocks": [
+              {
+                "type": "paragraph",
+                "model": {
+                  "text": "Text block after an media block.",
+                  "blocks": [
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "Text block after an media block.",
+                        "attributes": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "image",
+          "model": {
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "Image block after a media block",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "Image block after a media block",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "altText",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "Image after an AV block",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "Image after an AV block",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "rawImage",
+                "model": {
+                  "width": 624,
+                  "height": 351,
+                  "locator": "4c13/test/967bd1f0-ef50-11e9-88d6-81aa2ccc6d4c.jpg",
+                  "originCode": "cpsdevpb",
+                  "copyrightHolder": "BBC"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "subheadline",
+          "model": {
+            "blocks": [
+              {
+                "type": "text",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "paragraph",
+                      "model": {
+                        "text": "Subheadline block after a media block",
+                        "blocks": [
+                          {
+                            "type": "fragment",
+                            "model": {
+                              "text": "Subheadline block after a media block",
+                              "attributes": []
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "caption",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "text",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "They may be tiny, but us humans could learn a thing or two from ants.",
+                                    "attributes": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "type": "aresMediaMetadata",
+                      "model": {
+                        "id": "p01k6msm",
+                        "subType": "clip",
+                        "format": "audio_video",
+                        "title": "Five things ants can teach us about management",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "imageCopyright": "BBC",
+                        "embedding": true,
+                        "advertising": true,
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": ["Original"],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "syndication": { "destinations": [] }
+                      }
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "width": 1920,
+                              "height": 1080,
+                              "locator": "ichef.test.bbci.co.uk/images/ic/$widthxn/p01k6mtv.jpg",
+                              "originCode": "mpv",
+                              "copyrightHolder": "BBC"
+                            }
+                          },
+                          {
+                            "type": "altText",
+                            "model": {
+                              "blocks": [
+                                {
+                                  "type": "text",
+                                  "model": {
+                                    "blocks": [
+                                      {
+                                        "type": "paragraph",
+                                        "model": {
+                                          "text": "Ants",
+                                          "blocks": [
+                                            {
+                                              "type": "fragment",
+                                              "model": {
+                                                "text": "Ants",
+                                                "attributes": []
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "model": {
+            "blocks": [
+              {
+                "type": "paragraph",
+                "model": {
+                  "text": "Above is two media blocks one after the other.",
+                  "blocks": [
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "Above is two media blocks one after the other.",
+                        "attributes": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "promo": {
+    "headlines": { "seoHeadline": "AV test article " },
+    "locators": {
+      "optimoUrn": "urn:bbc:optimo:asset:cjn0qpz3jjvo",
+      "canonicalUrl": "https://www.bbc.com/news/articles/cjn0qpz3jjvo"
+    },
+    "summary": "",
+    "timestamp": 1571149356325,
+    "id": "urn:bbc:ares::article:cjn0qpz3jjvo",
+    "type": "cps"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "News",
+      "uri": "/news",
+      "type": "simple"
+    },
+    "groups": []
+  }
+}

--- a/src/app/containers/ArticleMediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMediaPlayer/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,12 @@ exports[`MediaPlayer Calls the amp media player 1`] = `
   </head>
   <body>
     .c1 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c2 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -68,29 +74,33 @@ exports[`MediaPlayer Calls the amp media player 1`] = `
       <div
         class="c0"
       >
-        <div
+        <figure
           class="c1"
         >
-          <amp-iframe
-            allowfullscreen="allowfullscreen"
-            frameborder="0"
-            layout="fill"
-            sandbox="allow-scripts allow-same-origin"
-            src="https://www.test.bbc.com/ws/av-embeds/articles/c1234567890/p01k6msp/en-GB/amp"
-            title="Media player"
+          <div
+            class="c2"
           >
-            <amp-img
-              alt=""
-              attribution=""
-              height="16"
+            <amp-iframe
+              allowfullscreen="allowfullscreen"
+              frameborder="0"
               layout="fill"
-              placeholder="true"
-              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-              width="9"
-            />
-          </amp-iframe>
-        </div>
+              sandbox="allow-scripts allow-same-origin"
+              src="https://www.test.bbc.com/ws/av-embeds/articles/c1234567890/p01k6msp/en-GB/amp"
+              title="Media player"
+            >
+              <amp-img
+                alt=""
+                attribution=""
+                height="16"
+                layout="fill"
+                placeholder="true"
+                src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+                srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+                width="9"
+              />
+            </amp-iframe>
+          </div>
+        </figure>
       </div>
     </div>
   </body>
@@ -98,7 +108,7 @@ exports[`MediaPlayer Calls the amp media player 1`] = `
 `;
 
 exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = `
-.c10 {
+.c11 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -107,13 +117,19 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   height: 0.75rem;
 }
 
-.c12 {
+.c1 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c13 {
   display: block;
   width: 100%;
   visibility: visible;
 }
 
-.c8 {
+.c9 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -125,7 +141,7 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   margin: 0;
 }
 
-.c6 {
+.c7 {
   background-color: #222222;
   border: none;
   color: #FFFFFF;
@@ -143,14 +159,14 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   width: 5rem;
 }
 
-.c6:hover,
-.c6:focus {
+.c7:hover,
+.c7:focus {
   background-color: #B80000;
   -webkit-transition: background-color 300ms;
   transition: background-color 300ms;
 }
 
-.c9 > svg {
+.c10 > svg {
   color: #FFFFFF;
   fill: currentColor;
   height: 1.5rem;
@@ -158,12 +174,12 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   width: 1.5rem;
 }
 
-.c11 {
+.c12 {
   display: block;
   margin-top: 0.5rem;
 }
 
-.c4 {
+.c5 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -177,11 +193,11 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   padding: 0.5rem;
 }
 
-.c5 {
+.c6 {
   font-weight: normal;
 }
 
-.c3 {
+.c4 {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -190,17 +206,17 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
   height: 100%;
 }
 
-.c7 {
+.c8 {
   position: absolute;
   bottom: 0;
 }
 
-.c2:hover .c7,
-.c2:focus .c7 {
+.c3:hover .c8,
+.c3:focus .c8 {
   background-color: #B80000;
 }
 
-.c1 {
+.c2 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -211,13 +227,13 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c5 {
     font-size: 0.875rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c4 {
+  .c5 {
     padding: 1rem;
   }
 }
@@ -274,61 +290,65 @@ exports[`MediaPlayer Calls the canonical media player, with a placeholder 1`] = 
       <div
         class="c0"
       >
-        <div
+        <figure
           class="c1"
         >
           <div
-            class="c2 c3"
+            class="c2"
           >
             <div
-              class="c4"
+              class="c3 c4"
             >
-              <strong
+              <div
                 class="c5"
               >
-                Contains strong language and adult humour.
-              </strong>
-            </div>
-            <button
-              class="c6 c7"
-            >
-              <span
-                class="c8"
-              >
-                Play video, "Five things ants can teach us about management", 3,11
-              </span>
-              <div
-                aria-hidden="true"
-                class="c9"
-              >
-                <svg
-                  class="c10"
-                  focusable="false"
-                  height="12px"
-                  viewBox="0 0 32 32"
-                  width="12px"
+                <strong
+                  class="c6"
                 >
-                  <polygon
-                    points="3,32 29,16 3,0"
-                  />
-                </svg>
+                  Contains strong language and adult humour.
+                </strong>
               </div>
-              <time
-                aria-hidden="true"
-                class="c11"
-                datetime="PT3M11S"
+              <button
+                class="c7 c8"
               >
-                3:11
-              </time>
-            </button>
-            <img
-              alt=""
-              class="c12"
-              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-            />
+                <span
+                  class="c9"
+                >
+                  Play video, "Five things ants can teach us about management", 3,11
+                </span>
+                <div
+                  aria-hidden="true"
+                  class="c10"
+                >
+                  <svg
+                    class="c11"
+                    focusable="false"
+                    height="12px"
+                    viewBox="0 0 32 32"
+                    width="12px"
+                  >
+                    <polygon
+                      points="3,32 29,16 3,0"
+                    />
+                  </svg>
+                </div>
+                <time
+                  aria-hidden="true"
+                  class="c12"
+                  datetime="PT3M11S"
+                >
+                  3:11
+                </time>
+              </button>
+              <img
+                alt=""
+                class="c13"
+                src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+                srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+              />
+            </div>
           </div>
-        </div>
+        </figure>
       </div>
     </div>
   </body>

--- a/src/app/containers/CpsAssetMediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetMediaPlayer/__snapshots__/index.test.jsx.snap
@@ -16,6 +16,12 @@ exports[`MediaPlayer render the amp player 1`] = `
   </head>
   <body>
     .c1 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c2 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -59,29 +65,33 @@ exports[`MediaPlayer render the amp player 1`] = `
       <div
         class="c0"
       >
-        <div
+        <figure
           class="c1"
         >
-          <amp-iframe
-            allowfullscreen="allowfullscreen"
-            frameborder="0"
-            layout="fill"
-            sandbox="allow-scripts allow-same-origin"
-            src="https://www.test.bbc.com/ws/av-embeds/cps/pidgin/123456789/p01k6msp/en-GB/amp"
-            title="Media player"
+          <div
+            class="c2"
           >
-            <amp-img
-              alt=""
-              attribution=""
-              height="16"
+            <amp-iframe
+              allowfullscreen="allowfullscreen"
+              frameborder="0"
               layout="fill"
-              placeholder="true"
-              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-              width="9"
-            />
-          </amp-iframe>
-        </div>
+              sandbox="allow-scripts allow-same-origin"
+              src="https://www.test.bbc.com/ws/av-embeds/cps/pidgin/123456789/p01k6msp/en-GB/amp"
+              title="Media player"
+            >
+              <amp-img
+                alt=""
+                attribution=""
+                height="16"
+                layout="fill"
+                placeholder="true"
+                src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+                srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+                width="9"
+              />
+            </amp-iframe>
+          </div>
+        </figure>
       </div>
     </div>
   </body>
@@ -90,6 +100,12 @@ exports[`MediaPlayer render the amp player 1`] = `
 
 exports[`MediaPlayer render the canonical player without a placeholder 1`] = `
 .c1 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c2 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -99,7 +115,7 @@ exports[`MediaPlayer render the canonical player without a placeholder 1`] = `
   margin-bottom: 1.5rem;
 }
 
-.c2 {
+.c3 {
   position: absolute;
   top: 0;
   left: 0;
@@ -152,17 +168,21 @@ exports[`MediaPlayer render the canonical player without a placeholder 1`] = `
       <div
         class="c0"
       >
-        <div
+        <figure
           class="c1"
         >
-          <iframe
-            allow="autoplay; fullscreen"
-            allowfullscreen=""
+          <div
             class="c2"
-            src="https://www.test.bbc.com/ws/av-embeds/cps/pidgin/123456789/p01k6msp/en-GB"
-            title="Media player"
-          />
-        </div>
+          >
+            <iframe
+              allow="autoplay; fullscreen"
+              allowfullscreen=""
+              class="c3"
+              src="https://www.test.bbc.com/ws/av-embeds/cps/pidgin/123456789/p01k6msp/en-GB"
+              title="Media player"
+            />
+          </div>
+        </figure>
       </div>
     </div>
   </body>

--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -18,11 +18,11 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   grid-column-gap: 1rem;
 }
 
-.c8 {
+.c9 {
   grid-column: 1 / span 6;
 }
 
-.c7 {
+.c8 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -34,7 +34,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   padding: 2rem 0;
 }
 
-.c11 {
+.c12 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: italic;
@@ -42,7 +42,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   font-weight: inherit;
 }
 
-.c9 {
+.c10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -53,11 +53,11 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   padding-bottom: 0.25rem;
 }
 
-.c9:last-child {
+.c10:last-child {
   padding-bottom: 1rem;
 }
 
-.c10 {
+.c11 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -68,25 +68,25 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   margin: 0;
 }
 
-.c12 {
+.c13 {
   color: #222222;
   border-bottom: 1px solid #B80000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12:visited {
+.c13:visited {
   color: #6E6E73;
   border-bottom: 1px solid #6E6E73;
 }
 
-.c12:focus,
-.c12:hover {
+.c13:focus,
+.c13:hover {
   border-bottom: 2px solid #B80000;
   color: #B80000;
 }
 
-.c14 {
+.c4 {
   margin: 0;
   padding-bottom: 1.5rem;
   width: 100%;
@@ -131,7 +131,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
 }
 
-.c4 {
+.c5 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -141,7 +141,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
   margin-bottom: 1.5rem;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   top: 0;
   left: 0;
@@ -231,49 +231,49 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
 }
 
 @media (max-width:63rem) {
-  .c6 {
+  .c7 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c6 {
+  .c7 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c6 {
+  .c7 {
     padding: 0 1rem;
   }
 }
 
 @media (max-width:63rem) {
-  .c13 {
+  .c14 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c13 {
+  .c14 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c13 {
+  .c14 {
     grid-column: 6 / span 12;
   }
 }
@@ -339,87 +339,87 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
 }
 
 @media (max-width:25rem) {
-  .c8 {
+  .c9 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c8 {
+  .c9 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c8 {
+  .c9 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c8 {
+  .c9 {
     grid-column: 2 / span 4;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c9 {
     max-width: initial;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
+  .c8 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
+  .c10 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c10 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c10 {
+  .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -479,39 +479,43 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
     <div
       class="c3"
     >
-      <div
+      <figure
         class="c4"
       >
-        <iframe
-          allow="autoplay; fullscreen"
-          allowfullscreen=""
+        <div
           class="c5"
-          src="https://www.test.bbc.co.uk/ws/av-embeds/cps/uzbek/sport-23248721/bbc_world_service_west_africa/ig"
-          title="Media player"
-        />
-      </div>
+        >
+          <iframe
+            allow="autoplay; fullscreen"
+            allowfullscreen=""
+            class="c6"
+            src="https://www.test.bbc.co.uk/ws/av-embeds/cps/uzbek/sport-23248721/bbc_world_service_west_africa/ig"
+            title="Media player"
+          />
+        </div>
+      </figure>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <strong
         aria-hidden="true"
-        class="c7"
+        class="c8"
       >
         Ўзбек деҳқонининг косаси нега оқармайдиshort
       </strong>
     </div>
     <div
-      class="c8"
+      class="c9"
     >
       <time
-        class="c9"
+        class="c10"
         datetime="2019-09-13"
       >
         13 Septemba 2019
       </time>
       <time
-        class="c9"
+        class="c10"
         datetime="2019-11-06"
       >
         Mgbe ikpeazụ e tinyere ya ozi ọhụrụ 6 Nọvemba 2019
@@ -521,7 +525,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         <b>
           Ўзбек деҳқонининг косаси нега оқармайди
@@ -532,7 +536,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         <b>
           Ўзбек деҳқонининг косаси нега оқармайди
@@ -546,17 +550,17 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         <i
-          class="c11"
+          class="c12"
         >
           <b>
             Ўзбек деҳқонининг косаси нега оқармайди
           </b>
         </i>
         <i
-          class="c11"
+          class="c12"
         >
           <b>
              heading
@@ -568,7 +572,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         <b>
           Ўзбек деҳқонининг косаси нега оқармайди
@@ -582,11 +586,11 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Шу йил апрел ойида Ўзбекистон Президенти Ислом 
         <a
-          class="c12"
+          class="c13"
           href="https://bbc.com/uzbek"
         >
           Каримов ўзининг
@@ -598,7 +602,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Шу вақтгача ҳам ўзбекистонлик деҳқонлар ўз маҳсулотларини хорижга олиб 
         <b>
@@ -611,7 +615,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Ўз мева-сабзавотини Россияга олиб чиқишда бу компания ёрдамига умид қилган боғбонларнинг гилослари бузила бошлагани ҳақидаги хабарлар ҳам тарқалди..
       </p>
@@ -620,7 +624,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Ҳозирда Ўзбекистонда айни пишиқчилик ва етиштирилган маҳсулот учун кенгроқ бозор топиш масаласи яна долзарб турар экан, мамлакат раҳбарининг сўзларидан сўнг вазият нақадар ўзгарган?
       </p>
@@ -629,7 +633,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Би-би-си билан суҳбатда иқтисодий таҳлилчи Анвар Ҳусаиновнинг айтишича, юқори минбардан айтилган сўзларга қарамай, қишлоқ хўжалиги маҳсулотларини хорижга, жумладан Россия бозорига олиб чиқишда ҳануз кўплаб муаммолар мавжуд.
       </p>
@@ -638,16 +642,16 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         "Албатта ўтган йилларга қараганда маҳсулотлар экспорти анча кўпайган. Россиядан юк машиналари келиб, тўғридан-тўғри деҳқонлардан нақд пулга 
       </p>
     </div>
     <div
-      class="c13"
+      class="c14"
     >
       <figure
-        class="c14"
+        class="c4"
       >
         <div
           class="c15"
@@ -689,7 +693,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Ўзбек деҳқонининг косаси нега оқармайди transmission info 
       </p>
@@ -698,7 +702,7 @@ exports[`CpsAssetPageMain should correctly handle live streams 1`] = `
       class="c1"
     >
       <p
-        class="c10"
+        class="c11"
       >
         Ўзбек деҳқонининг косаси нега оқармайди footer 
       </p>
@@ -933,11 +937,11 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   grid-column: 1 / span 6;
 }
 
-.c8 {
+.c9 {
   grid-column: 1 / span 6;
 }
 
-.c7 {
+.c8 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -949,7 +953,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding: 2rem 0;
 }
 
-.c9 {
+.c10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -960,11 +964,11 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 0.25rem;
 }
 
-.c9:last-child {
+.c10:last-child {
   padding-bottom: 1rem;
 }
 
-.c29 {
+.c30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -974,7 +978,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   font-style: normal;
 }
 
-.c10 {
+.c11 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -983,6 +987,12 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   color: #3F3F42;
   padding-bottom: 1.5rem;
   margin: 0;
+}
+
+.c4 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
 }
 
 .c2 {
@@ -997,7 +1007,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   margin: 0;
 }
 
-.c23 {
+.c24 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -1010,7 +1020,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
 }
 
-.c4 {
+.c5 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -1020,7 +1030,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   margin-bottom: 1.5rem;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1030,7 +1040,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   flex-direction: column;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1049,7 +1059,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   align-items: baseline;
 }
 
-.c17 {
+.c18 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1069,57 +1079,57 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   align-items: center;
 }
 
-.c13 {
+.c14 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c12 {
+.c13 {
   position: relative;
   margin-top: 2rem;
 }
 
-.c14 {
-  margin: 0;
-  padding: 0;
-}
-
-.c19 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c19:first-child {
-  padding-top: 0;
-}
-
-.c19:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c18 {
-  list-style-type: none;
+.c15 {
   margin: 0;
   padding: 0;
 }
 
 .c20 {
-  position: relative;
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c20:first-child {
+  padding-top: 0;
+}
+
+.c20:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c19 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
 }
 
 .c21 {
+  position: relative;
+}
+
+.c22 {
   display: inline-block;
   vertical-align: top;
   position: relative;
   width: 33.33%;
 }
 
-.c22 {
+.c23 {
   position: relative;
 }
 
-.c26 {
+.c27 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1130,7 +1140,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c28 {
+.c29 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1141,21 +1151,21 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   padding-bottom: 0.5rem;
 }
 
-.c25 {
+.c26 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c27 {
+.c28 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c27:before {
+.c28:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1167,21 +1177,21 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
   z-index: 1;
 }
 
-.c27:hover,
-.c27:focus {
+.c28:hover,
+.c28:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c27:visited {
+.c28:visited {
   color: #6E6E73;
 }
 
-.c11 {
+.c12 {
   z-index: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   top: 0;
   left: 0;
@@ -1271,131 +1281,131 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (max-width:63rem) {
-  .c6 {
+  .c7 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c6 {
+  .c7 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c6 {
+  .c7 {
     padding: 0 1rem;
   }
 }
 
 @media (max-width:25rem) {
-  .c8 {
+  .c9 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c8 {
+  .c9 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     grid-column: 1 / span 5;
     max-width: 83.33%;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c8 {
+  .c9 {
     grid-column: 3 / span 5;
     max-width: 37.75rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c8 {
+  .c9 {
     grid-column: 2 / span 4;
     max-width: 38.5rem;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c9 {
     max-width: initial;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
+  .c8 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c9 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c9 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c29 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c10 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c10 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c30 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c30 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -1432,7 +1442,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c16 {
+  .c17 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1441,39 +1451,39 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c18 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c13 {
+  .c14 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c14 {
     position: absolute;
     left: 0;
     right: 0;
@@ -1482,37 +1492,37 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
+  .c13 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c20 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c19 {
+  .c20 {
     padding: 1.5rem 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19:first-child {
+  .c20:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c19:first-child {
+  .c20:first-child {
     padding-top: 1.5rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c20 {
+  .c21 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
     grid-column-gap: 0.5rem;
@@ -1520,13 +1530,13 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:80rem) {
-  .c21 {
+  .c22 {
     width: 33.33%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c21 {
+  .c22 {
     display: block;
     width: initial;
     grid-column: 1 / span 2;
@@ -1534,68 +1544,68 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (min-width:25rem) {
-  .c24 {
+  .c25 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c28 {
+  .c29 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c28 {
+  .c29 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c28 {
+  .c29 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c25 {
+  .c26 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c25 {
+  .c26 {
     width: 66.67%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c25 {
+  .c26 {
     display: block;
     width: initial;
     padding: initial;
@@ -1604,31 +1614,31 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
 }
 
 @media (max-width:63rem) {
-  .c11 {
+  .c12 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c11 {
+  .c12 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c11 {
+  .c12 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c11 {
+  .c12 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c11 {
+  .c12 {
     padding: 0 1rem;
   }
 }
@@ -1659,39 +1669,43 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
         <div
           class="c3"
         >
-          <div
+          <figure
             class="c4"
           >
-            <iframe
-              allow="autoplay; fullscreen"
-              allowfullscreen=""
+            <div
               class="c5"
-              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
-              title="Media player"
-            />
-          </div>
+            >
+              <iframe
+                allow="autoplay; fullscreen"
+                allowfullscreen=""
+                class="c6"
+                src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
+                title="Media player"
+              />
+            </div>
+          </figure>
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           <strong
             aria-hidden="true"
-            class="c7"
+            class="c8"
           >
             Nigerian man Emeka Nelson don produce generator wey dey use only water
           </strong>
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <time
-            class="c9"
+            class="c10"
             datetime="2019-08-23"
           >
             23 Ọgọọst 2019
           </time>
           <time
-            class="c9"
+            class="c10"
             datetime="2019-08-23"
           >
             Mgbe ikpeazụ e tinyere ya ozi ọhụrụ 
@@ -1702,7 +1716,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             <b>
               As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
@@ -1713,7 +1727,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Wetin ginger Emeka na im friend wey smoke from generator kill.
           </p>
@@ -1722,7 +1736,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
           </p>
@@ -1731,7 +1745,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
           </p>
@@ -1740,7 +1754,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
           </p>
@@ -1749,7 +1763,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
           </p>
@@ -1758,7 +1772,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Most of di material wey Nelson take arrange im generator na from  scrap.
           </p>
@@ -1767,7 +1781,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
           </p>
@@ -1776,7 +1790,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
           </p>
@@ -1785,7 +1799,7 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
           </p>
@@ -1794,32 +1808,32 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
           class="c1"
         >
           <p
-            class="c10"
+            class="c11"
           >
             Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
           </p>
         </div>
         <div
           aria-labelledby="related-content-heading"
-          class="c11"
+          class="c12"
         >
           <div
-            class="c12"
+            class="c13"
           >
             <div
-              class="c13"
+              class="c14"
             />
             <h2
-              class="c14"
+              class="c15"
             >
               <div
-                class="c15"
+                class="c16"
               >
                 <span
-                  class="c16"
+                  class="c17"
                 >
                   <span
-                    class="c17"
+                    class="c18"
                     dir="ltr"
                     id="related-content-heading"
                   >
@@ -1830,42 +1844,42 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
             </h2>
           </div>
           <ul
-            class="c18"
+            class="c19"
             role="list"
           >
             <li
-              class="c19"
+              class="c20"
               role="listitem"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
-                    class="c22"
+                    class="c23"
                   >
                     <div
-                      class="c23"
+                      class="c24"
                     >
                       <div
                         class="lazyload-placeholder"
                       />
                     </div>
                     <div
-                      class="c24"
+                      class="c25"
                     />
                   </div>
                 </div>
                 <div
-                  class="c25"
+                  class="c26"
                 >
                   <h3
-                    class="c26"
+                    class="c27"
                   >
                     <a
-                      class="c27"
+                      class="c28"
                       href="/pidgin/44508901"
                     >
                       <span
@@ -1883,12 +1897,12 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
                     </a>
                   </h3>
                   <p
-                    class="c28"
+                    class="c29"
                   >
                     James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
                   </p>
                   <time
-                    class="c29"
+                    class="c30"
                     datetime="1970-01-18"
                   >
                     18 Jenụwarị 1970
@@ -1897,50 +1911,50 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
               </div>
             </li>
             <li
-              class="c19"
+              class="c20"
               role="listitem"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
-                    class="c22"
+                    class="c23"
                   >
                     <div
-                      class="c23"
+                      class="c24"
                     >
                       <div
                         class="lazyload-placeholder"
                       />
                     </div>
                     <div
-                      class="c24"
+                      class="c25"
                     />
                   </div>
                 </div>
                 <div
-                  class="c25"
+                  class="c26"
                 >
                   <h3
-                    class="c26"
+                    class="c27"
                   >
                     <a
-                      class="c27"
+                      class="c28"
                       href="/pidgin/tori-46975713"
                     >
                       How light companies dey use estimated billing show Nigerians pepper
                     </a>
                   </h3>
                   <p
-                    class="c28"
+                    class="c29"
                   >
                     Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
                   </p>
                   <time
-                    class="c29"
+                    class="c30"
                     datetime="1970-01-18"
                   >
                     18 Jenụwarị 1970
@@ -1949,50 +1963,50 @@ exports[`CpsAssetPageMain should match snapshot for MAP 1`] = `
               </div>
             </li>
             <li
-              class="c19"
+              class="c20"
               role="listitem"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
-                    class="c22"
+                    class="c23"
                   >
                     <div
-                      class="c23"
+                      class="c24"
                     >
                       <div
                         class="lazyload-placeholder"
                       />
                     </div>
                     <div
-                      class="c24"
+                      class="c25"
                     />
                   </div>
                 </div>
                 <div
-                  class="c25"
+                  class="c26"
                 >
                   <h3
-                    class="c26"
+                    class="c27"
                   >
                     <a
-                      class="c27"
+                      class="c28"
                       href="/pidgin/tori-42494678"
                     >
                       Nigeria: Wetin 5,222 megawatts electric fit do?
                     </a>
                   </h3>
                   <p
-                    class="c28"
+                    class="c29"
                   >
                     Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
                   </p>
                   <time
-                    class="c29"
+                    class="c30"
                     datetime="1970-01-18"
                   >
                     18 Jenụwarị 1970
@@ -3189,17 +3203,21 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
         <div
           class="c19"
         >
-          <div
-            class="c20"
+          <figure
+            class="c5"
           >
-            <iframe
-              allow="autoplay; fullscreen"
-              allowfullscreen=""
-              class="c21"
-              src="https://www.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/ig"
-              title="Media player"
-            />
-          </div>
+            <div
+              class="c20"
+            >
+              <iframe
+                allow="autoplay; fullscreen"
+                allowfullscreen=""
+                class="c21"
+                src="https://www.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/ig"
+                title="Media player"
+              />
+            </div>
+          </figure>
         </div>
         <div
           class="c1"
@@ -3330,7 +3348,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   grid-column: 1 / span 6;
 }
 
-.c7 {
+.c8 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3342,7 +3360,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   padding: 2rem 0;
 }
 
-.c27 {
+.c28 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -3352,7 +3370,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   font-style: normal;
 }
 
-.c8 {
+.c9 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3361,6 +3379,12 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   color: #3F3F42;
   padding-bottom: 1.5rem;
   margin: 0;
+}
+
+.c4 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
 }
 
 .c2 {
@@ -3375,7 +3399,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   margin: 0;
 }
 
-.c21 {
+.c22 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -3388,7 +3412,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
 }
 
-.c4 {
+.c5 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
@@ -3398,7 +3422,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   margin-bottom: 1.5rem;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3408,7 +3432,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   flex-direction: column;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3427,7 +3451,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   align-items: baseline;
 }
 
-.c15 {
+.c16 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3447,57 +3471,57 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   align-items: center;
 }
 
-.c11 {
+.c12 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c10 {
+.c11 {
   position: relative;
   margin-top: 2rem;
 }
 
-.c12 {
-  margin: 0;
-  padding: 0;
-}
-
-.c17 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c17:first-child {
-  padding-top: 0;
-}
-
-.c17:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c16 {
-  list-style-type: none;
+.c13 {
   margin: 0;
   padding: 0;
 }
 
 .c18 {
-  position: relative;
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c18:first-child {
+  padding-top: 0;
+}
+
+.c18:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c17 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
 }
 
 .c19 {
+  position: relative;
+}
+
+.c20 {
   display: inline-block;
   vertical-align: top;
   position: relative;
   width: 33.33%;
 }
 
-.c20 {
+.c21 {
   position: relative;
 }
 
-.c24 {
+.c25 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3508,7 +3532,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   padding-bottom: 0.5rem;
 }
 
-.c26 {
+.c27 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3519,21 +3543,21 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   padding-bottom: 0.5rem;
 }
 
-.c23 {
+.c24 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c25 {
+.c26 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c25:before {
+.c26:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -3545,21 +3569,21 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   z-index: 1;
 }
 
-.c25:hover,
-.c25:focus {
+.c26:hover,
+.c26:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c25:visited {
+.c26:visited {
   color: #6E6E73;
 }
 
-.c9 {
+.c10 {
   z-index: 0;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   top: 0;
   left: 0;
@@ -3649,78 +3673,78 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (max-width:63rem) {
-  .c6 {
+  .c7 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c6 {
+  .c7 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c6 {
+  .c7 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c6 {
+  .c7 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c7 {
+  .c8 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c7 {
+  .c8 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c27 {
+  .c28 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c27 {
+  .c28 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c8 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -3757,7 +3781,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c15 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3766,39 +3790,39 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c15 {
+  .c16 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c16 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c16 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c16 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c11 {
+  .c12 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c11 {
+  .c12 {
     position: absolute;
     left: 0;
     right: 0;
@@ -3807,37 +3831,37 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c11 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c17 {
+  .c18 {
     padding: 1.5rem 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17:first-child {
+  .c18:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c17:first-child {
+  .c18:first-child {
     padding-top: 1.5rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c18 {
+  .c19 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
     grid-column-gap: 0.5rem;
@@ -3845,13 +3869,13 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:80rem) {
-  .c19 {
+  .c20 {
     width: 33.33%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c19 {
+  .c20 {
     display: block;
     width: initial;
     grid-column: 1 / span 2;
@@ -3859,68 +3883,68 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:25rem) {
-  .c22 {
+  .c23 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
+  .c25 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c24 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c23 {
+  .c24 {
     width: 66.67%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c23 {
+  .c24 {
     display: block;
     width: initial;
     padding: initial;
@@ -3929,31 +3953,31 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (max-width:63rem) {
-  .c9 {
+  .c10 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c9 {
+  .c10 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c9 {
+  .c10 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c9 {
+  .c10 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c9 {
+  .c10 {
     padding: 0 1rem;
   }
 }
@@ -3982,24 +4006,28 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
     <div
       class="c3"
     >
-      <div
+      <figure
         class="c4"
       >
-        <iframe
-          allow="autoplay; fullscreen"
-          allowfullscreen=""
+        <div
           class="c5"
-          src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
-          title="Media player"
-        />
-      </div>
+        >
+          <iframe
+            allow="autoplay; fullscreen"
+            allowfullscreen=""
+            class="c6"
+            src="https://www.test.bbc.co.uk/ws/av-embeds/cps/pidgin/tori-49450859/p07lg239/ig"
+            title="Media player"
+          />
+        </div>
+      </figure>
     </div>
     <div
-      class="c6"
+      class="c7"
     >
       <strong
         aria-hidden="true"
-        class="c7"
+        class="c8"
       >
         Nigerian man Emeka Nelson don produce generator wey dey use only water
       </strong>
@@ -4008,7 +4036,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         <b>
           As Nigeria authorities still dey try to find solution to light mata, e be like say 26-year old Emeka Nelson don find di solution afta im produce generator wey go dey run on water
@@ -4019,7 +4047,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Wetin ginger Emeka na im friend wey smoke from generator kill.
       </p>
@@ -4028,7 +4056,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         BBC carri waka go Awka Anambra state inside South-east Nigeria go see di ogbonge invention wey Nelson produce.
       </p>
@@ -4037,7 +4065,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Nelson wey no be certified engineer struggle to read for elementary school, work as house help for di age of 5, and no get any university education.
       </p>
@@ -4046,7 +4074,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Wen we go im house, e dey full with Structural drawings and designs wey e pin for wall and na so e dey take im time dey study di drawing.
       </p>
@@ -4055,7 +4083,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         For 16 years, e dey focus to make im dream turn to something real-dat na to make generator wey go run on water.
       </p>
@@ -4064,7 +4092,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Most of di material wey Nelson take arrange im generator na from  scrap.
       </p>
@@ -4073,7 +4101,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Di first generator wey im do explode wen e test am. Dis come make am dey doubt di project but afta plenti years of struggle e come get am right.
       </p>
@@ -4082,7 +4110,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Nelson says im generator get maximum output capacity of 1,000 watts and di voltage dey fluctuate between 220 and 240.
       </p>
@@ -4091,7 +4119,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         E say one litre of clean water fit power di generator for 6 hours, and e no go bring out smoke like oda generators, e dey environment friendly.
       </p>
@@ -4100,32 +4128,32 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
       class="c1"
     >
       <p
-        class="c8"
+        class="c9"
       >
         Dis ogbonge inventor add say im dream na for di generator to dey for millions of homes all ova di world.
       </p>
     </div>
     <div
       aria-labelledby="related-content-heading"
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         />
         <h2
-          class="c12"
+          class="c13"
         >
           <div
-            class="c13"
+            class="c14"
           >
             <span
-              class="c14"
+              class="c15"
             >
               <span
-                class="c15"
+                class="c16"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -4136,42 +4164,42 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
         </h2>
       </div>
       <ul
-        class="c16"
+        class="c17"
         role="list"
       >
         <li
-          class="c17"
+          class="c18"
           role="listitem"
         >
           <div
-            class="c18"
+            class="c19"
           >
             <div
-              class="c19"
+              class="c20"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c22"
+                  class="c23"
                 />
               </div>
             </div>
             <div
-              class="c23"
+              class="c24"
             >
               <h3
-                class="c24"
+                class="c25"
               >
                 <a
-                  class="c25"
+                  class="c26"
                   href="/pidgin/44508901"
                 >
                   <span
@@ -4189,12 +4217,12 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
                 </a>
               </h3>
               <p
-                class="c26"
+                class="c27"
               >
                 James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
               </p>
               <time
-                class="c27"
+                class="c28"
                 datetime="1970-01-18"
               >
                 18 Jenụwarị 1970
@@ -4203,50 +4231,50 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
           </div>
         </li>
         <li
-          class="c17"
+          class="c18"
           role="listitem"
         >
           <div
-            class="c18"
+            class="c19"
           >
             <div
-              class="c19"
+              class="c20"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c22"
+                  class="c23"
                 />
               </div>
             </div>
             <div
-              class="c23"
+              class="c24"
             >
               <h3
-                class="c24"
+                class="c25"
               >
                 <a
-                  class="c25"
+                  class="c26"
                   href="/pidgin/tori-46975713"
                 >
                   How light companies dey use estimated billing show Nigerians pepper
                 </a>
               </h3>
               <p
-                class="c26"
+                class="c27"
               >
                 Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
               </p>
               <time
-                class="c27"
+                class="c28"
                 datetime="1970-01-18"
               >
                 18 Jenụwarị 1970
@@ -4255,50 +4283,50 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
           </div>
         </li>
         <li
-          class="c17"
+          class="c18"
           role="listitem"
         >
           <div
-            class="c18"
+            class="c19"
           >
             <div
-              class="c19"
+              class="c20"
             >
               <div
-                class="c20"
+                class="c21"
               >
                 <div
-                  class="c21"
+                  class="c22"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c22"
+                  class="c23"
                 />
               </div>
             </div>
             <div
-              class="c23"
+              class="c24"
             >
               <h3
-                class="c24"
+                class="c25"
               >
                 <a
-                  class="c25"
+                  class="c26"
                   href="/pidgin/tori-42494678"
                 >
                   Nigeria: Wetin 5,222 megawatts electric fit do?
                 </a>
               </h3>
               <p
-                class="c26"
+                class="c27"
               >
                 Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
               </p>
               <time
-                class="c27"
+                class="c28"
                 datetime="1970-01-18"
               >
                 18 Jenụwarị 1970

--- a/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MediaPlayer/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MediaPlayer Calls the canonical placeholder when platform is canonical and showPlaceholder is true 1`] = `
-.c9 {
+.c10 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -10,13 +10,19 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   height: 0.75rem;
 }
 
-.c11 {
+.c0 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c12 {
   display: block;
   width: 100%;
   visibility: visible;
 }
 
-.c7 {
+.c8 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -28,7 +34,7 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   margin: 0;
 }
 
-.c5 {
+.c6 {
   background-color: #222222;
   border: none;
   color: #FFFFFF;
@@ -46,14 +52,14 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   width: 5rem;
 }
 
-.c5:hover,
-.c5:focus {
+.c6:hover,
+.c6:focus {
   background-color: #B80000;
   -webkit-transition: background-color 300ms;
   transition: background-color 300ms;
 }
 
-.c8 > svg {
+.c9 > svg {
   color: #FFFFFF;
   fill: currentColor;
   height: 1.5rem;
@@ -61,12 +67,12 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   width: 1.5rem;
 }
 
-.c10 {
+.c11 {
   display: block;
   margin-top: 0.5rem;
 }
 
-.c3 {
+.c4 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -80,11 +86,11 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   padding: 0.5rem;
 }
 
-.c4 {
+.c5 {
   font-weight: normal;
 }
 
-.c2 {
+.c3 {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -93,30 +99,30 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   height: 100%;
 }
 
-.c6 {
+.c7 {
   position: absolute;
   bottom: 0;
 }
 
-.c1:hover .c6,
-.c1:focus .c6 {
+.c2:hover .c7,
+.c2:focus .c7 {
   background-color: #B80000;
 }
 
-.c0 {
+.c1 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 0.875rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c3 {
+  .c4 {
     padding: 1rem;
   }
 }
@@ -131,61 +137,65 @@ exports[`MediaPlayer Calls the canonical placeholder when platform is canonical 
   </head>
   <body>
     <div>
-      <div
+      <figure
         class="c0"
       >
         <div
-          class="c1 c2"
+          class="c1"
         >
           <div
-            class="c3"
+            class="c2 c3"
           >
-            <strong
+            <div
               class="c4"
             >
-              Contains strong language and adult humour.
-            </strong>
-          </div>
-          <button
-            class="c5 c6"
-          >
-            <span
-              class="c7"
-            >
-              Play video, "Five things ants can teach us about management", 3,11
-            </span>
-            <div
-              aria-hidden="true"
-              class="c8"
-            >
-              <svg
-                class="c9"
-                focusable="false"
-                height="12px"
-                viewBox="0 0 32 32"
-                width="12px"
+              <strong
+                class="c5"
               >
-                <polygon
-                  points="3,32 29,16 3,0"
-                />
-              </svg>
+                Contains strong language and adult humour.
+              </strong>
             </div>
-            <time
-              aria-hidden="true"
-              class="c10"
-              datetime="PT3M11S"
+            <button
+              class="c6 c7"
             >
-              3:11
-            </time>
-          </button>
-          <img
-            alt=""
-            class="c11"
-            src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-            srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-          />
+              <span
+                class="c8"
+              >
+                Play video, "Five things ants can teach us about management", 3,11
+              </span>
+              <div
+                aria-hidden="true"
+                class="c9"
+              >
+                <svg
+                  class="c10"
+                  focusable="false"
+                  height="12px"
+                  viewBox="0 0 32 32"
+                  width="12px"
+                >
+                  <polygon
+                    points="3,32 29,16 3,0"
+                  />
+                </svg>
+              </div>
+              <time
+                aria-hidden="true"
+                class="c11"
+                datetime="PT3M11S"
+              >
+                3:11
+              </time>
+            </button>
+            <img
+              alt=""
+              class="c12"
+              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+            />
+          </div>
         </div>
-      </div>
+      </figure>
     </div>
   </body>
 </html>
@@ -202,12 +212,18 @@ exports[`MediaPlayer Does not Call the canonical placeholder when platform is ca
   </head>
   <body>
     .c0 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c1 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c1 {
+.c2 {
   position: absolute;
   top: 0;
   left: 0;
@@ -218,17 +234,21 @@ exports[`MediaPlayer Does not Call the canonical placeholder when platform is ca
 }
 
 <div>
-      <div
+      <figure
         class="c0"
       >
-        <iframe
-          allow="autoplay; fullscreen"
-          allowfullscreen=""
+        <div
           class="c1"
-          src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB"
-          title="Media player"
-        />
-      </div>
+        >
+          <iframe
+            allow="autoplay; fullscreen"
+            allowfullscreen=""
+            class="c2"
+            src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB"
+            title="Media player"
+          />
+        </div>
+      </figure>
     </div>
   </body>
 </html>
@@ -250,35 +270,45 @@ exports[`MediaPlayer Renders the AMP player when platform is AMP 1`] = `
   </head>
   <body>
     .c0 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c1 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
 <div>
-      <div
+      <figure
         class="c0"
       >
-        <amp-iframe
-          allowfullscreen="allowfullscreen"
-          frameborder="0"
-          layout="fill"
-          sandbox="allow-scripts allow-same-origin"
-          src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB/amp"
-          title="Media player"
+        <div
+          class="c1"
         >
-          <amp-img
-            alt=""
-            attribution=""
-            height="16"
+          <amp-iframe
+            allowfullscreen="allowfullscreen"
+            frameborder="0"
             layout="fill"
-            placeholder="true"
-            src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-            srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-            width="9"
-          />
-        </amp-iframe>
-      </div>
+            sandbox="allow-scripts allow-same-origin"
+            src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB/amp"
+            title="Media player"
+          >
+            <amp-img
+              alt=""
+              attribution=""
+              height="16"
+              layout="fill"
+              placeholder="true"
+              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+              width="9"
+            />
+          </amp-iframe>
+        </div>
+      </figure>
     </div>
   </body>
 </html>
@@ -299,7 +329,13 @@ exports[`MediaPlayer Renders the AMP player with a caption 1`] = `
     />
   </head>
   <body>
-    .c2 {
+    .c0 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c3 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -311,13 +347,13 @@ exports[`MediaPlayer Renders the AMP player with a caption 1`] = `
   margin: 0;
 }
 
-.c0 {
+.c1 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c1 {
+.c2 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -328,81 +364,85 @@ exports[`MediaPlayer Renders the AMP player with a caption 1`] = `
   width: 100%;
 }
 
-.c1 > p {
+.c2 > p {
   padding-bottom: 1.5rem;
   margin: 0;
 }
 
-.c1 > p:last-child {
+.c2 > p:last-child {
   padding-bottom: 0;
 }
 
-.c1 i {
+.c2 i {
   font-style: normal;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c1 {
+  .c2 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c2 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c1 {
+  .c2 {
     padding: 0.5rem 1rem 0;
   }
 }
 
 @media (min-width:63rem) {
-  .c1 {
+  .c2 {
     padding: 0.5rem 0 0;
   }
 }
 
 <div>
-      <div
+      <figure
         class="c0"
       >
-        <amp-iframe
-          allowfullscreen="allowfullscreen"
-          frameborder="0"
-          layout="fill"
-          sandbox="allow-scripts allow-same-origin"
-          src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB/amp"
-          title="Media player"
+        <div
+          class="c1"
         >
-          <amp-img
-            alt=""
-            attribution=""
-            height="16"
+          <amp-iframe
+            allowfullscreen="allowfullscreen"
+            frameborder="0"
             layout="fill"
-            placeholder="true"
-            src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-            srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-            width="9"
-          />
-        </amp-iframe>
-      </div>
-      <figcaption
-        class="c1"
-      >
-        <span
+            sandbox="allow-scripts allow-same-origin"
+            src="https://www.test.bbc.com/ws/av-embeds/articles/c123456789o/p01k6msp/en-GB/amp"
+            title="Media player"
+          >
+            <amp-img
+              alt=""
+              attribution=""
+              height="16"
+              layout="fill"
+              placeholder="true"
+              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+              width="9"
+            />
+          </amp-iframe>
+        </div>
+        <figcaption
           class="c2"
         >
-          Video caption, 
-        </span>
-        <p>
-          Media Player With Caption
-        </p>
-      </figcaption>
+          <span
+            class="c3"
+          >
+            Video caption, 
+          </span>
+          <p>
+            Media Player With Caption
+          </p>
+        </figcaption>
+      </figure>
     </div>
   </body>
 </html>
@@ -418,7 +458,7 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
     </script>
   </head>
   <body>
-    .c9 {
+    .c10 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -427,13 +467,19 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   height: 0.75rem;
 }
 
-.c11 {
+.c0 {
+  margin: 0;
+  padding-bottom: 1.5rem;
+  width: 100%;
+}
+
+.c12 {
   display: block;
   width: 100%;
   visibility: visible;
 }
 
-.c7 {
+.c8 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -445,7 +491,7 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   margin: 0;
 }
 
-.c5 {
+.c6 {
   background-color: #222222;
   border: none;
   color: #FFFFFF;
@@ -463,14 +509,14 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   width: 5rem;
 }
 
-.c5:hover,
-.c5:focus {
+.c6:hover,
+.c6:focus {
   background-color: #B80000;
   -webkit-transition: background-color 300ms;
   transition: background-color 300ms;
 }
 
-.c8 > svg {
+.c9 > svg {
   color: #FFFFFF;
   fill: currentColor;
   height: 1.5rem;
@@ -478,12 +524,12 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   width: 1.5rem;
 }
 
-.c10 {
+.c11 {
   display: block;
   margin-top: 0.5rem;
 }
 
-.c3 {
+.c4 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -497,11 +543,11 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   padding: 0.5rem;
 }
 
-.c4 {
+.c5 {
   font-weight: normal;
 }
 
-.c2 {
+.c3 {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -510,23 +556,23 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   height: 100%;
 }
 
-.c6 {
+.c7 {
   position: absolute;
   bottom: 0;
 }
 
-.c1:hover .c6,
-.c1:focus .c6 {
+.c2:hover .c7,
+.c2:focus .c7 {
   background-color: #B80000;
 }
 
-.c0 {
+.c1 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c12 {
+.c13 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -537,125 +583,129 @@ exports[`MediaPlayer Renders the canonical player with a caption 1`] = `
   width: 100%;
 }
 
-.c12 > p {
+.c13 > p {
   padding-bottom: 1.5rem;
   margin: 0;
 }
 
-.c12 > p:last-child {
+.c13 > p:last-child {
   padding-bottom: 0;
 }
 
-.c12 i {
+.c13 i {
   font-style: normal;
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 0.875rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c3 {
+  .c4 {
     padding: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c13 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
+  .c13 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c12 {
+  .c13 {
     padding: 0.5rem 1rem 0;
   }
 }
 
 @media (min-width:63rem) {
-  .c12 {
+  .c13 {
     padding: 0.5rem 0 0;
   }
 }
 
 <div>
-      <div
+      <figure
         class="c0"
       >
         <div
-          class="c1 c2"
+          class="c1"
         >
           <div
-            class="c3"
+            class="c2 c3"
           >
-            <strong
+            <div
               class="c4"
             >
-              Contains strong language and adult humour.
-            </strong>
-          </div>
-          <button
-            class="c5 c6"
-          >
-            <span
-              class="c7"
-            >
-              Play video, "Five things ants can teach us about management", 3,11
-            </span>
-            <div
-              aria-hidden="true"
-              class="c8"
-            >
-              <svg
-                class="c9"
-                focusable="false"
-                height="12px"
-                viewBox="0 0 32 32"
-                width="12px"
+              <strong
+                class="c5"
               >
-                <polygon
-                  points="3,32 29,16 3,0"
-                />
-              </svg>
+                Contains strong language and adult humour.
+              </strong>
             </div>
-            <time
-              aria-hidden="true"
-              class="c10"
-              datetime="PT3M11S"
+            <button
+              class="c6 c7"
             >
-              3:11
-            </time>
-          </button>
-          <img
-            alt=""
-            class="c11"
-            src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
-            srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
-          />
+              <span
+                class="c8"
+              >
+                Play video, "Five things ants can teach us about management", 3,11
+              </span>
+              <div
+                aria-hidden="true"
+                class="c9"
+              >
+                <svg
+                  class="c10"
+                  focusable="false"
+                  height="12px"
+                  viewBox="0 0 32 32"
+                  width="12px"
+                >
+                  <polygon
+                    points="3,32 29,16 3,0"
+                  />
+                </svg>
+              </div>
+              <time
+                aria-hidden="true"
+                class="c11"
+                datetime="PT3M11S"
+              >
+                3:11
+              </time>
+            </button>
+            <img
+              alt=""
+              class="c12"
+              src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01k6mtv.jpg"
+              srcset="https://ichef.test.bbci.co.uk/images/ic/240xn/p01k6mtv.jpg 240w, https://ichef.test.bbci.co.uk/images/ic/320xn/p01k6mtv.jpg 320w, https://ichef.test.bbci.co.uk/images/ic/480xn/p01k6mtv.jpg 480w, https://ichef.test.bbci.co.uk/images/ic/624xn/p01k6mtv.jpg 624w, https://ichef.test.bbci.co.uk/images/ic/800xn/p01k6mtv.jpg 800w"
+            />
+          </div>
         </div>
-      </div>
-      <figcaption
-        class="c12"
-      >
-        <span
-          class="c7"
+        <figcaption
+          class="c13"
         >
-          Video caption, 
-        </span>
-        <p>
-          Media Player With Caption
-        </p>
-      </figcaption>
+          <span
+            class="c8"
+          >
+            Video caption, 
+          </span>
+          <p>
+            Media Player With Caption
+          </p>
+        </figcaption>
+      </figure>
     </div>
   </body>
 </html>

--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -3,6 +3,7 @@ import { string, bool } from 'prop-types';
 import moment from 'moment-timezone';
 import pathOr from 'ramda/src/pathOr';
 import path from 'ramda/src/path';
+import Figure from '@bbc/psammead-figure';
 import {
   CanonicalMediaPlayer,
   AmpMediaPlayer,
@@ -103,25 +104,27 @@ const MediaPlayerContainer = ({
   return (
     <>
       <Metadata aresMediaBlock={aresMediaBlock} />
-      {isAmp ? (
-        <AmpMediaPlayer
-          src={embedSource}
-          placeholderSrc={placeholderSrc}
-          placeholderSrcset={placeholderSrcset}
-          title={iframeTitle}
-        />
-      ) : (
-        <CanonicalMediaPlayer
-          src={embedSource}
-          placeholderSrc={showPlaceholder ? placeholderSrc : null}
-          placeholderSrcset={placeholderSrcset}
-          showPlaceholder={showPlaceholder}
-          title={iframeTitle}
-          service={service}
-          mediaInfo={mediaInfo}
-        />
-      )}
-      {captionBlock && <Caption block={captionBlock} type={mediaInfo.type} />}
+      <Figure>
+        {isAmp ? (
+          <AmpMediaPlayer
+            src={embedSource}
+            placeholderSrc={placeholderSrc}
+            placeholderSrcset={placeholderSrcset}
+            title={iframeTitle}
+          />
+        ) : (
+          <CanonicalMediaPlayer
+            src={embedSource}
+            placeholderSrc={showPlaceholder ? placeholderSrc : null}
+            placeholderSrcset={placeholderSrcset}
+            showPlaceholder={showPlaceholder}
+            title={iframeTitle}
+            service={service}
+            mediaInfo={mediaInfo}
+          />
+        )}
+        {captionBlock && <Caption block={captionBlock} type={mediaInfo.type} />}
+      </Figure>
     </>
   );
 };


### PR DESCRIPTION
Signed-off-by: RayNjeri <rachael.njeri@andela.com>

Resolves #4647 &&  #4239 and addresses this revert #4682

**Overall change:** _Adds figure HTML to media player._

**Code changes:**

- _Adds @psammead-figure to amp and canonical media player._
- _Adds padding to the bottom of media player_(Test article for padding: **cjn0qpz3jjvo**)
- _Updated snapshots._
- Have a fix to check if mediaPlayer is enabled on live or not in e2e based on this revert #4682


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
