### PR TITLE
Fix Bulletin e2e

### DIFF
--- a/cypress/integration/pages/frontPage/tests.js
+++ b/cypress/integration/pages/frontPage/tests.js
@@ -1,5 +1,6 @@
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
+import applySquashTopstories from '../../../../src/app/lib/utilities/preprocessor/rules/topstories';
 
 const serviceJsonPath = service =>
   `${config[service].pageTypes.frontPage.path}.json`;
@@ -229,8 +230,10 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
 
         it('should contain Radio Bulletin if a promo of type RadioBulletin is in the feed', () => {
           cy.request(serviceJsonPath(service)).then(({ body }) => {
-            const pageData = body.content.groups;
-            if (isValidRadioBulletin(pageData)) {
+            const processData = applySquashTopstories(body);
+            const { groups } = processData.content;
+
+            if (isValidRadioBulletin(groups)) {
               cy.get('[class^="RadioBulletin"]')
                 .eq(0)
                 .should('be.visible');
@@ -242,8 +245,10 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
 
         it('should contain TV Bulletin if a promo of type TVBulletin is in the feed', () => {
           cy.request(serviceJsonPath(service)).then(({ body }) => {
-            const pageData = body.content.groups;
-            if (isValidTvBulletin(pageData)) {
+            const processData = applySquashTopstories(body);
+            const { groups } = processData.content;
+
+            if (isValidTvBulletin(groups)) {
               cy.get('[class^="TVBulletin"]')
                 .eq(0)
                 .should('be.visible');

--- a/cypress/integration/pages/frontPage/tests.js
+++ b/cypress/integration/pages/frontPage/tests.js
@@ -230,8 +230,8 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
 
         it('should contain Radio Bulletin if a promo of type RadioBulletin is in the feed', () => {
           cy.request(serviceJsonPath(service)).then(({ body }) => {
-            const processData = applySquashTopstories(body);
-            const { groups } = processData.content;
+            const pageData = applySquashTopstories(body);
+            const { groups } = pageData.content;
 
             if (isValidRadioBulletin(groups)) {
               cy.get('[class^="RadioBulletin"]')
@@ -245,8 +245,8 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
 
         it('should contain TV Bulletin if a promo of type TVBulletin is in the feed', () => {
           cy.request(serviceJsonPath(service)).then(({ body }) => {
-            const processData = applySquashTopstories(body);
-            const { groups } = processData.content;
+            const pageData = applySquashTopstories(body);
+            const { groups } = pageData.content;
 
             if (isValidTvBulletin(groups)) {
               cy.get('[class^="TVBulletin"]')


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
The bulletin e2es are failing on some services in test, because the `TVBulletin` and `RadioBulletin` promos are located in a `top story` group type without a `strapline` which is then merged in a new group which it has a strapline.

Since we don't display groups in the Front Page which doesn't have `strapline`, the e2e's were not expecting them to be on the page, but they actually are because this new group has a strapline.

Example of top stories group types
```
const squashKeys = [
  'responsive-top-stories',
  'top-story',
  'secondary-top-story',
  'other-top-stories',
];

```
```
Section 1 - responsive-top-stories
strapline

Section 2 - top-story
no strapline

Section 3 - secondary-top-story
no strapline

Section 4 - weather
strapline

Section 5 - sport
strapline

⬇️


Section 1 - new top story group
strapline

Section 2 - weather
strapline

Section 3 - sport
strapline
```

In order to fix this, we should apply the same function which squashes the top stories groups into one, to the groups used in the e2e, to be equal to the ones used in the FrontPage.

**Code changes:**
- Import `applySquashTopstories` function in `frontPage/tests.js`
- Apply `applySquashTopstories` function to the data we are passing to the `isValidRadioBulletin` and `isValidTvBulletin`

Tested against test:
 `CYPRESS_APP_ENV=test CYPRESS_SMOKE=false npm run test:e2e:interactive`.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [X] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [X] This PR requires manual testing
