### PR TITLE
Disable original MAP E2Es on test

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -517,7 +517,10 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/japanese/video-23248670',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/japanese/video-23248670',
         smoke: false,
       },
     },
@@ -550,7 +553,10 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/korean/media-23248686',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/korean/media-23248686',
         smoke: false,
       },
     },
@@ -880,7 +886,10 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/punjabi/media-23248705',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/punjabi/media-23248705',
         smoke: false,
       },
     },
@@ -1035,7 +1044,8 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/sinhala/23248970',
+        path:
+          isLive(appEnv) || isTest(appEnv) ? undefined : '/sinhala/23248970',
         smoke: false,
       },
     },
@@ -1205,7 +1215,10 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/thai/thailand-23248713',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/thai/thailand-23248713',
         smoke: false,
       },
     },
@@ -1439,7 +1452,10 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path: isLive(appEnv) ? undefined : '/uzbek/sport-23248721',
+        path:
+          isLive(appEnv) || isTest(appEnv)
+            ? undefined
+            : '/uzbek/sport-23248721',
         smoke: true,
       },
     },


### PR DESCRIPTION
Resolves NO TICKET

**Overall change:** 
Stop the original test MAPs running E2Es in the TEST environment

These URLs no longer work following the refactor of media pod code within Mozart

https://github.com/bbc/simorgh/pull/5324

**Code changes:**
- Cypress config updates

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
