### PR TITLE
Updated STY fixture for bold italic and media content

### DIFF
--- a/src/app/pages/CpsSty/fixtureData.json
+++ b/src/app/pages/CpsSty/fixtureData.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
     "firstPublished": 1580745507000,
-    "lastPublished": 1580749716000,
-    "lastUpdated": 1580749723227,
+    "lastPublished": 1580922773000,
+    "lastUpdated": 1580922784342,
     "id": "urn:bbc:ares::asset:mundo/23263889",
     "locators": {
       "assetUri": "/mundo/23263889",
@@ -45,7 +45,25 @@
           "campaignName": "Amuse me"
         }
       ],
-      "taggings": []
+      "language": "es",
+      "home": "http://www.bbc.co.uk/ontologies/passport/home/Mundo",
+      "passportId": "d7d7cd86-30b1-412f-8c9e-712f806c7357",
+      "locator": "urn:bbc:cps:asset:23263889",
+      "availability": "AVAILABLE",
+      "taggings": [
+        {
+          "predicate": "http://www.bbc.co.uk/ontologies/coreconcepts/editorialSensitivity",
+          "value": "http://www.bbc.co.uk/things/c6979033-cb72-4d07-9897-adc348a4332e#id"
+        },
+        {
+          "predicate": "http://www.bbc.co.uk/ontologies/passport/predicate/About",
+          "value": "http://www.bbc.co.uk/things/992e096e-28e6-412d-b6a1-652f78be63c7#id"
+        },
+        {
+          "predicate": "http://www.bbc.co.uk/ontologies/passport/predicate/About",
+          "value": "http://www.bbc.co.uk/things/b9bb453a-a3e2-46b4-9d20-35efa09d72b8#id"
+        }
+      ]
     },
     "tags": {
       "about": [
@@ -91,6 +109,7 @@
       "heading",
       "subheading",
       "social_embed",
+      "media",
       "include"
     ],
     "includeComments": false
@@ -147,7 +166,7 @@
                               "text": "WS STY TEST - Full Headline",
                               "attributes": []
                             },
-                            "id": "822df0be-2818-4df9-a27c-d08e9054be47",
+                            "id": "81416772-42c3-44d8-8dd9-32e0001dd3f5",
                             "position": [
                               1,
                               1,
@@ -157,7 +176,7 @@
                           }
                         ]
                       },
-                      "id": "6e05043e-79bc-40c7-88f0-235ea4f44db4",
+                      "id": "c2dcbadd-c6ec-4112-a9a6-56a3c6df40f7",
                       "position": [
                         1,
                         1,
@@ -166,7 +185,7 @@
                     }
                   ]
                 },
-                "id": "d4bd380f-65c2-4277-8ff0-2dbf44861ab9",
+                "id": "987bb7f4-0776-4f30-a398-cd1c9dd47ff0",
                 "position": [
                   1,
                   1
@@ -175,9 +194,29 @@
             ]
           },
           "type": "headline",
-          "id": "ccd7be06-a4aa-43d3-9584-a2a4c0d1ca7e",
+          "id": "654c0ebd-c639-4080-ab4f-13b4ee3088c5",
           "position": [
             1
+          ]
+        },
+        {
+          "model": {
+            "blocks": [
+              {
+                "name": "James Bond",
+                "title": "Spy",
+                "id": "8b0cd910-d30f-48c5-935e-d2673c3fe442",
+                "position": [
+                  2,
+                  1
+                ]
+              }
+            ]
+          },
+          "type": "byline",
+          "id": "0dd65bfb-ecb4-45f7-82bd-af4907a96518",
+          "position": [
+            2
           ]
         },
         {
@@ -203,9 +242,9 @@
                                     "text": "Index Image Large",
                                     "attributes": []
                                   },
-                                  "id": "c1e4a5f7-9035-4549-a94f-1578e8c3cc0a",
+                                  "id": "ec0069fe-feb6-4882-8349-360888a5cac7",
                                   "position": [
-                                    2,
+                                    3,
                                     1,
                                     1,
                                     1,
@@ -214,9 +253,9 @@
                                 }
                               ]
                             },
-                            "id": "79e2e30a-1e65-42eb-92ea-27d908ac269b",
+                            "id": "e492a52a-54ff-441c-89ad-0b1512058604",
                             "position": [
-                              2,
+                              3,
                               1,
                               1,
                               1
@@ -224,18 +263,18 @@
                           }
                         ]
                       },
-                      "id": "c287912c-7e46-4c8d-b851-d039ddc6f2e2",
+                      "id": "86dab815-f5d5-4b32-9b74-d01b34e7d525",
                       "position": [
-                        2,
+                        3,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "0ca543ee-0b19-4000-8794-e0cf1a885f56",
+                "id": "8559985a-98c3-48f7-a821-25db4c337632",
                 "position": [
-                  2,
+                  3,
                   1
                 ]
               },
@@ -258,9 +297,9 @@
                                     "text": "Index image large",
                                     "attributes": []
                                   },
-                                  "id": "04a810e9-1fba-4262-88e6-2d37fa4e9f4f",
+                                  "id": "1b9305df-5e34-4a83-9fce-0f2d1373c0f3",
                                   "position": [
-                                    2,
+                                    3,
                                     2,
                                     1,
                                     1,
@@ -269,9 +308,9 @@
                                 }
                               ]
                             },
-                            "id": "b0167e0e-736a-4634-8b58-b8603712c4db",
+                            "id": "555abfeb-d5f2-4425-ac91-0b0f3f54c3bb",
                             "position": [
-                              2,
+                              3,
                               2,
                               1,
                               1
@@ -279,18 +318,18 @@
                           }
                         ]
                       },
-                      "id": "477eb19c-68b1-4faf-913c-6e675a477a35",
+                      "id": "f6e75266-387d-4628-a58c-60204c4e680e",
                       "position": [
-                        2,
+                        3,
                         2,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "4b919225-3d11-40b7-afbd-f107a6bf5c6b",
+                "id": "43ff120a-06b0-4d4f-8d04-9fd055265bee",
                 "position": [
-                  2,
+                  3,
                   2
                 ]
               },
@@ -303,28 +342,28 @@
                   "originCode": "cpsdevpb",
                   "width": 976
                 },
