### PR TITLE
Bump version of tree-kill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22567,7 +22567,7 @@
         "slash": "^3.0.0",
         "strip-color": "^0.1.0",
         "tmp": "^0.1.0",
-        "tree-kill": "^1.1.0",
+        "tree-kill": "^1.2.2",
         "ts-dedent": "^1.1.0",
         "util-deprecate": "^1.0.2",
         "uuid": "^3.3.3",
@@ -24867,9 +24867,9 @@
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "treeify": {


### PR DESCRIPTION
Required by storybook-chromatic, due to a high sev security vulnerability -> https://npmjs.com/advisories/1432

**Overall change:** 
Ran `npm audit fix`

**Code changes:**
- Update version of tree-kill in package.json

---
- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
