### PR TITLE
Additional logging of url, path and data

### DIFF
--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -18,7 +18,11 @@ const baseUrl = onClient()
   ? getBaseUrl(window.location.origin)
   : process.env.SIMORGH_BASE_URL;
 
-const getUrl = pathname => `${baseUrl}${pathname.replace(ampRegex, '')}.json`;
+const getUrl = pathname => {
+  const url = `${baseUrl}${pathname.replace(ampRegex, '')}.json`;
+  logger.info(`Data: [${url}]`);
+  return url;
+};
 
 const handleResponse = async response => {
   const { status } = response;
@@ -59,10 +63,12 @@ const handleError = error => {
   return { error, status: STATUS_CODE_BAD_GATEWAY };
 };
 
-const fetchData = pathname =>
-  fetch(getUrl(pathname)) // Remove .amp at the end of pathnames for AMP pages.
+const fetchData = pathname => {
+  const url = getUrl(pathname);
+  return fetch(url) // Remove .amp at the end of pathnames for AMP pages.
     .then(handleResponse)
-    .then(checkForError(getUrl(pathname)))
+    .then(checkForError(url))
     .catch(handleError);
+};
 
 export default fetchData;

--- a/src/app/routes/getInitialData/index.js
+++ b/src/app/routes/getInitialData/index.js
@@ -18,11 +18,7 @@ const baseUrl = onClient()
   ? getBaseUrl(window.location.origin)
   : process.env.SIMORGH_BASE_URL;
 
-const getUrl = pathname => {
-  const url = `${baseUrl}${pathname.replace(ampRegex, '')}.json`;
-  logger.info(`Data: [${url}]`);
-  return url;
-};
+const getUrl = pathname => `${baseUrl}${pathname.replace(ampRegex, '')}.json`;
 
 const handleResponse = async response => {
   const { status } = response;
@@ -64,8 +60,10 @@ const handleError = error => {
 };
 
 const fetchData = pathname => {
-  const url = getUrl(pathname);
-  return fetch(url) // Remove .amp at the end of pathnames for AMP pages.
+  const url = getUrl(pathname); // Remove .amp at the end of pathnames for AMP pages.
+  logger.info(`DataRequest: [${url}]`);
+
+  return fetch(url)
     .then(handleResponse)
     .then(checkForError(url))
     .catch(handleError);

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -208,6 +208,8 @@ server
     },
   )
   .get('/*', cspInjectFun, async ({ url, headers, path: urlPath }, res) => {
+    logger.info(`URL: [${url}] Path: [${urlPath}]`);
+
     try {
       const { service, isAmp, route, variant } = getRouteProps(routes, url);
       const data = await route.getInitialData(urlPath);

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -208,7 +208,7 @@ server
     },
   )
   .get('/*', cspInjectFun, async ({ url, headers, path: urlPath }, res) => {
-    logger.info(`URL: [${url}] Path: [${urlPath}]`);
+    logger.info(`Path: [${urlPath}] URL: [${url}]`);
 
     try {
       const { service, isAmp, route, variant } = getRouteProps(routes, url);


### PR DESCRIPTION
Resolves #4822

**Overall change:** 
Log the url, path and data endpoint for diagnostic purposes 

**Code changes:**
- Log the data endpoint
- Log the path (excludes query string) & url (includes query string)

Result:
```
info [server/index.jsx] Path: [/pidgin/23248703] URL: [/pidgin/23248703?a=b]
info [getInitialData/index.js] Data: [http://localhost:7080/pidgin/23248703.json]
```
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