-                "id": "0901c27d-b667-4e7b-aed8-899f9fdd7dd9",
+                "id": "5874c5e8-4460-4cf5-9575-6a8b9456e152",
                 "position": [
-                  2,
+                  3,
                   3
                 ]
               }
             ]
           },
-          "id": "81a7a86b-f807-4a60-a478-812aebfec0ac",
+          "id": "da4b828e-9043-4102-99de-39f5c70c7087",
           "position": [
-            2
+            3
           ]
         },
         {
           "type": "timestamp",
           "model": {
             "firstPublished": 1580745507000,
-            "lastPublished": 1580749716000
+            "lastPublished": 1580922773000
           },
-          "id": "6fe468ba-325e-4596-9af7-9839c7188790",
+          "id": "0cecc952-82f5-4491-9fa7-6a8bded6138c",
           "position": [
-            3
+            4
           ]
         },
         {
@@ -344,26 +383,26 @@
                           "bold"
                         ]
                       },
-                      "id": "fdf4b527-dc32-4a9c-9f53-705c6321adc7",
+                      "id": "3e7d96fc-3326-49d6-8c6c-d2f5bfd06ccd",
                       "position": [
-                        4,
+                        5,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "c58ba4cd-2037-4b24-ba99-54ea08a7ba5c",
+                "id": "a9058c59-3fb4-40c4-adcc-673021fcda9e",
                 "position": [
-                  4,
+                  5,
                   1
                 ]
               }
             ]
           },
-          "id": "5ecf00f7-410d-4305-9e45-eb8efb3caa01",
+          "id": "02f25938-5b16-4d5c-903f-103e8d94b323",
           "position": [
-            4
+            5
           ]
         },
         {
@@ -381,26 +420,26 @@
                         "text": "The next paragraph isn't marked up in any way - it's just \"normal\".",
                         "attributes": []
                       },
-                      "id": "e6e5a937-9368-4b19-91ca-ac627ab19375",
+                      "id": "259b9460-b792-49c4-b1b1-b3ebf1429efa",
                       "position": [
-                        5,
+                        6,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "6b829541-6350-4497-8695-0b773283817c",
+                "id": "30402c84-41e4-4ed3-8a9c-e9eeb839bca0",
                 "position": [
-                  5,
+                  6,
                   1
                 ]
               }
             ]
           },
-          "id": "2ed51bc8-3d46-455f-8fbe-d971fd510934",
+          "id": "0259d59f-1564-46e2-83fc-4c2ec4c2a01d",
           "position": [
-            5
+            6
           ]
         },
         {
@@ -422,9 +461,9 @@
                               "text": "This is a crosshead",
                               "attributes": []
                             },
-                            "id": "b37e3e9e-d6c5-4267-bb6b-48da590906f7",
+                            "id": "a3357ae9-225a-47ed-9779-3181bf24ab06",
                             "position": [
-                              6,
+                              7,
                               1,
                               1,
                               1
@@ -432,26 +471,26 @@
                           }
                         ]
                       },
-                      "id": "ac4caa18-9b4e-4810-9d25-b89b60088706",
+                      "id": "6ef19ea3-7992-4810-8fa8-da82f56e0088",
                       "position": [
-                        6,
+                        7,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "f6b6362a-5819-4af4-8ddc-4734027da666",
+                "id": "1da64d7e-5c74-4a4a-904b-aa4d1f3ec834",
                 "position": [
-                  6,
+                  7,
                   1
                 ]
               }
             ]
           },
-          "id": "7a712f67-e005-4cc2-9ab2-e4f17f0387d6",
+          "id": "8ae45c2c-038a-45e4-9296-86d48063e724",
           "position": [
-            6
+            7
           ]
         },
         {
@@ -461,7 +500,7 @@
               {
                 "type": "paragraph",
                 "model": {
-                  "text": "Paragraphs can contain bold and italic in CPS at the moment, and these are rendered on the page as bold and italic.",
+                  "text": "Paragraphs can contain bold and italic in CPS at the moment, and these are rendered on the page as bold and italic or both.",
                   "blocks": [
                     {
                       "type": "fragment",
@@ -469,9 +508,9 @@
                         "text": "Paragraphs can contain ",
                         "attributes": []
                       },
-                      "id": "78d04fa1-04be-4ff6-ab2a-160a2fc79e2f",
+                      "id": "8689545b-b2de-4c07-ab01-0d367f99082f",
                       "position": [
-                        7,
+                        8,
                         1,
                         1
                       ]
@@ -484,9 +523,9 @@
                           "bold"
                         ]
                       },
-                      "id": "26e919a3-1064-4b88-9b96-c7c8cada0c89",
+                      "id": "a5228724-5d12-4771-8381-e2c1202c10b7",
                       "position": [
-                        7,
+                        8,
                         1,
                         2
                       ]
@@ -497,9 +536,9 @@
                         "text": "and ",
                         "attributes": []
                       },
-                      "id": "2d0a75e9-3783-4027-b8f6-adbb26958392",
+                      "id": "3f2296f3-eea8-4662-ac31-65868a75775e",
                       "position": [
-                        7,
+                        8,
                         1,
                         3
                       ]
@@ -512,9 +551,9 @@
                           "italic"
                         ]
                       },
-                      "id": "51134ada-ef35-4da0-b93e-6cb867d792ce",
+                      "id": "041c25eb-658a-4e4d-8cdf-a8d3b7c67651",
                       "position": [
-                        7,
+                        8,
                         1,
                         4
                       ]
@@ -525,9 +564,9 @@
                         "text": "in CPS at the moment, and these are rendered on the page as ",
                         "attributes": []
                       },
-                      "id": "1ffbb054-6b8b-4ca9-917f-943f4ecd7041",
+                      "id": "61fcc66f-109f-490a-8d28-4fd0e336fcc9",
                       "position": [
-                        7,
+                        8,
                         1,
                         5
                       ]
@@ -540,9 +579,9 @@
                           "bold"
                         ]
                       },
-                      "id": "20f09e98-b0a7-43ec-a144-81a242e7de94",
+                      "id": "d2a136e5-a87f-4038-bdbc-cce3ad767dd9",
                       "position": [
-                        7,
+                        8,
                         1,
                         6
                       ]
@@ -553,9 +592,9 @@
                         "text": "and ",
                         "attributes": []
                       },
