### PR TITLE
[DO NOT MERGE] Added E2E live URLs for Pidgin, Yoruba, Igbo

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -455,7 +455,7 @@ const genServices = appEnv => ({
       frontPage: { path: '/igbo', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/igbo/media-23256786',
+        path: isLive(appEnv) ? '/igbo/media-42986440' : '/igbo/media-23256786', // live is audio clip
         smoke: false,
       },
     },
@@ -822,7 +822,7 @@ const genServices = appEnv => ({
       frontPage: { path: '/pidgin', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/pidgin/23248703',
+        path: isLive(appEnv) ? '/pidgin/tori-50974590' : '/pidgin/23248703', // live is video with related content
         smoke: false,
       },
     },
@@ -1495,7 +1495,9 @@ const genServices = appEnv => ({
       frontPage: { path: '/yoruba', smoke: false },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/yoruba/media-23256797',
+        path: isLive(appEnv)
+          ? '/yoruba/afrika-51116686'
+          : '/yoruba/media-23256797', // live is video clip
         smoke: false,
       },
     },


### PR DESCRIPTION


**Overall change:** 
Added live URLs in the E2E test config for Yoruba, Pidgin and Igbo. 
https://www.bbc.com/igbo/media-42986440 (audio)
https://www.bbc.com/pidgin/tori-50974590 (video with related content)
https://www.bbc.com/yoruba/afrika-51116686 (video)

TO BE MERGED AFTER GO LIVE

**Code changes:**

Added URLs as below:
mediaAssetPage: {
        path: isLive(appEnv) ? **'/igbo/media-42986440'** : '/igbo/media-23256786', // live is audio clip
        smoke: false,
      },

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
No errors on local or test
