### PR TITLE
[DO NOT MERGE] Somali and Hausa liveradio e2es on live

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -387,10 +387,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path:
-          isLive(appEnv) || isTest(appEnv) || Cypress.env('APP_ENV') === 'local'
-            ? undefined
-            : '/hausa/bbc_hausa_radio/liveradio',
+        path: '/hausa/bbc_hausa_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {
@@ -1066,10 +1063,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path:
-          isLive(appEnv) || isTest(appEnv) || Cypress.env('APP_ENV') === 'local'
-            ? undefined
-            : '/somali/bbc_somali_radio/liveradio',
+        path: '/somali/bbc_somali_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {


### PR DESCRIPTION

**Overall change:** 
In the services config, added somali and hausa to run on live (same url for live, test and local)

**Code changes:**
E.g 
liveRadio: {
        path: '/somali/bbc_somali_radio/liveradio',
        smoke: false,
      },

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
To be checked manually after go live also
