### PR TITLE
FIx ampersand issue for MAPs

### DIFF
--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.js
@@ -25,7 +25,11 @@ External links then get converted into the optimo format as part of the existing
 // A later transformer converts them into the optimo format
 const buildUrlString = ({ url, linkText }) => {
   // simorgh#5078 - The psammead-rich-text-transforms package does not like chevrons
-  const parsedLinkText = linkText.replace('<', '&lt;').replace('>', '&gt;');
+  const parsedLinkText = linkText
+    .replace('<', '&lt;')
+    .replace('>', '&gt;')
+    .replace('&', '&amp;');
+
   return `
         <link>
             <caption>${parsedLinkText}</caption>

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.js
@@ -28,7 +28,7 @@ const buildUrlString = ({ url, linkText }) => {
   const parsedLinkText = linkText
     .replace('<', '&lt;')
     .replace('>', '&gt;')
-    .replace('&', '&amp;');
+    .replace(/&(?!amp|gt|lt)/, '&amp;');
 
   return `
         <link>
@@ -77,7 +77,11 @@ const parseText = block => {
 
   // Iterate over every <itemMeta> tag, and pass it off to be replaced
   matches.forEach(([match, id]) => {
-    provideLinkXML({ block, match, metadata: findMetadata(block.meta, id) });
+    provideLinkXML({
+      block,
+      match,
+      metadata: findMetadata(block.meta, id),
+    });
   });
 };
 

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
@@ -72,14 +72,14 @@ const scenarios = [
     }),
   },
   {
-    name: 'Chevrons',
+    name: 'Special Chars',
     input: wrapBlock({
-      meta: generateMeta(['afrique/23248423', '<Hello>']),
+      meta: generateMeta(['afrique/23248423', '<Hello&>']),
       text: '<itemMeta>afrique/23248423</itemMeta>',
     }),
     expectation: wrapBlock({
       meta: generateMeta(['afrique/23248423', '<Hello>']),
-      text: generateUrl(['afrique/23248423', '&lt;Hello&gt;']),
+      text: generateUrl(['afrique/23248423', '&lt;Hello&amp;&gt;']),
     }),
   },
   {

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
@@ -72,7 +72,7 @@ const scenarios = [
     }),
   },
   {
-    name: 'Special Chars',
+    name: 'Special Characters',
     input: wrapBlock({
       meta: generateMeta(['afrique/23248423', '<Hello&>']),
       text: '<itemMeta>afrique/23248423</itemMeta>',

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/internalLinks/index.test.js
@@ -78,7 +78,7 @@ const scenarios = [
       text: '<itemMeta>afrique/23248423</itemMeta>',
     }),
     expectation: wrapBlock({
-      meta: generateMeta(['afrique/23248423', '<Hello>']),
+      meta: generateMeta(['afrique/23248423', '<Hello&>']),
       text: generateUrl(['afrique/23248423', '&lt;Hello&amp;&gt;']),
     }),
   },


### PR DESCRIPTION
Resolves Live Issue

**Overall change:** 
Live pages have issues with ampersands in links - this fixes this

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
