### PR TITLE
Fixing E2Es for PGLs & MAPs - services with variants

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -92,7 +92,10 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
             const imageSrc =
               (imagePath && pageType === mediaAssetPageType) ||
               (imagePath && pageType === photoGalleryPageType)
-                ? getBrandedImage(imagePath, service)
+                ? getBrandedImage({
+                    imagePath,
+                    serviceName: config[service].name,
+                  })
                 : appConfig[config[service].name][variant].defaultImage;
 
             const ogType = [

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -1154,7 +1154,7 @@ const genServices = appEnv => ({
         path:
           isLive(appEnv) || isTest(appEnv)
             ? undefined
-            : 'serbian/srbija-46748932/lat',
+            : '/serbian/srbija-46748932/lat',
         smoke: false,
       },
     },
@@ -1558,7 +1558,7 @@ const genServices = appEnv => ({
         path:
           isLive(appEnv) || isTest(appEnv)
             ? undefined
-            : 'ukchina/cool-britannia-38434549/trad',
+            : '/ukchina/cool-britannia-38434549/trad',
         smoke: false,
       },
     },
@@ -1831,8 +1831,8 @@ const genServices = appEnv => ({
         path:
           isLive(appEnv) || isTest(appEnv)
             ? undefined
-            : 'zhongwen/chinese-news-49065935/trad',
-        smoke: false,
+            : '/zhongwen/chinese-news-49065935/trad',
+        smoke: true,
       },
     },
   },

--- a/cypress/support/helpers/getBrandedImage.js
+++ b/cypress/support/helpers/getBrandedImage.js
@@ -1,10 +1,10 @@
 import { getImageParts } from '../../../src/app/lib/utilities/preprocessor/rules/cpsAssetPage/convertToOptimoBlocks/blocks/image/helpers';
 
-export default (imagePath, service) => {
+export default ({ imagePath, serviceName }) => {
   const [, locator] = getImageParts(imagePath);
   const iChefHost =
     Cypress.env('APP_ENV') === 'live'
       ? 'http://ichef.bbci.co.uk'
       : 'http://ichef.test.bbci.co.uk';
-  return `${iChefHost}/news/1024/branded_${service}/${locator}`;
+  return `${iChefHost}/news/1024/branded_${serviceName}/${locator}`;
 };


### PR DESCRIPTION
Resolves No ticket - fixing failing e2es
Fixing these three types of issue:

**brandImage URL needing service name not service**
```
should have the correct shared metadata

CypressError: Timed out retrying: expected '<meta>' to have attribute 'content' with the value 'http://ichef.test.bbci.co.uk/news/1024/branded_ukchinaTrad/C00A/production/_93126194_liveaidpa.jpg', but the value was 'http://ichef.test.bbci.co.uk/news/1024/branded_ukchina/C00A/production/_93126194_liveaidpa.jpg'
```

**missing `/` in path** fixes these two errors:
```
should include the canonical URL

CypressError: Timed out retrying: expected '<link>' to have attribute 'href' with the value 'http://localhost:7080ukchina/cool-britannia-38434549/trad', but the value was 'http://localhost:7080/ukchina/cool-britannia-38434549/trad'
```
**articleTimestampPrefix**
```
TypeError: Cannot read property 'articleTimestampPrefix' of undefined
    at Context.<anonymous> (http://localhost:7080/__cypress/tests?p=cypress/integration/pages/photoGalleryPage/index.js-329:872:140)
```
**Overall change:** 
Fixing e2es on local dev for Photogalleries & Media pages

**Code changes:**
- Update brandedImage to take service name  using `ukchina` instead of `ukchinaTrad` 
- Fixing paths to include preceding `/`
- Making zhongwen trad PGL a smoke test example, to surface issues with services with variants at PR time, not on CI. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
