### PR TITLE
fix for sendCanonicalChartbeatBeacon is not a function

### DIFF
--- a/src/app/containers/ArticleMain/index.stories.jsx
+++ b/src/app/containers/ArticleMain/index.stories.jsx
@@ -4,6 +4,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
+import { UserContextProvider } from '#contexts/UserContext';
 import ArticleMain from '.';
 
 // article c5jje4ejkqvo contains a Headline, a Paragraph, a timestamp
@@ -19,7 +20,9 @@ storiesOf('Main|Article', module)
     <ToggleContextProvider>
       <ServiceContextProvider service="news">
         <RequestContextProvider isAmp={false} pageType="article" service="news">
-          <ArticleMain articleData={articleData} />
+          <UserContextProvider>
+            <ArticleMain articleData={articleData} />
+          </UserContextProvider>
         </RequestContextProvider>
       </ServiceContextProvider>
     </ToggleContextProvider>

--- a/src/app/containers/FrontPageMain/index.stories.jsx
+++ b/src/app/containers/FrontPageMain/index.stories.jsx
@@ -11,6 +11,7 @@ import FrontPageMain from '.';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import { ToggleContextProvider } from '../../contexts/ToggleContext';
 import { RequestContextProvider } from '../../contexts/RequestContext';
+import { UserContextProvider } from '#contexts/UserContext';
 
 const serviceDataSets = {
   news: newsData,
@@ -34,7 +35,9 @@ Object.keys(serviceDataSets).forEach(service => {
           pageType="frontPage"
           service={service}
         >
-          <FrontPageMain frontPageData={serviceDataSets[service]} />
+          <UserContextProvider>
+            <FrontPageMain frontPageData={serviceDataSets[service]} />
+          </UserContextProvider>
         </RequestContextProvider>
       </ServiceContextProvider>
     </ToggleContextProvider>


### PR DESCRIPTION
Resolves #5239 

**Overall change:** 
Fix broken storybook for article and frontpage main by wrapping story component with UserContext.

The [UserContext](https://github.com/bbc/simorgh/blob/latest/src/app/contexts/UserContext/index.jsx#L10) is used to decorate components using the Chartbeat component with the `sendCanonicalChartbeatBeacon` function but in cases where it's not decorated the function becomes undefined hence the error. 

![Screen Shot 2020-01-27 at 10 32 01](https://user-images.githubusercontent.com/25608386/73163950-4361cb80-40f1-11ea-8ca8-53ba57577d76.png)


**Code changes:**
- Wrap ArticleMain and FrontpageMain  stories with UserContext provider

**To test locally:**
- Enable the [toggle for chartbeat](https://github.com/bbc/simorgh/blob/latest/src/app/lib/config/toggles/index.js#L4)
- start storybook --> `npm run storybook`
- check on the stories in Main besides the Radio Page.
- confirm that the error above does not show.
---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
