### PR TITLE
Group all dependabot PRs bumping Psammead packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3390,13 +3390,6 @@
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
-      },
-      "dependencies": {
-        "@bbc/psammead-assets": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
-          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
-        }
       }
     },
     "@bbc/psammead-calendars": {
@@ -3473,13 +3466,6 @@
       "requires": {
         "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
-      },
-      "dependencies": {
-        "@bbc/psammead-assets": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
-          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
-        }
       }
     },
     "@bbc/psammead-inline-link": {
@@ -3507,13 +3493,6 @@
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
-      },
-      "dependencies": {
-        "@bbc/psammead-assets": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
-          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
-        }
       }
     },
     "@bbc/psammead-media-player": {
@@ -3560,13 +3539,6 @@
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
-      },
-      "dependencies": {
-        "@bbc/psammead-assets": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
-          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
-        }
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,13 +3503,6 @@
         "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-image": "^1.2.4",
         "@bbc/psammead-play-button": "^1.1.10"
-      },
-      "dependencies": {
-        "@bbc/psammead-assets": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
-          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
-        }
       }
     },
     "@bbc/psammead-navigation": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,13 +3493,20 @@
       }
     },
     "@bbc/psammead-media-indicator": {
-      "version": "2.6.24",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.24.tgz",
-      "integrity": "sha512-DtEjh6VERRECuEY10SqeJUcYXiErDgcDGBS31x3pAIcZz7LlFMgqlWos7uj3x5NPuxK9aj4KUrJ0Laorkn4bMQ==",
+      "version": "2.6.26",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-indicator/-/psammead-media-indicator-2.6.26.tgz",
+      "integrity": "sha512-Qs6ndvqbcJYVUPWdypmhUfAgP0RueBS5REzw/N+TybJuOQXJ8nuPjusEfbzRZuayZVASndyG67wlbGQppVcBDg==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
-        "@bbc/psammead-assets": "^2.12.0",
+        "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-assets": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
+        }
       }
     },
     "@bbc/psammead-media-player": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3383,13 +3383,20 @@
       }
     },
     "@bbc/psammead-bulletin": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-bulletin/-/psammead-bulletin-1.0.6.tgz",
-      "integrity": "sha512-q1NvHh51wxxHk6JQwvgqa7aramDIAwKghuBcA5MuBVa7j3wZAa4uEhwHKEigo2xPGf73tbgCWcEXH7lrJD6Brg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-bulletin/-/psammead-bulletin-1.0.7.tgz",
+      "integrity": "sha512-9+mIiSxBPNsAVLnJlYMkEKT6Ihyv+sgeShnGA+yc+1VYfEy9VckWRXXxUMmok9vfN2eEI4gO51nb1mpWWgIpzA==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
-        "@bbc/psammead-assets": "^2.12.0",
+        "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-assets": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
+        }
       }
     },
     "@bbc/psammead-calendars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3567,9 +3567,9 @@
       }
     },
     "@bbc/psammead-sitewide-links": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-sitewide-links/-/psammead-sitewide-links-4.0.5.tgz",
-      "integrity": "sha512-3DYbZ+8nv4ToM52YE29kIovWH2yp9TDZ+2NkjxmkMlj8KhlmqRx83lGonjgvJR9q29w4erAd5wSjn5CQvqD4bg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-sitewide-links/-/psammead-sitewide-links-4.0.6.tgz",
+      "integrity": "sha512-H1+ShIKbHLf+aKZ3UbN3MP9G42dd8r3H+0VHRyYakxeqCx59byomteAZw0PWB1jrkFjJ7cU+smVhRQaukyd2/A==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-styles": "^4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3606,9 +3606,9 @@
       }
     },
     "@bbc/psammead-story-promo-list": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo-list/-/psammead-story-promo-list-2.1.25.tgz",
