### PR TITLE
Disable frontPage tests for naidheachdan and cymrufyw

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -295,13 +295,7 @@ const services = {
             : '/cymrufyw/erthyglau/c123456abcdo',
         smoke: false,
       },
-      frontPage: {
-        path:
-          Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
-            ? undefined
-            : '/cymrufyw',
-        smoke: false,
-      },
+      frontPage: {},
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: { path: undefined, smoke: false },
     },
@@ -735,10 +729,7 @@ const services = {
             : '/naidheachdan/sgeulachdan/c123456abcdo',
         smoke: false,
       },
-      frontPage: {
-        path: Cypress.env('APP_ENV') === 'live' ? undefined : '/naidheachdan',
-        smoke: false,
-      },
+      frontPage: {},
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: { path: undefined, smoke: false },
     },


### PR DESCRIPTION
[no issue]

**Overall change:** _Disables the frontPage tests for the Welsh and Scottish language sites_

The e2e tests for `/naidheachdan` are failing due to 404ing images in the CPS test data. As it has been recently decided these sites will be rendered by WebCore it is not worth the effort to debug and support these tests. Other leftover code will be removed separately.

**Code changes:**

- Remove relevant Cypress config

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
