### PR TITLE
E2Es for MAPs Thai, Punjabi, Afaan Oromo, Amharic, Tigrinya, Marathi, Gujarati, Korean on test and local

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -39,7 +39,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/afaanoromoo/23149891',
         smoke: false,
       },
       photoGalleryPage: {
@@ -119,7 +119,7 @@ const genServices = appEnv => ({
         smoke: true,
       },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/amharic/news-23263266',
         smoke: false,
       },
       photoGalleryPage: {
@@ -377,7 +377,7 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/gujarati/other-news-23130286',
         smoke: false,
       },
       photoGalleryPage: {
@@ -608,10 +608,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path:
-          isLive(appEnv) || isTest(appEnv)
-            ? undefined
-            : '/korean/media-23248686',
+        path: isLive(appEnv) ? undefined : '/korean/media-23248686',
         smoke: false,
       },
       photoGalleryPage: {
@@ -688,7 +685,7 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/marathi/media-23127353',
         smoke: false,
       },
       photoGalleryPage: {
@@ -1006,10 +1003,7 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path:
-          isLive(appEnv) || isTest(appEnv)
-            ? undefined
-            : '/punjabi/media-23248705',
+        path: isLive(appEnv) ? undefined : '/punjabi/media-23248705',
         smoke: false,
       },
       photoGalleryPage: {
@@ -1355,7 +1349,7 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/telugu/international-23263261',
         smoke: false,
       },
       photoGalleryPage: {
@@ -1392,10 +1386,7 @@ const genServices = appEnv => ({
       },
       liveRadio: { path: undefined, smoke: false },
       mediaAssetPage: {
-        path:
-          isLive(appEnv) || isTest(appEnv)
-            ? undefined
-            : '/thai/thailand-23248713',
+        path: isLive(appEnv) ? undefined : '/thai/thailand-23248713',
         smoke: false,
       },
       photoGalleryPage: {
@@ -1435,7 +1426,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path: undefined,
+        path: isLive(appEnv) ? undefined : '/tigrinya/news-23263262',
         smoke: false,
       },
       photoGalleryPage: {

--- a/data/afaanoromoo/cpsAssets/23149891.json
+++ b/data/afaanoromoo/cpsAssets/23149891.json
@@ -1,0 +1,140 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "Quba abbudduu miilaatiin yeroo dorggoman",
+        "embedding": false,
+        "format": "video",
+        "id": "p01cynmd",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01cynqv.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "Quba abbudduu miilaatiin dorggommiin akka jiru beektuu?"
+        },
+        "title": "Dorggommii quba abbudduu miilaatiin",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1503567046000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 53,
+            "durationISO8601": "PT53S",
+            "types": ["Original"],
+            "versionId": "p01cynmg",
+            "warnings": {}
+          }
+        ]
+      },
+      { "markupType": "plain_text", "text": "test", "type": "paragraph" }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "afaanoromoo.media_asset.23149891.page",
+      "cps_asset_id": "23149891",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph"],
+    "createdBy": "oromo-v6",
+    "firstPublished": 1503567591000,
+    "id": "urn:bbc:ares::asset:afaanoromoo/23149891",
+    "includeComments": false,
+    "language": "om",
+    "lastPublished": 1580128335000,
+    "lastUpdated": 1580128341788,
+    "locators": {
+      "assetUri": "/afaanoromoo/23149891",
+      "cpsUrn": "urn:bbc:content:assetUri:afaanoromoo/23149891",
+      "curie": "http://www.bbc.co.uk/asset/c182ef59-3f36-4844-991f-c35f96b98d23"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1503567591000,
+    "type": "MAP",
+    "version": "v1.1.4"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Quba abbudduu miilaatiin dorggommiin akka jiru beektuu?",
+      "shortHeadline": "Dorggommii quba abbudduu miilaatiin"
+    },
+    "id": "urn:bbc:ares::asset:afaanoromoo/23149891",
+    "indexImage": {
+      "altText": "Keyframe #5",
+      "copyrightHolder": "BBC",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/12FE6/test/_63589777_p01cynqv.jpg",
+      "id": "63589777",
+      "path": "/cpsdevpb/12FE6/test/_63589777_p01cynqv.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "locators": {
+      "assetUri": "/afaanoromoo/23149891",
+      "cpsUrn": "urn:bbc:content:assetUri:afaanoromoo/23149891",
+      "curie": "http://www.bbc.co.uk/asset/c182ef59-3f36-4844-991f-c35f96b98d23"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "Quba abbudduu miilaatiin yeroo dorggoman",
+      "embedding": false,
+      "format": "video",
+      "id": "p01cynmd",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01cynqv.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "Quba abbudduu miilaatiin dorggommiin akka jiru beektuu?"
+      },
+      "title": "Dorggommii quba abbudduu miilaatiin",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1503567046000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 53,
+          "durationISO8601": "PT53S",
+          "types": ["Original"],
+          "versionId": "p01cynmg",
+          "warnings": {}
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "Ingilaanditti dorgommiin quba abbudduu miilaatiin, waggaa waggaan ni gaggeefama.",
+    "timestamp": 1503567591000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Oduu",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/afaanoromoo/front_page"
+    },
+    "site": {
+      "name": "BBC Afaan Oromoo",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/afaanoromoo"
+    }
+  }
+}

