### PR TITLE
Ensure APP_ENV environment variable is reset after each test

### DIFF
--- a/src/app/routes/getInitialData/index.test.js
+++ b/src/app/routes/getInitialData/index.test.js
@@ -390,6 +390,10 @@ describe('getUrl', () => {
       expect(getUrl('/test/article.amp?param=test')).toEqual(
         'http://localhost/test/article.json?param=test',
       );
+
+      afterEach(() => {
+        process.env.APP_ENV = environment;
+      });
     });
 
     describe('is live', () => {
@@ -420,10 +424,10 @@ describe('getUrl', () => {
           'http://localhost/test/article.json',
         );
       });
-    });
 
-    afterAll(() => {
-      process.env.APP_ENV = environment;
+      afterEach(() => {
+        process.env.APP_ENV = environment;
+      });
     });
   });
 });


### PR DESCRIPTION
**Overall change:** 
Fix the getInitialData test to ensure APP_ENV is being reset correctly after each test

**Code changes:**
Use `afterEach` instead of `afterAll` to reset the environment variable correctly

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
