### PR TITLE
Fix spacing at the end of bulleted lists

### DIFF
--- a/src/app/containers/BulletedList/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/BulletedList/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BulletedListContainer should render ltr correctly 1`] = `
-.c1 {
+.c2 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -11,7 +11,7 @@ exports[`BulletedListContainer should render ltr correctly 1`] = `
   list-style-type: none;
 }
 
-.c1 > li::before {
+.c2 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -19,7 +19,7 @@ exports[`BulletedListContainer should render ltr correctly 1`] = `
   margin-left: -2rem;
 }
 
-.c2 {
+.c3 {
   margin-bottom: 1rem;
 }
 
@@ -27,15 +27,19 @@ exports[`BulletedListContainer should render ltr correctly 1`] = `
   grid-column: 1 / span 6;
 }
 
+.c1 {
+  margin-bottom: 1.5rem;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c1 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -83,29 +87,33 @@ exports[`BulletedListContainer should render ltr correctly 1`] = `
 <div
   class="c0"
 >
-  <ul
+  <div
     class="c1"
-    dir="ltr"
-    role="list"
   >
-    <li
+    <ul
       class="c2"
-      role="listitem"
+      dir="ltr"
+      role="list"
     >
-      It is unordered
-    </li>
-    <li
-      class="c2"
-      role="listitem"
-    >
-      It has three list items
-    </li>
-  </ul>
+      <li
+        class="c3"
+        role="listitem"
+      >
+        It is unordered
+      </li>
+      <li
+        class="c3"
+        role="listitem"
+      >
+        It has three list items
+      </li>
+    </ul>
+  </div>
 </div>
 `;
 
 exports[`BulletedListContainer should render rtl correctly 1`] = `
-.c1 {
+.c2 {
   font-size: 1.125rem;
   line-height: 1.75rem;
   font-family: "BBC Nassim Arabic",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -115,7 +123,7 @@ exports[`BulletedListContainer should render rtl correctly 1`] = `
   list-style-type: none;
 }
 
-.c1 > li::before {
+.c2 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -123,7 +131,7 @@ exports[`BulletedListContainer should render rtl correctly 1`] = `
   margin-right: -2rem;
 }
 
-.c2 {
+.c3 {
   margin-bottom: 1rem;
 }
 
@@ -131,15 +139,19 @@ exports[`BulletedListContainer should render rtl correctly 1`] = `
   grid-column: 1 / span 6;
 }
 
+.c1 {
+  margin-bottom: 1.5rem;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c1 {
+  .c2 {
     font-size: 1.375rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c2 {
     font-size: 1.375rem;
     line-height: 2rem;
   }
@@ -187,23 +199,27 @@ exports[`BulletedListContainer should render rtl correctly 1`] = `
 <div
   class="c0"
 >
-  <ul
+  <div
     class="c1"
-    dir="rtl"
-    role="list"
   >
-    <li
+    <ul
       class="c2"
-      role="listitem"
+      dir="rtl"
+      role="list"
     >
-      It is unordered
-    </li>
-    <li
-      class="c2"
-      role="listitem"
-    >
-      It has three list items
-    </li>
-  </ul>
+      <li
+        class="c3"
+        role="listitem"
+      >
+        It is unordered
+      </li>
+      <li
+        class="c3"
+        role="listitem"
+      >
+        It has three list items
+      </li>
+    </ul>
+  </div>
 </div>
 `;

--- a/src/app/containers/BulletedList/index.jsx
+++ b/src/app/containers/BulletedList/index.jsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
+import styled from 'styled-components';
 import BulletedList from '@bbc/psammead-bulleted-list';
+import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import { arrayOf, shape, oneOf } from 'prop-types';
 import { ServiceContext } from '#contexts/ServiceContext';
 import Blocks from '../Blocks';
@@ -8,14 +10,20 @@ import { GridItemConstrainedMedium } from '#lib/styledGrid';
 
 const componentsToRender = { listItem };
 
+const Wrapper = styled.div`
+  margin-bottom: ${GEL_SPACING_TRPL};
+`;
+
 const BulletedListContainer = ({ blocks }) => {
   const { script, service, dir } = useContext(ServiceContext);
 
   return (
     <GridItemConstrainedMedium>
-      <BulletedList script={script} service={service} dir={dir}>
-        <Blocks blocks={blocks} componentsToRender={componentsToRender} />
-      </BulletedList>
+      <Wrapper>
+        <BulletedList script={script} service={service} dir={dir}>
+          <Blocks blocks={blocks} componentsToRender={componentsToRender} />
+        </BulletedList>
+      </Wrapper>
     </GridItemConstrainedMedium>
   );
 };

--- a/src/app/containers/CpsText/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsText/__snapshots__/index.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`CpsTextContainer with data should render correctly 1`] = `
   grid-column: 1 / span 6;
 }
 
-.c2 {
+.c3 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -26,7 +26,7 @@ exports[`CpsTextContainer with data should render correctly 1`] = `
   list-style-type: none;
 }
 
-.c2 > li::before {
+.c3 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -34,8 +34,12 @@ exports[`CpsTextContainer with data should render correctly 1`] = `
   margin-left: -2rem;
 }
 
-.c3 {
+.c4 {
   margin-bottom: 1rem;
+}
+
+.c2 {
+  margin-bottom: 1.5rem;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -92,14 +96,14 @@ exports[`CpsTextContainer with data should render correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
+  .c3 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -154,34 +158,42 @@ exports[`CpsTextContainer with data should render correctly 1`] = `
   <div
     class="c0"
   >
-    <ul
+    <div
       class="c2"
-      dir="ltr"
-      role="list"
     >
-      <li
+      <ul
         class="c3"
-        role="listitem"
+        dir="ltr"
+        role="list"
       >
-        This is a list item
-      </li>
-    </ul>
+        <li
+          class="c4"
+          role="listitem"
+        >
+          This is a list item
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     class="c0"
   >
-    <ul
+    <div
       class="c2"
-      dir="ltr"
-      role="list"
     >
-      <li
+      <ul
         class="c3"
-        role="listitem"
+        dir="ltr"
+        role="list"
       >
-        This is a list item
-      </li>
-    </ul>
+        <li
+          class="c4"
+          role="listitem"
+        >
+          This is a list item
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 `;

--- a/src/app/pages/CpsMap/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsMap/__snapshots__/index.test.jsx.snap
@@ -204,92 +204,100 @@ exports[`CPS MAP Page AV player should render version (live audio stream) 1`] = 
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
               >
-                <ul
-                  class="BulletedList-sc-13z0d8v-0 zkoYd"
-                  dir="ltr"
-                  role="list"
+                <div
+                  class="Wrapper-e2169q-0 kopXQT"
                 >
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
+                  <ul
+                    class="BulletedList-sc-13z0d8v-0 zkoYd"
+                    dir="ltr"
+                    role="list"
                   >
-                    Ўзбек деҳқонининг косаси нега оқармайди
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    Ўзбек деҳқонининг косаси нега оқармайди
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <b>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
                       Ўзбек деҳқонининг косаси нега оқармайди
-                    </b>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    Ўзбек деҳқонининг косаси нега оқармайди
-                  </li>
-                </ul>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      Ўзбек деҳқонининг косаси нега оқармайди
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      <b>
+                        Ўзбек деҳқонининг косаси нега оқармайди
+                      </b>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      Ўзбек деҳқонининг косаси нега оқармайди
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
               >
-                <ul
-                  class="BulletedList-sc-13z0d8v-0 zkoYd"
-                  dir="ltr"
-                  role="list"
+                <div
+                  class="Wrapper-e2169q-0 kopXQT"
                 >
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
+                  <ul
+                    class="BulletedList-sc-13z0d8v-0 zkoYd"
+                    dir="ltr"
+                    role="list"
                   >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/uzbek"
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      Ўзбек деҳқонининг косаси нега оқармайди
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/uzbek"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/uzbek"
+                      >
+                        Ўзбек деҳқонининг косаси нега оқармайди
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      Ўзбек деҳқонининг косаси нега оқармайди
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/uzbek"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/uzbek"
+                      >
+                        Ўзбек деҳқонининг косаси нега оқармайди
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      Ўзбек деҳқонининг косаси нега оқармайди
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/uzbek"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/uzbek"
+                      >
+                        Ўзбек деҳқонининг косаси нега оқармайди
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      Ўзбек деҳқонининг косаси нега оқармайди
-                    </a>
-                  </li>
-                </ul>
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/uzbek"
+                      >
+                        Ўзбек деҳқонининг косаси нега оқармайди
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="GridItemConstrainedLargeNoMargin-sc-12lwanc-6 kXuCUa"
@@ -500,78 +508,82 @@ exports[`CPS MAP Page should render component 1`] = `
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
               >
-                <ul
-                  class="BulletedList-sc-13z0d8v-0 zkoYd"
-                  dir="ltr"
-                  role="list"
+                <div
+                  class="Wrapper-e2169q-0 kopXQT"
                 >
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
+                  <ul
+                    class="BulletedList-sc-13z0d8v-0 zkoYd"
+                    dir="ltr"
+                    role="list"
                   >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                </ul>
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
@@ -585,78 +597,82 @@ exports[`CPS MAP Page should render component 1`] = `
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
               >
-                <ul
-                  class="BulletedList-sc-13z0d8v-0 zkoYd"
-                  dir="ltr"
-                  role="list"
+                <div
+                  class="Wrapper-e2169q-0 kopXQT"
                 >
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
+                  <ul
+                    class="BulletedList-sc-13z0d8v-0 zkoYd"
+                    dir="ltr"
+                    role="list"
                   >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="http://www.bbc.com/afrique/23248423"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      &lt;Media Asset Page&gt;
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="http://www.bbc.com/afrique/23248423"
+                      >
+                        &lt;Media Asset Page&gt;
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    <a
-                      class="InlineLink-hkwpaz-0 idscKS"
-                      href="https://bbc.com/pidgin"
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
                     >
-                      this is the link text
-                    </a>
-                  </li>
-                </ul>
+                      <a
+                        class="InlineLink-hkwpaz-0 idscKS"
+                        href="https://bbc.com/pidgin"
+                      >
+                        this is the link text
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
@@ -889,36 +905,40 @@ exports[`CPS MAP Page should render component 1`] = `
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"
               >
-                <ul
-                  class="BulletedList-sc-13z0d8v-0 zkoYd"
-                  dir="ltr"
-                  role="list"
+                <div
+                  class="Wrapper-e2169q-0 kopXQT"
                 >
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
+                  <ul
+                    class="BulletedList-sc-13z0d8v-0 zkoYd"
+                    dir="ltr"
+                    role="list"
                   >
-                    sunt in culpa qui officia deserunt mollit anim id est laborum
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    sunt in culpa qui officia deserunt mollit anim id est laborum
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    sunt in culpa qui officia deserunt mollit anim id est laborum
-                  </li>
-                  <li
-                    class="BulletedListItem-sc-13z0d8v-1 kHsWph"
-                    role="listitem"
-                  >
-                    v3 draft
-                  </li>
-                </ul>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      sunt in culpa qui officia deserunt mollit anim id est laborum
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      sunt in culpa qui officia deserunt mollit anim id est laborum
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      sunt in culpa qui officia deserunt mollit anim id est laborum
+                    </li>
+                    <li
+                      class="BulletedListItem-sc-13z0d8v-1 kHsWph"
+                      role="listitem"
+                    >
+                      v3 draft
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="GridItemConstrainedMedium-sc-12lwanc-3 fexpEX"

--- a/src/app/pages/CpsPgl/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsPgl/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
-  .c23 {
+  .c24 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -17,7 +17,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   grid-column-gap: 1rem;
 }
 
-.c22 {
+.c23 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -81,7 +81,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   color: #B80000;
 }
 
-.c17 {
+.c18 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -91,7 +91,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   list-style-type: none;
 }
 
-.c17 > li::before {
+.c18 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -99,8 +99,12 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   margin-left: -2rem;
 }
 
-.c18 {
+.c19 {
   margin-bottom: 1rem;
+}
+
+.c17 {
+  margin-bottom: 1.5rem;
 }
 
 .c4 {
@@ -182,21 +186,21 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   transition: visibility 0.2s linear;
 }
 
-.c20 {
+.c21 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c19 {
+.c20 {
   margin-top: 1rem;
 }
 
-.c19 figure {
+.c20 figure {
   padding-bottom: 0;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,7 +210,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   flex-direction: column;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -225,7 +229,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   align-items: baseline;
 }
 
-.c30 {
+.c31 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -245,42 +249,42 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   align-items: center;
 }
 
-.c26 {
+.c27 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c25 {
+.c26 {
   position: relative;
   margin-top: 2rem;
 }
 
-.c27 {
+.c28 {
   margin: 0;
   padding: 0;
 }
 
-.c32 {
+.c33 {
   border-bottom: 0.0625rem solid #F2F2F2;
   padding: 0.5rem 0 1rem;
 }
 
-.c32:first-child {
+.c33:first-child {
   padding-top: 0;
 }
 
-.c32:last-child {
+.c33:last-child {
   padding-bottom: 0;
   border: none;
 }
 
-.c31 {
+.c32 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.c24 {
+.c25 {
   margin-bottom: 1rem;
   z-index: 0;
 }
@@ -295,7 +299,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
   flex-grow: 1;
 }
 
-.c21 {
+.c22 {
   border: 0;
   left: 0;
   overflow: hidden;
@@ -306,39 +310,39 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (max-width:37.4375rem) {
-  .c23 {
+  .c24 {
     grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c24 {
     grid-column-gap: 1rem;
   }
 }
 
 @media (max-width:62.9375rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
     max-width: 45.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
     max-width: 46.4rem;
   }
 }
 
 @supports (display:grid) {
-  .c23 {
+  .c24 {
     display: grid;
     max-width: initial;
     margin: initial;
@@ -493,21 +497,21 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     padding-top: 2rem;
   }
 }
@@ -547,14 +551,14 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c18 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -587,44 +591,44 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (max-width:63rem) {
-  .c19 {
+  .c20 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c19 {
+  .c20 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c19 {
+  .c20 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c19 {
+  .c20 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c19 {
+  .c20 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c19 {
+  .c20 {
     padding-top: 0.5rem;
     margin-top: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c29 {
+  .c30 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -633,39 +637,39 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
+  .c31 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     position: absolute;
     left: 0;
     right: 0;
@@ -674,67 +678,67 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:37.5rem) {
-  .c25 {
+  .c26 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32 {
+  .c33 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c32 {
+  .c33 {
     padding: 1.5rem 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32:first-child {
+  .c33:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c32:first-child {
+  .c33:first-child {
     padding-top: 1.5rem;
   }
 }
 
 @media (max-width:63rem) {
-  .c24 {
+  .c25 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
+  .c25 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c24 {
+  .c25 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c24 {
+  .c25 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
+  .c25 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     margin-bottom: 1.5rem;
   }
 }
@@ -911,49 +915,53 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
               <div
                 class="c13"
               >
-                <ul
+                <div
                   class="c17"
-                  dir="ltr"
-                  role="list"
                 >
-                  <li
+                  <ul
                     class="c18"
-                    role="listitem"
+                    dir="ltr"
+                    role="list"
                   >
-                    This is a unordered list
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    It can have 
-                    <b>
-                      bold text
-                    </b>
-                     in it
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <a
-                      class="c15"
-                      href="https://bbc.com/pidgin/23248703"
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can also have links
-                    </a>
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <i
-                      class="c16"
+                      This is a unordered list
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can even have italic text in it!
-                    </i>
-                  </li>
-                </ul>
+                      It can have 
+                      <b>
+                        bold text
+                      </b>
+                       in it
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <a
+                        class="c15"
+                        href="https://bbc.com/pidgin/23248703"
+                      >
+                        It can also have links
+                      </a>
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <i
+                        class="c16"
+                      >
+                        It can even have italic text in it!
+                      </i>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="c13"
@@ -1066,49 +1074,53 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
               <div
                 class="c13"
               >
-                <ul
+                <div
                   class="c17"
-                  dir="ltr"
-                  role="list"
                 >
-                  <li
+                  <ul
                     class="c18"
-                    role="listitem"
+                    dir="ltr"
+                    role="list"
                   >
-                    This is a ordered list
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    It can have 
-                    <b>
-                      bold text
-                    </b>
-                     in it
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <a
-                      class="c15"
-                      href="https://bbc.com/pidgin/23248703"
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can also have links
-                    </a>
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <i
-                      class="c16"
+                      This is a ordered list
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can even have italic text in it!
-                    </i>
-                  </li>
-                </ul>
+                      It can have 
+                      <b>
+                        bold text
+                      </b>
+                       in it
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <a
+                        class="c15"
+                        href="https://bbc.com/pidgin/23248703"
+                      >
+                        It can also have links
+                      </a>
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <i
+                        class="c16"
+                      >
+                        It can even have italic text in it!
+                      </i>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="c13"
@@ -1120,18 +1132,18 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
                 </p>
               </div>
               <div
-                class="c19"
+                class="c20"
               >
                 <figure
                   class="c4"
                 >
                   <div
-                    class="c20"
+                    class="c21"
                   >
                     <iframe
                       allow="autoplay; fullscreen"
                       allowfullscreen=""
-                      class="c21"
+                      class="c22"
                       scrolling="no"
                       src="https://polling.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/pcm"
                       title="Media player"
@@ -1143,7 +1155,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-heading"
                   tabindex="-1"
                 >
@@ -1154,7 +1166,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-subheading"
                   tabindex="-1"
                 >
@@ -1174,7 +1186,7 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-crosshead"
                   tabindex="-1"
                 >
@@ -1217,29 +1229,29 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
             </main>
             <aside
               aria-labelledby="related-content-heading"
-              class="c23"
+              class="c24"
               role="complementary"
             >
               <div
-                class="c24"
+                class="c25"
               >
                 <div
-                  class="c25"
+                  class="c26"
                 >
                   <div
-                    class="c26"
+                    class="c27"
                   />
                   <h2
-                    class="c27"
+                    class="c28"
                   >
                     <div
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       >
                         <span
-                          class="c30"
+                          class="c31"
                           dir="ltr"
                           id="related-content-heading"
                         >
@@ -1250,11 +1262,11 @@ exports[`CPS PGL Page should not show the pop-out timestamp when allowDateStamp 
                   </h2>
                 </div>
                 <ul
-                  class="c31"
+                  class="c32"
                   role="list"
                 >
                   <li
-                    class="c32"
+                    class="c33"
                     role="listitem"
                   />
                 </ul>

--- a/src/app/pages/CpsSty/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsSty/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
-  .c23 {
+  .c24 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -17,7 +17,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   grid-column-gap: 1rem;
 }
 
-.c22 {
+.c23 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -81,7 +81,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   color: #B80000;
 }
 
-.c17 {
+.c18 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -91,7 +91,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   list-style-type: none;
 }
 
-.c17 > li::before {
+.c18 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -99,8 +99,12 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   margin-left: -2rem;
 }
 
-.c18 {
+.c19 {
   margin-bottom: 1rem;
+}
+
+.c17 {
+  margin-bottom: 1.5rem;
 }
 
 .c4 {
@@ -182,21 +186,21 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   transition: visibility 0.2s linear;
 }
 
-.c20 {
+.c21 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c19 {
+.c20 {
   margin-top: 1rem;
 }
 
-.c19 figure {
+.c20 figure {
   padding-bottom: 0;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,7 +210,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   flex-direction: column;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -225,7 +229,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   align-items: baseline;
 }
 
-.c30 {
+.c31 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -245,42 +249,42 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   align-items: center;
 }
 
-.c26 {
+.c27 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c25 {
+.c26 {
   position: relative;
   margin-top: 2rem;
 }
 
-.c27 {
+.c28 {
   margin: 0;
   padding: 0;
 }
 
-.c32 {
+.c33 {
   border-bottom: 0.0625rem solid #F2F2F2;
   padding: 0.5rem 0 1rem;
 }
 
-.c32:first-child {
+.c33:first-child {
   padding-top: 0;
 }
 
-.c32:last-child {
+.c33:last-child {
   padding-bottom: 0;
   border: none;
 }
 
-.c31 {
+.c32 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.c24 {
+.c25 {
   margin-bottom: 1rem;
   z-index: 0;
 }
@@ -295,7 +299,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
   flex-grow: 1;
 }
 
-.c21 {
+.c22 {
   border: 0;
   left: 0;
   overflow: hidden;
@@ -306,39 +310,39 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (max-width:37.4375rem) {
-  .c23 {
+  .c24 {
     grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c24 {
     grid-column-gap: 1rem;
   }
 }
 
 @media (max-width:62.9375rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
     max-width: 45.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c23 {
+  .c24 {
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
     max-width: 46.4rem;
   }
 }
 
 @supports (display:grid) {
-  .c23 {
+  .c24 {
     display: grid;
     max-width: initial;
     margin: initial;
@@ -493,21 +497,21 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     padding-top: 2rem;
   }
 }
@@ -547,14 +551,14 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c18 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c18 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -587,44 +591,44 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (max-width:63rem) {
-  .c19 {
+  .c20 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c19 {
+  .c20 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c19 {
+  .c20 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c19 {
+  .c20 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c19 {
+  .c20 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c19 {
+  .c20 {
     padding-top: 0.5rem;
     margin-top: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c29 {
+  .c30 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -633,39 +637,39 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c30 {
+  .c31 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c31 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c26 {
+  .c27 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     position: absolute;
     left: 0;
     right: 0;
@@ -674,67 +678,67 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 }
 
 @media (min-width:37.5rem) {
-  .c25 {
+  .c26 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32 {
+  .c33 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c32 {
+  .c33 {
     padding: 1.5rem 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32:first-child {
+  .c33:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c32:first-child {
+  .c33:first-child {
     padding-top: 1.5rem;
   }
 }
 
 @media (max-width:63rem) {
-  .c24 {
+  .c25 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c24 {
+  .c25 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c24 {
+  .c25 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c24 {
+  .c25 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c24 {
+  .c25 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     margin-bottom: 1.5rem;
   }
 }
@@ -911,49 +915,53 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
               <div
                 class="c13"
               >
-                <ul
+                <div
                   class="c17"
-                  dir="ltr"
-                  role="list"
                 >
-                  <li
+                  <ul
                     class="c18"
-                    role="listitem"
+                    dir="ltr"
+                    role="list"
                   >
-                    This is a unordered list
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    It can have 
-                    <b>
-                      bold text
-                    </b>
-                     in it
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <a
-                      class="c15"
-                      href="https://bbc.com/pidgin/23248703"
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can also have links
-                    </a>
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <i
-                      class="c16"
+                      This is a unordered list
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can even have italic text in it!
-                    </i>
-                  </li>
-                </ul>
+                      It can have 
+                      <b>
+                        bold text
+                      </b>
+                       in it
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <a
+                        class="c15"
+                        href="https://bbc.com/pidgin/23248703"
+                      >
+                        It can also have links
+                      </a>
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <i
+                        class="c16"
+                      >
+                        It can even have italic text in it!
+                      </i>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="c13"
@@ -1066,49 +1074,53 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
               <div
                 class="c13"
               >
-                <ul
+                <div
                   class="c17"
-                  dir="ltr"
-                  role="list"
                 >
-                  <li
+                  <ul
                     class="c18"
-                    role="listitem"
+                    dir="ltr"
+                    role="list"
                   >
-                    This is a ordered list
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    It can have 
-                    <b>
-                      bold text
-                    </b>
-                     in it
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <a
-                      class="c15"
-                      href="https://bbc.com/pidgin/23248703"
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can also have links
-                    </a>
-                  </li>
-                  <li
-                    class="c18"
-                    role="listitem"
-                  >
-                    <i
-                      class="c16"
+                      This is a ordered list
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
                     >
-                      It can even have italic text in it!
-                    </i>
-                  </li>
-                </ul>
+                      It can have 
+                      <b>
+                        bold text
+                      </b>
+                       in it
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <a
+                        class="c15"
+                        href="https://bbc.com/pidgin/23248703"
+                      >
+                        It can also have links
+                      </a>
+                    </li>
+                    <li
+                      class="c19"
+                      role="listitem"
+                    >
+                      <i
+                        class="c16"
+                      >
+                        It can even have italic text in it!
+                      </i>
+                    </li>
+                  </ul>
+                </div>
               </div>
               <div
                 class="c13"
@@ -1120,18 +1132,18 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
                 </p>
               </div>
               <div
-                class="c19"
+                class="c20"
               >
                 <figure
                   class="c4"
                 >
                   <div
-                    class="c20"
+                    class="c21"
                   >
                     <iframe
                       allow="autoplay; fullscreen"
                       allowfullscreen=""
-                      class="c21"
+                      class="c22"
                       scrolling="no"
                       src="https://polling.test.bbc.co.uk/ws/av-embeds/cps/igbo/afirika-23252735/p01mr6r9/pcm"
                       title="Media player"
@@ -1143,7 +1155,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-heading"
                   tabindex="-1"
                 >
@@ -1154,7 +1166,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-subheading"
                   tabindex="-1"
                 >
@@ -1174,7 +1186,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
                 class="c13"
               >
                 <h2
-                  class="c22"
+                  class="c23"
                   id="This-is-a-crosshead"
                   tabindex="-1"
                 >
@@ -1217,29 +1229,29 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
             </main>
             <aside
               aria-labelledby="related-content-heading"
-              class="c23"
+              class="c24"
               role="complementary"
             >
               <div
-                class="c24"
+                class="c25"
               >
                 <div
-                  class="c25"
+                  class="c26"
                 >
                   <div
-                    class="c26"
+                    class="c27"
                   />
                   <h2
-                    class="c27"
+                    class="c28"
                   >
                     <div
-                      class="c28"
+                      class="c29"
                     >
                       <span
-                        class="c29"
+                        class="c30"
                       >
                         <span
-                          class="c30"
+                          class="c31"
                           dir="ltr"
                           id="related-content-heading"
                         >
@@ -1250,11 +1262,11 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
                   </h2>
                 </div>
                 <ul
-                  class="c31"
+                  class="c32"
                   role="list"
                 >
                   <li
-                    class="c32"
+                    class="c33"
                     role="listitem"
                   />
                 </ul>
@@ -1269,7 +1281,7 @@ exports[`CPS STY Page should not show the pop-out timestamp when allowDateStamp 
 `;
 
 exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
-.c25 {
+.c26 {
   margin: 0 auto;
   background: #FDFDFD;
   padding-bottom: 2rem;
@@ -1284,7 +1296,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   grid-column-gap: 1rem;
 }
 
-.c24 {
+.c25 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1363,7 +1375,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   color: #B80000;
 }
 
-.c19 {
+.c20 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1373,7 +1385,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   list-style-type: none;
 }
 
-.c19 > li::before {
+.c20 > li::before {
   content: ' ';
   display: inline-block;
   width: 2rem;
@@ -1381,8 +1393,12 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   margin-left: -2rem;
 }
 
-.c20 {
+.c21 {
   margin-bottom: 1rem;
+}
+
+.c19 {
+  margin-bottom: 1.5rem;
 }
 
 .c4 {
@@ -1464,21 +1480,21 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   transition: visibility 0.2s linear;
 }
 
-.c22 {
+.c23 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c21 {
+.c22 {
   margin-top: 1rem;
 }
 
-.c21 figure {
+.c22 figure {
   padding-bottom: 0;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1488,7 +1504,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   flex-direction: column;
 }
 
-.c31 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1507,7 +1523,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   align-items: baseline;
 }
 
-.c32 {
+.c33 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1527,42 +1543,42 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   align-items: center;
 }
 
-.c28 {
+.c29 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c27 {
+.c28 {
   position: relative;
   margin-top: 2rem;
 }
 
-.c29 {
+.c30 {
   margin: 0;
   padding: 0;
 }
 
-.c34 {
+.c35 {
   border-bottom: 0.0625rem solid #F2F2F2;
   padding: 0.5rem 0 1rem;
 }
 
-.c34:first-child {
+.c35:first-child {
   padding-top: 0;
 }
 
-.c34:last-child {
+.c35:last-child {
   padding-bottom: 0;
   border: none;
 }
 
-.c33 {
+.c34 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.c26 {
+.c27 {
   margin-bottom: 1rem;
   z-index: 0;
 }
@@ -1581,7 +1597,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
   flex-grow: 1;
 }
 
-.c23 {
+.c24 {
   border: 0;
   left: 0;
   overflow: hidden;
@@ -1592,39 +1608,39 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (max-width:37.4375rem) {
-  .c25 {
+  .c26 {
     grid-column-gap: 0.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c25 {
+  .c26 {
     grid-column-gap: 1rem;
   }
 }
 
 @media (max-width:62.9375rem) {
-  .c25 {
+  .c26 {
     grid-template-columns: repeat(6,1fr);
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c25 {
+  .c26 {
     grid-template-columns: 1fr repeat(8,minmax(0,6.75rem)) 1fr;
     max-width: 45.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c25 {
+  .c26 {
     grid-template-columns: 1fr repeat(20,minmax(0,2.95rem)) 1fr;
     max-width: 46.4rem;
   }
 }
 
 @supports (display:grid) {
-  .c25 {
+  .c26 {
     display: grid;
     max-width: initial;
     margin: initial;
@@ -1779,21 +1795,21 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
+  .c25 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c25 {
     padding-top: 2rem;
   }
 }
@@ -1847,14 +1863,14 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c19 {
+  .c20 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c20 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -1887,44 +1903,44 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (max-width:63rem) {
-  .c21 {
+  .c22 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c21 {
+  .c22 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c21 {
+  .c22 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c21 {
+  .c22 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c21 {
+  .c22 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c21 {
+  .c22 {
     padding-top: 0.5rem;
     margin-top: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c31 {
+  .c32 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1933,39 +1949,39 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c32 {
+  .c33 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32 {
+  .c33 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32 {
+  .c33 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c32 {
+  .c33 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c28 {
+  .c29 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c28 {
+  .c29 {
     position: absolute;
     left: 0;
     right: 0;
@@ -1974,67 +1990,67 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c27 {
+  .c28 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c34 {
+  .c35 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c34 {
+  .c35 {
     padding: 1.5rem 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c34:first-child {
+  .c35:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c34:first-child {
+  .c35:first-child {
     padding-top: 1.5rem;
   }
 }
 
 @media (max-width:63rem) {
-  .c26 {
+  .c27 {
     grid-column: 1 / span 6;
   }
 }
 
 @media (min-width:63rem) and (max-width:80rem) {
-  .c26 {
+  .c27 {
     grid-column: 3 / span 6;
   }
 }
 
 @media (min-width:80rem) {
-  .c26 {
+  .c27 {
     grid-column: 6 / span 12;
   }
 }
 
 @media (max-width:25rem) {
-  .c26 {
+  .c27 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c26 {
+  .c27 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     margin-bottom: 1.5rem;
   }
 }
@@ -2450,49 +2466,53 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                   <div
                     class="c13"
                   >
-                    <ul
+                    <div
                       class="c19"
-                      dir="ltr"
-                      role="list"
                     >
-                      <li
+                      <ul
                         class="c20"
-                        role="listitem"
+                        dir="ltr"
+                        role="list"
                       >
-                        This is a unordered list
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        It can have 
-                        <b>
-                          bold text
-                        </b>
-                         in it
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        <a
-                          class="c17"
-                          href="https://bbc.com/pidgin/23248703"
+                        <li
+                          class="c21"
+                          role="listitem"
                         >
-                          It can also have links
-                        </a>
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        <i
-                          class="c18"
+                          This is a unordered list
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
                         >
-                          It can even have italic text in it!
-                        </i>
-                      </li>
-                    </ul>
+                          It can have 
+                          <b>
+                            bold text
+                          </b>
+                           in it
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
+                        >
+                          <a
+                            class="c17"
+                            href="https://bbc.com/pidgin/23248703"
+                          >
+                            It can also have links
+                          </a>
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
+                        >
+                          <i
+                            class="c18"
+                          >
+                            It can even have italic text in it!
+                          </i>
+                        </li>
+                      </ul>
+                    </div>
                   </div>
                   <div
                     class="c13"
@@ -2605,49 +2625,53 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                   <div
                     class="c13"
                   >
-                    <ul
+                    <div
                       class="c19"
-                      dir="ltr"
-                      role="list"
                     >
-                      <li
+                      <ul
                         class="c20"
-                        role="listitem"
+                        dir="ltr"
+                        role="list"
                       >
-                        This is a ordered list
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        It can have 
-                        <b>
-                          bold text
-                        </b>
-                         in it
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        <a
-                          class="c17"
-                          href="https://bbc.com/pidgin/23248703"
+                        <li
+                          class="c21"
+                          role="listitem"
                         >
-                          It can also have links
-                        </a>
-                      </li>
-                      <li
-                        class="c20"
-                        role="listitem"
-                      >
-                        <i
-                          class="c18"
+                          This is a ordered list
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
                         >
-                          It can even have italic text in it!
-                        </i>
-                      </li>
-                    </ul>
+                          It can have 
+                          <b>
+                            bold text
+                          </b>
+                           in it
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
+                        >
+                          <a
+                            class="c17"
+                            href="https://bbc.com/pidgin/23248703"
+                          >
+                            It can also have links
+                          </a>
+                        </li>
+                        <li
+                          class="c21"
+                          role="listitem"
+                        >
+                          <i
+                            class="c18"
+                          >
+                            It can even have italic text in it!
+                          </i>
+                        </li>
+                      </ul>
+                    </div>
                   </div>
                   <div
                     class="c13"
@@ -2659,18 +2683,18 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                     </p>
                   </div>
                   <div
-                    class="c21"
+                    class="c22"
                   >
                     <figure
                       class="c4"
                     >
                       <div
-                        class="c22"
+                        class="c23"
                       >
                         <iframe
                           allow="autoplay; fullscreen"
                           allowfullscreen=""
-                          class="c23"
+                          class="c24"
                           scrolling="no"
                           src="https://polling.test.bbc.co.uk/ws/av-embeds/cps/pidgin/world-23252817/p01mr6r9/pcm"
                           title="Media player"
@@ -2682,7 +2706,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                     class="c13"
                   >
                     <h2
-                      class="c24"
+                      class="c25"
                       id="This-is-a-heading"
                       tabindex="-1"
                     >
@@ -2702,7 +2726,7 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                     class="c13"
                   >
                     <h2
-                      class="c24"
+                      class="c25"
                       id="This-is-a-crosshead"
                       tabindex="-1"
                     >
@@ -2745,29 +2769,29 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                 </main>
                 <aside
                   aria-labelledby="related-content-heading"
-                  class="c25"
+                  class="c26"
                   role="complementary"
                 >
                   <div
-                    class="c26"
+                    class="c27"
                   >
                     <div
-                      class="c27"
+                      class="c28"
                     >
                       <div
-                        class="c28"
+                        class="c29"
                       />
                       <h2
-                        class="c29"
+                        class="c30"
                       >
                         <div
-                          class="c30"
+                          class="c31"
                         >
                           <span
-                            class="c31"
+                            class="c32"
                           >
                             <span
-                              class="c32"
+                              class="c33"
                               dir="ltr"
                               id="related-content-heading"
                             >
@@ -2778,11 +2802,11 @@ exports[`CPS STY Page snapshots should match snapshot for STY 1`] = `
                       </h2>
                     </div>
                     <ul
-                      class="c33"
+                      class="c34"
                       role="list"
                     >
                       <li
-                        class="c34"
+                        class="c35"
                         role="listitem"
                       />
                     </ul>


### PR DESCRIPTION
Resolves #5303

**Overall change:** 
Set the right spacing at the end of bulleted lists

**Code changes:**
- Add a wrapper to bulleted lists with 24px margin-button
- Update snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