--- a/data/amharic/cpsAssets/news-23263266.json
+++ b/data/amharic/cpsAssets/news-23263266.json
@@ -1,0 +1,156 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "A vertical video pretending to be a cat short synopsis",
+        "embedding": true,
+        "format": "video",
+        "id": "p01n40vn",
+        "imageCopyright": "BBC",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01n71w7.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "A vertical video pretending to be a cat short synopsis"
+        },
+        "title": "A vertical video pretending to be a cat title",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1563017501000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 11,
+            "durationISO8601": "PT11S",
+            "types": ["Portrait"],
+            "versionId": "p01n40vq",
+            "warnings": {}
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Random cat text",
+        "type": "heading"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "My left donut is missing, as is my right more napping, more napping all the napping is exhausting. Lick yarn hanging out of own butt. Weigh eight pounds but take up a full-size bed stare at ceiling light or claw drapes making bread on the bathrobe annoy the old grumpy cat, start a fight and then retreat to wash when i lose sleep. Sleep everywhere, but not in my bed scratch at door to be let outside, get let out then scratch at door immmediately after to be let back in meeeeouw good morning sunshine. I is not fat, i is fluffy scratch the box but meowzer that box?",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Munch on tasty moths being gorgeous with belly side up stuff and things yet hunt by meowing loudly at 5am next to human slave food dispenser lick the curtain just to be annoying so favor packaging over toy and cats go for world domination. More napping, more napping all the napping is exhausting lounge in doorway. Somehow manage to catch a bird but have no idea what to do next,",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "amharic.news.media_asset.23263266.page",
+      "cps_asset_id": "23263266",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "heading", "paragraph"],
+    "createdBy": "amharic-v6",
+    "firstPublished": 1580305097000,
+    "id": "urn:bbc:ares::asset:amharic/news-23263266",
+    "includeComments": false,
+    "language": "am",
+    "lastPublished": 1580305098000,
+    "lastUpdated": 1580305109175,
+    "locators": {
+      "assetUri": "/amharic/news-23263266",
+      "cpsUrn": "urn:bbc:content:assetUri:amharic/news-23263266",
+      "curie": "http://www.bbc.co.uk/asset/1d1cb419-974b-8241-99b1-a13a7c5220fe"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1580305097000,
+    "type": "MAP",
+    "version": "v1.1.4"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Amharic test MAP A vertical video pretending to be a cat short synopsis",
+      "shortHeadline": "Amharic test MAP A vertical video pretending to be a cat title"
+    },
+    "id": "urn:bbc:ares::asset:amharic/news-23263266",
+    "indexImage": {
+      "altText": "Cat",
+      "copyrightHolder": "BBC",
+      "height": 1152,
+      "href": "http://b.files.bbci.co.uk/C41B/test/_63730205_p01n71w7.jpg",
+      "id": "63730205",
+      "path": "/cpsdevpb/C41B/test/_63730205_p01n71w7.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 2048
+    },
+    "locators": {
+      "assetUri": "/amharic/news-23263266",
+      "cpsUrn": "urn:bbc:content:assetUri:amharic/news-23263266",
+      "curie": "http://www.bbc.co.uk/asset/1d1cb419-974b-8241-99b1-a13a7c5220fe"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "A vertical video pretending to be a cat short synopsis",
+      "embedding": true,
+      "format": "video",
+      "id": "p01n40vn",
+      "imageCopyright": "BBC",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01n71w7.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "A vertical video pretending to be a cat short synopsis"
+      },
+      "title": "A vertical video pretending to be a cat title",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1563017501000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 11,
+          "durationISO8601": "PT11S",
+          "types": ["Portrait"],
+          "versionId": "p01n40vq",
+          "warnings": {}
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "amharic test",
+    "timestamp": 1580305097000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "ዜና",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/amharic/news"
+    },
+    "site": {
+      "name": "BBC አማርኛ",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/amharic"
+    }
+  }
+}

