### PR TITLE
Revert running live e2es against ref obtained from server

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -2,7 +2,7 @@
 library 'Simorgh'
 
 // Run latest every 3 hours
-def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""
+def cron_string = env.BRANCH_NAME == "latest" ? "0 0,6,9,12,15,18,21 * * *" : ""
 
 node {
     properties(

--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -2,7 +2,7 @@
 library 'Simorgh'
 
 // Run latest every 3 hours
-def cron_string = env.BRANCH_NAME == "latest" ? "0 0,6,9,12,15,18,21 * * *" : ""
+def cron_string = env.BRANCH_NAME == "latest" ? "0 */3 * * *" : ""
 
 node {
     properties(
@@ -16,7 +16,7 @@ node {
             pipelineTriggers([cron(cron_string)]),
             parameters(
                 [
-                    string(defaultValue: '', name: 'BRANCH')
+                    string(defaultValue: 'latest', name: 'BRANCH')
                 ]
             )
         ]
@@ -27,14 +27,11 @@ node {
         ]) {
             cleanWs() // Clean the workspace
 
-            def hashToCheckout = params.BRANCH == '' ? Simorgh.getLiveCommitHash() : params.BRANCH
-
             docker.image(Simorgh.nodeDockerImage()).inside('--ipc host') {
                 try {
-                    Simorgh.checkout("${hashToCheckout}", 'simorgh')
+                    Simorgh.checkout("${params.BRANCH}", 'simorgh')
                     Simorgh.installNodeModules()
                     stage ('Live E2Es') {
-                        echo "e2e's running againt commit: ${hashToCheckout}"
                         Simorgh.runE2Es('live', false)
                     }
                 } finally {


### PR DESCRIPTION
[NOISSUE]

**Overall change:** _Do not use version of e2e tests matching live server as not working as expected._

Partial revert of https://github.com/bbc/simorgh/pull/4820 which is not working as expected:

1. The scheduled live e2e build quits after 15s apparently after being unable to check out simorgh properly
2. The job reports a SUCCESS notification to the Slack channel despite being red on Jenkins

**Code changes:**

- Revert code from live e2e Jenkinsfile

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [no] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
