### PR TITLE
Enable e2es for Archive and Ukrainian Articles

### DIFF
--- a/cypress/integration/application/index.js
+++ b/cypress/integration/application/index.js
@@ -4,7 +4,7 @@ import appConfig from '../../../src/server/utilities/serviceConfigs';
 const serviceHasPageType = (service, pageType) =>
   config[service].pageTypes[pageType].path !== undefined;
 
-const servicesUsingArticlePaths = ['news', 'scotland'];
+const servicesUsingArticlePaths = ['news', 'scotland', 'archive'];
 
 describe('Application', () => {
   Object.keys(config)

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -153,7 +153,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: undefined,
+        path: isLive(appEnv)
+          ? '/archive/articles/c413ngjk87wo'
+          : '/archive/articles/cqv9w00mgjpo',
         smoke: false,
       },
       errorPage404: {
@@ -1352,7 +1354,9 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv) ? undefined : '/ukrainian/articles/cp4l2mrejvdo',
+        path: isLive(appEnv)
+          ? '/ukrainian/articles/c8zv0eed9gko'
+          : '/ukrainian/articles/cp4l2mrejvdo',
         smoke: false,
       },
       errorPage404: {


### PR DESCRIPTION
Part of #4276 

**Overall change:** 
Enables e2e tests for Archive and Ukrainian articles

**Code changes:**
- Adds test assets on Test and Live for Archive
- Adds test asset on Live for /ukrainian
- Assigns Archive as an articles-only service, which points the tests for sw and manifest at the correct URLs

**Notes**
- Running the e2es locally in the UK fails on cookie/privacy banner tests for Archive as Cypress gets confused by the 302 redirects from .com to .co.uk - this matches the existing behaviour for /scotland

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