--- a/data/gujarati/cpsAssets/other-news-23130286.json
+++ b/data/gujarati/cpsAssets/other-news-23130286.json
@@ -1,0 +1,158 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "યુવરાજ સિંહ અને વિરાટ કોહલી",
+        "embedding": true,
+        "format": "audio",
+        "id": "p01blkgh",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01blmqx.jpg",
+        "subType": "clip",
+        "synopses": { "short": "આગળની સ્લાઇડમાં જુઓ, સબંધિત વધુ તસવીરો..." },
+        "title": "શિખર-રોહિતની કરી પ્રશંસા",
+        "type": "media",
+        "versions": [
+          {
+            "availableTerritories": { "nonUk": true, "uk": true },
+            "duration": 16,
+            "types": ["Original"],
+            "versionId": "p01blkgq",
+            "warnings": {}
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "વિરાટે ભારતીય ટીમના પ્રદર્શનને લઇ બેટ્સમેન અને બોલરોને 10માંથી 9 અંક આપ્યા જ્યારે ફિલ્ડરને 6 અંક આપ્યા હતા.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "- વિરાટે કહ્યું અમારે સર્વશ્રેષ્ઠ ટીમો વિરૂદ્ધ જોરદાર સ્પર્ધા માટે ફિલ્ડિંગ પર ભાર આપવાની જરૂર છે, અમારે આગળ આનાથી પણ સારૂ પ્રદર્શન કરવાનું છે॥",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "gujarati.also_in_the_news.media_asset.23130286.page",
+      "cps_asset_id": "23130286",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph"],
+    "createdBy": "gujarati-v6",
+    "firstPublished": 1496745098,
+    "id": "urn:bbc:ares::asset:gujarati/other-news-23130286",
+    "includeComments": false,
+    "language": "gu",
+    "lastPublished": 1496745799,
+    "lastUpdated": 1557824474879,
+    "locators": {
+      "assetUri": "/gujarati/other-news-23130286",
+      "cpsUrn": "urn:bbc:content:assetUri:gujarati/other-news-23130286",
+      "curie": "http://www.bbc.co.uk/asset/77bd783c-5f55-1a4f-8704-baaaee04a4e4"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "passport": {
+      "category": {
+        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
+        "categoryName": "News"
+      }
+    },
+    "tags": {
+      "about": [
+        {
+          "thingId": "103fc7e4-3a8d-491c-9a75-3c37c299d48f",
+          "thingLabel": "Narendra Modi",
+          "thingSameAs": [],
+          "thingType": ["Person", "Thing"],
+          "thingUri": "http://www.bbc.co.uk/things/103fc7e4-3a8d-491c-9a75-3c37c299d48f#id"
+        }
+      ]
+    },
+    "type": "MAP",
+    "version": "v1.0.7"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "આગળની સ્લાઇડમાં જુઓ, સબંધિત વધુ તસવીરો...",
+      "shortHeadline": "શિખર-રોહિતની કરી પ્રશંસા"
+    },
+    "id": "urn:bbc:ares::asset:gujarati/other-news-23130286",
+    "indexImage": {
+      "altText": "શિખર-રોહિતની કરી પ્રશંસા",
+      "copyrightHolder": "Reuters",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/C281/test/_63539794_p01blmqx.jpg",
+      "id": "63539794",
+      "path": "/cpsdevpb/C281/test/_63539794_p01blmqx.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "locators": {
+      "assetUri": "/gujarati/other-news-23130286",
+      "cpsUrn": "urn:bbc:content:assetUri:gujarati/other-news-23130286",
+      "curie": "http://www.bbc.co.uk/asset/77bd783c-5f55-1a4f-8704-baaaee04a4e4"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "યુવરાજ સિંહ અને વિરાટ કોહલી",
+      "embedding": true,
+      "format": "audio",
+      "id": "p01blkgh",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01blmqx.jpg",
+      "subType": "clip",
+      "synopses": { "short": "આગળની સ્લાઇડમાં જુઓ, સબંધિત વધુ તસવીરો..." },
+      "title": "શિખર-રોહિતની કરી પ્રશંસા",
+      "type": "media",
+      "versions": [
+        {
+          "availableTerritories": { "nonUk": true, "uk": true },
+          "duration": 16,
+          "types": ["Original"],
+          "versionId": "p01blkgq",
+          "warnings": {}
+        }
+      ]
+    },
+    "passport": {
+      "category": {
+        "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
+        "categoryName": "News"
+      }
+    },
+    "summary": "ભારતીય કેપ્ટન વિરાટ કોહલીએ પાકિસ્તાન વિરૂદ્ધ જીત બાદ કહ્યું યુવરાજની પાકિસ્તાન વિરૂદ્ધ વિસ્ફોટક બેટિંગ દરમિયાન હું પોતાને 'ક્લબ બેટ્સમેન' ગણી રહ્યો હતો.",
+    "timestamp": 1557824474879,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "અન્ય સમાચાર",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/gujarati/other_news"
+    },
+    "site": {
+      "name": "BBC ગુજરાતી",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/gujarati"
+    }
+  }
+}

