### PR TITLE
Fix oops in Archive manifest

### DIFF
--- a/public/archive/manifest.json
+++ b/public/archive/manifest.json
@@ -42,7 +42,7 @@
       "type": "image/png"
     },
     {
-      "src": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-512x512.png",
+      "src": "https://news.files.bbci.co.uk/include/articles/public/archive/images/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
Resolves N/A

**Overall change:** 
- Fixes an oops in the Archive manifest

**Code changes:**
- Replaces the word 'scotland' with 'archive' where I must have forgotten to before

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
