### PR TITLE
fix feature index pages. if transformers fail then fallback to json

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -29,9 +29,13 @@ const processOptimoBlocks = pipe(
   cpsOnlyOnwardJourneys,
 );
 const transformJson = async json => {
-  const formattedPageData = formatPageData(json);
-  const optimoBlocks = await convertToOptimoBlocks(formattedPageData);
-  return processOptimoBlocks(optimoBlocks);
+  try {
+    const formattedPageData = formatPageData(json);
+    const optimoBlocks = await convertToOptimoBlocks(formattedPageData);
+    return processOptimoBlocks(optimoBlocks);
+  } catch (e) {
+    return json;
+  }
 };
 
 export default async path => {

--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -34,6 +34,8 @@ const transformJson = async json => {
     const optimoBlocks = await convertToOptimoBlocks(formattedPageData);
     return processOptimoBlocks(optimoBlocks);
   } catch (e) {
+    // We can arrive here if the CPS asset is a FIX page
+    // TODO: consider checking if FIX then don't transform JSON
     return json;
   }
 };


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5679

**Overall change:** 
Fixes broken feature index pages

**Code changes:**
- If data transformers fail then they are caught and handled to just return un-transformed data
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
