### PR TITLE
E2E fix for TV bulletin on front pages

### DIFF
--- a/cypress/integration/pages/frontPage/tests.js
+++ b/cypress/integration/pages/frontPage/tests.js
@@ -45,8 +45,9 @@ const isValidTvBulletin = pageData => {
     const hasTvBulletin = group.items.some(
       item => item.assetTypeCode === 'PRO' && item.contentType === 'TVBulletin',
     );
+    const isInCorrectGroup = group.type === 'av-live-streams';
 
-    return hasStrapline && hasTvBulletin;
+    return hasStrapline && hasTvBulletin && isInCorrectGroup;
   });
 };
 
@@ -248,7 +249,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) =>
           });
         });
 
-        it('should contain TV Bulletin if a promo of type TVBulletin is in the feed', () => {
+        it('should contain TV Bulletin if a promo of type TVBulletin is in the feed in correct group', () => {
           cy.request(serviceJsonPath(service)).then(({ body }) => {
             const pageData = applySquashTopstories(body);
             const { groups } = pageData.content;


### PR DESCRIPTION
No ticket - E2E fix as part of logic introduced by [Desktop layout PR](https://github.com/bbc/simorgh/pull/5139/files#diff-125cfc3a970c1ebca6927bdbbcae288cR163)

**Overall change:** 
Ensure we only expect TV bulletin to be in av-live-streams group for front page

**Code changes:**
- Ensure we only expect TV bulletin to be in av-live-streams group for front page

Tested locally with: `CYPRESS_SMOKE=false CYPRESS_ONLY_SERVICE=tamil npm run test:e2e:interactive`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
