### PR TITLE
Disable /archive e2e tests entirely

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -146,37 +146,6 @@ const genServices = appEnv => ({
       },
     },
   },
-  archive: {
-    name: 'archive',
-    font: 'Reith',
-    isWorldService: false,
-    variant: 'default',
-    pageTypes: {
-      articles: {
-        path: undefined,
-        smoke: false,
-      },
-      errorPage404: {
-        path:
-          isLive(appEnv) || isTest(appEnv)
-            ? undefined
-            : '/archive/articles/c123456abcdo',
-        smoke: false,
-      },
-      frontPage: {
-        path: undefined,
-        smoke: false,
-      },
-      liveRadio: {
-        path: undefined,
-        smoke: false,
-      },
-      mediaAssetPage: {
-        path: undefined,
-        smoke: false,
-      },
-    },
-  },
   azeri: {
     name: 'azeri',
     font: undefined,


### PR DESCRIPTION
Although /archive tests were mostly disabled in #5337 some still run such
as cookie banner tests. This PR completely disables all tests till #5339
can be resolved.

(no issue)

**Overall change:** 
_Remove all test config for /archive_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
