### PR TITLE
update cypress helper getBrandedImage

### DIFF
--- a/cypress/support/helpers/getBrandedImage.js
+++ b/cypress/support/helpers/getBrandedImage.js
@@ -1,7 +1,10 @@
-import getBrandedImage from '../../../src/app/containers/CpsMetadata/utils/getBrandedImage';
 import { getImageParts } from '../../../src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/image/helpers';
 
 export default (imagePath, service) => {
   const [, locator] = getImageParts(imagePath);
-  return getBrandedImage(locator, service);
+  const iChefHost =
+    Cypress('APP_ENV') === 'live'
+      ? 'http://ichef.bbci.co.uk'
+      : 'http://ichef.test.bbci.co.uk';
+  return `${iChefHost}/news/1024/branded_${service}/${locator}`;
 };

--- a/cypress/support/helpers/getBrandedImage.js
+++ b/cypress/support/helpers/getBrandedImage.js
@@ -3,7 +3,7 @@ import { getImageParts } from '../../../src/app/lib/utilities/preprocessor/rules
 export default (imagePath, service) => {
   const [, locator] = getImageParts(imagePath);
   const iChefHost =
-    Cypress('APP_ENV') === 'live'
+    Cypress.env('APP_ENV') === 'live'
       ? 'http://ichef.bbci.co.uk'
       : 'http://ichef.test.bbci.co.uk';
   return `${iChefHost}/news/1024/branded_${service}/${locator}`;


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5367

**Overall change:** 
Update the Cypress helper getBrandedImage so that it returns the correct iChef url appropriate for the environment it is running against because node environment variables cannot be accessed when Cypress is running against live.

**Code changes:**
- Updates `cypress/support/helpers/getBrandedImage.js` by not importing Simorgh code that gets the current environment by checking node vars. Instead we check the current environment with `Cypress('APP_ENV')`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