--- a/data/marathi/cpsAssets/media-23127353.json
+++ b/data/marathi/cpsAssets/media-23127353.json
@@ -1,0 +1,140 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "आयपीएल (IPL) ट्रॉफी सिद्धिविनायक चरणी caption!",
+        "embedding": true,
+        "format": "video",
+        "id": "p01b7vw2",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01b7w2v.jpg",
+        "subType": "clip",
+        "synopses": {
+          "long": "अंबानी परिवाराची सिद्धिविनायकावर श्रद्धा आहे. या श्रद्धेतूनच अनंत यांनी ट्रॉफीसह बाप्पांचं दर्शन घेतल्याचं सांगण्यात येत आहे. विशेष म्हणजे केवळ अनंतच नाही तर अनंत यांची आजी, नीता अंबानी यांची आई पुर्णिमाबेन दलाल यांचीही प्रचंड श्रद्धाळू आहेत. अंतिम सामन्याच्या शेवटच्या षटकामध्ये हात जोडून, डोळे बंद करून त्या देवाचा धावा करत असल्याचे चित्र सगळ्यांनीच पाहिलं आहे. त्यातच आज सोशल मीडियातही पुर्णिमाबेन यांचा हा फोटो व्हायरल झाला आहे आणि त्याच्या बातम्याही झाल्या आहेत.",
+          "medium": "अनंत यांच्यासोबत पोलिसांचा फौजफाटाही दिसत होता. सिद्धिविनायक चरणी ट्रॉफी ठेऊन दर्शन घेऊन अनंत अंबानी माघारी परतले.",
+          "short": "मुंबई इंडियन्स संघा मालक अंबानी यांनी आज आयपीएल ट्रॉफीसह सिद्धिविनायक मंदिरात दर्शन घेतले"
+        },
+        "title": "आयपीएल (IPL) ट्रॉफी सिद्धिविनायक चरणी!",
+        "type": "media",
+        "versions": [
+          {
+            "availableTerritories": { "nonUk": true, "uk": true },
+            "duration": 20,
+            "types": ["Original"],
+            "versionId": "p01b7vw8",
+            "warnings": {}
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "अंबानी परिवाराची सिद्धिविनायकावर श्रद्धा आहे. या श्रद्धेतूनच अनंत यांनी ट्रॉफीसह बाप्पांचं दर्शन घेतल्याचं सांगण्यात येत आहे. विशेष म्हणजे केवळ अनंतच नाही तर अनंत यांची आजी, नीता अंबानी यांची आई पुर्णिमाबेन दलाल यांचीही प्रचंड श्रद्धाळू आहेत. अंतिम सामन्याच्या शेवटच्या षटकामध्ये हात जोडून, डोळे बंद करून त्या देवाचा धावा करत असल्याचे चित्र सगळ्यांनीच पाहिलं आहे. त्यातच आज सोशल मीडियातही पुर्णिमाबेन यांचा हा फोटो व्हायरल झाला आहे आणि त्याच्या बातम्याही झाल्या आहेत.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "marathi.embedded_media.media_asset.23127353.page",
+      "cps_asset_id": "23127353",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph"],
+    "createdBy": "marathi-v6",
+    "firstPublished": 1495468060,
+    "id": "urn:bbc:ares::asset:marathi/media-23127353",
+    "includeComments": false,
+    "language": "mr",
+    "lastPublished": 1495468061,
+    "lastUpdated": 1557824968121,
+    "locators": {
+      "assetUri": "/marathi/media-23127353",
+      "cpsUrn": "urn:bbc:content:assetUri:marathi/media-23127353",
+      "curie": "http://www.bbc.co.uk/asset/4dadc808-3e48-314a-99fb-11f6418379f9"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "type": "MAP",
+    "version": "v1.0.7"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "मुंबई इंडियन्स संघा मालक अंबानी यांनी आज आयपीएल ट्रॉफीसह सिद्धिविनायक मंदिरात दर्शन घेतले २०१७",
+      "shortHeadline": "आयपीएल (IPL) ट्रॉफी सिद्धिविनायक चरणी २०१७!"
+    },
+    "id": "urn:bbc:ares::asset:marathi/media-23127353",
+    "indexImage": {
+      "altText": "आयपीएल ट्रॉफी सिद्धिविनायक चरणी!",
+      "copyrightHolder": "Magnum Photos",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/049F/test/_63538110_p01b7w2v.jpg",
+      "id": "63538110",
+      "path": "/cpsdevpb/049F/test/_63538110_p01b7w2v.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "locators": {
+      "assetUri": "/marathi/media-23127353",
+      "cpsUrn": "urn:bbc:content:assetUri:marathi/media-23127353",
+      "curie": "http://www.bbc.co.uk/asset/4dadc808-3e48-314a-99fb-11f6418379f9"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "आयपीएल (IPL) ट्रॉफी सिद्धिविनायक चरणी caption!",
+      "embedding": true,
+      "format": "video",
+      "id": "p01b7vw2",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01b7w2v.jpg",
+      "subType": "clip",
+      "synopses": {
+        "long": "अंबानी परिवाराची सिद्धिविनायकावर श्रद्धा आहे. या श्रद्धेतूनच अनंत यांनी ट्रॉफीसह बाप्पांचं दर्शन घेतल्याचं सांगण्यात येत आहे. विशेष म्हणजे केवळ अनंतच नाही तर अनंत यांची आजी, नीता अंबानी यांची आई पुर्णिमाबेन दलाल यांचीही प्रचंड श्रद्धाळू आहेत. अंतिम सामन्याच्या शेवटच्या षटकामध्ये हात जोडून, डोळे बंद करून त्या देवाचा धावा करत असल्याचे चित्र सगळ्यांनीच पाहिलं आहे. त्यातच आज सोशल मीडियातही पुर्णिमाबेन यांचा हा फोटो व्हायरल झाला आहे आणि त्याच्या बातम्याही झाल्या आहेत.",
+        "medium": "अनंत यांच्यासोबत पोलिसांचा फौजफाटाही दिसत होता. सिद्धिविनायक चरणी ट्रॉफी ठेऊन दर्शन घेऊन अनंत अंबानी माघारी परतले.",
+        "short": "मुंबई इंडियन्स संघा मालक अंबानी यांनी आज आयपीएल ट्रॉफीसह सिद्धिविनायक मंदिरात दर्शन घेतले"
+      },
+      "title": "आयपीएल (IPL) ट्रॉफी सिद्धिविनायक चरणी!",
+      "type": "media",
+      "versions": [
+        {
+          "availableTerritories": { "nonUk": true, "uk": true },
+          "duration": 20,
+          "types": ["Original"],
+          "versionId": "p01b7vw8",
+          "warnings": {}
+        }
+      ]
+    },
+    "passport": {},
+    "summary": "अनंत यांच्यासोबत पोलिसांचा फौजफाटाही दिसत होता. सिद्धिविनायक चरणी ट्रॉफी ठेऊन दर्शन घेऊन अनंत अंबानी माघारी परतले.",
+    "timestamp": 1557824968121,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Media",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/marathi/media"
+    },
+    "site": {
+      "name": "BBC मराठी",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/marathi"
+    }
+  }
+}

