### PR TITLE
replace compose with pipe

### DIFF
--- a/src/app/lib/utilities/preprocessor/rules/addIdsToBlocks.js
+++ b/src/app/lib/utilities/preprocessor/rules/addIdsToBlocks.js
@@ -1,5 +1,5 @@
 import uuid from 'uuid';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import pathOr from 'ramda/src/pathOr';
 
 let mapIdsToBlocks;
@@ -39,11 +39,11 @@ const mergeJsonRawWithBlocks = blocksWithIds => jsonRaw => ({
 });
 
 export default jsonRaw => {
-  const addIdsToBlocks = compose(
-    mergeJsonRawWithBlocks,
-    mapIdsToBlocks,
-    getBlocks,
+  const addIdsToBlocks = pipe(
     getJsonContent,
+    getBlocks,
+    mapIdsToBlocks,
+    mergeJsonRawWithBlocks,
   )(jsonRaw);
 
   return addIdsToBlocks(jsonRaw);

--- a/src/app/lib/utilities/preprocessor/rules/addIdsToItems.js
+++ b/src/app/lib/utilities/preprocessor/rules/addIdsToItems.js
@@ -1,5 +1,5 @@
 import uuid from 'uuid';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import path from 'ramda/src/path';
 
 const getGroups = path(['content', 'groups']);
@@ -22,10 +22,10 @@ const mergeContentWithAddedIdItems = itemsWithIds => jsonRaw => ({
 });
 
 export default jsonRaw => {
-  const addIdsToItems = compose(
-    mergeContentWithAddedIdItems,
-    mapGroups,
+  const addIdsToItems = pipe(
     getGroups,
+    mapGroups,
+    mergeContentWithAddedIdItems,
   )(jsonRaw);
 
   return addIdsToItems(jsonRaw);

--- a/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/timestampToMilliseconds/index.js
+++ b/src/app/lib/utilities/preprocessor/rules/cpsAssetPage/timestampToMilliseconds/index.js
@@ -1,6 +1,6 @@
 import path from 'ramda/src/path';
 import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 
 // ARES sometimes reports timestamps in seconds; sometimes in milliseconds
 // This standardises that by assuming any timestamp before 1973 needs converted to ms
@@ -57,7 +57,4 @@ const standardisePromoTimestamps = json => {
   );
 };
 
-export default compose(
-  standardiseMetadataTimestamps,
-  standardisePromoTimestamps,
-);
+export default pipe(standardisePromoTimestamps, standardiseMetadataTimestamps);

--- a/src/app/pages/Article/index.jsx
+++ b/src/app/pages/Article/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shape } from 'prop-types';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import articlePropTypes from '#models/propTypes/article';
 import ArticleMain from '../../containers/ArticleMain';
 
@@ -23,13 +23,13 @@ ArticleContainer.defaultProps = {
   pageData: null,
 };
 
-const EnhancedArticleContainer = compose(
-  withVariant,
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedArticleContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
+  withVariant,
 )(ArticleContainer);
 
 export default EnhancedArticleContainer;

--- a/src/app/pages/CpsMap/index.jsx
+++ b/src/app/pages/CpsMap/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import styled from 'styled-components';
 import {
   GEL_SPACING_DBL,
@@ -121,12 +121,12 @@ const CpsMapContainer = ({ pageData }) => {
 
 CpsMapContainer.propTypes = cpsAssetPagePropTypes;
 
-const EnhancedCpsMapContainer = compose(
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedCpsMapContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
 )(CpsMapContainer);
 
 export default EnhancedCpsMapContainer;

--- a/src/app/pages/CpsPgl/index.jsx
+++ b/src/app/pages/CpsPgl/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import styled from 'styled-components';
 import {
   GEL_SPACING_DBL,
@@ -123,12 +123,12 @@ const CpsPglContainer = ({ pageData }) => {
 
 CpsPglContainer.propTypes = cpsAssetPagePropTypes;
 
-const EnhancedCpsPglContainer = compose(
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedCpsPglContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
 )(CpsPglContainer);
 
 export default EnhancedCpsPglContainer;

--- a/src/app/pages/CpsSty/index.jsx
+++ b/src/app/pages/CpsSty/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import styled from 'styled-components';
 import {
   GEL_SPACING_DBL,
@@ -122,12 +122,12 @@ const CpsStyContainer = ({ pageData }) => {
 
 CpsStyContainer.propTypes = cpsAssetPagePropTypes;
 
-const EnhancedCpsStyContainer = compose(
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedCpsStyContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
 )(CpsStyContainer);
 
 export default EnhancedCpsStyContainer;

--- a/src/app/pages/Error/index.jsx
+++ b/src/app/pages/Error/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { number } from 'prop-types';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import ErrorMain from '../../containers/ErrorMain';
 
 import withContexts from '../../containers/PageHandlers/withContexts';
@@ -20,10 +20,10 @@ ErrorContainer.defaultProps = {
   errorCode: null,
 };
 
-const EnhancedErrorContainer = compose(
-  withContexts,
-  withPageWrapper,
+const EnhancedErrorContainer = pipe(
   withLoading,
+  withPageWrapper,
+  withContexts,
 )(ErrorContainer);
 
 export default EnhancedErrorContainer;

--- a/src/app/pages/FrontPage/index.jsx
+++ b/src/app/pages/FrontPage/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shape } from 'prop-types';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import frontPagePropTypes from '#models/propTypes/frontPage';
 import FrontPageMain from '../../containers/FrontPageMain';
 
@@ -23,13 +23,13 @@ FrontPageContainer.defaultProps = {
   pageData: null,
 };
 
-const EnhancedFrontPageContainer = compose(
-  withVariant,
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedFrontPageContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
+  withVariant,
 )(FrontPageContainer);
 
 export default EnhancedFrontPageContainer;

--- a/src/app/pages/RadioPage/index.jsx
+++ b/src/app/pages/RadioPage/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import compose from 'ramda/src/compose';
+import pipe from 'ramda/src/pipe';
 import RadioPageMain from '../../containers/RadioPageMain';
 
 import withContexts from '../../containers/PageHandlers/withContexts';
@@ -12,12 +12,12 @@ const RadioContainer = props => {
   return <RadioPageMain {...props} />;
 };
 
-const EnhancedRadioContainer = compose(
-  withContexts,
-  withPageWrapper,
-  withLoading,
-  withError,
+const EnhancedRadioContainer = pipe(
   withData,
+  withError,
+  withLoading,
+  withPageWrapper,
+  withContexts,
 )(RadioContainer);
 
 export default EnhancedRadioContainer;


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5481

**Overall change:** 
Replace `compose` with `pipe` so we are consistent about how we compose functions together. They both produce the same result however argument order is the inverse of the other.

**Code changes:**
- Change all instances of `compose` to `pipe` and reverse argument order

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing notes**
A light regression testing of all page types would be good because this could potentially break a lot of things as `compose` is used for processing page data and enhancing page functionality. Unit and integration tests would very likely catch any problems though.

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
