### PR TITLE
Removing archive from cypress testing

### DIFF
--- a/cypress/integration/application/index.js
+++ b/cypress/integration/application/index.js
@@ -4,7 +4,7 @@ import appConfig from '../../../src/server/utilities/serviceConfigs';
 const serviceHasPageType = (service, pageType) =>
   config[service].pageTypes[pageType].path !== undefined;
 
-const servicesUsingArticlePaths = ['news', 'scotland', 'archive'];
+const servicesUsingArticlePaths = ['news', 'scotland'];
 
 describe('Application', () => {
   Object.keys(config)

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -153,9 +153,7 @@ const genServices = appEnv => ({
     variant: 'default',
     pageTypes: {
       articles: {
-        path: isLive(appEnv)
-          ? '/archive/articles/c413ngjk87wo'
-          : '/archive/articles/cqv9w00mgjpo',
+        path: undefined,
         smoke: false,
       },
       errorPage404: {


### PR DESCRIPTION
**Overall change:** 
Partially undoes the work in #5285 
Our live tests (on CD and our live e2es) keep failing on the archive service worker and manifest tests:

```
Application should return a 200 status code for archive manifest file:
CypressError: cy.request() failed trying to load:

https://www.bbc.com/archive/articles/manifest.json

We attempted to make an http request to this URL but the request failed without a response.

We received this error at the network level:

  > Error: Exceeded maxRedirects. Probably stuck in a redirect loop https://www.bbc.com/archive/articles/manifest.json
```

**Code changes:**
- This removes the page urls from the cypress config so archive will not be tested in our e2es.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