-                      "id": "1287039e-7135-4a22-a898-446c11d38b7a",
+                      "id": "c78bd8d3-75f4-4c87-a2ec-4cadb6774e12",
                       "position": [
-                        7,
+                        8,
                         1,
                         7
                       ]
@@ -563,14 +602,14 @@
                     {
                       "type": "fragment",
                       "model": {
-                        "text": "it",
+                        "text": "italic",
                         "attributes": [
                           "italic"
                         ]
                       },
-                      "id": "1ab0f313-1e50-4c38-8e35-9cab0193de66",
+                      "id": "7f16e1d6-6c11-4158-b02b-2f6eef6ba9a7",
                       "position": [
-                        7,
+                        8,
                         1,
                         8
                       ]
@@ -578,31 +617,113 @@
                     {
                       "type": "fragment",
                       "model": {
-                        "text": "alic.",
+                        "text": " ",
                         "attributes": [
                           "italic"
                         ]
                       },
-                      "id": "b1e4db72-1b25-4719-b155-987b11f7b1b0",
+                      "id": "d345d71b-38c8-4bb7-bd86-366bf79dfef2",
                       "position": [
-                        7,
+                        8,
                         1,
                         9
+                      ]
+                    },
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "or ",
+                        "attributes": []
+                      },
+                      "id": "8a12f8b3-c5ef-4838-84a6-626030f42734",
+                      "position": [
+                        8,
+                        1,
+                        10
+                      ]
+                    },
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "both",
+                        "attributes": [
+                          "bold",
+                          "italic"
+                        ]
+                      },
+                      "id": "3ee3f7b5-95bd-4eae-99cd-8e266e88bc8d",
+                      "position": [
+                        8,
+                        1,
+                        11
+                      ]
+                    },
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": ".",
+                        "attributes": []
+                      },
+                      "id": "88020eaf-855d-4cef-b4ea-95acb9b3f0c2",
+                      "position": [
+                        8,
+                        1,
+                        12
                       ]
                     }
                   ]
                 },
-                "id": "16996ecb-4e2b-4eef-b871-9c9de88bd321",
+                "id": "51fd8cfc-ba38-46ad-a453-f8096036682b",
                 "position": [
-                  7,
+                  8,
                   1
                 ]
               }
             ]
           },
-          "id": "8f3126d6-22d8-4761-aea6-4b563f014b18",
+          "id": "d47ec881-2d3a-44e4-aa31-83beb68b1fd2",
           "position": [
-            7
+            8
+          ]
+        },
+        {
+          "type": "text",
+          "model": {
+            "blocks": [
+              {
+                "type": "paragraph",
+                "model": {
+                  "text": "Bold and italic can also be rendered together.",
+                  "blocks": [
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "Bold and italic can also be rendered together.",
+                        "attributes": [
+                          "bold",
+                          "italic"
+                        ]
+                      },
+                      "id": "6895190c-bd16-44d8-b73c-f05a44a622cd",
+                      "position": [
+                        9,
+                        1,
+                        1
+                      ]
+                    }
+                  ]
+                },
+                "id": "905ac7a4-cc37-4561-9411-74b6acce1bb8",
+                "position": [
+                  9,
+                  1
+                ]
+              }
+            ]
+          },
+          "id": "40908429-7e51-4f11-a959-aaa0be29d7c4",
+          "position": [
+            9
           ]
         },
         {
@@ -626,9 +747,9 @@
                                     "text": "This is a bulleted list",
                                     "attributes": []
                                   },
-                                  "id": "570da1ea-f8cc-44a5-b6a2-12802dd22295",
+                                  "id": "a3bcc403-14af-46a3-9158-4c22ffb1966d",
                                   "position": [
-                                    8,
+                                    10,
                                     1,
                                     1,
                                     1,
@@ -637,9 +758,9 @@
                                 }
                               ]
                             },
-                            "id": "b63dcdaf-d3ba-47a6-a51e-9ab17ca28a5f",
+                            "id": "bde0b08e-1b07-4fc1-be89-7eabe1569b4d",
                             "position": [
-                              8,
+                              10,
                               1,
                               1,
                               1
@@ -647,28 +768,114 @@
                           }
                         ]
                       },
-                      "id": "0c98ea3f-0575-4b5f-9fb8-f0b1222fe3d8",
+                      "id": "61673c6b-f919-45ec-86f3-68e974219790",
                       "position": [
-                        8,
+                        10,
                         1,
                         1
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "Bullet 2",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "Bullet 2",
+                                    "attributes": []
+                                  },
+                                  "id": "aa7f7f87-a472-4536-b19d-3ebdb5ea685e",
+                                  "position": [
+                                    10,
+                                    1,
+                                    2,
+                                    1,
+                                    1
+                                  ]
+                                }
+                              ]
+                            },
+                            "id": "5143f88e-858f-447f-bf96-1b115d885880",
+                            "position": [
+                              10,
+                              1,
+                              2,
+                              1
+                            ]
+                          }
+                        ]
+                      },
+                      "id": "2ddf3571-c226-4f77-97a4-f2317b328645",
+                      "position": [
+                        10,
+                        1,
+                        2
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "Bullet 3",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "Bullet 3",
+                                    "attributes": []
+                                  },
+                                  "id": "3d7f914e-6b00-44b6-b890-e7b3e648499c",
+                                  "position": [
+                                    10,
+                                    1,
+                                    3,
+                                    1,
+                                    1
+                                  ]
+                                }
+                              ]
+                            },
+                            "id": "7df5dee7-3a09-4837-8a9f-abb24f91e8ce",
+                            "position": [
+                              10,
+                              1,
+                              3,
+                              1
+                            ]
+                          }
+                        ]
+                      },
+                      "id": "b03bbc9d-6af3-44dc-b8d9-3fe25f50a651",
+                      "position": [
+                        10,
+                        1,
+                        3
                       ]
                     }
                   ]
                 },
                 "type": "unorderedList",
-                "id": "da325050-5789-4695-a37f-d3d83f58229f",
+                "id": "0ab813dc-8abf-4415-9c31-02d7d1ab4379",
                 "position": [
-                  8,
+                  10,
                   1
                 ]
               }
             ]
           },
           "type": "text",
