### PR TITLE
patches handles @4.5.3 to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9384,9 +9384,9 @@
           }
         },
         "execa": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
-          "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.3.0.tgz",
+          "integrity": "sha512-j5Vit5WZR/cbHlqU97+qcnw9WHRCIL4V1SVe75VcHcD1JRBdt8fv0zw89b7CQHQdUHTt2VjuhcF5ibAgVOxqpg==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -9463,9 +9463,9 @@
           "dev": true
         },
         "which": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -10715,9 +10715,9 @@
       "dev": true
     },
     "fake-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-1.0.0.tgz",
-      "integrity": "sha512-o6qVT71RflbTdY8zr4e+pCdLrdJUpCnSl2pOjqvnCObqsAfFwNzalzlmmEz2NneiYkiY7qWF7z6vIcRf9Pl7yA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-1.0.1.tgz",
+      "integrity": "sha512-qmewZoBpa71mM+y6oxXYW/d1xOYQmeIvnEXAt1oCmdP0sqcogWYLepR87QL1jQVLSVMVYDq2cjY6ec/Wu8/4pg==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -11637,7 +11637,7 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.2",
+      "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
       "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
@@ -13308,7 +13308,7 @@
       "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "handlebars": "^4.5.3"
       }
     },
     "jalaali-js": {
@@ -18582,6 +18582,11 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-adaptive-hooks": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/react-adaptive-hooks/-/react-adaptive-hooks-0.0.5.tgz",
+      "integrity": "sha512-voZSslyRG5qBJJka4lGivlEB+q8+1fjxmqznOq8K/+/LDlAu2bKx7NvihX85WdUhw3kOkQm6/oO7Ec0lHUutFg=="
+    },
     "react-clientside-effect": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
@@ -21094,9 +21099,9 @@
           "dev": true
         },
         "which": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"


### PR DESCRIPTION
Resolves N/A

**Overall change:**

Sets handlebars to version 4.5.3 where the prototype-polution security vuln has been patched - see [npm advisory](https://www.npmjs.com/advisories/1325)

The bad version of handlebars is pulled in via jest and storybook-chromatic. We are up to date on both of these dependancies, so until they release a patched version we will need to patch handlebars manually

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