-      "integrity": "sha512-30YOLq19Wry/IUlYW2U5kU64c9WFgy1Tkh6MniB57rilAmVuJuuDgybBB/Oy5pyI9iSk24p9HcNutCMBVvTHdQ==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-story-promo-list/-/psammead-story-promo-list-2.1.26.tgz",
+      "integrity": "sha512-CczsbZfsjwukpMGCGHkMySj/2QzqwG2h4I84b8CTWRnmTG3WlM0iR5y53GEAOvGCdZEkRK6ZPhHadi4jd0xf/w==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-styles": "^4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3510,13 +3510,20 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.6.0.tgz",
-      "integrity": "sha512-zLt43iBK+sLk5ZcMeHXJF7Q4t2oRXX2opcOdXHbVE5yUGm0NCzO2K9QP8y4i0dCvAu9LPbWoNqzZmy5q4ZwMvw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.6.2.tgz",
+      "integrity": "sha512-4nMZrfRctUqm0K37zJofANeqmh/VUNB778BRMk82z68RRVNiGag00e0mV6P7der43S0OHxaNJfcGw8/OmX3YOQ==",
       "requires": {
-        "@bbc/psammead-assets": "^2.12.0",
+        "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-image": "^1.2.4",
-        "@bbc/psammead-play-button": "^1.1.9"
+        "@bbc/psammead-play-button": "^1.1.10"
+      },
+      "dependencies": {
+        "@bbc/psammead-assets": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
+        }
       }
     },
     "@bbc/psammead-navigation": {
@@ -3539,13 +3546,20 @@
       }
     },
     "@bbc/psammead-play-button": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-play-button/-/psammead-play-button-1.1.9.tgz",
-      "integrity": "sha512-4fdTxrT1awuqRRLbsvkPUODX445hCKlg/1b1lQmXxpStdhDOP1XzdnKv2SLhKtiwn/WeUoTdUWnmx2aHWuuhbA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-play-button/-/psammead-play-button-1.1.10.tgz",
+      "integrity": "sha512-4/47KQRJs61jEIRg9k45MXUy1IK/lstnPIEg73u87FrV78O2QxfLD7na/4LroWaEmPujv6/2jpE7vv9bVEWw7w==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
-        "@bbc/psammead-assets": "^2.12.0",
+        "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-assets": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
+        }
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3630,9 +3630,9 @@
       }
     },
     "@bbc/psammead-useful-links": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-useful-links/-/psammead-useful-links-1.0.12.tgz",
-      "integrity": "sha512-EZKAptlUqcFIruMCdfGryO42gWwTZ0k572ehlLFzom4PRd/89/vb6oj8VDgMUzWbxVqwZHzB+bZSogQeYNAdXQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-useful-links/-/psammead-useful-links-1.0.13.tgz",
+      "integrity": "sha512-aKxEjwO4gOFRtODrt3FL6g0Au7m01DWKv0MIxS02qoFYmpVAoARvs8/54EyDZgU7nD61Uq7WgTSZG/x9ClTsmQ==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-styles": "^4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3360,9 +3360,9 @@
       "integrity": "sha512-Jjkk9ieEa0WXK4Wvw82YVvMhP4yi0pBOftwNhQGOVLx1Av8KSHFHacFxHEiVcVxoXCPpdeWaLYrKm0fcyoxlKA=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.0.tgz",
-      "integrity": "sha512-t97aAOxl52b8212S6CyCuh8iLhCx5oUYWpb5fUdDTrVQmIPQEklzbr9e/W3FY0Fj3yyrGXjezTNwjfddmlXbow=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+      "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
     },
     "@bbc/psammead-brand": {
       "version": "5.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3374,12 +3374,12 @@
       }
     },
     "@bbc/psammead-bulleted-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-bulleted-list/-/psammead-bulleted-list-1.0.1.tgz",