-          "id": "6e2dae38-57c1-46a2-a115-8943aaeb67bf",
+          "id": "2f1bb598-31dd-4f22-959a-0f98b10005da",
           "position": [
-            8
+            10
           ]
         },
         {
@@ -686,26 +893,26 @@
                         "text": "This is a normal paragraph again.",
                         "attributes": []
                       },
-                      "id": "33d7e358-ff93-4486-a868-77175a815054",
+                      "id": "913c8489-3b5c-463f-8f3b-41ff70a56e9b",
                       "position": [
-                        9,
+                        11,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "ee800238-1fed-4027-bcfc-8b2226d6b6bd",
+                "id": "d98b13c8-afc3-492e-ae1e-33e9d5e7915c",
                 "position": [
-                  9,
+                  11,
                   1
                 ]
               }
             ]
           },
-          "id": "648d4e8b-5c74-4f0c-b86e-a05e0b7d434c",
+          "id": "2afb6558-f551-4a78-a78f-b1c179408daa",
           "position": [
-            9
+            11
           ]
         },
         {
@@ -727,9 +934,9 @@
                               "text": "This is a Heading",
                               "attributes": []
                             },
-                            "id": "c6add4a8-2654-4ce1-8be1-870f2052a78f",
+                            "id": "cdc31988-8725-4e6c-b452-5151b93dbe5b",
                             "position": [
-                              10,
+                              12,
                               1,
                               1,
                               1
@@ -737,26 +944,26 @@
                           }
                         ]
                       },
-                      "id": "65168956-7809-49fc-be2c-44e7cfb317c4",
+                      "id": "f9b2d3da-a199-4a78-b0be-c85f23ba1cd6",
                       "position": [
-                        10,
+                        12,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "76cda5c9-5e6d-4013-8eb3-c0c12332c633",
+                "id": "e434990d-e10f-462c-8a6a-76355fa36c3f",
                 "position": [
-                  10,
+                  12,
                   1
                 ]
               }
             ]
           },
-          "id": "1a863140-c514-42a1-9681-5d4e97253078",
+          "id": "98c55bbd-1f26-40c5-8fc6-7185e01a53db",
           "position": [
-            10
+            12
           ]
         },
         {
@@ -774,26 +981,26 @@
                         "text": "Normal paragraph.",
                         "attributes": []
                       },
-                      "id": "9554b71a-db9e-4b94-8268-59e0042b7a16",
+                      "id": "a298064e-9b6f-4569-8471-e4e4c922eea7",
                       "position": [
-                        11,
+                        13,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "1e8391e6-7673-4180-aa96-d5be7d794dd8",
+                "id": "64c7faba-6a21-41f2-9928-841edb356aa1",
                 "position": [
-                  11,
+                  13,
                   1
                 ]
               }
             ]
           },
-          "id": "3c187f49-edb3-4674-9abc-ea612e25d320",
+          "id": "a9362cc5-add2-43bc-a965-b308d2d6bdc4",
           "position": [
-            11
+            13
           ]
         },
         {
@@ -817,9 +1024,9 @@
                                     "text": "This is a numbered list",
                                     "attributes": []
                                   },
-                                  "id": "bcbc8fdc-c094-41f7-aa2c-23ae005edbda",
+                                  "id": "27b0108e-f6a5-45d8-98db-43a20abf843c",
                                   "position": [
-                                    12,
+                                    14,
                                     1,
                                     1,
                                     1,
@@ -828,9 +1035,9 @@
                                 }
                               ]
                             },
-                            "id": "66d80ea9-9708-4c0f-b808-71cc140791d3",
+                            "id": "21645256-bc13-43ae-ada7-4342a51a27f8",
                             "position": [
-                              12,
+                              14,
                               1,
                               1,
                               1
@@ -838,9 +1045,9 @@
                           }
                         ]
                       },
-                      "id": "604f2be4-8e49-4026-9789-79da1dce4232",
+                      "id": "40a1a9d9-ac24-4262-9a94-602d7c091324",
                       "position": [
-                        12,
+                        14,
                         1,
                         1
                       ]
@@ -852,17 +1059,17 @@
                           {
                             "type": "paragraph",
                             "model": {
-                              "text": "And so on",
+                              "text": "Number 2",
                               "blocks": [
                                 {
                                   "type": "fragment",
                                   "model": {
-                                    "text": "And so on",
+                                    "text": "Number 2",
                                     "attributes": []
                                   },
-                                  "id": "7da6ab0b-5adc-4bcc-9d0a-ac0a6171516d",
+                                  "id": "1d4edda8-5171-4958-9d55-9a3f699d60c9",
                                   "position": [
-                                    12,
+                                    14,
                                     1,
                                     2,
                                     1,
@@ -871,9 +1078,9 @@
                                 }
                               ]
                             },
-                            "id": "e414c1af-976e-4e16-b741-79e7ee6afd88",
+                            "id": "f7d6f07b-ea28-4604-9409-ddb3636220bd",
                             "position": [
-                              12,
+                              14,
                               1,
                               2,
                               1
@@ -881,28 +1088,71 @@
                           }
                         ]
                       },
-                      "id": "71cdc785-2ca3-4cc3-a47a-7e6cf6ac7d33",
+                      "id": "61f844d9-96c3-40de-80d1-35ea9e5279f3",
                       "position": [
-                        12,
+                        14,
                         1,
                         2
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "paragraph",
+                            "model": {
+                              "text": "Number 3, and so on",
+                              "blocks": [
+                                {
+                                  "type": "fragment",
+                                  "model": {
+                                    "text": "Number 3, and so on",
+                                    "attributes": []
+                                  },
+                                  "id": "8a35dbd8-76c6-4cf3-b561-e4619c3e9406",
+                                  "position": [
+                                    14,
+                                    1,
+                                    3,
+                                    1,
+                                    1
+                                  ]
+                                }
+                              ]
+                            },
+                            "id": "5cd76564-5e25-4885-8d70-140cd4244701",
+                            "position": [
+                              14,
+                              1,
+                              3,
+                              1
+                            ]
+                          }
+                        ]
+                      },
+                      "id": "8d40df2d-0028-4cd7-98e7-0ff154e0357c",
+                      "position": [
+                        14,
+                        1,
+                        3
                       ]
                     }
                   ]
                 },
                 "type": "orderedList",
-                "id": "16f93d46-ffd0-4f86-9c62-fefe81fc0fad",
+                "id": "0cf26197-5dfb-4427-82b6-fed7785ff264",
                 "position": [
-                  12,
+                  14,
                   1
                 ]
               }
             ]
           },
           "type": "text",
