### PR TITLE
Enable Hausa & Somali Live Radio E2Es

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -387,7 +387,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path: isLive(appEnv) ? undefined : '/hausa/bbc_hausa_radio/liveradio',
+        path: '/hausa/bbc_hausa_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {
@@ -1063,7 +1063,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       liveRadio: {
-        path: isLive(appEnv) ? undefined : '/somali/bbc_somali_radio/liveradio',
+        path: '/somali/bbc_somali_radio/liveradio',
         smoke: false,
       },
       mediaAssetPage: {


### PR DESCRIPTION
Resolves NO TICKET

**Overall change:** 
Enable Hausa & Somali Live Radio E2Es following forge decom team putting them live

**Code changes:**
Enable Hausa & Somali Live Radio E2Es

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