--- a/data/telugu/cpsAssets/international-23263261.json
+++ b/data/telugu/cpsAssets/international-23263261.json
@@ -1,0 +1,204 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "They may be tiny, but us humans could learn a thing or two from ants.",
+        "embedding": true,
+        "format": "video",
+        "id": "p01k6msm",
+        "imageCopyright": "BBC",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+        },
+        "title": "Five things ants can teach us about management",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1540218932000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 191,
+            "durationISO8601": "PT3M11S",
+            "types": ["Original"],
+            "versionId": "p01k6msp",
+            "warnings": {
+              "long": "Contains strong language and adult humour.",
+              "short": "Contains strong language and adult humour."
+            }
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "Ants Ants Ants",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Test Heading",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Test Subheading",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Test Crosshead",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "No poster image ",
+        "type": "paragraph"
+      },
+      {
+        "items": [
+          { "markupType": "plain_text", "text": "Ants", "type": "listItem" },
+          {
+            "markupType": "plain_text",
+            "text": "More ants",
+            "type": "listItem"
+          },
+          {
+            "markupType": "plain_text",
+            "text": "So many ants",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "items": [
+          { "markupType": "plain_text", "text": "One ant", "type": "listItem" },
+          { "markupType": "plain_text", "text": "Two ant", "type": "listItem" },
+          {
+            "markupType": "plain_text",
+            "text": "Three ant",
+            "type": "listItem"
+          }
+        ],
+        "numbered": true,
+        "type": "list"
+      },
+      {
+        "altText": "Ant",
+        "copyrightHolder": "Shutterstock",
+        "height": 549,
+        "href": "http://b.files.bbci.co.uk/46B7/test/_63730181_ant.png",
+        "id": "63730181",
+        "path": "/cpsdevpb/46B7/test/_63730181_ant.png",
+        "positionHint": "full-width",
+        "subType": "body",
+        "type": "image",
+        "width": 976
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "telugu.international.media_asset.23263261.page",
+      "cps_asset_id": "23263261",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph", "list", "image"],
+    "createdBy": "telugu-v6",
+    "firstPublished": 1580303105000,
+    "id": "urn:bbc:ares::asset:telugu/international-23263261",
+    "includeComments": false,
+    "language": "te",
+    "lastPublished": 1580303106000,
+    "lastUpdated": 1580303113108,
+    "locators": {
+      "assetUri": "/telugu/international-23263261",
+      "cpsUrn": "urn:bbc:content:assetUri:telugu/international-23263261",
+      "curie": "http://www.bbc.co.uk/asset/4aeed9e6-5f64-344e-89c8-b17e31301b9f"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1580303105000,
+    "type": "MAP",
+    "version": "v1.1.4"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Test Telugu MAP",
+      "shortHeadline": "Test Telugu MAP"
+    },
+    "id": "urn:bbc:ares::asset:telugu/international-23263261",
+    "locators": {
+      "assetUri": "/telugu/international-23263261",
+      "cpsUrn": "urn:bbc:content:assetUri:telugu/international-23263261",
+      "curie": "http://www.bbc.co.uk/asset/4aeed9e6-5f64-344e-89c8-b17e31301b9f"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "They may be tiny, but us humans could learn a thing or two from ants.",
+      "embedding": true,
+      "format": "video",
+      "id": "p01k6msm",
+      "imageCopyright": "BBC",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "They may be tiny, but us humans could learn a thing or two from ants."
+      },
+      "title": "Five things ants can teach us about management",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1540218932000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 191,
+          "durationISO8601": "PT3M11S",
+          "types": ["Original"],
+          "versionId": "p01k6msp",
+          "warnings": {
+            "long": "Contains strong language and adult humour.",
+            "short": "Contains strong language and adult humour."
+          }
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "Ants...",
+    "timestamp": 1580303105000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "అంతర్జాతీయం",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/telugu/international"
+    },
+    "site": {
+      "name": "BBC తెలుగు",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/telugu"
+    }
+  }
+}