-          "id": "b05b5775-3baa-46f0-ac89-9e78c5ad0cc6",
+          "id": "c421799c-9ad1-42ea-8125-be3c8b9d8e26",
           "position": [
-            12
+            14
           ]
         },
         {
@@ -928,9 +1178,9 @@
                                     "text": "Body image #1 with caption",
                                     "attributes": []
                                   },
-                                  "id": "5ec35300-e34b-4878-a256-a1d3fd6ba642",
+                                  "id": "262c27fe-d108-4938-9963-c9c654b65633",
                                   "position": [
-                                    13,
+                                    15,
                                     1,
                                     1,
                                     1,
@@ -939,9 +1189,9 @@
                                 }
                               ]
                             },
-                            "id": "6ac954ea-ef1b-4af2-8ef0-36d9c7f1042f",
+                            "id": "813da526-0780-4fa2-9f6c-fcca1b2d73eb",
                             "position": [
-                              13,
+                              15,
                               1,
                               1,
                               1
@@ -949,18 +1199,18 @@
                           }
                         ]
                       },
-                      "id": "5aa2c7cf-7f90-4b6c-9519-5dfa226e44b0",
+                      "id": "c279d29c-e651-488f-94f0-be32bb935d67",
                       "position": [
-                        13,
+                        15,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "7f2086eb-d511-4168-8be4-9ff7a67327d1",
+                "id": "bf949986-9b2e-4fce-9031-c274962a3c07",
                 "position": [
-                  13,
+                  15,
                   1
                 ]
               },
@@ -983,9 +1233,9 @@
                                     "text": "image",
                                     "attributes": []
                                   },
-                                  "id": "9623840c-7d0a-4ed8-afb3-577b2d473f68",
+                                  "id": "1f52974d-b002-4742-8df4-99f21bb27fb2",
                                   "position": [
-                                    13,
+                                    15,
                                     2,
                                     1,
                                     1,
@@ -994,9 +1244,9 @@
                                 }
                               ]
                             },
-                            "id": "f4d54cfb-dec5-4878-9851-2386f6effebc",
+                            "id": "8c208606-415b-41b3-8867-d43540bcb6b7",
                             "position": [
-                              13,
+                              15,
                               2,
                               1,
                               1
@@ -1004,18 +1254,18 @@
                           }
                         ]
                       },
-                      "id": "f56574cf-adc2-45e2-b683-a405637f7fd3",
+                      "id": "bb3fe401-db82-4b79-906b-47d23c74544d",
                       "position": [
-                        13,
+                        15,
                         2,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "e287e42d-0602-4215-82d7-f0d005667223",
+                "id": "279d3e87-3510-4d46-ad83-72adf0d8bdda",
                 "position": [
-                  13,
+                  15,
                   2
                 ]
               },
@@ -1028,17 +1278,17 @@
                   "originCode": "cpsdevpb",
                   "width": 976
                 },
-                "id": "c9bdc230-fb6c-416a-ab11-517515a0dba6",
+                "id": "fd49615e-696a-4572-9eb5-f736da69459d",
                 "position": [
-                  13,
+                  15,
                   3
                 ]
               }
             ]
           },
-          "id": "c2cfe76f-cb37-4a22-bd98-6b12160d69f4",
+          "id": "2513068a-6dc7-465c-b306-9086be3d8597",
           "position": [
-            13
+            15
           ]
         },
         {
@@ -1056,26 +1306,26 @@
                         "text": "Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. Longer paragraph of normal body text. ",
                         "attributes": []
                       },
-                      "id": "ceb44c94-fec8-4813-b836-731edcce38a4",
+                      "id": "ea717494-2419-4a49-9bba-df6161db9e04",
                       "position": [
-                        14,
+                        16,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "f2bfbffc-34ba-4577-8d8f-4427d0d31f08",
+                "id": "399a0dfb-a4e2-4c1b-a7d9-45b45e86565f",
                 "position": [
-                  14,
+                  16,
                   1
                 ]
               }
             ]
           },
-          "id": "a627dcdc-80be-4ef2-abe7-c56cc606d56d",
+          "id": "64b80281-95df-4937-a2a9-5a380eab28b0",
           "position": [
-            14
+            16
           ]
         },
         {
@@ -1093,26 +1343,26 @@
                         "text": "Another paragraph of body text.",
                         "attributes": []
                       },
-                      "id": "47d741b7-3012-4cf3-bf03-6bd8986ef0aa",
+                      "id": "198b7a8a-ff3a-4df1-9b3f-300b794efb5f",
                       "position": [
-                        15,
+                        17,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "b1a71704-2d6d-4a50-82eb-ce9eb5cad08a",
+                "id": "f048d8c4-a6fc-4a1e-a72f-29dd4b9e21c0",
                 "position": [
-                  15,
+                  17,
                   1
                 ]
               }
             ]
           },
-          "id": "ddc235e2-4a28-4945-b5fe-d2c29d8456d0",
+          "id": "5d2f73b7-4bf4-43e8-9963-a7d26e548403",
           "position": [
-            15
+            17
           ]
         },
         {
@@ -1134,9 +1384,9 @@
                               "text": "This is a Subheading",
                               "attributes": []
                             },
-                            "id": "ccc28ebb-6517-4285-8290-62989cab93da",
+                            "id": "cab8f00e-3023-4fe2-926c-5cf91f76da5f",
                             "position": [
-                              16,
+                              18,
                               1,
                               1,
                               1
@@ -1144,26 +1394,26 @@
                           }
                         ]
                       },
-                      "id": "f850b0dd-b439-434c-ad2f-32606e225d73",
+                      "id": "d8db32ad-6db6-4c05-a793-bdc596a39980",
                       "position": [
-                        16,
+                        18,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "74233264-761a-4ba6-9fe6-4188625df424",
+                "id": "d03da4cd-3caf-48c4-a7c1-19b4a3d102e3",
                 "position": [
-                  16,
+                  18,
                   1
                 ]
               }
             ]
           },
-          "id": "55860334-b3ac-4671-bc60-d7e3dd93f474",
+          "id": "d3dadac9-766d-4888-8c7b-86464467566f",
           "position": [
-            16
+            18
           ]
         },
         {
@@ -1181,26 +1431,26 @@
                         "text": "A grey line appears after a subheading.",
                         "attributes": []
                       },
