### PR TITLE
Enable live e2es for bttajk

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -84,7 +84,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/amharic/articles/czqverekrldo',
+        path: isLive(appEnv)
+          ? '/amharic/articles/c0lgxqknqkdo'
+          : '/amharic/articles/czqverekrldo',
         smoke: false,
       },
       errorPage404: {
@@ -243,7 +245,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/burmese/articles/cn0exdy1jzvo',
+        path: isLive(appEnv)
+          ? '/burmese/articles/c41px3vd4nxo'
+          : '/burmese/articles/cn0exdy1jzvo',
         smoke: false,
       },
       errorPage404: {
@@ -493,7 +497,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/japanese/articles/cdd6p3r9g7jo',
+        path: isLive(appEnv)
+          ? '/japanese/articles/cj4m7n5nrd8o'
+          : '/japanese/articles/cdd6p3r9g7jo',
         smoke: false,
       },
       errorPage404: {
@@ -520,7 +526,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/korean/articles/c3mn1lvz65xo',
+        path: isLive(appEnv)
+          ? '/korean/articles/crym1243d97o'
+          : '/korean/articles/c3mn1lvz65xo',
         smoke: false,
       },
       errorPage404: {
@@ -1139,7 +1147,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/thai/articles/c442rl3md0eo',
+        path: isLive(appEnv)
+          ? '/thai/articles/czx7w3zyme1o'
+          : '/thai/articles/c442rl3md0eo',
         smoke: false,
       },
       errorPage404: {
@@ -1166,7 +1176,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/tigrinya/articles/ck62z3rjwdeo',
+        path: isLive(appEnv)
+          ? '/tigrinya/articles/c3vq38ve33xo'
+          : '/tigrinya/articles/ck62z3rjwdeo',
         smoke: false,
       },
       errorPage404: {


### PR DESCRIPTION
Part of #4276 

**Overall change:**
Enables Live e2es for six services

**Code changes:**

- Enables e2es for Burmese, Thai, Tigrinya, Amharic, Japanese and Korean articles on Live

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