-      "integrity": "sha512-ekXJNl2V9XajWmWxMY8GYu+9nqG09Qt1+ATFRkN1aRXvUVhsv1eMCJfk8YXjbiD1Y+k+B41yetdMQ5TFq3nhNA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-bulleted-list/-/psammead-bulleted-list-1.0.4.tgz",
+      "integrity": "sha512-+Gen+9czavcUCV/aH7GNAgreheCGtPzxqVteHAxlW8ANIaTp5r3AUkVGSr7B90vU77QQ/WrtAU8rAV+hAlMy5w==",
       "requires": {
-        "@bbc/gel-foundations": "^3.4.1",
-        "@bbc/psammead-styles": "^4.1.2"
+        "@bbc/gel-foundations": "^3.4.3",
+        "@bbc/psammead-styles": "^4.2.0"
       }
     },
     "@bbc/psammead-bulletin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3365,9 +3365,9 @@
       "integrity": "sha512-t97aAOxl52b8212S6CyCuh8iLhCx5oUYWpb5fUdDTrVQmIPQEklzbr9e/W3FY0Fj3yyrGXjezTNwjfddmlXbow=="
     },
     "@bbc/psammead-brand": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-5.1.7.tgz",
-      "integrity": "sha512-4snBmP9f0VjjhgFRJj4fAMuDMJq4pYBv8GUuKYDrJKqPjrY6AC6jDdqvKBCNDynZs+BVCmiX1jY9pFJlc8+ZIw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-5.1.9.tgz",
+      "integrity": "sha512-R5e/zgT/LYO1yEHxbQUco6ugSLHGlJy17gXsGeN++Ifg7kO/n6Q50pzfczKulMFSz0Jw/6JuAQgh6MmX4i6gSg==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-visually-hidden-text": "^1.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3551,9 +3551,9 @@
       }
     },
     "@bbc/psammead-section-label": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-3.0.11.tgz",
