### PR TITLE
Removed service URLs that have variants as these tests fail

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -994,7 +994,7 @@ const genServices = appEnv => ({
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
-            : '/serbian/srbija-49427344/cyr',
+            : undefined, // '/serbian/srbija-49427344/cyr'
         smoke: false,
       },
     },
@@ -1371,7 +1371,7 @@ const genServices = appEnv => ({
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
-            : '/ukchina/49375846/trad',
+            : undefined, // '/ukchina/49375846/trad'
         smoke: false,
       },
     },
@@ -1597,7 +1597,7 @@ const genServices = appEnv => ({
         path:
           Cypress.env('APP_ENV') === 'live' || Cypress.env('APP_ENV') === 'test'
             ? undefined
-            : '/zhongwen/chinese-news-49631219/trad',
+            : undefined, // '/zhongwen/chinese-news-49631219/trad'
         smoke: false,
       },
     },


### PR DESCRIPTION

**Overall change:** 
Tests were run for services with variants (Serbian, Zhongwen and UK Chinese), but pages with variants do not currently work. I removed the URLs from the test config. 

The URLs are still there in a comment so they can easily be put back in when variant service pages work, but after discussion with Graeme we decided it will be best to remove these in the future.

**Code changes:**
Changed the URLs to 'undefined' for tests on MAPs for Serbian, Zhongwen and UK China.

Changes in cypress/support/config/services.js
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 

Ran with no errors on local and test.