-                      "id": "b6d18f3c-064f-4e4d-8b52-3d8ebf5def9a",
+                      "id": "ff76a9db-7dd4-43c7-844a-90b2b6368117",
                       "position": [
-                        17,
+                        19,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "0773fdb4-e1e5-473f-9fde-a1a01a5aa3bf",
+                "id": "d8fd3e33-7f79-496a-b3b9-3b89d0ddc364",
                 "position": [
-                  17,
+                  19,
                   1
                 ]
               }
             ]
           },
-          "id": "c01b6564-a225-40b4-aba1-14c0bd513b84",
+          "id": "d0612875-35e4-4063-a942-3c3cafb45b6d",
           "position": [
-            17
+            19
           ]
         },
         {
@@ -1218,9 +1468,9 @@
                         "text": "This is a paragraph with an ",
                         "attributes": []
                       },
-                      "id": "5557b830-ddd3-4f4b-b6d8-8146a9c94ef4",
+                      "id": "0c0f032a-3138-46bd-9f28-e19c1a1392f0",
                       "position": [
-                        18,
+                        20,
                         1,
                         1
                       ]
@@ -1237,9 +1487,9 @@
                               "text": "inline link",
                               "attributes": []
                             },
-                            "id": "4b027e74-09e1-43b9-82ed-49bffae48818",
+                            "id": "cfd2b0db-8c09-46fa-84e5-0b6fe7d94409",
                             "position": [
-                              18,
+                              20,
                               1,
                               2,
                               1
@@ -1248,9 +1498,9 @@
                         ],
                         "isExternal": false
                       },
-                      "id": "abf9ddcd-8911-46ea-b631-291f585b93c2",
+                      "id": "eb0e8ada-7731-4b93-baa1-d9ac2a5aadc8",
                       "position": [
-                        18,
+                        20,
                         1,
                         2
                       ]
@@ -1261,9 +1511,9 @@
                         "text": " to an internal site. Here's a link to an ",
                         "attributes": []
                       },
-                      "id": "863f0d07-2fd2-4800-b5d7-b82446c6bda1",
+                      "id": "d5e2b1e3-7f77-4c60-822d-8a7b88e4d364",
                       "position": [
-                        18,
+                        20,
                         1,
                         3
                       ]
@@ -1280,9 +1530,9 @@
                               "text": "external site",
                               "attributes": []
                             },
-                            "id": "f20e1aea-0672-4062-8cf9-c939c5fab6d0",
+                            "id": "77ba277f-4cef-4128-bb03-5859d56921c7",
                             "position": [
-                              18,
+                              20,
                               1,
                               4,
                               1
@@ -1291,9 +1541,9 @@
                         ],
                         "isExternal": true
                       },
-                      "id": "c62d3bab-f0d4-44b6-8572-a391fc0bc562",
+                      "id": "fbae426a-7cd6-4ef8-aae5-22d3656feaa0",
                       "position": [
-                        18,
+                        20,
                         1,
                         4
                       ]
@@ -1304,26 +1554,26 @@
                         "text": ".",
                         "attributes": []
                       },
-                      "id": "81057a16-58de-4dbf-b159-6b60e90e497a",
+                      "id": "2a080cc4-def3-45c7-9a45-14c88d342278",
                       "position": [
-                        18,
+                        20,
                         1,
                         5
                       ]
                     }
                   ]
                 },
-                "id": "ae2b759d-642b-404c-91a5-626e6a5b9929",
+                "id": "6089b8d9-8365-429d-a956-f502a2b3c97d",
                 "position": [
-                  18,
+                  20,
                   1
                 ]
               }
             ]
           },
-          "id": "7969945a-6835-4e89-b2ed-0c591d6c08d9",
+          "id": "b33e2e01-802a-48be-98ef-5bd74b606760",
           "position": [
-            18
+            20
           ]
         },
         {
@@ -1341,26 +1591,26 @@
                         "text": "More normal paragraph text. The body image below doesn't have a caption, but does have copyright.",
                         "attributes": []
                       },
-                      "id": "8a6b48e9-c7ce-4922-950d-286d490a4f7e",
+                      "id": "fbf0b51f-e3c0-4945-8efe-ec20d1ee2b31",
                       "position": [
-                        19,
+                        21,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "10a3e93c-98b2-4df3-b324-45c584da883a",
+                "id": "1eb98783-10eb-434a-89be-8ae3b6f7bed8",
                 "position": [
-                  19,
+                  21,
                   1
                 ]
               }
             ]
           },
-          "id": "e0e886c2-7b99-48e8-a925-2ed3af71b745",
+          "id": "dca39a82-27ef-4996-8671-789709590831",
           "position": [
-            19
+            21
           ]
         },
         {
@@ -1386,9 +1636,9 @@
                                     "text": "Dogs",
                                     "attributes": []
                                   },
-                                  "id": "93d8bc7b-be84-4770-86d8-dd4342205e3d",
+                                  "id": "91617f9b-0cd6-44dc-a9c0-4f415e664838",
                                   "position": [
-                                    20,
+                                    22,
                                     1,
                                     1,
                                     1,
@@ -1397,9 +1647,9 @@
                                 }
                               ]
                             },
-                            "id": "2d7b01e5-eeae-4299-b222-2dcbf06f453e",
+                            "id": "d7f4163b-72c7-485e-9778-a10fcad69b9f",
                             "position": [
-                              20,
+                              22,
                               1,
                               1,
                               1
@@ -1407,18 +1657,18 @@
                           }
                         ]
                       },
-                      "id": "afef8537-2b93-48b9-8fb8-dfc1254db54a",
+                      "id": "37ad79ed-ba27-4b4f-b913-1b6287d11300",
                       "position": [
-                        20,
+                        22,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "9f1ae7c0-b41c-4638-9a1a-d2e9eccd4202",
+                "id": "f3743487-65dc-4e10-a293-5008e9cd8fbb",
                 "position": [
-                  20,
+                  22,
                   1
                 ]
               },
@@ -1431,17 +1681,17 @@
                   "originCode": "cpsdevpb",
                   "width": 976
                 },