--- a/data/tigrinya/cpsAssets/news-23263262.json
+++ b/data/tigrinya/cpsAssets/news-23263262.json
@@ -1,0 +1,168 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": false,
+        "caption": "Some audio from a supermarket checkout in Birmingham",
+        "embedding": false,
+        "format": "audio",
+        "id": "p01m7d07",
+        "imageCopyright": "Getty Images",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01mt2kt.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "Some audio from a supermarket checkout in Birmingham"
+        },
+        "title": "Birmingham checkout",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1555067395000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 127,
+            "durationISO8601": "PT2M7S",
+            "types": ["Original"],
+            "versionId": "p01m7d09",
+            "warnings": {
+              "long": "Contains some strong language.",
+              "short": "Contains some strong language."
+            }
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "Tigrinya introduction &lt;lalala&gt;&amp;blabla",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "<bold>Tigrinya </bold><bold>heading</bold><bold> &lt;lalala&gt;&amp;blabla</bold>",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "<link><caption>Mystery test link&amp;</caption><altText>link</altText><url href=\"https://en.wikipedia.org/wiki/Hamster\" platform=\"highweb\"/></link>",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "<link><caption>Link</caption><altText>Link to another &lt;map&gt;</altText><url href=\"https://www.bbc.com/pidgin/tori-51268839\" platform=\"highweb\"/></link>",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "tigrinya.news.media_asset.23263262.page",
+      "cps_asset_id": "23263262",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph"],
+    "createdBy": "tigrinya-v6",
+    "firstPublished": 1580304209000,
+    "id": "urn:bbc:ares::asset:tigrinya/news-23263262",
+    "includeComments": false,
+    "language": "ti",
+    "lastPublished": 1580304211000,
+    "lastUpdated": 1580304220417,
+    "locators": {
+      "assetUri": "/tigrinya/news-23263262",
+      "cpsUrn": "urn:bbc:content:assetUri:tigrinya/news-23263262",
+      "curie": "http://www.bbc.co.uk/asset/2494dfe3-6374-414a-91d4-8a62cb9c7152"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1580304209000,
+    "type": "MAP",
+    "version": "v1.1.4"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Test Tigrinya Audio MAP Some audio from a supermarket checkout in Birmingham",
+      "shortHeadline": "Test Tigrinya Audio MAP Birmingham checkout"
+    },
+    "id": "urn:bbc:ares::asset:tigrinya/news-23263262",
+    "indexImage": {
+      "altText": "England star Fran Kirby",
+      "copyrightHolder": "Getty Images",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/6DC7/test/_63730182_p01mt2kt.jpg",
+      "id": "63730182",
+      "path": "/cpsdevpb/6DC7/test/_63730182_p01mt2kt.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "locators": {
+      "assetUri": "/tigrinya/news-23263262",
+      "cpsUrn": "urn:bbc:content:assetUri:tigrinya/news-23263262",
+      "curie": "http://www.bbc.co.uk/asset/2494dfe3-6374-414a-91d4-8a62cb9c7152"
+    },
+    "media": {
+      "advertising": false,
+      "caption": "Some audio from a supermarket checkout in Birmingham",
+      "embedding": false,
+      "format": "audio",
+      "id": "p01m7d07",
+      "imageCopyright": "Getty Images",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01mt2kt.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "Some audio from a supermarket checkout in Birmingham"
+      },
+      "title": "Birmingham checkout",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1555067395000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 127,
+          "durationISO8601": "PT2M7S",
+          "types": ["Original"],
+          "versionId": "p01m7d09",
+          "warnings": {
+            "long": "Contains some strong language.",
+            "short": "Contains some strong language."
+          }
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "audio",
+    "timestamp": 1580304209000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "ዜና",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/tigrinya/news"
+    },
+    "site": {
+      "name": "BBC ትግርኛ",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/tigrinya"
+    }
+  }
+}


### PR DESCRIPTION
Korean left out of branch name but it is in this

**Overall change:** 
Added fixture data and URLs for the MAPs Thai, Punjabi, Afaan Oromo, Amharic, Tigrinya, Marathi, Gujarati, Korean to run E2Es on live and test

**Code changes:**

Ficture data added in /data -> CPS assets

URLs added e.g 
mediaAssetPage: {
        path: isLive(appEnv) ? undefined : '/thai/thailand-23248713',
        smoke: false,
      },

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
No failures on local or test
