### PR TITLE
Changed URLs to be the same for test and local for TC2 MAPs

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -201,9 +201,7 @@ const genServices = appEnv => ({
       mediaAssetPage: {
         path: isLive(appEnv)
           ? undefined
-          : isTest(appEnv)
-          ? '/azeri/multimedia/2015/08/150804_azeri_test'
-          : '/azeri/multimedia/2012/09/120919_georgia_prison_video',
+          : '/azeri/multimedia/2015/08/150804_azeri_test',
         smoke: false,
       },
       photoGalleryPage: {
@@ -351,9 +349,7 @@ const genServices = appEnv => ({
       mediaAssetPage: {
         path: isLive(appEnv)
           ? undefined
-          : isTest(appEnv)
-          ? '/gahuza/video/2015/12/151217_test_long'
-          : '/gahuza/video/2015/12/151201_100womenburundi',
+          : '/gahuza/video/2015/12/151217_test_long',
         smoke: false,
       },
       photoGalleryPage: {
@@ -667,9 +663,7 @@ const genServices = appEnv => ({
       mediaAssetPage: {
         path: isLive(appEnv)
           ? undefined
-          : isTest(appEnv)
-          ? '/kyrgyz/multimedia/2015/03/150330_map_test'
-          : '/kyrgyz/entertainment/2014/07/140725_egypt_tentmaking',
+          : '/kyrgyz/multimedia/2015/03/150330_map_test',
         smoke: false,
       },
       photoGalleryPage: {
@@ -878,9 +872,7 @@ const genServices = appEnv => ({
       mediaAssetPage: {
         path: isLive(appEnv)
           ? undefined
-          : isTest(appEnv)
-          ? '/pashto/world/2016/09/160921_tc2_testmap1'
-          : '/pashto/multimedia/2012/09/120928_naghma_video',
+          : '/pashto/world/2016/09/160921_tc2_testmap1',
         smoke: false,
       },
       photoGalleryPage: {
@@ -923,10 +915,9 @@ const genServices = appEnv => ({
         smoke: false,
       },
       mediaAssetPage: {
-        path:
-          isLive(appEnv) || isTest(appEnv)
-            ? undefined
-            : '/persian/arts/2011/08/110802_doublage_sherlock_promo',
+        path: isLive(appEnv)
+          ? undefined
+          : '/persian/iran/2016/09/160907_tc2_testmap1',
         smoke: false,
       },
       photoGalleryPage: {
@@ -1744,9 +1735,7 @@ const genServices = appEnv => ({
         // eslint-disable-next-line no-nested-ternary
         path: isLive(appEnv)
           ? undefined
-          : isTest(appEnv)
-          ? '/vietnamese/sport/2016/09/160922_tc2_testmap2'
-          : '/vietnamese/multimedia/2015/04/150428_david_wheat_interview',
+          : '/vietnamese/sport/2016/09/160922_tc2_testmap2',
         smoke: false,
       },
       photoGalleryPage: {

--- a/data/azeri/legacyAssets/multimedia/2015/08/150804_azeri_test.json
+++ b/data/azeri/legacyAssets/multimedia/2015/08/150804_azeri_test.json
@@ -1,0 +1,84 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/azeri/meta/dps/junk/2015/08/emp/150804_azeri_test.emp.xml",
+        "id": "17692696",
+        "live": false,
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      { "markupType": "plain_text", "text": "blah blah", "type": "paragraph" }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17692696", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "azeri",
+    "firstPublished": 1438686912000,
+    "id": "urn:bbc:ares::asset:azeri/multimedia/2015/08/150804_azeri_test",
+    "includeComments": false,
+    "language": "az",
+    "lastPublished": 1452178359000,
+    "lastUpdated": 1581959937665,
+    "locators": {
+      "assetId": "17692696",
+      "assetUri": "/azeri/multimedia/2015/08/150804_azeri_test",
+      "cpsUrn": "urn:bbc:content:assetUri:azeri/multimedia/2015/08/150804_azeri_test",
+      "curie": "http://www.bbc.co.uk/asset/dd784ca2-3a99-11e5-9d74-f6fa66e7eb9d"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1438686912000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": { "headline": "test1" },
+    "id": "urn:bbc:ares::asset:azeri/multimedia/2015/08/150804_azeri_test",
+    "language": "az",
+    "locators": {
+      "assetId": "17692696",
+      "assetUri": "/azeri/multimedia/2015/08/150804_azeri_test",
+      "cpsUrn": "urn:bbc:content:assetUri:azeri/multimedia/2015/08/150804_azeri_test",
+      "curie": "http://www.bbc.co.uk/asset/dd784ca2-3a99-11e5-9d74-f6fa66e7eb9d"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/azeri/meta/dps/junk/2015/08/emp/150804_azeri_test.emp.xml",
+      "id": "17692696",
+      "live": false,
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "test2",
+    "timestamp": 1438686912000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Multimedia",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/azeri/multimedia"
+    },
+    "site": {
+      "name": "BBCAzeri.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/azeri"
+    }
+  }
+}

--- a/data/gahuza/legacyAssets/video/2015/12/151217_test_long.json
+++ b/data/gahuza/legacyAssets/video/2015/12/151217_test_long.json
@@ -1,0 +1,90 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "entityType": "Clip",
+        "externalId": "p010l641",
+        "format": "video",
+        "id": "17694770",
+        "statusCode": 404,
+        "statusMessage": "Asset could not be found. Perhaps it was withdrawn.",
+        "subType": "primary",
+        "type": "external_vpid"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Test Panorama (Long synopsis)",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17694770", "cps_asset_type": "map" },
+    "blockTypes": ["external_vpid", "paragraph"],
+    "createdBy": "greatlakes",
+    "firstPublished": 1450350361000,
+    "id": "urn:bbc:ares::asset:gahuza/video/2015/12/151217_test_long",
+    "includeComments": false,
+    "language": "rw",
+    "lastPublished": 1455103442000,
+    "lastUpdated": 1582030676261,
+    "locators": {
+      "assetId": "17694770",
+      "assetUri": "/gahuza/video/2015/12/151217_test_long",
+      "cpsUrn": "urn:bbc:content:assetUri:gahuza/video/2015/12/151217_test_long",
+      "curie": "http://www.bbc.co.uk/asset/fe263dc8-a4ad-11e5-a72f-33a878c49305"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1450350361000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": { "headline": "Test Panorama" },
+    "id": "urn:bbc:ares::asset:gahuza/video/2015/12/151217_test_long",
+    "language": "rw",
+    "locators": {
+      "assetId": "17694770",
+      "assetUri": "/gahuza/video/2015/12/151217_test_long",
+      "cpsUrn": "urn:bbc:content:assetUri:gahuza/video/2015/12/151217_test_long",
+      "curie": "http://www.bbc.co.uk/asset/fe263dc8-a4ad-11e5-a72f-33a878c49305"
+    },
+    "media": {
+      "entityType": "Clip",
+      "externalId": "p010l641",
+      "format": "video",
+      "id": "17694770",
+      "statusCode": 404,
+      "statusMessage": "Asset could not be found. Perhaps it was withdrawn.",
+      "subType": "primary",
+      "type": "external_vpid"
+    },
+    "passport": { "taggings": [] },
+    "summary": "Test Panorama (Short synopsis) ",
+    "timestamp": 1450350361000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Video",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/gahuza/video"
+    },
+    "site": {
+      "name": "BBCGahuza.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/gahuza"
+    }
+  }
+}

--- a/data/kyrgyz/legacyAssets/multimedia/2015/03/150330_map_test.json
+++ b/data/kyrgyz/legacyAssets/multimedia/2015/03/150330_map_test.json
@@ -1,0 +1,104 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "format": "audio",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/kyrgyz/meta/dps/junk/2015/03/emp/150330_map_test.emp.xml",
+        "id": "17692134",
+        "live": false,
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Жерүй алтын кенин иштетүүгө конкурстун биринчи айлампасы жыйынтыкталды. Документтерин тапшырган үч компаниянын баары экинчиси айлампага өттү. Көп чырга аралашып келген, Кыргызстандагы экинчи ири алтын кенин иштетчү компания май айында аныкталып калат деп күтүлүүдө.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Таластагы Жерүй алтын кенин иштетүү каалоосу менен Британиядан инвестор тапкан жергиликтүү “Кыргызалтын” жана Орусиянын “Всток-геолдобыча”, “Алдан золото ГРК” деген эки ишканасы кайрылган. Февралда башталган кабыл алуунун жыйынтыгы кечээ чыгарылып, үч компания тең экинчи айлампага ат салышууга киришти.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17692134", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "kyrgyz",
+    "firstPublished": 1427730161000,
+    "id": "urn:bbc:ares::asset:kyrgyz/multimedia/2015/03/150330_map_test",
+    "includeComments": false,
+    "language": "ky",
+    "lastPublished": 1427730161000,
+    "lastUpdated": 1582030793390,
+    "locators": {
+      "assetId": "17692134",
+      "assetUri": "/kyrgyz/multimedia/2015/03/150330_map_test",
+      "cpsUrn": "urn:bbc:content:assetUri:kyrgyz/multimedia/2015/03/150330_map_test",
+      "curie": "http://www.bbc.co.uk/asset/3a722316-d6f3-11e4-b8fa-be05f7c8d5b8"
+    },
+    "options": {
+      "allowAdvertising": false,
+      "allowDateStamp": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1427730161000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "\"Сапар\": Биринчи дүйнөлүк согуштун 100 жылдыгы",
+      "shortHeadline": "\"Сапар\": Биринчи дүйнөлүк согуштун 100 жылдыгы"
+    },
+    "id": "urn:bbc:ares::asset:kyrgyz/multimedia/2015/03/150330_map_test",
+    "indexImage": {
+      "altText": "ds",
+      "copyrightHolder": "BBC World Service",
+      "height": 63,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/09/22/140922130100_112x63.jpg",
+      "id": "d5e206",
+      "path": "/amz/worldservice/test/assets/images/2014/09/22/140922130100_112x63.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 112
+    },
+    "language": "ky",
+    "locators": {
+      "assetId": "17692134",
+      "assetUri": "/kyrgyz/multimedia/2015/03/150330_map_test",
+      "cpsUrn": "urn:bbc:content:assetUri:kyrgyz/multimedia/2015/03/150330_map_test",
+      "curie": "http://www.bbc.co.uk/asset/3a722316-d6f3-11e4-b8fa-be05f7c8d5b8"
+    },
+    "media": {
+      "format": "audio",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/kyrgyz/meta/dps/junk/2015/03/emp/150330_map_test.emp.xml",
+      "id": "17692134",
+      "live": false,
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "Жерүй алтын кенин иштетүүгө конкурстун биринчи айлампасы жыйынтыкталды. Документтерин тапшырган үч компаниянын баары экинчиси айлампага өттү.",
+    "timestamp": 1427730161000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Мультимедиа",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/kyrgyz/multimedia"
+    },
+    "site": {
+      "name": "BBCkyrgyz.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/kyrgyz"
+    }
+  }
+}

--- a/data/pashto/legacyAssets/world/2016/09/160921_tc2_testmap1.json
+++ b/data/pashto/legacyAssets/world/2016/09/160921_tc2_testmap1.json
@@ -1,0 +1,102 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/pashto/meta/dps/junk/2016/09/emp/160921_tc2_testmap1.emp.xml",
+        "id": "17698414",
+        "live": false,
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "په افغانستان کې د ملي وحدت پر اوسني حکومت دوه کاله اوړي. دا حکومت له لانجمنو ټاکنو وروسته واک ته ورسېد. خو دا چې عام ولس د دې حکومت لاسته راوړنې څه گڼي او په کومو برخو کې يې پاتې بولي په همدې تړاو د بي بي سي ازاده جرگه جوړه شوې ده.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17698414", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "pashto",
+    "firstPublished": 1474472581000,
+    "id": "urn:bbc:ares::asset:pashto/world/2016/09/160921_tc2_testmap1",
+    "includeComments": false,
+    "language": "ps",
+    "lastPublished": 1474472581000,
+    "lastUpdated": 1582030879332,
+    "locators": {
+      "assetId": "17698414",
+      "assetUri": "/pashto/world/2016/09/160921_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:pashto/world/2016/09/160921_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/cb3cbe10-8011-11e6-a923-003d34ba44a4"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1474472581000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "ازاده جرګه: د ملي وحدت حکومت لاسته راوړنې او نيمګړتياوې",
+      "shortHeadline": "ازاده جرګه: د ملي وحدت حکومت لاسته راوړنې او نيمګړتياوې"
+    },
+    "id": "urn:bbc:ares::asset:pashto/world/2016/09/160921_tc2_testmap1",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "BBC",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/02/26/150226142623_netball_144x81_bbc.jpg",
+      "id": "d5e212",
+      "path": "/amz/worldservice/test/assets/images/2015/02/26/150226142623_netball_144x81_bbc.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "ps",
+    "locators": {
+      "assetId": "17698414",
+      "assetUri": "/pashto/world/2016/09/160921_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:pashto/world/2016/09/160921_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/cb3cbe10-8011-11e6-a923-003d34ba44a4"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/pashto/meta/dps/junk/2016/09/emp/160921_tc2_testmap1.emp.xml",
+      "id": "17698414",
+      "live": false,
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "په افغانستان کې د ملي وحدت پر اوسني حکومت دوه کاله اوړي. دا حکومت له لانجمنو ټاکنو وروسته واک ته ورسېد.",
+    "timestamp": 1474472581000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "نړۍ",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/pashto/world"
+    },
+    "site": {
+      "name": "BBCPashto.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/pashto"
+    }
+  }
+}

--- a/data/persian/legacyAssets/iran/2016/09/160907_tc2_testmap1.json
+++ b/data/persian/legacyAssets/iran/2016/09/160907_tc2_testmap1.json
@@ -1,0 +1,102 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/persian/meta/dps/junk/2016/09/emp/160907_tc2_testmap1.emp.xml",
+        "id": "17698244",
+        "live": false,
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "میسر عالی سازمان ملل در امور حقوق بشر به تندی از سیاستمدارهایی که آنها را عوام‌فریب و خیال‌پرداز خوانده، انتقاد کرده است. زید رعد حسین گفته است افرادی مثل دونالد ترامپ، نامزد ریاست جمهوری آمریکا و خرت ویلدرز، سیاستمدار راست گرای هلندی و نایجل فراژ، سیاستمدار بریتانیایی از شیوه های تبلیغاتی داعش استفاده می کنند. سعیده هاشمی گزارش می دهد.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17698244", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "persian",
+    "firstPublished": 1473242019000,
+    "id": "urn:bbc:ares::asset:persian/iran/2016/09/160907_tc2_testmap1",
+    "includeComments": false,
+    "language": "fa",
+    "lastPublished": 1473242019000,
+    "lastUpdated": 1582019287717,
+    "locators": {
+      "assetId": "17698244",
+      "assetUri": "/persian/iran/2016/09/160907_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:persian/iran/2016/09/160907_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/6c9d7b1a-74e0-11e6-a1c8-2acfb99d427b"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1473242019000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "جامعه بهایی خواستار رفع 'بی عدالتی های اقتصادی' علیه بهاییان ایران شد",
+      "shortHeadline": "جامعه بهایی خواستار رفع 'بی عدالتی های اقتصادی' علیه بهاییان ایران شد"
+    },
+    "id": "urn:bbc:ares::asset:persian/iran/2016/09/160907_tc2_testmap1",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "Getty",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "id": "d5e237",
+      "path": "/amz/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "fa",
+    "locators": {
+      "assetId": "17698244",
+      "assetUri": "/persian/iran/2016/09/160907_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:persian/iran/2016/09/160907_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/6c9d7b1a-74e0-11e6-a1c8-2acfb99d427b"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/persian/meta/dps/junk/2016/09/emp/160907_tc2_testmap1.emp.xml",
+      "id": "17698244",
+      "live": false,
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "دفتر جامعه جهانی بهایی در سازمان ملل متحد، با انتشار نامه ای سرگشاده خطاب به حسن روحانی رئیس جمهور ایران خواستار رسیدگی به \"بی عدالتی های اقتصادی وارده بر بهاییان\" در ایرن کشور شد.",
+    "timestamp": 1473242019000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "ايران",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/persian/iran"
+    },
+    "site": {
+      "name": "BBCPersian.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/persian"
+    }
+  }
+}

--- a/data/vietnamese/legacyAssets/sport/2016/09/160922_tc2_testmap2.json
+++ b/data/vietnamese/legacyAssets/sport/2016/09/160922_tc2_testmap2.json
@@ -1,0 +1,102 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/vietnamese/meta/dps/junk/2016/09/emp/160922_tc2_testmap2.emp.xml",
+        "id": "17698461",
+        "live": false,
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Vận động viên Lê Văn Công ngay trong ngày thi đấu đấu tiên của Paralympics Rio 2016 đã đạt kỳ tích, phá vỡ kỷ lục của chính mình và kỷ lục thế giới, giành được tấm huy chương vàng lịch sử đầu tiên cho Việt Nam tại các kỳ Paralympics từ trước tới nay. Anh trò chuyện với BBC Tiếng Việt vào sáng sớm hôm 9/9/2016, một đêm sau khi giành được chiến thắng đẹp như mơ. &quot;Tôi bước vào thi đấu ở hạng cân 49kg với những diễn biến rất căng thẳng. Tới tận giây phút cuối cùng tôi mới bứt lên để giành được chiến thắng.&quot; &quot;Ở hạng cân này quy tụ tới ba vận động viên thay phiên nhau giữ kỷ lục thế giới nên cuộc đấu rất căng thẳng và khó lường. Tôi đã có một chút may mắn, một chút tự tin để giành được tấm huy chương vàng danh giá.&quot; &quot;Bản thân tôi cùng ban huấn luyện tới kỳ Paralympics lần này chỉ đặt ra chỉ tiêu giành được huy chương, nhưng huy chương vàng thì thực sự tôi chưa nghĩ tới vì các đối thủ cùng hạng cân đều rất mạnh.&quot; &quot;Sau khi thất bại ở lần thực hiện động tác cử đẩy lượt thứ hai, tới lượt thứ ba, tôi và ban huấn luyện bàn bạc và đã quyết định tăng thêm 2kg, lên thành 181kg. Lúc đó tôi nghĩ bản thân mình đang giữ kỷ lục thế giới [182kg] thì mình phải cố gắng thực hiện được mức tạ hiện còn đang nằm dưới mức mình đã đạt được.&quot; &quot;Lúc đó tôi chỉ tập trung nghĩ phải thực hiện cho bằng được để giành lại tấm huy chương vàng cao quý.&quot; &quot;Tấm huy chương vàng này sẽ làm thay đổi cuộc sống của tôi rất nhiều. Các nguồn tài trợ và các khoản tiền thưởng sẽ giúp tôi không phải lo nhiều về vấn đề kinh tế, để tôi có thể chú tâm tập luyện, hướng tới các thành tích tốt trong các giải đấu sắp tới.&quot; &quot;Với tấm huy chương vàng giành được, tôi cũng hy vọng là các anh chị em trong đoàn Việt Nam sẽ cố gắng phấn đấu tập luyện thật tốt tại Rio, để không chỉ cạnh tranh được không chỉ một tấm huy chương vàng này mà còn truyền được cảm hứng cho lớp thế hệ sau, và hy vọng các anh chị em khuyết tật sẽ làm được nhiều hơn những gì tôi đã đạt được hôm nay.&quot;",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17698461", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "vietnamese",
+    "firstPublished": 1474553442000,
+    "id": "urn:bbc:ares::asset:vietnamese/sport/2016/09/160922_tc2_testmap2",
+    "includeComments": false,
+    "language": "vi",
+    "lastPublished": 1474553442000,
+    "lastUpdated": 1582029532713,
+    "locators": {
+      "assetId": "17698461",
+      "assetUri": "/vietnamese/sport/2016/09/160922_tc2_testmap2",
+      "cpsUrn": "urn:bbc:content:assetUri:vietnamese/sport/2016/09/160922_tc2_testmap2",
+      "curie": "http://www.bbc.co.uk/asset/33e94bc4-80ce-11e6-ab5d-feb034ba44a4"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1474553442000,
+    "type": "MAP",
+    "version": "v1.1.6"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "HCV: Lê Văn Công 'bứt lên ở phút cuối'",
+      "shortHeadline": "HCV: Lê Văn Công 'bứt lên ở phút cuối'"
+    },
+    "id": "urn:bbc:ares::asset:vietnamese/sport/2016/09/160922_tc2_testmap2",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "Getty",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "id": "d5e214",
+      "path": "/amz/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "vi",
+    "locators": {
+      "assetId": "17698461",
+      "assetUri": "/vietnamese/sport/2016/09/160922_tc2_testmap2",
+      "cpsUrn": "urn:bbc:content:assetUri:vietnamese/sport/2016/09/160922_tc2_testmap2",
+      "curie": "http://www.bbc.co.uk/asset/33e94bc4-80ce-11e6-ab5d-feb034ba44a4"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/vietnamese/meta/dps/junk/2016/09/emp/160922_tc2_testmap2.emp.xml",
+      "id": "17698461",
+      "live": false,
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "Vận động viên Lê Văn Công ngay trong ngày thi đấu đấu tiên của Paralympics Rio 2016 đã đạt kỳ tích, phá vỡ kỷ lục của chính mình và kỷ lục thế giới, giành được tấm huy chương vàng lịch sử đầu tiên cho Việt Nam tại các kỳ Paralympics từ trước tới nay.",
+    "timestamp": 1474553442000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Thể thao",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/vietnamese/sport"
+    },
+    "site": {
+      "name": "BBCVietnamese.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/vietnamese"
+    }
+  }
+}


### PR DESCRIPTION

**Overall change:** 
Now we have TC2 assets on test found, we can use the same URL for local and test. Got rid of the pesky nested ternary operations!

**Code changes:**

e.g 
mediaAssetPage: {
        path: isLive(appEnv)
          ? undefined
          : '/azeri/multimedia/2015/08/150804_azeri_test',
        smoke: false,

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
Passes all on local and test
