### PR TITLE
Removing inline link test for test env

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -149,11 +149,7 @@ export const testsThatFollowSmokeTestConfig = ({
         );
       });
 
-      if (
-        serviceHasInlineLink(service) &&
-        (Cypress.env('APP_ENV') === 'local' ||
-          Cypress.env('APP_ENV') === 'test')
-      ) {
+      if (serviceHasInlineLink(service) && Cypress.env('APP_ENV') === 'local') {
         it('should have an inlink link to an article page', () => {
           cy.get('[class^="InlineLink"]')
             .eq(1)


### PR DESCRIPTION
**Overall change:** 
A test article we were using to test inline links has been removed (https://www.test.bbc.co.uk/news/articles/c8xxl4l3dzeo linked from https://www.test.bbc.co.uk/news/articles/c6v11qzyv8po). This means our e2e tests are failing so we cannot deploy to live. This stops our e2e tests from checking the inline links on our test environment until we have either reinstated the test article or linked to a new one.

**Code changes:**
- Cypress test 'should have an inlink link to an article page' no longer runs on the test environment

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
