### PR TITLE
Fix e2e default branch to make git ref logic work

### DIFF
--- a/Jenkinsfile-e2e
+++ b/Jenkinsfile-e2e
@@ -16,7 +16,7 @@ node {
             pipelineTriggers([cron(cron_string)]),
             parameters(
                 [
-                    string(defaultValue: 'latest', name: 'BRANCH')
+                    string(defaultValue: '', name: 'BRANCH')
                 ]
             )
         ]


### PR DESCRIPTION
Required branch name change from https://github.com/bbc/simorgh/pull/4820 that was missed off reinstatement https://github.com/bbc/simorgh/pull/4907

**Code changes:**

- Update default branch to empty string to allow conditional logic for live commit hash to work

---

- [x] I have assigned myself to this PR and the corresponding issues
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [NA] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
