### PR TITLE
Fixes map left alignment bug

### DIFF
--- a/src/app/pages/CpsMap/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/CpsMap/__snapshots__/index.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`CPS MAP Page AV player should render version (live audio stream) 1`] = 
           >
             <noscript />
             <main
-              class="GhostGrid-sc-12lwanc-1 StyledGhostGrid-sc-10y88yd-0 gLWwCc"
+              class="GhostGrid-sc-12lwanc-1 StyledGhostGrid-sc-10y88yd-0 dJygcZ"
               role="main"
             >
               <h1
@@ -388,7 +388,7 @@ exports[`CPS MAP Page should render component 1`] = `
           >
             <noscript />
             <main
-              class="GhostGrid-sc-12lwanc-1 StyledGhostGrid-sc-10y88yd-0 gLWwCc"
+              class="GhostGrid-sc-12lwanc-1 StyledGhostGrid-sc-10y88yd-0 dJygcZ"
               role="main"
             >
               <h1

--- a/src/app/pages/CpsMap/index.jsx
+++ b/src/app/pages/CpsMap/index.jsx
@@ -74,9 +74,8 @@ const CpsMapContainer = ({ pageData }) => {
   };
 
   const StyledGhostGrid = styled(GhostGrid)`
-    flex-grow: 1;
+    width: 100%;
     padding-bottom: ${GEL_SPACING_TRPL};
-
     @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
       padding-bottom: ${GEL_SPACING_QUAD};
     }


### PR DESCRIPTION
Co-authored-by: Rebecca McGinn <rebecca.mcginn@bbc.co.uk>

Resolves https://github.com/bbc/simorgh/issues/5416

**Overall change:** 
Fixes a bug that left aligns page content within a MAP. This bug was introduced when the work to remove spacing at the bottom of the footer as fixed by using flex-box.

**Code changes:**
- Make the `main` container element 100% width

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
