### PR TITLE
added `withVariant` documentation block

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,19 @@ This process is repeated for each block within an article, ultimately rendering 
 
 Each render is passed through a set of HOC's (Higher Order Components) to enhance the page, these HOC's are;
 
+- withVariant
 - withContexts
 - withPageWrapper
 - withLoading
 - withError
 - withData
+
+#### withVariant
+
+The variant HOC ensures that services that have variants (e.g. `simp`, `lat`) always redirects to a url that renders the appropriate variant.
+
+- If a user navigates to a url without providing the variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the default variant page is rendered
+- If a user navigates to a url with a variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the requested variant page is rendered.
 
 #### withContexts
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Each render is passed through a set of HOC's (Higher Order Components) to enhanc
 
 The variant HOC ensures that services that have variants (e.g. `simp`, `lat`) always redirects to a url that renders the appropriate variant.
 
-- If a user navigates to a url without providing the variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the default variant page is rendered
-- If a user navigates to a url with a variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the requested variant page is rendered.
+If a user navigates to a url without providing the variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the default variant page is rendered
+
+If a user navigates to a url with a variant, and variant is set in cookie, the cookie variant page is rendered. Otherwise, the requested variant page is rendered.
 
 #### withContexts
 


### PR DESCRIPTION
Resolves #4722

**Overall change:** _Added a documentation block for `withVariant` HOC._

**Code changes:**

- _Updated README.md ._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
