### PR TITLE
Ensure nav remains visible when screen width changes

### DIFF
--- a/src/app/containers/Navigation/index.canonical.jsx
+++ b/src/app/containers/Navigation/index.canonical.jsx
@@ -8,6 +8,8 @@ import {
   CanonicalDropdown,
   CanonicalMenuButton,
 } from '@bbc/psammead-navigation/dropdown';
+import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/dist/breakpoints';
+import useMediaQuery from '#lib/utilities/useMediaQuery';
 
 const ScrollableWrapper = styled.div`
   position: relative;
@@ -22,6 +24,12 @@ const CanonicalNavigationContainer = ({
   dropdownListItems,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+
+  useMediaQuery(`(max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX})`, event => {
+    if (!event.matches) {
+      setIsOpen(false);
+    }
+  });
 
   return (
     <Navigation script={script} service={service} dir={dir} isOpen={isOpen}>

--- a/src/app/lib/utilities/useMediaQuery/index.jsx
+++ b/src/app/lib/utilities/useMediaQuery/index.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+const useMediaQuery = (query, handler) => {
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+
+    handler(mediaQueryList);
+
+    mediaQueryList.addListener(handler);
+    return () => mediaQueryList.removeListener(handler);
+  }, [query, handler]);
+};
+
+export default useMediaQuery;

--- a/src/app/lib/utilities/useMediaQuery/index.test.jsx
+++ b/src/app/lib/utilities/useMediaQuery/index.test.jsx
@@ -1,0 +1,44 @@
+import { renderHook, cleanup } from '@testing-library/react-hooks';
+import useMediaQuery from '.';
+
+describe('useMediaQuery', () => {
+  const mockAddListener = jest.fn();
+  const mockRemoveListener = jest.fn();
+
+  window.matchMedia = jest.fn().mockImplementation(query => {
+    return {
+      matches: query === '(max-width: 600px)',
+      addListener: mockAddListener,
+      removeListener: mockRemoveListener,
+    };
+  });
+
+  beforeEach(() => {
+    mockAddListener.mockReset();
+    mockRemoveListener.mockReset();
+  });
+
+  it('should run handler straight away', () => {
+    const testFn = jest.fn();
+    renderHook(() => useMediaQuery('(max-width: 600px)', testFn));
+    expect(testFn.mock.calls.length).toBe(1);
+  });
+
+  it('should set up the handler as a listener', () => {
+    const testFn = jest.fn();
+    renderHook(() => useMediaQuery('(max-width: 600px)', testFn));
+    expect(mockAddListener.mock.calls.length).toBe(1);
+
+    mockAddListener.mock.calls[0][0]();
+    expect(testFn.mock.calls.length).toEqual(2);
+  });
+
+  it('should call removeListener on cleanup', () => {
+    const testFn = jest.fn();
+    renderHook(() => useMediaQuery('(max-width: 600px)', testFn));
+    cleanup().then(() => {
+      expect(mockRemoveListener.mock.calls.length).toEqual(1);
+      expect(mockRemoveListener.mock.calls[0][0]).toEqual(testFn);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #5155

If you opened the navigation on mobile, and then resized the window to desktop view, the nav would disappear. This ensures that doesn't happen.

**Overall change:** 
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._

**Code changes:**
- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
