### PR TITLE
Enable E2Es for Nepali, Afaanoromoo, Amharic, Bengali, Sinhala, and Tigrinya

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -31,7 +31,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/afaanoromoo',
+        path: isLive(appEnv) ? undefined : '/afaanoromoo',
         smoke: false,
       },
       liveRadio: {
@@ -97,7 +97,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/amharic',
+        path: isLive(appEnv) ? undefined : '/amharic',
         smoke: false,
       },
       liveRadio: {
@@ -227,7 +227,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/bengali',
+        path: isLive(appEnv) ? undefined : '/bengali',
         smoke: false,
       },
       liveRadio: {
@@ -694,7 +694,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/nepali',
+        path: isLive(appEnv) ? undefined : '/nepali',
         smoke: false,
       },
       liveRadio: {
@@ -1028,7 +1028,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/sinhala',
+        path: isLive(appEnv) ? undefined : '/sinhala',
         smoke: false,
       },
       liveRadio: {
@@ -1234,7 +1234,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       frontPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '/tigrinya',
+        path: isLive(appEnv) ? undefined : '/tigrinya',
         smoke: false,
       },
       liveRadio: {


### PR DESCRIPTION
Resolves N/A

**Overall change:** 
Enable E2Es for Nepali, Afaanoromoo, Amharic, Bengali, Sinhala, and Tigrinya on TEST

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- ~~Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~~
- ~~If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- ~~This PR requires manual testing~~
