### PR TITLE
Use "property" attribute on facebook's "og:" meta tags

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -225,12 +225,12 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
 
                 cy.get('head').within(() => {
                   cy.title().should('eq', pageTitle);
-                  cy.get('meta[name="og:description"]').should(
+                  cy.get('meta[property="og:description"]').should(
                     'have.attr',
                     'content',
                     description,
                   );
-                  cy.get('meta[name="og:title"]').should(
+                  cy.get('meta[property="og:title"]').should(
                     'have.attr',
                     'content',
                     pageTitle,

--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -101,42 +101,42 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
                 : 'website';
 
               cy.get('head').within(() => {
-                cy.get('meta[name="fb:admins"]').should(
+                cy.get('meta[property="fb:admins"]').should(
                   'have.attr',
                   'content',
                   '100004154058350',
                 );
-                cy.get('meta[name="fb:app_id"]').should(
+                cy.get('meta[property="fb:app_id"]').should(
                   'have.attr',
                   'content',
                   '1609039196070050',
                 );
-                cy.get('meta[name="og:image"]').should(
+                cy.get('meta[property="og:image"]').should(
                   'have.attr',
                   'content',
                   imageSrc,
                 );
-                cy.get('meta[name="og:image:alt"]').should(
+                cy.get('meta[property="og:image:alt"]').should(
                   'have.attr',
                   'content',
                   imageAltText,
                 );
-                cy.get('meta[name="og:locale"]').should(
+                cy.get('meta[property="og:locale"]').should(
                   'have.attr',
                   'content',
                   appConfig[config[service].name][variant].locale,
                 );
-                cy.get('meta[name="og:type"]').should(
+                cy.get('meta[property="og:type"]').should(
                   'have.attr',
                   'content',
                   ogType,
                 );
-                cy.get('meta[name="og:url"]').should(
+                cy.get('meta[property="og:url"]').should(
                   'have.attr',
                   'content',
                   `${envConfig.baseUrl}${config[service].pageTypes[pageType].path}`,
                 );
-                cy.get('meta[name="og:site_name"]').should(
+                cy.get('meta[property="og:site_name"]').should(
                   'have.attr',
                   'content',
                   appConfig[config[service].name][variant].brandName,

--- a/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMain/__snapshots__/index.test.jsx.snap
@@ -323,11 +323,11 @@ exports[`should render a news article correctly 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -343,35 +343,35 @@ exports[`should render a news article correctly 1`] = `
     />
     <meta
       content="Article summary."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="en_GB"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO - BBC News"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -592,11 +592,11 @@ exports[`should render a persian article correctly 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -612,35 +612,35 @@ exports[`should render a persian article correctly 1`] = `
     />
     <meta
       content="خلاصه مقاله"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News فارسی"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="fa"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News فارسی"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="سرصفحه مقاله - BBC News فارسی"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -1036,11 +1036,11 @@ exports[`should render a pidgin article correctly (with navigation) 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -1056,35 +1056,35 @@ exports[`should render a pidgin article correctly (with navigation) 1`] = `
     />
     <meta
       content="Article summary in Pidgin"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="pcm"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO in Pidgin - BBC News Pidgin"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/containers/ArticleMetadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleMetadata/__snapshots__/index.test.jsx.snap
@@ -136,11 +136,11 @@ exports[`should match snapshot for News & International 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -156,35 +156,35 @@ exports[`should match snapshot for News & International 1`] = `
     />
     <meta
       content="Article Headline for SEO"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="en_GB"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO - BBC News"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -366,11 +366,11 @@ exports[`should match snapshot for Persian News & UK origin 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -386,35 +386,35 @@ exports[`should match snapshot for Persian News & UK origin 1`] = `
     />
     <meta
       content="سرصفحه مقاله"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News فارسی"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="fa"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News فارسی"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="سرصفحه مقاله - BBC News فارسی"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/containers/CpsMetadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsMetadata/__snapshots__/index.test.jsx.snap
@@ -136,11 +136,11 @@ exports[`should match snapshot for News & International 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -156,35 +156,35 @@ exports[`should match snapshot for News & International 1`] = `
     />
     <meta
       content="Article Headline for SEO"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="http://ichef.test.bbci.co.uk/news/1024/branded_news/6FC4/test/_63721682_p01kx435.jpg"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="connectionAltText"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="en_GB"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO - BBC News"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/containers/CpsMetadata/index.test.jsx
+++ b/src/app/containers/CpsMetadata/index.test.jsx
@@ -59,20 +59,27 @@ describe('CpsMetadata get branded image', () => {
 
     const actual = Array.from(
       document.querySelectorAll(
-        'head > meta[name^="article:"], head > meta[name*="image"]',
+        'head > meta[name^="article:"], head > meta[property*="image"], head > meta[name*="image"]',
       ),
-    ).map(tag => ({
-      name: tag.getAttribute('name'),
-      content: tag.getAttribute('content'),
-    }));
+    ).map(tag =>
+      tag.hasAttribute('property')
+        ? {
+            property: tag.getAttribute('property'),
+            content: tag.getAttribute('content'),
+          }
+        : {
+            name: tag.getAttribute('name'),
+            content: tag.getAttribute('content'),
+          },
+    );
 
     const expected = [
       {
-        name: 'og:image',
+        property: 'og:image',
         content:
           'http://ichef.test.bbci.co.uk/news/1024/branded_news/6FC4/test/_63721682_p01kx435.jpg',
       },
-      { name: 'og:image:alt', content: 'connectionAltText' },
+      { property: 'og:image:alt', content: 'connectionAltText' },
       { name: 'twitter:image:alt', content: 'connectionAltText' },
       {
         name: 'twitter:image:src',

--- a/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageMain/__snapshots__/index.test.jsx.snap
@@ -996,11 +996,11 @@ exports[`FrontPageMain snapshots should render a pidgin frontpage correctly 1`] 
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -1016,35 +1016,35 @@ exports[`FrontPageMain snapshots should render a pidgin frontpage correctly 1`] 
     />
     <meta
       content="We dey give una latest tori on top politics, environment, business, sports, entertainment, health, fashion and all di oda things wey dey happen for West and Central Africa come add di rest of di world join. For better informate plus explanation of all di ogbonge tori wey pipo never hear about for inside West and Central Africa, BBC Pidgin dey serve am with video, audio, maps and oda graphics join."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News Ìgbò"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="ig"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Ìgbò"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Ogbako - BBC News Ìgbò"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="website"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="http://localhost/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Metadata/__snapshots__/index.test.jsx.snap
@@ -133,11 +133,11 @@ exports[`should match for AMP News & UK origin 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -153,35 +153,35 @@ exports[`should match for AMP News & UK origin 1`] = `
     />
     <meta
       content="Article summary."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="en_GB"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO - BBC News"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/news/articles/c0000000001o"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -354,11 +354,11 @@ exports[`should match for Canonical News & international origin 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -374,35 +374,35 @@ exports[`should match for Canonical News & international origin 1`] = `
     />
     <meta
       content="Article summary."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="en_GB"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Article Headline for SEO - BBC News"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/news/articles/c0000000001o"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -557,11 +557,11 @@ exports[`should match for Persian News & UK origin 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -577,35 +577,35 @@ exports[`should match for Persian News & UK origin 1`] = `
     />
     <meta
       content="خلاصه مقاله"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News فارسی"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="fa"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News فارسی"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="سرصفحه مقاله - BBC News فارسی"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/persian/articles/c4vlle3q337o"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -764,11 +764,11 @@ exports[`should match for Persian News & international origin 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -784,35 +784,35 @@ exports[`should match for Persian News & international origin 1`] = `
     />
     <meta
       content="خلاصه مقاله"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/persian.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News فارسی"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="fa"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News فارسی"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="سرصفحه مقاله - BBC News فارسی"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/persian/articles/c4vlle3q337o"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -976,11 +976,11 @@ exports[`should match for WS Frontpages 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -996,35 +996,35 @@ exports[`should match for WS Frontpages 1`] = `
     />
     <meta
       content="BBC News Igbo na-agbasa akụkọ sị Naịjirịa, Afịrịka na mba ụwa niile... Ihe na-eme ugbua gbasara akụkọ, egwuregwu, ihe nkiri na ihe na-ewu ewu... BBC Nkeji."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/igbo.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News Ìgbò"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="ig"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Ìgbò"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Ogbako - BBC News Ìgbò"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="website"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/igbo"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -1183,11 +1183,11 @@ exports[`should match for WS Media liveradio 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -1203,35 +1203,35 @@ exports[`should match for WS Media liveradio 1`] = `
     />
     <meta
       content="세계와 한반도 뉴스를 공정하고 객관적으로 전달해 드립니다"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/korean.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News 코리아"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="ko-KO"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News 코리아"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="BBC 코리아 라디오 - BBC News 코리아"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="website"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.bbc.com/korean/bbc_korean_radio/liveradio"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -113,22 +113,22 @@ const MetadataContainer = ({
       <meta name="apple-mobile-web-app-title" content={brandName} />
       <meta name="application-name" content={brandName} />
       <meta name="description" content={description} />
-      <meta name="fb:admins" content={FACEBOOK_ADMIN_ID} />
-      <meta name="fb:app_id" content={FACEBOOK_APP_ID} />
+      <meta property="fb:admins" content={FACEBOOK_ADMIN_ID} />
+      <meta property="fb:app_id" content={FACEBOOK_APP_ID} />
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="msapplication-TileColor" content={themeColor} />
       <meta
         name="msapplication-TileImage"
         content={getIconAssetUrl(service, '144x144')}
       />
-      <meta name="og:description" content={description} />
-      <meta name="og:image" content={metaImage} />
-      <meta name="og:image:alt" content={metaImageAltText} />
-      <meta name="og:locale" content={locale} />
-      <meta name="og:site_name" content={brandName} />
-      <meta name="og:title" content={pageTitle} />
-      <meta name="og:type" content={openGraphType} />
-      <meta name="og:url" content={canonicalNonUkLink} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={metaImage} />
+      <meta property="og:image:alt" content={metaImageAltText} />
+      <meta property="og:locale" content={locale} />
+      <meta property="og:site_name" content={brandName} />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:type" content={openGraphType} />
+      <meta property="og:url" content={canonicalNonUkLink} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:creator" content={twitterCreator} />
       <meta name="twitter:description" content={description} />

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -338,10 +338,10 @@ it('should render the facebook metatags', async () => {
   await renderMetadataToDocument();
 
   const fbAdminId = document
-    .querySelector('head > meta[name="fb:admins"]')
+    .querySelector('head > meta[property="fb:admins"]')
     .getAttribute('content');
   const fbAppId = document
-    .querySelector('head > meta[name="fb:app_id"]')
+    .querySelector('head > meta[property="fb:app_id"]')
     .getAttribute('content');
 
   expect(fbAdminId).toEqual('100004154058350');
@@ -379,26 +379,26 @@ it('should render the OG metatags', async () => {
   await renderMetadataToDocument();
 
   const actual = Array.from(
-    document.querySelectorAll('head > meta[name^="og:"]'),
+    document.querySelectorAll('head > meta[property^="og:"]'),
   ).map(tag => ({
-    name: tag.getAttribute('name'),
+    property: tag.getAttribute('property'),
     content: tag.getAttribute('content'),
   }));
   const expected = [
-    { content: 'Article summary.', name: 'og:description' },
+    { content: 'Article summary.', property: 'og:description' },
     {
       content:
         'https://www.bbc.co.uk/news/special/2015/newsspec_10857/bbc_news_logo.png',
-      name: 'og:image',
+      property: 'og:image',
     },
-    { content: 'BBC News', name: 'og:image:alt' },
-    { content: 'en_GB', name: 'og:locale' },
-    { content: 'BBC News', name: 'og:site_name' },
-    { content: 'Article Headline for SEO - BBC News', name: 'og:title' },
-    { content: 'article', name: 'og:type' },
+    { content: 'BBC News', property: 'og:image:alt' },
+    { content: 'en_GB', property: 'og:locale' },
+    { content: 'BBC News', property: 'og:site_name' },
+    { content: 'Article Headline for SEO - BBC News', property: 'og:title' },
+    { content: 'article', property: 'og:type' },
     {
       content: 'https://www.bbc.com/news/articles/c0000000001o',
-      name: 'og:url',
+      property: 'og:url',
     },
   ];
 
@@ -436,17 +436,26 @@ it('should render the default service image as open graph image', async () => {
   const serviceConfig = services.news.default;
 
   const actual = Array.from(
-    document.querySelectorAll('head > meta[name*="image"]'),
-  ).map(tag => ({
-    name: tag.getAttribute('name'),
-    content: tag.getAttribute('content'),
-  }));
+    document.querySelectorAll(
+      'head > meta[property*="image"], head > meta[name*="image"]',
+    ),
+  ).map(tag =>
+    tag.hasAttribute('property')
+      ? {
+          property: tag.getAttribute('property'),
+          content: tag.getAttribute('content'),
+        }
+      : {
+          name: tag.getAttribute('name'),
+          content: tag.getAttribute('content'),
+        },
+  );
   const expected = [
     {
-      name: 'og:image',
+      property: 'og:image',
       content: serviceConfig.defaultImage,
     },
-    { name: 'og:image:alt', content: serviceConfig.defaultImageAltText },
+    { property: 'og:image:alt', content: serviceConfig.defaultImageAltText },
     { name: 'twitter:image:alt', content: serviceConfig.defaultImageAltText },
     {
       name: 'twitter:image:src',
@@ -460,18 +469,27 @@ it('should render the open graph image if provided', async () => {
   await renderMapMetadataToDocument();
 
   const actual = Array.from(
-    document.querySelectorAll('head > meta[name*="image"]'),
-  ).map(tag => ({
-    name: tag.getAttribute('name'),
-    content: tag.getAttribute('content'),
-  }));
+    document.querySelectorAll(
+      'head > meta[property*="image"], head > meta[name*="image"]',
+    ),
+  ).map(tag =>
+    tag.hasAttribute('property')
+      ? {
+          property: tag.getAttribute('property'),
+          content: tag.getAttribute('content'),
+        }
+      : {
+          name: tag.getAttribute('name'),
+          content: tag.getAttribute('content'),
+        },
+  );
   const expected = [
     {
-      name: 'og:image',
+      property: 'og:image',
       content:
         'http://ichef.test.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg',
     },
-    { name: 'og:image:alt', content: 'connectionAltText' },
+    { property: 'og:image:alt', content: 'connectionAltText' },
     { name: 'twitter:image:alt', content: 'connectionAltText' },
     {
       name: 'twitter:image:src',

--- a/src/app/containers/RadioPageMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageMain/__snapshots__/index.test.jsx.snap
@@ -118,11 +118,11 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -138,35 +138,35 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
     />
     <meta
       content="ዝግጅቶቻችንን’"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/amharic.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News አማርኛ"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="am-ET"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News አማርኛ"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="ያድምጡ - BBC News አማርኛ"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="website"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -770,11 +770,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -790,35 +790,35 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
     />
     <meta
       content="ዝግጅቶቻችንን’"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/amharic.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News አማርኛ"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="am-ET"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News አማርኛ"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="ያድምጡ - BBC News አማርኛ"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="website"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pathname"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/pages/CpsMap/index.test.jsx
+++ b/src/app/pages/CpsMap/index.test.jsx
@@ -144,18 +144,27 @@ describe('CPS MAP Page', () => {
     });
 
     const actual = Array.from(
-      document.querySelectorAll('head > meta[name*="image"]'),
-    ).map(tag => ({
-      name: tag.getAttribute('name'),
-      content: tag.getAttribute('content'),
-    }));
+      document.querySelectorAll(
+        'head > meta[property*="image"], head > meta[name*="image"]',
+      ),
+    ).map(tag =>
+      tag.hasAttribute('property')
+        ? {
+            property: tag.getAttribute('property'),
+            content: tag.getAttribute('content'),
+          }
+        : {
+            name: tag.getAttribute('name'),
+            content: tag.getAttribute('content'),
+          },
+    );
     const expected = [
       {
-        name: 'og:image',
+        property: 'og:image',
         content:
           'http://ichef.test.bbci.co.uk/news/1024/branded_pidgin/6FC4/test/_63721682_p01kx435.jpg',
       },
-      { name: 'og:image:alt', content: 'connectionAltText' },
+      { property: 'og:image:alt', content: 'connectionAltText' },
       { name: 'twitter:image:alt', content: 'connectionAltText' },
       {
         name: 'twitter:image:src',

--- a/src/app/pages/CpsPgl/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsPgl/__snapshots__/index.test.jsx.snap
@@ -1790,11 +1790,11 @@ exports[`CPS PGL Page snapshots should match snapshot for PGL 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -1810,35 +1810,35 @@ exports[`CPS PGL Page snapshots should match snapshot for PGL 1`] = `
     />
     <meta
       content="This is a test asset used in Simorgh, please do not edit it without asking."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="pcm"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="PGL - Blood pressure drugs dey work better - BBC News Pidgin"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pidgin/sport-23252855"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"
@@ -2461,11 +2461,11 @@ exports[`CPS PGL Page snapshots should match snapshot for PGL with about tags 1`
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -2481,35 +2481,35 @@ exports[`CPS PGL Page snapshots should match snapshot for PGL with about tags 1`
     />
     <meta
       content="Manneen durii 5 Magaalaa Finfinnee keessaa daawwachuu qabdan"
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="http://ichef.test.bbci.co.uk/news/1024/branded_afaanoromoo/726D/production/_97739292_img_1620.jpg"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="Mana Dubbii Hiimaa Mootii Axinaafuu Sagadi"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="om-ET"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Afaan Oromoo"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="Manneen durii 5 Magaalaa Finfinnee keessaa daawwachuu qabdan - BBC News Afaan Oromoo"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/afaanoromoo/oduu-41217768"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"

--- a/src/app/pages/CpsSty/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsSty/__snapshots__/index.test.jsx.snap
@@ -2205,11 +2205,11 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
     />
     <meta
       content="100004154058350"
-      name="fb:admins"
+      property="fb:admins"
     />
     <meta
       content="1609039196070050"
-      name="fb:app_id"
+      property="fb:app_id"
     />
     <meta
       content="yes"
@@ -2225,35 +2225,35 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
     />
     <meta
       content="This is a test asset used in Simorgh, please do not edit it without asking."
-      name="og:description"
+      property="og:description"
     />
     <meta
       content="https://news.files.bbci.co.uk/ws/img/logos/og/pidgin.png"
-      name="og:image"
+      property="og:image"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:image:alt"
+      property="og:image:alt"
     />
     <meta
       content="pcm"
-      name="og:locale"
+      property="og:locale"
     />
     <meta
       content="BBC News Pidgin"
-      name="og:site_name"
+      property="og:site_name"
     />
     <meta
       content="STY - Blood pressure drugs dey work better - BBC News Pidgin"
-      name="og:title"
+      property="og:title"
     />
     <meta
       content="article"
-      name="og:type"
+      property="og:type"
     />
     <meta
       content="https://www.test.bbc.com/pidgin/world-23252817"
-      name="og:url"
+      property="og:url"
     />
     <meta
       content="summary_large_image"


### PR DESCRIPTION
Resolves #5305

**Overall change:** 
Fix facebook's open graph sharing data.

**Code changes:**
- Rename `name` attribute to `property`
- Update unit tests
- Update e2e tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
