### PR TITLE
Log route page type for diagnostic purposes

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -40,6 +40,14 @@ logger.debug(
   `Application outputting logs to directory "${process.env.LOG_DIR}"`,
 );
 
+const logRouteInfo = route => {
+  if (route.pageType === 'error') {
+    logger.error(`No route found`);
+  } else {
+    logger.info(`Page Type: ${route.pageType}`);
+  }
+};
+
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["write"] }] */
 class LoggerStream {
   write(message) {
@@ -212,6 +220,7 @@ server
 
     try {
       const { service, isAmp, route, variant } = getRouteProps(routes, url);
+      logRouteInfo(route);
       const data = await route.getInitialData(urlPath);
       const { status } = data;
       const bbcOrigin = headers['bbc-origin'];

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -41,10 +41,12 @@ logger.debug(
 );
 
 const logRouteInfo = route => {
-  logger.info(`Page Type: ${route.pageType}`);
+  const message = `Page Type: ${route.pageType}`;
 
   if (route.pageType === 'error') {
-    logger.error(`No matching route found`);
+    logger.error(`${message} - no matching route found`);
+  } else {
+    logger.info(message);
   }
 };
 

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -223,6 +223,7 @@ server
     try {
       const { service, isAmp, route, variant } = getRouteProps(routes, urlPath);
       logRouteInfo(route);
+
       const data = await route.getInitialData(url);
       const { status } = data;
       const bbcOrigin = headers['bbc-origin'];

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -41,10 +41,10 @@ logger.debug(
 );
 
 const logRouteInfo = route => {
+  logger.info(`Page Type: ${route.pageType}`);
+
   if (route.pageType === 'error') {
-    logger.error(`No route found`);
-  } else {
-    logger.info(`Page Type: ${route.pageType}`);
+    logger.error(`No matching route found`);
   }
 };
 

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -177,7 +177,7 @@ const testFrontPages = ({ platform, service, variant, queryString = '' }) => {
       service: 'someService',
       status: 200,
       variant,
-      pageType: 'FrontPage',
+      pageType,
     };
 
     const notFoundDataResponse = {


### PR DESCRIPTION
Resolves #4822 

**Overall change:** 
Add logging to the server index file, to provide additional information on the route page type.  If the page type is error, log an error.   

**Code changes:**
- Function which logs the route page type

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
