### PR TITLE
Fixes E2Es for PGLs

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -453,7 +453,7 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
                   .should('be.visible')
                   .should(
                     'contain',
-                    appConfig[config[service].name].default
+                    appConfig[config[service].name][variant || 'default']
                       .articleTimestampPrefix,
                   )
                   .should('have.attr', 'datetime');

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -421,7 +421,7 @@ const genServices = appEnv => ({
         smoke: false,
       },
       photoGalleryPage: {
-        path: isLive(appEnv) || isTest(appEnv) ? undefined : '',
+        path: undefined,
         smoke: false,
       },
     },


### PR DESCRIPTION
Resolves - no ticket - fixing failures on local CI

**Overall change:** 
Fixes these errors

```
photoGalleryPage - ukchinaTrad - Canonical
       Running testsForAllPages for ukchinaTrad photoGalleryPage
         CPS PGL and MAP Tests
           should render a timestamp:
TypeError: Cannot read property 'articleTimestampPrefix' of undefined

photoGalleryPage - ukchinaTrad - Amp
       Running testsForAllPages for ukchinaTrad photoGalleryPage
         CPS PGL and MAP Tests
           should render a timestamp:
TypeError: Cannot read property 'articleTimestampPrefix' of undefined

"before all" hook for "should have resource hints"
CypressError: cy.request() requires a url. You did not provide a url.
Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite: 'photoGalleryPage - hausa - ...'

"before all" hook for "should have resource hints"
AssertionError: Unexpected status code for .amp: expected 404 to equal 200
Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite: 'photoGalleryPage - hausa - Amp'
```

**Code changes:**
- Ensure correct variant config is used for timestamp test (Ran with `CYPRESS_APP_ENV=local CYPRESS_ONLY_SERVICE=ukchinaTrad CYPRESS_SMOKE=false npm run test:e2e`)
- Removed empty hausa path that is causing errors (Ran with `CYPRESS_APP_ENV=local CYPRESS_ONLY_SERVICE=hausa CYPRESS_SMOKE=false npm run test:e2e`)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
