### PR TITLE
Cypress test for AMP navigation toggling

### DIFF
--- a/cypress/integration/pages/testsForAllAMPPages.js
+++ b/cypress/integration/pages/testsForAllAMPPages.js
@@ -38,15 +38,15 @@ export const testsThatFollowSmokeTestConfigForAllAMPPages = ({
         cy.get('body amp-consent > script[type="application/json"]');
       });
 
-      // limiting number of tests to run for navigation toggling
       const { variant } = config[service];
-      const shouldTestNav = service === 'ukchina' || service === 'persian';
+      // limit number of tests to 2 services for navigation toggling
+      const shouldTestService = service === 'ukchina' || service === 'persian';
       const serviceHasNavigation = appConfig[service][variant].navigation;
       const pageTypeHasNavigation =
         pageType !== 'articles' ||
         (pageType === 'articles' && appToggles.navOnArticles.enabled);
 
-      if (shouldTestNav && serviceHasNavigation && pageTypeHasNavigation) {
+      if (shouldTestService && serviceHasNavigation && pageTypeHasNavigation) {
         it('should show dropdown menu and hide scrollable menu when menu button is clicked', () => {
           cy.viewport(320, 480);
           cy.get('#scrollable-nav').should('be.visible');

--- a/cypress/integration/pages/testsForAllAMPPages.js
+++ b/cypress/integration/pages/testsForAllAMPPages.js
@@ -1,4 +1,7 @@
+import config from '../../support/config/services';
 import envConfig from '../../support/config/envs';
+import appConfig from '../../../src/server/utilities/serviceConfigs';
+import appToggles from '../../support/helpers/useAppToggles';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -34,6 +37,27 @@ export const testsThatFollowSmokeTestConfigForAllAMPPages = ({
         cy.get('body amp-geo > script[type="application/json"]');
         cy.get('body amp-consent > script[type="application/json"]');
       });
+
+      // limiting number of tests to run for navigation toggling
+      const { variant } = config[service];
+      const shouldTestNav = service === 'ukchina' || service === 'persian';
+      const serviceHasNavigation = appConfig[service][variant].navigation;
+      const pageTypeHasNavigation =
+        pageType !== 'articles' ||
+        (pageType === 'articles' && appToggles.navOnArticles.enabled);
+
+      if (shouldTestNav && serviceHasNavigation && pageTypeHasNavigation) {
+        it('should have a dropdown menu that toggles on click', () => {
+          cy.viewport(320, 480);
+          cy.get('#scrollable-nav').should('be.visible');
+          cy.get('#dropdown-menu').should('not.be.visible');
+
+          cy.get('nav button').click();
+
+          cy.get('#scrollable-nav').should('not.be.visible');
+          cy.get('#dropdown-menu').should('be.visible');
+        });
+      }
 
       if (Cypress.env('SMOKE')) {
         describe('ATI', () => {

--- a/cypress/integration/pages/testsForAllAMPPages.js
+++ b/cypress/integration/pages/testsForAllAMPPages.js
@@ -47,7 +47,7 @@ export const testsThatFollowSmokeTestConfigForAllAMPPages = ({
         (pageType === 'articles' && appToggles.navOnArticles.enabled);
 
       if (shouldTestNav && serviceHasNavigation && pageTypeHasNavigation) {
-        it('should have a dropdown menu that toggles on click', () => {
+        it('should show dropdown menu and hide scrollable menu when menu button is clicked', () => {
           cy.viewport(320, 480);
           cy.get('#scrollable-nav').should('be.visible');
           cy.get('#dropdown-menu').should('not.be.visible');

--- a/scripts/bundleSizeConfig.js
+++ b/scripts/bundleSizeConfig.js
@@ -2,5 +2,5 @@ module.exports = {
   // Size limit for all bundles used by each service (K)
   // Keep these +/- 5K and update frequently!
   MIN_SIZE: 621,
-  MAX_SIZE: 668,
+  MAX_SIZE: 680,
 };


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
We can't test the AMP state management that handles the toggling of the dropdown menu in unit tests, as the test runner doesn't understand AMP actions. This adds a cypress test to check the toggling works for a small subset of services.

**Code changes:**
- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
