### PR TITLE
Related content layout update - Groups 4 & 5

### DIFF
--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -37,11 +37,13 @@ exports[`CpsRelatedContent should render Story Promo components in Live environm
         </h2>
       </div>
       <ul
-        class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+        class="StoryPromoUl-sc-171lqjd-1 isCYWc GridComponent-nf79gm-0 gjgzxV"
+        dir="ltr"
         role="list"
       >
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div
@@ -106,7 +108,8 @@ exports[`CpsRelatedContent should render Story Promo components in Live environm
           </div>
         </li>
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div
@@ -160,7 +163,8 @@ exports[`CpsRelatedContent should render Story Promo components in Live environm
           </div>
         </li>
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div
@@ -256,11 +260,13 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
         </h2>
       </div>
       <ul
-        class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+        class="StoryPromoUl-sc-171lqjd-1 isCYWc GridComponent-nf79gm-0 gjgzxV"
+        dir="ltr"
         role="list"
       >
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div
@@ -325,7 +331,8 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
           </div>
         </li>
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div
@@ -379,7 +386,8 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
           </div>
         </li>
         <li
-          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+          dir="ltr"
           role="listitem"
         >
           <div

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -75,6 +75,7 @@ const CpsRelatedContent = ({ content }) => {
           }}
           as={StoryPromoUl}
           enableGelGutters
+          dir={dir}
         >
           {content
             .map(item => formatItem(item, env))
@@ -91,6 +92,7 @@ const CpsRelatedContent = ({ content }) => {
                 }}
                 as={StoryPromoLi}
                 key={item.id || item.uri}
+                dir={dir}
               >
                 <StoryPromo item={item} />
               </Grid>

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -94,7 +94,7 @@ const CpsRelatedContent = ({ content }) => {
                 key={item.id || item.uri}
                 dir={dir}
               >
-                <StoryPromo item={item} />
+                <StoryPromo item={item} dir={dir} />
               </Grid>
             ))}
         </Grid>

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -17,6 +17,7 @@ import { storyItem } from '#models/propTypes/storyItem';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { GhostGrid, GridItemConstrainedLarge } from '#lib/styledGrid';
 import StoryPromo from '../StoryPromo';
+import Grid from '../../components/Grid';
 
 const Wrapper = styled(GridItemConstrainedLarge)`
   margin-bottom: ${GEL_SPACING_DBL};
@@ -63,16 +64,38 @@ const CpsRelatedContent = ({ content }) => {
         >
           {translations.relatedContent}
         </StyledSectionLabel>
-
-        <StoryPromoUl>
+        <Grid
+          columns={{
+            group0: 6,
+            group1: 6,
+            group2: 6,
+            group3: 6,
+            group4: 8,
+            group5: 8,
+          }}
+          as={StoryPromoUl}
+          enableGelGutters
+        >
           {content
             .map(item => formatItem(item, env))
             .map(item => (
-              <StoryPromoLi key={item.id || item.uri}>
+              <Grid
+                item
+                columns={{
+                  group0: 6,
+                  group1: 6,
+                  group2: 6,
+                  group3: 6,
+                  group4: 4,
+                  group5: 4,
+                }}
+                as={StoryPromoLi}
+                key={item.id || item.uri}
+              >
                 <StoryPromo item={item} />
-              </StoryPromoLi>
+              </Grid>
             ))}
-        </StoryPromoUl>
+        </Grid>
       </Wrapper>
     </GhostGrid>
   );

--- a/src/app/containers/CpsRelatedContent/index.stories.jsx
+++ b/src/app/containers/CpsRelatedContent/index.stories.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import CpsRelatedContent from '.';
+
+import igboData from '#data/igbo/cpsAssets/media-23256786.json';
+import arabicData from '#data/arabic/cpsAssets/media-49580542.json';
+import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import { RequestContextProvider } from '#contexts/RequestContext';
+
+const igboRelatedContentData = igboData.relatedContent.groups[0].promos;
+const arabicRelatedContentData = arabicData.relatedContent.groups[0].promos;
+
+const getRelatedContent = platform => ({ service, dir, data }) => (
+  <div dir={dir}>
+    {/* The above simulates dir being added at the page level */}
+    <ServiceContextProvider service={service}>
+      <RequestContextProvider
+        bbcOrigin="https://www.test.bbc.com"
+        isAmp={platform === 'amp'}
+        pageType="MAP" /* Can also be one of other CPS pagetypes */
+        pathname="/"
+        service={service}
+      >
+        <CpsRelatedContent content={data} />
+      </RequestContextProvider>
+    </ServiceContextProvider>
+  </div>
+);
+
+const canonicalRelatedContent = getRelatedContent('canonical');
+const ampRelatedContent = getRelatedContent('amp');
+
+storiesOf('Containers|CPS Related Content/Canonical', module)
+  .addParameters({ chromatic: { disable: true } })
+  .add('igbo (ltr)', () =>
+    canonicalRelatedContent({
+      service: 'igbo',
+      dir: 'ltr',
+      data: igboRelatedContentData,
+    }),
+  )
+  .add('arabic (rtl)', () =>
+    canonicalRelatedContent({
+      service: 'arabic',
+      dir: 'rtl',
+      data: arabicRelatedContentData,
+    }),
+  );
+
+storiesOf('Containers|CPS Related Content/AMP', module)
+  .addParameters({ chromatic: { disable: true } })
+  .addDecorator(AmpDecorator)
+  .add('igbo (ltr) - amp', () =>
+    ampRelatedContent({
+      service: 'igbo',
+      dir: 'ltr',
+      data: igboRelatedContentData,
+    }),
+  )
+  .add('arabic (rtl) - amp', () =>
+    ampRelatedContent({
+      service: 'arabic',
+      dir: 'rtl',
+      data: arabicRelatedContentData,
+    }),
+  );

--- a/src/app/containers/CpsRelatedContent/index.stories.jsx
+++ b/src/app/containers/CpsRelatedContent/index.stories.jsx
@@ -3,12 +3,12 @@ import { storiesOf } from '@storybook/react';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import CpsRelatedContent from '.';
 
-import igboData from '#data/igbo/cpsAssets/media-23256786.json';
+import pidginData from '#data/pidgin/cpsAssets/tori-49450859.json';
 import arabicData from '#data/arabic/cpsAssets/media-49580542.json';
 import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
 import { RequestContextProvider } from '#contexts/RequestContext';
 
-const igboRelatedContentData = igboData.relatedContent.groups[0].promos;
+const pidginRelatedContentData = pidginData.relatedContent.groups[0].promos;
 const arabicRelatedContentData = arabicData.relatedContent.groups[0].promos;
 
 const getRelatedContent = platform => ({ service, dir, data }) => (
@@ -33,11 +33,11 @@ const ampRelatedContent = getRelatedContent('amp');
 
 storiesOf('Containers|CPS Related Content/Canonical', module)
   .addParameters({ chromatic: { disable: true } })
-  .add('igbo (ltr)', () =>
+  .add('pidgin (ltr)', () =>
     canonicalRelatedContent({
-      service: 'igbo',
+      service: 'pidgin',
       dir: 'ltr',
-      data: igboRelatedContentData,
+      data: pidginRelatedContentData,
     }),
   )
   .add('arabic (rtl)', () =>
@@ -51,11 +51,11 @@ storiesOf('Containers|CPS Related Content/Canonical', module)
 storiesOf('Containers|CPS Related Content/AMP', module)
   .addParameters({ chromatic: { disable: true } })
   .addDecorator(AmpDecorator)
-  .add('igbo (ltr) - amp', () =>
+  .add('pidgin (ltr) - amp', () =>
     ampRelatedContent({
-      service: 'igbo',
+      service: 'pidgin',
       dir: 'ltr',
-      data: igboRelatedContentData,
+      data: pidginRelatedContentData,
     }),
   )
   .add('arabic (rtl) - amp', () =>

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -1000,11 +1000,13 @@ exports[`Media Asset Page should render component 1`] = `
                   </h2>
                 </div>
                 <ul
-                  class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+                  class="StoryPromoUl-sc-171lqjd-1 isCYWc GridComponent-nf79gm-0 gjgzxV"
+                  dir="ltr"
                   role="list"
                 >
                   <li
-                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+                    dir="ltr"
                     role="listitem"
                   >
                     <div
@@ -1058,7 +1060,8 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+                    dir="ltr"
                     role="listitem"
                   >
                     <div
@@ -1112,7 +1115,8 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+                    dir="ltr"
                     role="listitem"
                   >
                     <div
@@ -1201,7 +1205,8 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+                    class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 hgNruo"
+                    dir="ltr"
                     role="listitem"
                   >
                     <div

--- a/src/app/pages/PhotoGallery/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGallery/__snapshots__/index.test.jsx.snap
@@ -2891,7 +2891,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
     </script>
   </head>
   <body>
-    .c37 {
+    .c39 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -2946,7 +2946,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   padding-bottom: 1rem;
 }
 
-.c34 {
+.c36 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -3086,15 +3086,15 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   padding: 0;
 }
 
-.c25 {
+.c26 {
   padding: 0.5rem 0 1rem;
 }
 
-.c25:first-child {
+.c26:first-child {
   padding-top: 0;
 }
 
-.c25:last-child {
+.c26:last-child {
   padding-bottom: 0;
   border: none;
 }
@@ -3105,34 +3105,34 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   padding: 0;
 }
 
-.c27 {
+.c29 {
   display: inline-block;
   vertical-align: top;
   position: relative;
   width: 33.33%;
 }
 
-.c30 {
+.c32 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c26 {
-  position: relative;
-}
-
 .c28 {
   position: relative;
 }
 
-.c29 > * {
+.c30 {
+  position: relative;
+}
+
+.c31 > * {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.c31 {
+.c33 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -3143,7 +3143,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   line-height: 1.25rem;
 }
 
-.c33 {
+.c35 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3154,14 +3154,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   padding-bottom: 0.5rem;
 }
 
-.c32 {
+.c34 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c32:before {
+.c34:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -3173,17 +3173,17 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   z-index: 1;
 }
 
-.c32:hover,
-.c32:focus {
+.c34:hover,
+.c34:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c32:visited {
+.c34:visited {
   color: #6E6E73;
 }
 
-.c35 {
+.c37 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3194,7 +3194,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   display: block;
 }
 
-.c36 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3452,14 +3452,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c34 {
+  .c36 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c34 {
+  .c36 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -3568,51 +3568,51 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (max-width:62.9375rem) {
-  .c25 {
+  .c26 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c25 {
+  .c26 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c25 {
+  .c26 {
     padding: 0 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c25:first-child {
+  .c26:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c27 {
+  .c29 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c27 {
+  .c29 {
     width: initial;
     grid-column: 1 / span 2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c30 {
+  .c32 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c30 {
+  .c32 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -3620,7 +3620,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c30 {
+  .c32 {
     display: block;
     width: initial;
     padding: initial;
@@ -3629,7 +3629,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c26 {
+  .c28 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
     grid-column-gap: 0.5rem;
@@ -3637,72 +3637,139 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width:25rem) {
-  .c29 {
+  .c31 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c29 > * {
+  .c31 > * {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c31 {
+  .c33 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c31 {
+  .c33 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c33 {
+  .c35 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c33 {
+  .c35 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c33 {
+  .c35 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:63rem) {
-  .c33 {
+  .c35 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c35 {
+  .c37 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c35 {
+  .c37 {
     font-size: 0.75rem;
     line-height: 1rem;
+  }
+}
+
+@supports (display:grid) {
+  .c25 {
+    display: grid;
+    position: initial;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c27 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c27 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c27 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c27 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c27 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:80rem) {
+  .c27 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display:grid) {
+  .c27 {
+    display: block;
   }
 }
 
@@ -4330,22 +4397,24 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                       </h2>
                     </div>
                     <ul
-                      class="c24"
+                      class="c24 c25"
+                      dir="ltr"
                       role="list"
                     >
                       <li
-                        class="c25"
+                        class="c26 c27"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c26"
+                          class="c28"
                         >
                           <div
-                            class="c27"
+                            class="c29"
                             dir="ltr"
                           >
                             <div
-                              class="c28"
+                              class="c30"
                             >
                               <div
                                 class="c11"
@@ -4355,19 +4424,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                                 />
                               </div>
                               <div
-                                class="c29"
+                                class="c31"
                               />
                             </div>
                           </div>
                           <div
-                            class="c30"
+                            class="c32"
                             dir="ltr"
                           >
                             <h3
-                              class="c31"
+                              class="c33"
                             >
                               <a
-                                class="c32"
+                                class="c34"
                                 href="/pidgin/media-45132087?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 <span
@@ -4385,12 +4454,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                               </a>
                             </h3>
                             <p
-                              class="c33"
+                              class="c35"
                             >
                               Bole festival showcase di different types of bole dem.
                             </p>
                             <time
-                              class="c34"
+                              class="c36"
                               datetime="2018-08-09"
                             >
                               9th August 2018
@@ -4399,36 +4468,37 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                         </div>
                       </li>
                       <li
-                        class="c25"
+                        class="c26 c27"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c26"
+                          class="c28"
                         >
                           <div
-                            class="c27"
+                            class="c29"
                             dir="ltr"
                           >
                             <div
-                              class="c28"
+                              class="c30"
                             >
                               <div
                                 class="c11"
                               />
                               <div
-                                class="c29"
+                                class="c31"
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c35"
+                                  class="c37"
                                   dir="ltr"
                                 >
                                   <div
-                                    class="c36"
+                                    class="c38"
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      class="c37"
+                                      class="c39"
                                       focusable="false"
                                       height="13px"
                                       viewBox="0 0 32 26"
@@ -4449,14 +4519,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                             </div>
                           </div>
                           <div
-                            class="c30"
+                            class="c32"
                             dir="ltr"
                           >
                             <h3
-                              class="c31"
+                              class="c33"
                             >
                               <a
-                                class="c32"
+                                class="c34"
                                 href="/pidgin/tori-45242255?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 <span
@@ -4475,12 +4545,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                               </a>
                             </h3>
                             <p
-                              class="c33"
+                              class="c35"
                             >
                               Jollof Festival happun for Lagos Nigeria on Sunday and na time for pipo wey show to sample West Africa fine food dem.
                             </p>
                             <time
-                              class="c34"
+                              class="c36"
                               datetime="2018-08-19"
                             >
                               19th August 2018
@@ -5888,7 +5958,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   padding-bottom: 1rem;
 }
 
-.c54 {
+.c56 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -5965,7 +6035,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   font-style: normal;
 }
 
-.c48 {
+.c50 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -6237,15 +6307,15 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   padding: 0;
 }
 
-.c44 {
+.c45 {
   padding: 0.5rem 0 1rem;
 }
 
-.c44:first-child {
+.c45:first-child {
   padding-top: 0;
 }
 
-.c44:last-child {
+.c45:last-child {
   padding-bottom: 0;
   border: none;
 }
@@ -6256,34 +6326,34 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   padding: 0;
 }
 
-.c46 {
+.c48 {
   display: inline-block;
   vertical-align: top;
   position: relative;
   width: 33.33%;
 }
 
-.c50 {
+.c52 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c45 {
-  position: relative;
-}
-
 .c47 {
   position: relative;
 }
 
-.c49 > * {
+.c49 {
+  position: relative;
+}
+
+.c51 > * {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.c51 {
+.c53 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -6294,7 +6364,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   line-height: 1.25rem;
 }
 
-.c53 {
+.c55 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -6305,14 +6375,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   padding-bottom: 0.5rem;
 }
 
-.c52 {
+.c54 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c52:before {
+.c54:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -6324,13 +6394,13 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   z-index: 1;
 }
 
-.c52:hover,
-.c52:focus {
+.c54:hover,
+.c54:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c52:visited {
+.c54:visited {
   color: #6E6E73;
 }
 
@@ -6731,14 +6801,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c54 {
+  .c56 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c54 {
+  .c56 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -6847,51 +6917,51 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (max-width:62.9375rem) {
-  .c44 {
+  .c45 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c44 {
+  .c45 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c44 {
+  .c45 {
     padding: 0 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c44:first-child {
+  .c45:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c46 {
+  .c48 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c46 {
+  .c48 {
     width: initial;
     grid-column: 1 / span 2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c50 {
+  .c52 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c50 {
+  .c52 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -6899,7 +6969,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c50 {
+  .c52 {
     display: block;
     width: initial;
     padding: initial;
@@ -6908,7 +6978,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c45 {
+  .c47 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
     grid-column-gap: 0.5rem;
@@ -6916,58 +6986,125 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width:25rem) {
-  .c49 {
+  .c51 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c49 > * {
+  .c51 > * {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c51 {
+  .c53 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c51 {
+  .c53 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c53 {
+  .c55 {
     font-size: 0.9375rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c53 {
+  .c55 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c53 {
+  .c55 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:63rem) {
-  .c53 {
+  .c55 {
     display: none;
     visibility: hidden;
+  }
+}
+
+@supports (display:grid) {
+  .c44 {
+    display: grid;
+    position: initial;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c46 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c46 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:80rem) {
+  .c46 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display:grid) {
+  .c46 {
+    display: block;
   }
 }
 
@@ -8191,56 +8328,58 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                       </h2>
                     </div>
                     <ul
-                      class="c43"
+                      class="c43 c44"
+                      dir="ltr"
                       role="list"
                     >
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-44124647?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 ADR və Qazaxdan Qarsadək müsəlman dəhlizi ideyası
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               Bu il Azərbaycan Demokratik Respublikasının elan edilməsinin 100 illik yubileyidir. BBC Azərbaycanca bu ərəfədə Azərbaycan xalqının epik və mühüm günlərini həftəlik esselərlə təqdim edir.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-05-17"
                             >
                               17 May 2018
@@ -8249,52 +8388,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-43540056?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 ADR-100: Türk Əsgəri üçün Cəbrayıl çörəyi
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               ADR-100 layihəmizdə növbəti yazı: 1918-ci il martın 3-də Bolşeviklər Almaniya, Bolqarıstan, Avstriya-Macarıstan və Osmanlı nümayəndələri ilə Brest-Litovsk Sülh Sazişi imzalayır. İmzalanma Bakının azadlığı ilə nəticələnən bir sıra hadisələrə səbəb olur.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-03-27"
                             >
                               27 Mart 2018
@@ -8303,52 +8443,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-44022776?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 Borçalı: Tortdan hərəyə bir tikə - təkbaşına isə onu yemək olmaz
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               #ADR100 layihəmizdə: 1918-1920-ci illərdə Gürcüstanla Azərbaycan arasında əməkdaşlıq yeni respublikalar üçün olduqca mühüm idi. Eyni zamanda Bakı ilə Tbilisi arasında gərginlik yaradan məsələlər mövcud idi. Belə məsələlərdən biri də ərazi mübahisələri idi.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-05-10"
                             >
                               10 May 2018
@@ -8357,52 +8498,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-43713137?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 Cümhuriyyət hökuməti Azərbaycanı necə idarə edirdi? İlk 6 ayın hadisələri
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               1918-ci il mayın 28-də Azərbaycanın istiqlaliyyəti elan olunanda bu hadisədən bir gün əvvəl dağılmış Zaqafqaziya Seyminin 44 nəfər müsəlman nümayəndəsi Tiflisdə toplanır və özlərini Azərbaycanın Milli Şurası elan edirlər.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-04-10"
                             >
                               10 Aprel 2018
@@ -8411,52 +8553,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-37688691?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 1918-1991: Bir müstəqilliyin iki bəyanı
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               25 il əvvəl bu gün Azərbaycan çökməkdə olan Sovet İttifaqından özünün müstəqillyini bəyan edib. Bu, Azərbaycan Respublikasının ikinci doğuluşu idi.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2016-10-18"
                             >
                               18 Oktyabr 2016
@@ -8465,40 +8608,41 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-37691096?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 <span
@@ -8516,12 +8660,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               Çərşənbə axşamı şəhər sakinləri BBC Azərbaycancanın "Müstəqillik sizə nə verib?" sualını cavablandırıb.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2016-10-18"
                             >
                               18 Oktyabr 2016
@@ -8530,52 +8674,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-43499221?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 1918-ci ilə baxış: Mayın 28-nə aparan o yaz günlərində həyat necə idi?
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               Bu il Azərbaycan Demokratik Respublikasının elan edilməsinin 100 illik yubileyidir. BBC Azərbaycanca bu ərəfədə Azərbaycan xalqının epik və mühüm günlərini həftəlik esselərlə təqdim edəcək.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-03-22"
                             >
                               22 Mart 2018
@@ -8584,52 +8729,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-44004471?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 #ADR100 Zaqatala: Azərbaycanın qalib gəldiyi mübahisə
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               Bir çox azərbaycanlı və gürcüstanlı siyasətçiləri anlayırdılar ki, onların içində olduğu həssas dövrdən salamat çıxmaq üçün iqtisadi, siyasi və hərbi müttəfiqlik vacibdir. Eyni zamanda hər iki respublika arasında bir sıra mübahisələr də mövcud idi.
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-05-04"
                             >
                               4 May 2018
@@ -8638,52 +8784,53 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                         </div>
                       </li>
                       <li
-                        class="c44"
+                        class="c45 c46"
+                        dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="c45"
+                          class="c47"
                         >
                           <div
-                            class="c46"
+                            class="c48"
                             dir="ltr"
                           >
                             <div
-                              class="c47"
+                              class="c49"
                             >
                               <div
-                                class="c48"
+                                class="c50"
                               >
                                 <div
                                   class="lazyload-placeholder"
                                 />
                               </div>
                               <div
-                                class="c49"
+                                class="c51"
                               />
                             </div>
                           </div>
                           <div
-                            class="c50"
+                            class="c52"
                             dir="ltr"
                           >
                             <h3
-                              class="c51"
+                              class="c53"
                             >
                               <a
-                                class="c52"
+                                class="c54"
                                 href="/azeri/azerbaijan-43870815?_x_candy_override=https%3A%2F%2Fapi.test.bbc.co.uk"
                               >
                                 Cümhuriyyət hökumətinin İranla əlaqələri necə idi?
                               </a>
                             </h3>
                             <p
-                              class="c53"
+                              class="c55"
                             >
                               İranın Xəzər sahilinə çıxan bölgələrində Azərbaycan Respublikasını böyük ticari imkanlar gözləyirdi. İran ixracatının 60-70 faizinin istehsalı ənənəvi olaraq məhz həmin regionun payına düşüb. Azərbaycan və xüsusilə Bakı-Batumi dəhlizi isə Avropa bazarına aparan təbii çıxış idi. Bəs milli hökümət iqtisadi imkanları gəlirli xarici ticarətə çevirə bildimi?
                             </p>
                             <time
-                              class="c54"
+                              class="c56"
                               datetime="2018-04-29"
                             >
                               29 Aprel 2018

--- a/src/app/pages/Story/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/Story/__snapshots__/index.test.jsx.snap
@@ -264,15 +264,15 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding: 0;
 }
 
-.c39 {
+.c40 {
   padding: 0.5rem 0 1rem;
 }
 
-.c39:first-child {
+.c40:first-child {
   padding-top: 0;
 }
 
-.c39:last-child {
+.c40:last-child {
   padding-bottom: 0;
   border: none;
 }
@@ -736,26 +736,93 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (max-width:62.9375rem) {
-  .c39 {
+  .c40 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c39 {
+  .c40 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c39 {
+  .c40 {
     padding: 0 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c39:first-child {
+  .c40:first-child {
     padding-top: 1rem;
+  }
+}
+
+@supports (display:grid) {
+  .c39 {
+    display: grid;
+    position: initial;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c41 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c41 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c41 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c41 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c41 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:80rem) {
+  .c41 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display:grid) {
+  .c41 {
+    display: block;
   }
 }
 
@@ -1359,11 +1426,13 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   </h2>
                 </div>
                 <ul
-                  class="c38"
+                  class="c38 c39"
+                  dir="ltr"
                   role="list"
                 >
                   <li
-                    class="c39"
+                    class="c40 c41"
+                    dir="ltr"
                     role="listitem"
                   />
                 </ul>
@@ -1655,15 +1724,15 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding: 0;
 }
 
-.c41 {
+.c42 {
   padding: 0.5rem 0 1rem;
 }
 
-.c41:first-child {
+.c42:first-child {
   padding-top: 0;
 }
 
-.c41:last-child {
+.c42:last-child {
   padding-bottom: 0;
   border: none;
 }
@@ -2145,26 +2214,93 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (max-width:62.9375rem) {
-  .c41 {
+  .c42 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c41 {
+  .c42 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c41 {
+  .c42 {
     padding: 0 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c41:first-child {
+  .c42:first-child {
     padding-top: 1rem;
+  }
+}
+
+@supports (display:grid) {
+  .c41 {
+    display: grid;
+    position: initial;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c43 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c43 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c43 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c43 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c43 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width:80rem) {
+  .c43 {
+    width: calc(4/8*(100% - 8 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display:grid) {
+  .c43 {
+    display: block;
   }
 }
 
@@ -2996,11 +3132,13 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </h2>
                     </div>
                     <ul
-                      class="c40"
+                      class="c40 c41"
+                      dir="ltr"
                       role="list"
                     >
                       <li
-                        class="c41"
+                        class="c42 c43"
+                        dir="ltr"
                         role="listitem"
                       />
                     </ul>


### PR DESCRIPTION
No ticket

**Overall change:** 
Ensures that for CPS Related Content, currently used on CPS PGLs & MAPs, the story promos appear in two columns like this:


<img width="803" alt="Screenshot 2020-02-25 at 23 06 54" src="https://user-images.githubusercontent.com/3028997/75296363-dd1db500-5824-11ea-9cd2-9ed62ca3229a.png">

<img width="842" alt="Screenshot 2020-02-25 at 23 07 48" src="https://user-images.githubusercontent.com/3028997/75296360-db53f180-5824-11ea-8ebb-10f50a53af13.png">

Storybook stories added too for LTR and RTL:
<img width="967" alt="Screenshot storybook arabic" src="https://user-images.githubusercontent.com/3028997/75298322-10af0e00-582a-11ea-86a3-c4acbe710997.png">
<img width="969" alt="Screenshot storybook pidgin" src="https://user-images.githubusercontent.com/3028997/75298329-1278d180-582a-11ea-92f0-10bdf94b3e15.png">


We are fixing forwards since as a result of the desktop layout PR there was a regression, where the Story Promos used in CPS Related Content had their breakpoints updated. For this reason, these do not match designs on Zeplin. When reviewing/testing, we will discuss with @jimjohnsonrollings & @gavinspence to get the okay to fix forwards.

**Code changes:**
- Using `Grid` from `@bbc/psammead-grid` and ensuring the story promos span all 6 out of 6 columns in groups 0-3 (0px-1007px) and 4 out of 8 columns on groups 4-5 (1008px+)
- Add stories to storybook for this container

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
