### PR TITLE
Image SrcSet update for StoryPromos & Bulletins

### DIFF
--- a/src/app/containers/Bulletin/index.jsx
+++ b/src/app/containers/Bulletin/index.jsx
@@ -21,7 +21,7 @@ const BulletinImage = ({ imageValues, lazyLoad }) => {
   const ratio = (height / width) * 100;
   const originCode = getOriginCode(path);
   const locator = getLocator(path);
-  const imageResolutions = [70, 95, 144, 183, 240, 320, 480, 624];
+  const imageResolutions = [70, 95, 144, 183, 240, 320, 496, 624];
   const srcset = createSrcset(originCode, locator, width, imageResolutions);
   const sizes = '(max-width: 1008px) 33vw, 237px';
   const DEFAULT_IMAGE_RES = 660;

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -33,7 +33,7 @@ const StoryPromoImage = ({ topStory, imageValues, lazyLoad }) => {
   const ratio = (height / width) * 100;
   const originCode = getOriginCode(path);
   const locator = getLocator(path);
-  const imageResolutions = [70, 95, 144, 183, 240, 320, 480, 624];
+  const imageResolutions = [70, 95, 144, 183, 240, 320, 496, 624];
   const srcset = createSrcset(originCode, locator, width, imageResolutions);
   const sizes = topStory
     ? '(max-width: 600px) 100vw, (max-width: 1008px) 33vw, 237px'


### PR DESCRIPTION
Resolves #5531

**Overall change:** 
Fixes issue with image blurring due to stretching a 480px image to 496px by updating the image srcset value. 

**Code changes:**
- Update image resolutions for StoryPromo and Bulletin images - 480px->496px


---

- [ ] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
