### PR TITLE
Uzbek articles route has been disabled in Mozart for the test env

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -1416,7 +1416,10 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/uzbek/articles/cxj3rjxm6r0o',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/uzbek/articles/cxj3rjxm6r0o',
         smoke: false,
       },
       errorPage404: {


### PR DESCRIPTION
Articles test for Uzbek are failing on test. This is because we have disabled the Uzbek articles route in Mozart for the test env.