### PR TITLE
Fix failing Cypress test for timestamp

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -54,6 +54,9 @@ export const testsThatFollowSmokeTestConfig = ({
       cy.request(`${config[service].pageTypes[pageType].path}.json`).then(
         ({ body }) => {
           const { lastPublished, firstPublished } = body.metadata;
+          const timeDifferenceMinutes =
+            (lastPublished - firstPublished) / 1000 / 60;
+          const minutesTolerance = 1;
           cy.get('time')
             .eq(0)
             .should('exist')
@@ -61,7 +64,7 @@ export const testsThatFollowSmokeTestConfig = ({
             .should('have.attr', 'datetime')
             .should('not.be.empty');
 
-          if (lastPublished !== firstPublished) {
+          if (timeDifferenceMinutes > minutesTolerance) {
             cy.get('time')
               .eq(1)
               .should(


### PR DESCRIPTION
Resolves #5065 

**Overall change:** 
Updating Cypress test to match code change

**Code changes:**
Changed test to expect a second timestamp only if lastPublished is 1 minute later than firstPublished

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
