### PR TITLE
Remove Igbo, Pidgin, Yoruba MAPs from E2E test config

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -413,7 +413,8 @@ const genServices = appEnv => ({
       frontPage: { path: '/igbo', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/igbo/media-23256786',
+        path:
+          isLive(appEnv) || isTest(appEnv) ? undefined : '/igbo/media-23256786',
         smoke: false,
       },
     },
@@ -769,7 +770,7 @@ const genServices = appEnv => ({
       frontPage: { path: '/pidgin', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/pidgin/23248703',
+        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/pidgin/23248703',
         smoke: true,
       },
     },
@@ -1345,7 +1346,10 @@ const genServices = appEnv => ({
       frontPage: { path: '/yoruba', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/yoruba/media-23256797',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/yoruba/media-23256797',
         smoke: false,
       },
     },


### PR DESCRIPTION
Resolves No Ticket

**Overall change:** _Igbo, Pidgin and Yoruba maps are 404ing in the AMP test environment due to a mozart routing issue._

**Code changes:**

- _Disable these E2Es in TEST until the issue is resolved_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
