### PR TITLE
Fix propType errors in ArticleMetadata

### DIFF
--- a/src/app/containers/ArticleMetadata/index.jsx
+++ b/src/app/containers/ArticleMetadata/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, shape, arrayOf, objectOf, any } from 'prop-types';
+import { string, shape, arrayOf } from 'prop-types';
 import Metadata from '../Metadata';
 
 const ArticleMetadata = ({
@@ -52,7 +52,6 @@ ArticleMetadata.propTypes = {
   mentionsTags: arrayOf(tagPropTypes),
   lang: string.isRequired,
   description: string.isRequired,
-  linkedData: objectOf(any),
 };
 
 ArticleMetadata.defaultProps = {
@@ -60,7 +59,6 @@ ArticleMetadata.defaultProps = {
   section: '',
   aboutTags: [],
   mentionsTags: [],
-  linkedData: {},
 };
 
 export default ArticleMetadata;

--- a/src/app/containers/ArticleMetadata/index.jsx
+++ b/src/app/containers/ArticleMetadata/index.jsx
@@ -42,6 +42,7 @@ const tagPropTypes = shape({
 });
 
 ArticleMetadata.propTypes = {
+  articleId: string,
   title: string.isRequired,
   author: string.isRequired,
   firstPublished: string.isRequired,
@@ -55,6 +56,7 @@ ArticleMetadata.propTypes = {
 };
 
 ArticleMetadata.defaultProps = {
+  articleId: '',
   section: '',
   aboutTags: [],
   mentionsTags: [],


### PR DESCRIPTION
Resolves ![image](https://user-images.githubusercontent.com/34196381/73665424-fc4b7b80-4698-11ea-9db8-5b0737afe93a.png)

**Overall change:** 
_Fix propType errors in ArticleMetadata._

**Code changes:**
- _Added propType validation for `articleId`._
- _Removed `linkedData` prop._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
