### PR TITLE
Added Hausa and Somali to run on local and test E2Es

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -387,10 +387,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path:
-          isLive(appEnv) || isTest(appEnv) || Cypress.env('APP_ENV') === 'local'
-            ? undefined
-            : '/hausa/bbc_hausa_radio/liveradio',
+        path: isLive(appEnv) ? undefined : '/hausa/bbc_hausa_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {
@@ -1066,10 +1063,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path:
-          isLive(appEnv) || isTest(appEnv) || Cypress.env('APP_ENV') === 'local'
-            ? undefined
-            : '/somali/bbc_somali_radio/liveradio',
+        path: isLive(appEnv) ? undefined : '/somali/bbc_somali_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {


### PR DESCRIPTION

**Overall change:** 
In the services file config, added the URLs to run locally and on live

**Code changes:**

e.g 
`liveRadio: {
        path: isLive(appEnv) ? undefined : '/hausa/bbc_hausa_radio/liveradio',
        smoke: false,
      },`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

No errors on local or test