### PR TITLE
Move Related Content to a complementary aside (a11y)

### DIFF
--- a/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetPageMain/__snapshots__/index.test.jsx.snap
@@ -928,25 +928,7 @@ exports[`CpsAssetPageMain MAP AV player should render version (live audio stream
 exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -1009,16 +991,6 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -1148,197 +1120,6 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -1632,20 +1413,6 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -1725,215 +1492,6 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -2654,27 +2212,545 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -2685,54 +2761,54 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -2741,50 +2817,50 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -2793,33 +2869,33 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -2840,20 +2916,20 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -2864,12 +2940,12 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -2878,37 +2954,37 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -2922,7 +2998,7 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -2933,20 +3009,20 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -2954,7 +3030,7 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -2962,12 +3038,12 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -2977,32 +3053,14 @@ exports[`CpsAssetPageMain MAP AV player should render video 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -3065,16 +3123,6 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -3204,197 +3252,6 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -3688,20 +3545,6 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -3781,215 +3624,6 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -4710,27 +4344,545 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -4741,54 +4893,54 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -4797,50 +4949,50 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -4849,33 +5001,33 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -4896,20 +5048,20 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -4920,12 +5072,12 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -4934,37 +5086,37 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -4978,7 +5130,7 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -4989,20 +5141,20 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -5010,7 +5162,7 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -5018,12 +5170,12 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -5033,32 +5185,14 @@ exports[`CpsAssetPageMain MAP heading should render faux headline 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -5121,16 +5255,6 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -5260,197 +5384,6 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -5744,20 +5677,6 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -5837,215 +5756,6 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -6766,27 +6476,545 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -6797,54 +7025,54 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -6853,50 +7081,50 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -6905,33 +7133,33 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -6952,20 +7180,20 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -6976,12 +7204,12 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -6990,37 +7218,37 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -7034,7 +7262,7 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -7045,20 +7273,20 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -7066,7 +7294,7 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -7074,12 +7302,12 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -7089,32 +7317,14 @@ exports[`CpsAssetPageMain MAP heading should render visually hidden headline 1`]
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -7177,16 +7387,6 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -7316,197 +7516,6 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -7800,20 +7809,6 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -7893,215 +7888,6 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -8822,27 +8608,545 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -8853,54 +9157,54 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -8909,50 +9213,50 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -8961,33 +9265,33 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -9008,20 +9312,20 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -9032,12 +9336,12 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -9046,37 +9350,37 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -9090,7 +9394,7 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -9101,20 +9405,20 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -9122,7 +9426,7 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -9130,12 +9434,12 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -9145,32 +9449,14 @@ exports[`CpsAssetPageMain MAP should render crosshead 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -9233,16 +9519,6 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -9372,197 +9648,6 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -9856,20 +9941,6 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -9949,215 +10020,6 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -10878,27 +10740,545 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -10909,54 +11289,54 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -10965,50 +11345,50 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -11017,33 +11397,33 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -11064,20 +11444,20 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -11088,12 +11468,12 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -11102,37 +11482,37 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -11146,7 +11526,7 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -11157,20 +11537,20 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -11178,7 +11558,7 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -11186,12 +11566,12 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -11201,32 +11581,14 @@ exports[`CpsAssetPageMain MAP should render sub heading 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP should render image 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -11289,16 +11651,6 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -11428,197 +11780,6 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -11912,20 +12073,6 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -12005,215 +12152,6 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -12934,27 +12872,545 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -12965,54 +13421,54 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -13021,50 +13477,50 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -13073,33 +13529,33 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -13120,20 +13576,20 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -13144,12 +13600,12 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -13158,37 +13614,37 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -13202,7 +13658,7 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -13213,20 +13669,20 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -13234,7 +13690,7 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -13242,12 +13698,12 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -13257,32 +13713,14 @@ exports[`CpsAssetPageMain MAP should render image 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
 <DocumentFragment>
   <noscript />
-  .c45 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -13345,16 +13783,6 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
 
 .c10:last-child {
   padding-bottom: 1rem;
-}
-
-.c41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c11 {
@@ -13484,197 +13912,6 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c30 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c26 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c25 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-}
-
-.c32 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c32:first-child {
-  padding-top: 0;
-}
-
-.c32:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c31 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c35 {
-  position: relative;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c40 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c39:hover,
-.c39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c39:visited {
-  color: #6E6E73;
-}
-
-.c42 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c46 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c24 {
-  z-index: 0;
 }
 
 .c6 {
@@ -13968,20 +14205,6 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c11 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -14061,215 +14284,6 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c26 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c26 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c25 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c32:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c32:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c33 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c34 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c34 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c36 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c40 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c40 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c40 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c37 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c37 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c42 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c24 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c24 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c24 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
     padding: 0 1rem;
   }
 }
@@ -14990,27 +15004,545 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c24"
+      class="c1"
     >
       <div
-        class="c25"
+        class="c2"
       >
         <div
-          class="c26"
+          class="c3"
         />
         <h2
-          class="c27"
+          class="c4"
         >
           <div
-            class="c28"
+            class="c5"
           >
             <span
-              class="c29"
+              class="c6"
             >
               <span
-                class="c30"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -15021,54 +15553,54 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
         </h2>
       </div>
       <ul
-        class="c31"
+        class="c8"
         role="list"
       >
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -15077,50 +15609,50 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -15129,33 +15661,33 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 />
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c44"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -15176,20 +15708,20 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -15200,12 +15732,12 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -15214,37 +15746,37 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
           </div>
         </li>
         <li
-          class="c32"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c33"
+            class="c10"
           >
             <div
-              class="c34"
+              class="c11"
             >
               <div
-                class="c35"
+                class="c12"
               >
                 <div
-                  class="c20"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c36"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c42"
+                    class="c20"
                   >
                     <div
-                      class="c43"
+                      class="c21"
                     >
                       <svg
-                        class="c45"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -15258,7 +15790,7 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
                         />
                       </svg>
                       <time
-                        class="c46"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -15269,20 +15801,20 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
               </div>
             </div>
             <div
-              class="c37"
+              class="c15"
             >
               <h3
-                class="c38"
+                class="c16"
               >
                 <a
-                  class="c39"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -15290,7 +15822,7 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -15298,12 +15830,12 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
                 </a>
               </h3>
               <p
-                class="c40"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c41"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -15313,7 +15845,7 @@ exports[`CpsAssetPageMain MAP should render paragraph 1`] = `
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;
 
@@ -16849,8 +17381,13 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
             Cheese strings stilton cheesy feet. Cheese strings fondue cow fromage edam halloumi cut the cheese cream cheese. Melted cheese brie rubber cheese parmesan cut the cheese queso st. agur blue cheese dolcelatte. Port-salut croque monsieur cheese and wine cheese triangles cheesy grin.
           </p>
         </div>
+      </main>
+      <aside
+        aria-labelledby="related-content-heading"
+        class="c0"
+        role="complementary"
+      >
         <div
-          aria-labelledby="related-content-heading"
           class="c25"
         >
           <div
@@ -16889,7 +17426,7 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
             />
           </ul>
         </div>
-      </main>
+      </aside>
     </div>
   </body>
 </html>
@@ -16898,25 +17435,7 @@ exports[`CpsAssetPageMain should match snapshot for STY 1`] = `
 exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
   <noscript />
-  .c43 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 0.8125rem;
-  height: 0.75rem;
-}
-
-.c42 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-  color: #222222;
-  fill: currentColor;
-  width: 1rem;
-  height: 0.8125rem;
-}
-
-.c0 {
+  .c0 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -16960,16 +17479,6 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
   font-style: italic;
   font-family: inherit;
   font-weight: inherit;
-}
-
-.c39 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
 }
 
 .c9 {
@@ -17099,197 +17608,6 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 
 .c3 {
   margin-bottom: 1.5rem;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-.c28 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #222222;
-  background-color: #FFFFFF;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c24 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-.c23 {
-  position: relative;
-  margin-top: 2rem;
-}
-
-.c25 {
-  margin: 0;
-  padding: 0;
-}
-
-.c30 {
-  border-bottom: 0.0625rem solid #F2F2F2;
-  padding: 0.5rem 0 1rem;
-}
-
-.c30:first-child {
-  padding-top: 0;
-}
-
-.c30:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c29 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c31 {
-  position: relative;
-}
-
-.c32 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-.c33 {
-  position: relative;
-}
-
-.c36 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c38 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-.c35 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-.c37 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c37:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.c37:hover,
-.c37:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c37:visited {
-  color: #6E6E73;
-}
-
-.c40 {
-  padding: 0.5rem 0.25rem;
-  background-color: #FFFFFF;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  color: #222222;
-  height: 2rem;
-}
-
-.c41 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
-}
-
-.c44 {
-  vertical-align: middle;
-  margin: 0 0.25rem;
-}
-
-.c22 {
-  z-index: 0;
 }
 
 .c6 {
@@ -17530,20 +17848,6 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c39 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c39 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
   .c9 {
     font-size: 1rem;
     line-height: 1.375rem;
@@ -17623,215 +17927,6 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
   .c3 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c27 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c28 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c28 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c28 {
-    margin: 0;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c28 {
-    padding-right: 1rem;
-  }
-}
-
-@media screen and (-ms-high-contrast:active) {
-  .c24 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c24 {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c23 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c30 {
-    padding: 1.5rem 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c30:first-child {
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c30:first-child {
-    padding-top: 1.5rem;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c31 {
-    display: grid;
-    grid-template-columns: repeat(6,1fr);
-    grid-column-gap: 0.5rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c32 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c32 {
-    display: block;
-    width: initial;
-    grid-column: 1 / span 2;
-  }
-}
-
-@media (min-width:25rem) {
-  .c34 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c36 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c36 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c36 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c38 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c38 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c35 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c35 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns:fit-content(200px)) {
-  .c35 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3 / span 4;
-  }
-}
-
-@media (max-width:24.9375rem) {
-  .c40 {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-@media (max-width:63rem) {
-  .c22 {
-    grid-column: 1 / span 6;
-  }
-}
-
-@media (min-width:63rem) and (max-width:80rem) {
-  .c22 {
-    grid-column: 3 / span 6;
-  }
-}
-
-@media (min-width:80rem) {
-  .c22 {
-    grid-column: 6 / span 12;
-  }
-}
-
-@media (max-width:25rem) {
-  .c22 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c22 {
     padding: 0 1rem;
   }
 }
@@ -18536,27 +18631,545 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
         This is the footer 
       </p>
     </div>
+  </main>
+  .c24 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 0.8125rem;
+  height: 0.75rem;
+}
+
+.c22 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+  color: #222222;
+  fill: currentColor;
+  width: 1rem;
+  height: 0.8125rem;
+}
+
+.c0 {
+  margin: 0 auto;
+  background: #FDFDFD;
+  padding-bottom: 2rem;
+}
+
+.c19 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.c23 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.c13 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #ECEAE7;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 30%;
+  padding-bottom: 56.25%;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+.c7 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #222222;
+  background-color: #FFFFFF;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border-top: 0.0625rem solid #AEAEB5;
+  z-index: -1;
+}
+
+.c2 {
+  position: relative;
+  margin-top: 2rem;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  border-bottom: 0.0625rem solid #F2F2F2;
+  padding: 0.5rem 0 1rem;
+}
+
+.c9:first-child {
+  padding-top: 0;
+}
+
+.c9:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c8 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+.c12 {
+  position: relative;
+}
+
+.c16 {
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c18 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+.c15 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+.c17 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c17:hover,
+.c17:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c17:visited {
+  color: #6E6E73;
+}
+
+.c20 {
+  padding: 0.5rem 0.25rem;
+  background-color: #FFFFFF;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: #222222;
+  height: 2rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.c25 {
+  vertical-align: middle;
+  margin: 0 0.25rem;
+}
+
+.c1 {
+  z-index: 0;
+}
+
+@media (max-width:37.4375rem) {
+  .c0 {
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c0 {
+    grid-column-gap: 1rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c0 {
+    grid-template-columns: repeat(6,1fr);
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
+    max-width: 45.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c0 {
+    grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
+    max-width: 46.4rem;
+  }
+}
+
+@supports (display:grid) {
+  .c0 {
+    display: grid;
+    max-width: initial;
+    margin: initial;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c19 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c19 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c7 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    margin: 0;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c7 {
+    padding-right: 1rem;
+  }
+}
+
+@media screen and (-ms-high-contrast:active) {
+  .c3 {
+    border-color: windowText;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c3 {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 1.375rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9 {
+    padding: 1.5rem 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c9:first-child {
+    padding-top: 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c9:first-child {
+    padding-top: 1.5rem;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c10 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c11 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c11 {
+    display: block;
+    width: initial;
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (min-width:25rem) {
+  .c14 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c16 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c18 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c18 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c18 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c15 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c15 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c15 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+  }
+}
+
+@media (max-width:24.9375rem) {
+  .c20 {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+@media (max-width:63rem) {
+  .c1 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:80rem) {
+  .c1 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c1 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c1 {
+    padding: 0 1rem;
+  }
+}
+
+<aside
+    aria-labelledby="related-content-heading"
+    class="c0"
+    role="complementary"
+  >
     <div
-      aria-labelledby="related-content-heading"
-      class="c22"
+      class="c1"
     >
       <div
-        class="c23"
+        class="c2"
       >
         <div
-          class="c24"
+          class="c3"
         />
         <h2
-          class="c25"
+          class="c4"
         >
           <div
-            class="c26"
+            class="c5"
           >
             <span
-              class="c27"
+              class="c6"
             >
               <span
-                class="c28"
+                class="c7"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -18567,54 +19180,54 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
         </h2>
       </div>
       <ul
-        class="c29"
+        class="c8"
         role="list"
       >
         <li
-          class="c30"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c31"
+            class="c10"
           >
             <div
-              class="c32"
+              class="c11"
             >
               <div
-                class="c33"
+                class="c12"
               >
                 <div
-                  class="c18"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c34"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c35"
+              class="c15"
             >
               <h3
-                class="c36"
+                class="c16"
               >
                 <a
-                  class="c37"
+                  class="c17"
                   href="/pidgin/tori-23145776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Police Arrest 3 ontop Anambra Church Attack
                 </a>
               </h3>
               <p
-                class="c38"
+                class="c18"
               >
                 Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
               </p>
               <time
-                class="c39"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -18623,50 +19236,50 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
           </div>
         </li>
         <li
-          class="c30"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c31"
+            class="c10"
           >
             <div
-              class="c32"
+              class="c11"
             >
               <div
-                class="c33"
+                class="c12"
               >
                 <div
-                  class="c18"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c34"
+                  class="c14"
                 />
               </div>
             </div>
             <div
-              class="c35"
+              class="c15"
             >
               <h3
-                class="c36"
+                class="c16"
               >
                 <a
-                  class="c37"
+                  class="c17"
                   href="/pidgin/tori-23143754?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                 </a>
               </h3>
               <p
-                class="c38"
+                class="c18"
               >
                 The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
               </p>
               <time
-                class="c39"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -18675,33 +19288,33 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
           </div>
         </li>
         <li
-          class="c30"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c31"
+            class="c10"
           >
             <div
-              class="c32"
+              class="c11"
             >
               <div
-                class="c33"
+                class="c12"
               >
                 <div
-                  class="c18"
+                  class="c13"
                 />
                 <div
-                  class="c34"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c40"
+                    class="c20"
                   >
                     <div
-                      class="c41"
+                      class="c21"
                     >
                       <svg
-                        class="c42"
+                        class="c22"
                         focusable="false"
                         height="13px"
                         viewBox="0 0 32 26"
@@ -18722,20 +19335,20 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
               </div>
             </div>
             <div
-              class="c35"
+              class="c15"
             >
               <h3
-                class="c36"
+                class="c16"
               >
                 <a
-                  class="c37"
+                  class="c17"
                   href="/pidgin/23146654?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Image gallery, 
                     </span>
@@ -18746,12 +19359,12 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
                 </a>
               </h3>
               <p
-                class="c38"
+                class="c18"
               >
                 This na some of the picture wey our eye see as Kenya people go vote for election today
               </p>
               <time
-                class="c39"
+                class="c19"
                 datetime="2017-08-08"
               >
                 8th August 2017
@@ -18760,37 +19373,37 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
           </div>
         </li>
         <li
-          class="c30"
+          class="c9"
           role="listitem"
         >
           <div
-            class="c31"
+            class="c10"
           >
             <div
-              class="c32"
+              class="c11"
             >
               <div
-                class="c33"
+                class="c12"
               >
                 <div
-                  class="c18"
+                  class="c13"
                 >
                   <div
                     class="lazyload-placeholder"
                   />
                 </div>
                 <div
-                  class="c34"
+                  class="c14"
                 >
                   <div
                     aria-hidden="true"
-                    class="c40"
+                    class="c20"
                   >
                     <div
-                      class="c41"
+                      class="c21"
                     >
                       <svg
-                        class="c43"
+                        class="c24"
                         focusable="false"
                         height="12px"
                         viewBox="0 0 13 12"
@@ -18804,7 +19417,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
                         />
                       </svg>
                       <time
-                        class="c44"
+                        class="c25"
                         datetime="PT15S"
                       >
                         0:15
@@ -18815,20 +19428,20 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
               </div>
             </div>
             <div
-              class="c35"
+              class="c15"
             >
               <h3
-                class="c36"
+                class="c16"
               >
                 <a
-                  class="c37"
+                  class="c17"
                   href="/pidgin/media-23147054?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
                     role="text"
                   >
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       Audio, 
                     </span>
@@ -18836,7 +19449,7 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
                       BBC News Pidgin One Minute News
                     </span>
                     <span
-                      class="c2"
+                      class="c23"
                     >
                       , 0,15
                     </span>
@@ -18844,12 +19457,12 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
                 </a>
               </h3>
               <p
-                class="c38"
+                class="c18"
               >
                 All di local and world tori wey you suppose know in 60 seconds!
               </p>
               <time
-                class="c39"
+                class="c19"
                 datetime="2017-08-17"
               >
                 17th August 2017
@@ -18859,6 +19472,6 @@ exports[`CpsAssetPageMain should not show the pop-out timestamp when allowDateSt
         </li>
       </ul>
     </div>
-  </main>
+  </aside>
 </DocumentFragment>
 `;

--- a/src/app/containers/CpsAssetPageMain/index.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.jsx
@@ -59,8 +59,8 @@ const CpsAssetPageMain = ({ pageData }) => {
           </Link>
         </GridItemConstrainedMedium>
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
-        <CpsRelatedContent content={relatedContent} />
       </GhostGrid>
+      <CpsRelatedContent content={relatedContent} />
     </>
   );
 };

--- a/src/app/containers/CpsAssetPageMain/index.test.jsx
+++ b/src/app/containers/CpsAssetPageMain/index.test.jsx
@@ -230,4 +230,15 @@ describe('CpsAssetPageMain', () => {
     expect(document.querySelector('div[class^=PopOut]')).toBeNull();
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('has a single "main" element, and a single "complementary" element (a11y)', async () => {
+    const pageData = await preprocessor(
+      pidginPageData,
+      cpsAssetPreprocessorRules,
+    );
+
+    render(createAssetPage({ pageData }, 'pidgin'));
+    expect(document.querySelectorAll(`[role='main']`).length).toBe(1);
+    expect(document.querySelectorAll(`[role='complementary']`).length).toBe(1);
+  });
 });

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -2,416 +2,426 @@
 
 exports[`CpsRelatedContent should render Story Promo components in Live environment 1`] = `
 <DocumentFragment>
-  <div
+  <aside
     aria-labelledby="related-content-heading"
-    class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-sc-1itct8j-0 cGQhRq"
+    class="GhostGrid-sc-12lwanc-1 gfRQD"
+    role="complementary"
   >
     <div
-      class="SectionLabelWrapper-sc-1x4gwjz-1 fKCwVP"
+      class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-sc-1itct8j-0 cGQhRq"
     >
       <div
-        class="Bar-sc-1x4gwjz-0 qaAlR"
-      />
-      <h2
-        class="Heading-sc-1x4gwjz-2 eZofTG"
+        class="SectionLabelWrapper-sc-1x4gwjz-1 fKCwVP"
       >
         <div
-          class="FlexColumn-wx5kdp-0 dgpsiS"
+          class="Bar-sc-1x4gwjz-0 qaAlR"
+        />
+        <h2
+          class="Heading-sc-1x4gwjz-2 eZofTG"
         >
-          <span
-            class="FlexRow-wx5kdp-2 dVBNyZ"
+          <div
+            class="FlexColumn-wx5kdp-0 dgpsiS"
           >
             <span
-              class="Title-wx5kdp-4 jiurmA"
-              dir="ltr"
-              id="related-content-heading"
+              class="FlexRow-wx5kdp-2 dVBNyZ"
             >
-              Another thing we de for inside dis tori
+              <span
+                class="Title-wx5kdp-4 jiurmA"
+                dir="ltr"
+                id="related-content-heading"
+              >
+                Another thing we de for inside dis tori
+              </span>
             </span>
-          </span>
-        </div>
-      </h2>
-    </div>
-    <ul
-      class="StoryPromoUl-sc-171lqjd-1 isCYWc"
-      role="list"
-    >
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
+          </div>
+        </h2>
+      </div>
+      <ul
+        class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+        role="list"
       >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
         >
           <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
             <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
               <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
                 <div
-                  class="lazyload-placeholder"
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
                 />
               </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
             </div>
-          </div>
-          <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
-          >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
             >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/44508901"
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
               >
-                <span
-                  role="text"
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/44508901"
                 >
                   <span
-                    class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                    role="text"
                   >
-                    , 
+                    <span
+                      class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                    >
+                      , 
+                    </span>
+                    <span>
+                      Meet boys who dey convert cassava to electricity
+                    </span>
                   </span>
-                  <span>
-                    Meet boys who dey convert cassava to electricity
-                  </span>
-                </span>
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
-            >
-              James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
-          </div>
-        </div>
-      </li>
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
-      >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
-        >
-          <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
-          >
-            <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
-            >
-              <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
               >
-                <div
-                  class="lazyload-placeholder"
-                />
-              </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
+                James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
             </div>
           </div>
-          <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
-          >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
-            >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/tori-46975713"
-              >
-                How light companies dey use estimated billing show Nigerians pepper
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
-            >
-              Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
-          </div>
-        </div>
-      </li>
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
-      >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
+        </li>
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
         >
           <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
             <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
               <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
                 <div
-                  class="lazyload-placeholder"
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
                 />
               </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
+            </div>
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
+            >
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/tori-46975713"
+                >
+                  How light companies dey use estimated billing show Nigerians pepper
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
+              >
+                Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
             </div>
           </div>
+        </li>
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
+        >
           <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
+            <div
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/tori-42494678"
+              <div
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
-                Nigeria: Wetin 5,222 megawatts electric fit do?
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
+                <div
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
+                />
+              </div>
+            </div>
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
             >
-              Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/tori-42494678"
+                >
+                  Nigeria: Wetin 5,222 megawatts electric fit do?
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
+              >
+                Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
+            </div>
           </div>
-        </div>
-      </li>
-    </ul>
-  </div>
+        </li>
+      </ul>
+    </div>
+  </aside>
 </DocumentFragment>
 `;
 
 exports[`CpsRelatedContent should render Story Promo components when given appropriate data 1`] = `
 <DocumentFragment>
-  <div
+  <aside
     aria-labelledby="related-content-heading"
-    class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-sc-1itct8j-0 cGQhRq"
+    class="GhostGrid-sc-12lwanc-1 gfRQD"
+    role="complementary"
   >
     <div
-      class="SectionLabelWrapper-sc-1x4gwjz-1 fKCwVP"
+      class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-sc-1itct8j-0 cGQhRq"
     >
       <div
-        class="Bar-sc-1x4gwjz-0 qaAlR"
-      />
-      <h2
-        class="Heading-sc-1x4gwjz-2 eZofTG"
+        class="SectionLabelWrapper-sc-1x4gwjz-1 fKCwVP"
       >
         <div
-          class="FlexColumn-wx5kdp-0 dgpsiS"
+          class="Bar-sc-1x4gwjz-0 qaAlR"
+        />
+        <h2
+          class="Heading-sc-1x4gwjz-2 eZofTG"
         >
-          <span
-            class="FlexRow-wx5kdp-2 dVBNyZ"
+          <div
+            class="FlexColumn-wx5kdp-0 dgpsiS"
           >
             <span
-              class="Title-wx5kdp-4 jiurmA"
-              dir="ltr"
-              id="related-content-heading"
+              class="FlexRow-wx5kdp-2 dVBNyZ"
             >
-              Another thing we de for inside dis tori
+              <span
+                class="Title-wx5kdp-4 jiurmA"
+                dir="ltr"
+                id="related-content-heading"
+              >
+                Another thing we de for inside dis tori
+              </span>
             </span>
-          </span>
-        </div>
-      </h2>
-    </div>
-    <ul
-      class="StoryPromoUl-sc-171lqjd-1 isCYWc"
-      role="list"
-    >
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
+          </div>
+        </h2>
+      </div>
+      <ul
+        class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+        role="list"
       >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
         >
           <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
             <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
               <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
                 <div
-                  class="lazyload-placeholder"
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
                 />
               </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
             </div>
-          </div>
-          <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
-          >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
             >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/44508901?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
               >
-                <span
-                  role="text"
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/44508901?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                 >
                   <span
-                    class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                    role="text"
                   >
-                    , 
+                    <span
+                      class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                    >
+                      , 
+                    </span>
+                    <span>
+                      Meet boys who dey convert cassava to electricity
+                    </span>
                   </span>
-                  <span>
-                    Meet boys who dey convert cassava to electricity
-                  </span>
-                </span>
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
-            >
-              James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
-          </div>
-        </div>
-      </li>
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
-      >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
-        >
-          <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
-          >
-            <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
-            >
-              <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
               >
-                <div
-                  class="lazyload-placeholder"
-                />
-              </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
+                James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
             </div>
           </div>
-          <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
-          >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
-            >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/tori-46975713?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
-              >
-                How light companies dey use estimated billing show Nigerians pepper
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
-            >
-              Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
-          </div>
-        </div>
-      </li>
-      <li
-        class="StoryPromoLi-sc-171lqjd-0 diwbBz"
-        role="listitem"
-      >
-        <div
-          class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
+        </li>
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
         >
           <div
-            class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
             <div
-              class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
               <div
-                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
                 <div
-                  class="lazyload-placeholder"
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
                 />
               </div>
-              <div
-                class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
-              />
+            </div>
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
+            >
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/tori-46975713?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
+                >
+                  How light companies dey use estimated billing show Nigerians pepper
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
+              >
+                Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
             </div>
           </div>
+        </li>
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 diwbBz"
+          role="listitem"
+        >
           <div
-            class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
+            class="StoryPromoWrapper-sc-1dvfmi3-0 eYdwfL"
           >
-            <h3
-              class="Headline-sc-1dvfmi3-4 cWuUJx"
+            <div
+              class="ImageGridItem-sc-1dvfmi3-1 diQWZw"
             >
-              <a
-                class="Link-sc-1dvfmi3-7 iSHpco"
-                href="/pidgin/tori-42494678?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
+              <div
+                class="ImageContentsWrapper-sc-1dvfmi3-2 hEkcUX"
               >
-                Nigeria: Wetin 5,222 megawatts electric fit do?
-              </a>
-            </h3>
-            <p
-              class="Summary-sc-1dvfmi3-5 itgvLR"
+                <div
+                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+                <div
+                  class="InlineMediaIndicator-sc-1dvfmi3-3 ivGVpf"
+                />
+              </div>
+            </div>
+            <div
+              class="TextGridItem-sc-1dvfmi3-6 fdmIIY"
             >
-              Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
-            </p>
-            <time
-              class="StyledTimestamp-um718p-0 kVWTyt"
-              datetime="1970-01-18"
-            >
-              18th January 1970
-            </time>
+              <h3
+                class="Headline-sc-1dvfmi3-4 cWuUJx"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-7 iSHpco"
+                  href="/pidgin/tori-42494678?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
+                >
+                  Nigeria: Wetin 5,222 megawatts electric fit do?
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-5 itgvLR"
+              >
+                Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="1970-01-18"
+              >
+                18th January 1970
+              </time>
+            </div>
           </div>
-        </div>
-      </li>
-    </ul>
-  </div>
+        </li>
+      </ul>
+    </div>
+  </aside>
 </DocumentFragment>
 `;

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -9,7 +9,7 @@ import assocPath from 'ramda/src/assocPath';
 import { RequestContext } from '#contexts/RequestContext';
 import { storyItem } from '#models/propTypes/storyItem';
 import { ServiceContext } from '#contexts/ServiceContext';
-import { GridItemConstrainedLarge } from '#lib/styledGrid';
+import { GhostGrid, GridItemConstrainedLarge } from '#lib/styledGrid';
 import StoryPromo from '../StoryPromo';
 
 // z-index needs explicitly set as the psammead section label component uses negative z-indices
@@ -34,26 +34,32 @@ const CpsRelatedContent = ({ content }) => {
   if (!content.length) return null;
 
   return (
-    <Wrapper aria-labelledby="related-content-heading">
-      <SectionLabel
-        script={script}
-        service={service}
-        dir={dir}
-        labelId="related-content-heading"
-      >
-        {translations.relatedContent}
-      </SectionLabel>
+    <GhostGrid
+      as="aside"
+      role="complementary"
+      aria-labelledby="related-content-heading"
+    >
+      <Wrapper>
+        <SectionLabel
+          script={script}
+          service={service}
+          dir={dir}
+          labelId="related-content-heading"
+        >
+          {translations.relatedContent}
+        </SectionLabel>
 
-      <StoryPromoUl>
-        {content
-          .map(item => formatItem(item, env))
-          .map(item => (
-            <StoryPromoLi key={item.id || item.uri}>
-              <StoryPromo item={item} />
-            </StoryPromoLi>
-          ))}
-      </StoryPromoUl>
-    </Wrapper>
+        <StoryPromoUl>
+          {content
+            .map(item => formatItem(item, env))
+            .map(item => (
+              <StoryPromoLi key={item.id || item.uri}>
+                <StoryPromo item={item} />
+              </StoryPromoLi>
+            ))}
+        </StoryPromoUl>
+      </Wrapper>
+    </GhostGrid>
   );
 };
 

--- a/src/app/containers/CpsRelatedContent/index.test.jsx
+++ b/src/app/containers/CpsRelatedContent/index.test.jsx
@@ -8,11 +8,13 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import CpsRelatedContent from '.';
 import pidginPageData from '#data/pidgin/cpsAssets/tori-49450859';
 
+const promos = path(['relatedContent', 'groups', 0, 'promos'], pidginPageData);
+
 // eslint-disable-next-line react/prop-types
 const renderRelatedContent = ({
-  content,
+  content = promos,
   bbcOrigin = 'https://www.test.bbc.co.uk',
-}) => {
+} = {}) => {
   return render(
     <ServiceContextProvider service="pidgin">
       <RequestContextProvider
@@ -29,14 +31,12 @@ const renderRelatedContent = ({
   );
 };
 
-const promos = path(['relatedContent', 'groups', 0, 'promos'], pidginPageData);
-
 describe('CpsRelatedContent', () => {
   it('should render Story Promo components when given appropriate data', () => {
     // Ensure fixture still has promos
     expect(promos.length).toBe(3);
 
-    const { asFragment } = renderRelatedContent({ content: promos });
+    const { asFragment } = renderRelatedContent();
 
     expect(document.querySelectorAll(`li[class^='StoryPromoLi']`).length).toBe(
       promos.length,
@@ -51,12 +51,16 @@ describe('CpsRelatedContent', () => {
 
   it('should render Story Promo components in Live environment', () => {
     const { asFragment } = renderRelatedContent({
-      content: promos,
       bbcOrigin: 'https://www.bbc.co.uk',
     });
 
     // x_candy_override should not be used in the live environment
     expect(document.querySelector(`[href*='x_candy_override']`)).toBeNull();
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should have a "complementary" role (a11y)', () => {
+    renderRelatedContent();
+    expect(document.querySelectorAll(`[role='complementary']`).length).toBe(1);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/4807

**Overall change:** _Based on Catherine's feedback - moves related content out of the "main" section and into its own "complementary" section_

**Code changes:**

- _Some rejigging of the DOM_
- _Add tests_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
