### PR TITLE
Downgrading cypress to 3.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10062,9 +10062,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.3.tgz",
-      "integrity": "sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.1.tgz",
+      "integrity": "sha512-eLk5OpL/ZMDfQx9t7ZaDUAGVcvSOPTi7CG1tiUnu9BGk7caBiDhuFi3Tz/D5vWqH/Dl6Uh4X+Au4W+zh0xzbXw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -10078,7 +10078,6 @@
         "commander": "2.15.1",
         "common-tags": "1.8.0",
         "debug": "3.2.6",
-        "eventemitter2": "4.1.2",
         "execa": "0.10.0",
         "executable": "4.1.1",
         "extract-zip": "1.6.7",
@@ -10177,12 +10176,6 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -12799,12 +12792,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eventemitter2": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
-      "dev": true
     },
     "eventemitter3": {
       "version": "4.0.0",
@@ -20505,6 +20492,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "chrome-launcher": "^0.12.0",
     "compression-webpack-plugin": "^3.1.0",
     "copy-webpack-plugin": "^5.1.1",
-    "cypress": "^3.8.3",
+    "cypress": "3.8.1",
     "cypress-multi-reporters": "^1.2.3",
     "depcheck": "^0.9.1",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
**Overall change:** 
Downgrading the Cypress version used to 3.8.1 to see if it makes our e2es run quicker again

**Code changes:**
- cypress version changed to 3.8.1 in package.json and package-lock.json

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