-                "id": "45c49d92-5d81-48d3-b375-6ec3cf9d2e45",
+                "id": "d31823f9-24b5-487d-a298-cce2f3991959",
                 "position": [
-                  20,
+                  22,
                   2
                 ]
               }
             ]
           },
-          "id": "6cd6b80a-7e20-4abc-a1b8-355cc059997c",
+          "id": "01d4c17f-ca35-4092-9762-2a5a0c3a1e3c",
           "position": [
-            20
+            22
           ]
         },
         {
@@ -1459,26 +1709,26 @@
                         "text": "Social embed examples below for Twitter, YouTube and Instagram.",
                         "attributes": []
                       },
-                      "id": "9a61e50d-e418-48b5-8892-a5ec8e33f832",
+                      "id": "b0060f72-e9b1-4dfd-a08a-6385e96cb59b",
                       "position": [
-                        21,
+                        23,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "6b0ecb12-44cb-4468-87a5-1879a7dee856",
+                "id": "a7623ad1-027d-400b-8f1a-220a7222a693",
                 "position": [
-                  21,
+                  23,
                   1
                 ]
               }
             ]
           },
-          "id": "7afa2f27-dd48-4916-909e-53335c11ef0f",
+          "id": "c5d83f44-4a95-4d8d-bed2-49d043a03f1e",
           "position": [
-            21
+            23
           ]
         },
         {
@@ -1496,26 +1746,26 @@
                         "text": "Twitter",
                         "attributes": []
                       },
-                      "id": "e2713f0f-cb5b-4623-964b-da44e0231c65",
+                      "id": "f82c44fb-9799-421c-93de-73184cd42b2b",
                       "position": [
-                        22,
+                        24,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "93b7ce75-2af0-4362-a4a2-dda000c32d75",
+                "id": "8a8f27fd-a93a-4632-866b-abe73f44af7d",
                 "position": [
-                  22,
+                  24,
                   1
                 ]
               }
             ]
           },
-          "id": "16003bc8-8d0b-4eee-9c36-830d8735a325",
+          "id": "1aad51f3-84bb-4622-a7bb-6d24596f89a3",
           "position": [
-            22
+            24
           ]
         },
         {
@@ -1533,26 +1783,26 @@
                         "text": "YouTube",
                         "attributes": []
                       },
-                      "id": "cdf0a6eb-5f4a-40e0-b4a2-28b2a06b454f",
+                      "id": "40b125eb-ab14-4015-a21d-cc38b8b9c9b8",
                       "position": [
-                        23,
+                        25,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "7025503c-f125-454a-8159-638bc032c8f0",
+                "id": "db177924-03cd-4a0e-8574-e2d4e30244a7",
                 "position": [
-                  23,
+                  25,
                   1
                 ]
               }
             ]
           },
-          "id": "a2ea6074-baff-48ff-8e35-8fdcbb6e83d7",
+          "id": "1be5ad42-39d8-4d9f-80e8-d3c86cbb4c86",
           "position": [
-            23
+            25
           ]
         },
         {
@@ -1570,26 +1820,26 @@
                         "text": "Instagram",
                         "attributes": []
                       },
-                      "id": "0ceaa9a8-e52c-4239-adb9-998471103c34",
+                      "id": "b6476833-09ba-4a60-84bb-6b0fdaf39044",
                       "position": [
-                        24,
+                        26,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "7c013978-b73b-45fe-9d86-ef332dc9f02c",
+                "id": "f2428ccb-0ad7-4e03-bc5d-238bf8f428c5",
                 "position": [
-                  24,
+                  26,
                   1
                 ]
               }
             ]
           },