-      "integrity": "sha512-FRaEk2H5rxwBBa8sGYgnC2pnuz5ni2m8wAc+Mjv5ZOeLILV6wtWjkb/CjKw56jM2HNs80srDRO7oabbnKU29pA==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-3.0.12.tgz",
+      "integrity": "sha512-NAqPTv7Vkvr6uoG0GUJa0/DhVn7fqTDYxIkHyYClOusD650Hya7qO0Z7+xR7d7Y29yJQPHtIxgN3CiiIo9EGcg==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-styles": "^4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3467,12 +3467,19 @@
       "integrity": "sha512-1v9jM7RCizOqtCbUpuyK/YXb0UfskaAMwr2mhu+P38C/PNrhj2yIxtK820bWd/zpuKccFntOG70L4KHVO0W8hw=="
     },
     "@bbc/psammead-image-placeholder": {
-      "version": "1.2.31",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.31.tgz",
-      "integrity": "sha512-bxOyHFR1jerFneO4HKqoAQbqQRakaOiJ+QC9yk5GbShOdI0irpOjfC+z+aN1A6mTJKNV5IGFoREbSiarJwdgcw==",
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-1.2.32.tgz",
+      "integrity": "sha512-tiIKFUNtAwtTxMwntQE93SwD4pn0A7xErt3/RSiZTL1j4CGpX26aBKDTFYtf5u72GQBVwtoV1EtJuJHB8MWpgw==",
       "requires": {
-        "@bbc/psammead-assets": "^2.12.0",
+        "@bbc/psammead-assets": "^2.12.1",
         "@bbc/psammead-styles": "^4.2.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-assets": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.12.1.tgz",
+          "integrity": "sha512-Q0WCPK73aCCuoSHCSAkTajCAFOWEsjcu9H2zs0ZoDzCnao6RWlFRq9YwYcjALkwjUL8afW7mgv0BQAhyJnirlA=="
+        }
       }
     },
     "@bbc/psammead-inline-link": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3453,9 +3453,9 @@
       }
     },
     "@bbc/psammead-headings": {
-      "version": "3.1.24",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-headings/-/psammead-headings-3.1.24.tgz",
-      "integrity": "sha512-Ui6zGD6n8fuSeFNloMlr7dFVHAPB/GEOXBcT8IZiZmbe19ScpbqFr3Iac+aAei48Dl28aomwhaLAkZEQ9Yh0Fw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-headings/-/psammead-headings-3.1.25.tgz",
+      "integrity": "sha512-/u6MRemSqOgcsN/bapDgYr6FuKkbSVgmP9wWE2rpoPeui9+CKie1yNdcmpWUXiBPze1tUZgKHUNFlGThon4DJw==",
       "requires": {
         "@bbc/gel-foundations": "^3.4.3",
         "@bbc/psammead-styles": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@bbc/psammead-paragraph": "^2.2.23",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",
     "@bbc/psammead-section-label": "^3.0.12",
-    "@bbc/psammead-sitewide-links": "^4.0.5",
+    "@bbc/psammead-sitewide-links": "^4.0.6",
     "@bbc/psammead-story-promo": "^2.7.18",
     "@bbc/psammead-story-promo-list": "^2.1.25",
     "@bbc/psammead-styles": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@bbc/gel-foundations": "^3.4.3",
     "@bbc/moment-timezone-include": "^1.1.2",
     "@bbc/psammead-amp-geo": "^1.1.2",
-    "@bbc/psammead-assets": "^2.12.0",
+    "@bbc/psammead-assets": "^2.12.1",
     "@bbc/psammead-brand": "^5.1.9",
     "@bbc/psammead-bulleted-list": "1.0.4",
     "@bbc/psammead-bulletin": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@bbc/psammead-image-placeholder": "^1.2.31",
     "@bbc/psammead-inline-link": "^1.3.19",
     "@bbc/psammead-locales": "^4.1.1",
-    "@bbc/psammead-media-indicator": "^2.6.24",
+    "@bbc/psammead-media-indicator": "^2.6.26",
     "@bbc/psammead-media-player": "^2.6.0",
     "@bbc/psammead-navigation": "^3.0.5",
     "@bbc/psammead-paragraph": "^2.2.23",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@bbc/psammead-navigation": "^3.0.5",
     "@bbc/psammead-paragraph": "^2.2.23",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",
-    "@bbc/psammead-section-label": "^3.0.11",
+    "@bbc/psammead-section-label": "^3.0.12",
     "@bbc/psammead-sitewide-links": "^4.0.5",
     "@bbc/psammead-story-promo": "^2.7.18",
     "@bbc/psammead-story-promo-list": "^2.1.25",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@bbc/psammead-assets": "^2.12.0",
     "@bbc/psammead-brand": "^5.1.7",
     "@bbc/psammead-bulleted-list": "1.0.4",
-    "@bbc/psammead-bulletin": "^1.0.6",
+    "@bbc/psammead-bulletin": "^1.0.7",
     "@bbc/psammead-calendars": "^2.0.5",
     "@bbc/psammead-caption": "^2.2.23",
     "@bbc/psammead-consent-banner": "^2.3.25",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@bbc/psammead-copyright": "^1.2.21",
     "@bbc/psammead-figure": "^1.2.10",
     "@bbc/psammead-grid": "^1.1.4",
-    "@bbc/psammead-headings": "^3.1.24",
+    "@bbc/psammead-headings": "^3.1.25",
     "@bbc/psammead-image": "^1.2.4",
     "@bbc/psammead-image-placeholder": "^1.2.31",
     "@bbc/psammead-inline-link": "^1.3.19",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@bbc/psammead-amp-geo": "^1.1.2",
     "@bbc/psammead-assets": "^2.12.0",
     "@bbc/psammead-brand": "^5.1.7",
-    "@bbc/psammead-bulleted-list": "1.0.1",
+    "@bbc/psammead-bulleted-list": "1.0.4",
     "@bbc/psammead-bulletin": "^1.0.6",
     "@bbc/psammead-calendars": "^2.0.5",
     "@bbc/psammead-caption": "^2.2.23",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@bbc/moment-timezone-include": "^1.1.2",
     "@bbc/psammead-amp-geo": "^1.1.2",
     "@bbc/psammead-assets": "^2.12.0",
-    "@bbc/psammead-brand": "^5.1.7",
+    "@bbc/psammead-brand": "^5.1.9",
     "@bbc/psammead-bulleted-list": "1.0.4",
     "@bbc/psammead-bulletin": "^1.0.7",
     "@bbc/psammead-calendars": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@bbc/psammead-inline-link": "^1.3.19",
     "@bbc/psammead-locales": "^4.1.1",
     "@bbc/psammead-media-indicator": "^2.6.26",
-    "@bbc/psammead-media-player": "^2.6.0",
+    "@bbc/psammead-media-player": "^2.6.2",
     "@bbc/psammead-navigation": "^3.0.5",
     "@bbc/psammead-paragraph": "^2.2.23",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@bbc/psammead-grid": "^1.1.4",
     "@bbc/psammead-headings": "^3.1.25",
     "@bbc/psammead-image": "^1.2.4",
-    "@bbc/psammead-image-placeholder": "^1.2.31",
+    "@bbc/psammead-image-placeholder": "^1.2.32",
     "@bbc/psammead-inline-link": "^1.3.19",
     "@bbc/psammead-locales": "^4.1.1",
     "@bbc/psammead-media-indicator": "^2.6.26",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@bbc/psammead-story-promo-list": "^2.1.25",
     "@bbc/psammead-styles": "^4.2.0",
     "@bbc/psammead-timestamp-container": "^2.6.20",
-    "@bbc/psammead-useful-links": "^1.0.12",
+    "@bbc/psammead-useful-links": "^1.0.13",
     "@bbc/psammead-visually-hidden-text": "^1.2.3",
     "@loadable/component": "^5.12.0",
     "@loadable/server": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@bbc/psammead-section-label": "^3.0.12",
     "@bbc/psammead-sitewide-links": "^4.0.6",
     "@bbc/psammead-story-promo": "^2.7.18",
-    "@bbc/psammead-story-promo-list": "^2.1.25",
+    "@bbc/psammead-story-promo-list": "^2.1.26",
     "@bbc/psammead-styles": "^4.2.0",
     "@bbc/psammead-timestamp-container": "^2.6.20",
     "@bbc/psammead-useful-links": "^1.0.13",


### PR DESCRIPTION
**Overall change:** 

1. https://github.com/bbc/simorgh/pull/5272 - Bump @bbc/psammead-bulleted-list from 1.0.1 to 1.0.4
2. https://github.com/bbc/simorgh/pull/5271 - Bump @bbc/psammead-bulletin from 1.0.6 to 1.0.7
3. https://github.com/bbc/simorgh/pull/5270 - Bump @bbc/psammead-useful-links from 1.0.12 to 1.0.13
4. https://github.com/bbc/simorgh/pull/5268 - Bump @bbc/psammead-section-label from 3.0.11 to 3.0.12
5. https://github.com/bbc/simorgh/pull/5265 - Bump @bbc/psammead-media-indicator from 2.6.24 to 2.6.26
6. https://github.com/bbc/simorgh/pull/5264 - Bump @bbc/psammead-headings from 3.1.24 to 3.1.25
7. https://github.com/bbc/simorgh/pull/5263 - Bump @bbc/psammead-brand from 5.1.7 to 5.1.9
8. https://github.com/bbc/simorgh/pull/5262 - Bump @bbc/psammead-sitewide-links from 4.0.5 to 4.0.6
9. https://github.com/bbc/simorgh/pull/5261 - Bump @bbc/psammead-media-player from 2.6.0 to 2.6.2
10. https://github.com/bbc/simorgh/pull/5259 - Bump @bbc/psammead-assets from 2.12.0 to 2.12.1
11. https://github.com/bbc/simorgh/pull/5257 - Bump @bbc/psammead-image-placeholder from 1.2.31 to 1.2.32
12. https://github.com/bbc/simorgh/pull/5255 - Bump @bbc/psammead-story-promo-list from 2.1.25 to 2.1.26

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- ~~Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~~
- ~~If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- [x] This PR requires manual testing