-          "id": "af457ae5-500e-4603-b4e8-e0e5a69b4c97",
+          "id": "8de490f8-bf5c-4d8f-892f-3663af00c814",
           "position": [
-            24
+            26
           ]
         },
         {
@@ -1599,34 +1849,263 @@
               {
                 "type": "paragraph",
                 "model": {
-                  "text": "Includes: IDT2",
+                  "text": "Embedded MAP: video",
                   "blocks": [
                     {
                       "type": "fragment",
                       "model": {
-                        "text": "Includes: IDT2",
+                        "text": "Embedded MAP: video",
                         "attributes": []
                       },
-                      "id": "dca99aa0-4d7a-462c-a719-60df7211b2a7",
+                      "id": "8e9097b1-7191-494b-8621-8767cb36b3ff",
                       "position": [
-                        25,
+                        27,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "bdb29e6c-0374-4816-a4b3-56af8435f8b3",
+                "id": "741076c1-b802-4702-80c1-f7ea94914cc7",
                 "position": [
-                  25,
+                  27,
                   1
                 ]
               }
             ]
           },
-          "id": "75e17aef-e925-44e7-9c44-6e6bd020d3f9",
+          "id": "75cd7de0-894b-43fa-874c-a0283faa01e5",
           "position": [
-            25
+            27
+          ]
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01k6msm",
+            "blocks": [
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "aresMediaMetadata",
+                      "blockId": "urn:bbc:ares::clip:p01k6msm",
+                      "model": {
+                        "advertising": true,
+                        "embedding": true,
+                        "format": "audio_video",
+                        "id": "p01k6msm",
+                        "imageCopyright": "BBC",
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+                        "subType": "clip",
+                        "synopses": {
+                          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+                        },
+                        "title": "Five things ants can teach us about management",
+                        "versions": [
+                          {
+                            "versionId": "p01k6msp",
+                            "types": [
+                              "Original"
+                            ],
+                            "duration": 191,
+                            "durationISO8601": "PT3M11S",
+                            "warnings": {
+                              "short": "Contains strong language and adult humour.",
+                              "long": "Contains strong language and adult humour."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true,
+                              "world": false
+                            },
+                            "availableFrom": 1540218932000
+                          }
+                        ],
+                        "available": true
+                      },
+                      "id": "c65e45d8-4980-47fb-9393-4d9798d89854",
+                      "position": [
+                        28,
+                        1,
+                        1
+                      ]
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "copyrightHolder": "BBC",
+                              "locator": "https://ichef.test.bbci.co.uk/images/ic/1024x576/p01k6mtv.jpg",
+                              "originCode": "pips"
+                            },
+                            "id": "755a6dde-9360-4a9d-9915-a207871b70d7",
+                            "position": [
+                              28,
+                              1,
+                              2,
+                              1
+                            ]
+                          }
+                        ]
+                      },
+                      "id": "141a7615-282c-4ac1-ad3a-f4ad92a7ba44",
+                      "position": [
+                        28,
+                        1,
+                        2
+                      ]
+                    }
+                  ]
+                },
+                "id": "cbd9c131-fc21-4f34-bf81-495457246c94",
+                "position": [
+                  28,
+                  1
+                ]
+              }
+            ]
+          },
+          "id": "fd3bc533-b0c2-45ce-a500-6db1ebc150f6",
+          "position": [
+            28
+          ]
+        },
+        {
+          "type": "text",
+          "model": {
+            "blocks": [
+              {
+                "type": "paragraph",
+                "model": {
+                  "text": "Embedded MAP: audio",
+                  "blocks": [
+                    {
+                      "type": "fragment",
+                      "model": {
+                        "text": "Embedded MAP: audio",
+                        "attributes": []
+                      },
+                      "id": "5916c572-af47-40a2-b4a1-22c06e8af485",
+                      "position": [
+                        29,
+                        1,
+                        1
+                      ]
+                    }
+                  ]
+                },
+                "id": "78b46fb2-34cf-4da9-a4aa-31a8b95e229d",
+                "position": [
+                  29,
+                  1
+                ]
+              }
+            ]
+          },
+          "id": "875203e1-3394-4c98-839a-3771c8933fe1",
+          "position": [
+            29
+          ]
+        },
+        {
+          "type": "video",
+          "model": {
+            "locator": "urn:bbc:pips:pid:p01m7d07",
+            "blocks": [
+              {
+                "type": "aresMedia",
+                "model": {
+                  "blocks": [
+                    {
+                      "type": "aresMediaMetadata",
+                      "blockId": "urn:bbc:ares::clip:p01m7d07",
+                      "model": {
+                        "advertising": false,
+                        "embedding": false,
+                        "format": "audio",
+                        "id": "p01m7d07",
+                        "imageCopyright": "Getty Images",
+                        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01mt2kt.jpg",
+                        "subType": "clip",
+                        "synopses": {
+                          "short": "Some audio from a supermarket checkout in Birmingham"
+                        },
+                        "title": "Birmingham checkout",
+                        "versions": [
+                          {
+                            "versionId": "p01m7d09",
+                            "types": [
+                              "Original"
+                            ],
+                            "duration": 127,
+                            "durationISO8601": "PT2M7S",
+                            "warnings": {
+                              "short": "Contains some strong language.",
+                              "long": "Contains some strong language."
+                            },
+                            "availableTerritories": {
+                              "uk": true,
+                              "nonUk": true,
+                              "world": false
+                            },
+                            "availableFrom": 1555067395000
+                          }
+                        ],
+                        "available": true
+                      },
+                      "id": "1b50e6ad-0105-42e7-b000-e7a359b48fdb",
+                      "position": [
+                        30,
+                        1,
+                        1
+                      ]
+                    },
+                    {
+                      "type": "image",
+                      "model": {
+                        "blocks": [
+                          {
+                            "type": "rawImage",
+                            "model": {
+                              "copyrightHolder": "Getty Images",
+                              "locator": "https://ichef.test.bbci.co.uk/images/ic/1024x576/p01mt2kt.jpg",
+                              "originCode": "pips"
+                            },
+                            "id": "a73300d6-8c79-4722-8db2-5b0b88bbcfc1",
+                            "position": [
+                              30,
+                              1,
+                              2,
+                              1
+                            ]
+                          }
+                        ]
+                      },
+                      "id": "cc6a08fd-cc0d-4419-9358-6b7f97dd807e",
+                      "position": [
+                        30,
+                        1,
+                        2
+                      ]
+                    }
+                  ]
+                },
+                "id": "944b7116-a4e1-4f2b-938b-825be691fcbb",
+                "position": [
+                  30,
+                  1
+                ]
+              }
+            ]
+          },
+          "id": "789ff470-d6ea-4c2f-ab8f-d81cd732c76f",
+          "position": [
+            30
           ]
         },
         {
@@ -1644,26 +2123,26 @@
                         "text": "Includes: VisJo",
                         "attributes": []
                       },
-                      "id": "dca406ca-06c9-4963-bd2f-e0b796f04a67",
+                      "id": "7dbf9fa9-e45d-438c-8cf0-7a8c668b715a",
                       "position": [
-                        26,
+                        31,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "cacb691f-e161-480f-b684-d2adccfc3094",
+                "id": "b16e0fe3-fb09-4d3b-8372-5dd69c48f634",
                 "position": [
-                  26,
+                  31,
                   1
                 ]
               }
             ]
           },
-          "id": "05d549d8-425b-41f0-9d26-c3781b363d4c",
+          "id": "5a8c4559-93f3-4b80-a6fa-62433c2476d0",
           "position": [
-            26
+            31
           ]
         },
         {
@@ -1673,34 +2152,34 @@
               {
                 "type": "paragraph",
                 "model": {
-                  "text": "Below is some audio/video via an embedded MAP",
+                  "text": "Includes: IDT2",
                   "blocks": [
                     {
                       "type": "fragment",
                       "model": {
-                        "text": "Below is some audio/video via an embedded MAP",
+                        "text": "Includes: IDT2",
                         "attributes": []
                       },
-                      "id": "4fdb5390-eba1-401f-9629-e7f51dfdec31",
+                      "id": "d7d828a1-d73c-4b16-94ac-4cba1e625a44",
                       "position": [
-                        27,
+                        32,
                         1,
                         1
                       ]
                     }
                   ]
                 },
-                "id": "173f1a34-ec6f-48d9-a48f-2be1e663ce53",
+                "id": "87fba884-adba-4018-9229-4fb9fc156bc6",
                 "position": [
-                  27,
+                  32,
                   1
                 ]
               }
             ]
           },
-          "id": "c710ed93-7da1-4486-8fcc-8f64737781fc",
+          "id": "7eac3f39-5738-4b12-9d3d-02d8f8ea45bd",
           "position": [
-            27
+            32
           ]
         }
       ]


### PR DESCRIPTION
Resolves No Issue

**Overall change:** 
Updated fixture for STY story in Storybook for bold italic and media content (We have a story page in a story in storybook 🤯)

**Code changes:**
- Updated fixture for STY story in Storybook.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
