### PR TITLE
make front pages ghost-coloured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3631,9 +3631,9 @@
       }
     },
     "@bbc/psammead-section-label": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-4.0.2.tgz",
-      "integrity": "sha512-vxPQgsqnF87RK7Pd+kz5e9yzxBJjRx0ndJ+tUdGHMz2xCQ/KoTYxvK2Zr3XCe/UINuf2mfnjKNFqUFRuaDmB3g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-section-label/-/psammead-section-label-5.0.0.tgz",
+      "integrity": "sha512-O0RhMCFyceFI95KSgAY0um7/yTlTEIdUfJ1QLFGNtVwg2rQu8atx7/qB2PBLuEwdHhit00glRwVS/0Q8fd2rqg==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-styles": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@bbc/psammead-navigation": "^6.0.2",
     "@bbc/psammead-paragraph": "^2.2.26",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",
-    "@bbc/psammead-section-label": "^4.0.2",
+    "@bbc/psammead-section-label": "^5.0.0",
     "@bbc/psammead-sitewide-links": "^4.0.9",
     "@bbc/psammead-story-promo": "^4.0.0",
     "@bbc/psammead-story-promo-list": "^4.0.4",

--- a/src/app/components/Grid/index.jsx
+++ b/src/app/components/Grid/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@bbc/gel-foundations/breakpoints';
 import { C_GHOST } from '@bbc/psammead-styles/colours';
 
-const group4WrapperMaxWidth = `63rem`; // 1008px
+export const group4WrapperMaxWidth = `63rem`; // 1008px
 const group5WrapperMaxWidth = `80rem`; // 1280px
 
 const gelMaxWidths = css`
@@ -28,15 +28,6 @@ export const GelPageGrid = styled(Grid)`
 export const GhostGelPageGrid = styled(Grid)`
   ${gelMaxWidths}
   background-color: ${C_GHOST};
-`;
-
-export const StyledFrontPageMain = styled.main`
-  /* To centre page layout for Group 4+ */
-  margin: 0 auto;
-  width: 100%; /* Needed for IE11 */
-  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    max-width: ${group4WrapperMaxWidth};
-  }
 `;
 
 export default Grid;

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`CpsRelatedContent should render Story Promo components in Live environm
                 class="FlexRow-wx5kdp-2 dVBNyZ"
               >
                 <span
-                  class="Title-wx5kdp-4 jiurmA"
+                  class="Title-wx5kdp-4 BeqZV"
                   dir="ltr"
                   id="related-content-heading"
                 >
@@ -256,7 +256,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="FlexRow-wx5kdp-2 dVBNyZ"
               >
                 <span
-                  class="Title-wx5kdp-4 jiurmA"
+                  class="Title-wx5kdp-4 BeqZV"
                   dir="ltr"
                   id="related-content-heading"
                 >

--- a/src/app/containers/FrontPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageSection/__snapshots__/index.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`FrontPageSection Container snapshots should render correctly for canoni
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;
@@ -1033,7 +1033,7 @@ exports[`FrontPageSection Container snapshots should render correctly with a lin
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;
@@ -1808,7 +1808,7 @@ exports[`FrontPageSection Container snapshots should render with only one item 1
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;
@@ -2245,7 +2245,7 @@ exports[`FrontPageSection Container snapshots should render without a bar 1`] = 
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;

--- a/src/app/containers/MostRead/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MostRead/__snapshots__/index.test.jsx.snap
@@ -111,7 +111,7 @@ exports[`MostReadContainerCanonical Assertion should render most read correctly 
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-left: 0.5rem;
   display: -webkit-box;

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -55,7 +55,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
               class="FlexRow-wx5kdp-2 dVBNyZ"
             >
               <span
-                class="Title-wx5kdp-4 jiurmA"
+                class="Title-wx5kdp-4 BeqZV"
                 dir="ltr"
                 id="Most-Read"
               >
@@ -593,7 +593,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
               class="FlexRow-wx5kdp-2 dVBNyZ"
             >
               <span
-                class="Title-wx5kdp-4 dAMIcO"
+                class="Title-wx5kdp-4 htLcbq"
                 dir="rtl"
                 id="Most-Read"
               >

--- a/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
@@ -25,7 +25,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                 chartbeat
               </div>
               <main
-                class="StyledFrontPageMain-sc-58u5qv-0 jXCNVc"
+                class="StyledFrontPageMain-sc-58u5qv-0 buOiFm"
                 role="main"
               >
                 <div

--- a/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
@@ -25,222 +25,72 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                 chartbeat
               </div>
               <main
-                class="StyledFrontPageMain-ylca1m-2 ftqRFA"
+                class="StyledFrontPageMain-sc-58u5qv-0 jXCNVc"
                 role="main"
               >
-                <h1
-                  class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
-                  id="content"
-                  tabindex="-1"
+                <div
+                  class="StyledFrontPageWrapper-sc-58u5qv-1 klTYsg"
                 >
-                  <span
-                    role="text"
+                  <h1
+                    class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                    id="content"
+                    tabindex="-1"
                   >
                     <span
-                      lang="en-GB"
+                      role="text"
                     >
-                      BBC News
+                      <span
+                        lang="en-GB"
+                      >
+                        BBC News
+                      </span>
+                      , 
+                      Pidgin
+                       - 
+                      Home
                     </span>
-                    , 
-                    Pidgin
-                     - 
-                    Home
-                  </span>
-                </h1>
-                <div
-                  class="StyledFrontPageDiv-sc-58u5qv-0 fCyXlu"
-                >
-                  <section
-                    aria-labelledby="Top-stories"
-                    role="region"
+                  </h1>
+                  <div
+                    class="StyledFrontPageDiv-sc-58u5qv-2 cqnYJE"
                   >
-                    <div
-                      class="SectionLabelWrapper-sc-1x4gwjz-1 sdoTA"
+                    <section
+                      aria-labelledby="Top-stories"
+                      role="region"
                     >
                       <div
-                        class="Bar-sc-1x4gwjz-0 jsgdXU"
-                      />
-                      <h2
-                        class="Heading-sc-1x4gwjz-2 eZofTG"
+                        class="SectionLabelWrapper-sc-1x4gwjz-1 sdoTA"
                       >
                         <div
-                          class="FlexColumn-wx5kdp-0 dgpsiS"
-                        >
-                          <span
-                            class="FlexRow-wx5kdp-2 dVBNyZ"
-                          >
-                            <span
-                              class="Title-wx5kdp-4 jiurmA"
-                              dir="ltr"
-                              id="Top-stories"
-                            >
-                              Top tori
-                            </span>
-                          </span>
-                        </div>
-                      </h2>
-                    </div>
-                    <div
-                      class="FirstSectionTopMargin-sc-1t555e8-0 cnOysi"
-                    >
-                      <div
-                        class="StoryPromoWrapper-sc-1dvfmi3-0 hpUEiZ"
-                      >
-                        <div
-                          class="ImageGridItem-sc-1xk56cj-0 dGiaGH"
-                          dir="ltr"
+                          class="Bar-sc-1x4gwjz-0 jsgdXU"
+                        />
+                        <h2
+                          class="Heading-sc-1x4gwjz-2 eZofTG"
                         >
                           <div
-                            class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
+                            class="FlexColumn-wx5kdp-0 dgpsiS"
                           >
-                            <div
-                              class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                            >
-                              <div
-                                class="lazyload-placeholder"
-                              />
-                            </div>
-                            <div
-                              class="ImageOverlayWrapper-sc-1dvfmi3-2 cWJDXG"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          class="TextGridItem-sc-1lkbq5i-0 gAqLWy"
-                          dir="ltr"
-                        >
-                          <h3
-                            class="Headline-sc-1dvfmi3-3 fccgro"
-                          >
-                            <a
-                              class="Link-sc-1dvfmi3-5 yQgSu"
-                              href="/pidgin/live/tori-48591362"
+                            <span
+                              class="FlexRow-wx5kdp-2 dVBNyZ"
                             >
                               <span
-                                role="text"
+                                class="Title-wx5kdp-4 BeqZV"
+                                dir="ltr"
+                                id="Top-stories"
                               >
-                                <span
-                                  aria-hidden="true"
-                                  class="LiveLabel-sc-1dvfmi3-6 halTGG"
-                                  dir="ltr"
-                                >
-                                  LIVE
-                                </span>
-                                <span
-                                  class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
-                                  lang="en-GB"
-                                >
-                                   Live, 
-                                </span>
-                                Senators don begin vote for Senate President
+                                Top tori
                               </span>
-                            </a>
-                          </h3>
-                          <p
-                            class="Summary-sc-1dvfmi3-4 zsDkO"
-                          >
-                            Nigeria dey do inauguration to welcome im tear rubber lawmakers into di Ninth National Assembly.
-                          </p>
-                          <time
-                            class="StyledTimestamp-um718p-0 kVWTyt"
-                            datetime="2019-06-11"
-                          >
-                            11th June 2019
-                          </time>
-                          <div
-                            class="StyledIndexAlsos-xsqyvb-0 cMpdvs"
-                            data-e2e="index-alsos"
-                          >
-                            <h4
-                              class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
-                            >
-                              Another thing we de for inside dis tori
-                            </h4>
-                            <ul
-                              class="StyledIndexAlsosUl-xsqyvb-2 jXaBOE"
-                              role="list"
-                            >
-                              <li
-                                class="StyledIndexAlso-xsqyvb-1 kZPHaK"
-                                role="listitem"
-                              >
-                                <a
-                                  class="StyledIndexAlsosLink-xsqyvb-5 dwLQNJ"
-                                  href="/pidgin/tori-48591361"
-                                >
-                                  <span
-                                    class="IndexAlsosText-xsqyvb-4 gvRfTv"
-                                  >
-                                    Who go lead di Ninth National Assembly?
-                                  </span>
-                                </a>
-                              </li>
-                              <li
-                                class="StyledIndexAlso-xsqyvb-1 kZPHaK"
-                                role="listitem"
-                              >
-                                <a
-                                  class="StyledIndexAlsosLink-xsqyvb-5 dwLQNJ"
-                                  href="/pidgin/tori-47603701"
-                                >
-                                  <span
-                                    class="IndexAlsosText-xsqyvb-4 gvRfTv"
-                                  >
-                                    4 tins wey go determine who become di next Senate President, Speaker
-                                  </span>
-                                </a>
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </section>
-                  <section
-                    aria-labelledby="Frequency-info"
-                    role="region"
-                  >
-                    <div
-                      class="SectionLabelWrapper-sc-1x4gwjz-1 gKFUvc"
-                    >
-                      <div
-                        class="Bar-sc-1x4gwjz-0 jsgdXU"
-                      />
-                      <h2
-                        class="Heading-sc-1x4gwjz-2 eZofTG"
-                      >
-                        <div
-                          class="FlexColumn-wx5kdp-0 dgpsiS"
-                        >
-                          <span
-                            class="FlexRow-wx5kdp-2 dVBNyZ"
-                          >
-                            <span
-                              class="Title-wx5kdp-4 jiurmA"
-                              dir="ltr"
-                              id="Frequency-info"
-                            >
-                              2018 World Cup
                             </span>
-                          </span>
-                        </div>
-                      </h2>
-                    </div>
-                    <ul
-                      class="StoryPromoUl-sc-171lqjd-1 isCYWc GridComponent-nf79gm-0 gjgzxV"
-                      dir="ltr"
-                      role="list"
-                    >
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
+                          </div>
+                        </h2>
+                      </div>
+                      <div
+                        class="FirstSectionTopMargin-sc-1t555e8-0 cnOysi"
                       >
                         <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
+                          class="StoryPromoWrapper-sc-1dvfmi3-0 hpUEiZ"
                         >
                           <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
+                            class="ImageGridItem-sc-1xk56cj-0 dGiaGH"
                             dir="ltr"
                           >
                             <div
@@ -254,929 +104,1083 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                                 />
                               </div>
                               <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                class="ImageOverlayWrapper-sc-1dvfmi3-2 cWJDXG"
                               />
                             </div>
                           </div>
                           <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
+                            class="TextGridItem-sc-1lkbq5i-0 gAqLWy"
                             dir="ltr"
                           >
                             <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
+                              class="Headline-sc-1dvfmi3-3 fccgro"
                             >
                               <a
                                 class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44416820"
+                                href="/pidgin/live/tori-48591362"
                               >
-                                Take dis predictor choose who go reach World Cup final
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              >
-                                <div
-                                  aria-hidden="true"
-                                  class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
-                                  dir="ltr"
+                                <span
+                                  role="text"
                                 >
-                                  <div
-                                    class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                  <span
+                                    aria-hidden="true"
+                                    class="LiveLabel-sc-1dvfmi3-6 halTGG"
+                                    dir="ltr"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MediaIcon-sc-10lpekz-0 AudioMediaIcon-sc-10lpekz-2 jqcLqP"
-                                      focusable="false"
-                                      height="12px"
-                                      viewBox="0 0 13 12"
-                                      width="13px"
-                                    >
-                                      <path
-                                        d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-                                      />
-                                      <path
-                                        d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="http://www.bbc.com/pidgin"
-                              >
-                                Audio promo
+                                    LIVE
+                                  </span>
+                                  <span
+                                    class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
+                                    lang="en-GB"
+                                  >
+                                     Live, 
+                                  </span>
+                                  Senators don begin vote for Senate President
+                                </span>
                               </a>
                             </h3>
                             <p
-                              class="Summary-sc-1dvfmi3-4 eaCWBB"
+                              class="Summary-sc-1dvfmi3-4 zsDkO"
                             >
-                              Summary
+                              Nigeria dey do inauguration to welcome im tear rubber lawmakers into di Ninth National Assembly.
                             </p>
                             <time
                               class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2019-08-06"
+                              datetime="2019-06-11"
                             >
-                              6th August 2019
+                              11th June 2019
                             </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
                             <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
+                              class="StyledIndexAlsos-xsqyvb-0 cMpdvs"
+                              data-e2e="index-alsos"
                             >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                              <h4
+                                class="VisuallyHiddenText-sc-1yjwwa5-0 jFfEvX"
                               >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44439411"
+                                Another thing we de for inside dis tori
+                              </h4>
+                              <ul
+                                class="StyledIndexAlsosUl-xsqyvb-2 jXaBOE"
+                                role="list"
                               >
-                                World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44425543"
-                              >
-                                Select your best ever African 11 players for World Cup
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44425543"
-                              >
-                                Select your best ever African 11 players for World Cup as a feature
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              >
-                                <div
-                                  aria-hidden="true"
-                                  class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
-                                  dir="ltr"
+                                <li
+                                  class="StyledIndexAlso-xsqyvb-1 kZPHaK"
+                                  role="listitem"
                                 >
-                                  <div
-                                    class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                  <a
+                                    class="StyledIndexAlsosLink-xsqyvb-5 dwLQNJ"
+                                    href="/pidgin/tori-48591361"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MediaIcon-sc-10lpekz-0 VideoMediaIcon-sc-10lpekz-1 gUVBrE"
-                                      focusable="false"
-                                      height="12px"
-                                      viewBox="0 0 32 32"
-                                      width="12px"
+                                    <span
+                                      class="IndexAlsosText-xsqyvb-4 gvRfTv"
                                     >
-                                      <polygon
-                                        points="3,32 29,16 3,0"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44425543"
-                              >
-                                Select your best ever African 11 players for World Cup - Video
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="https://www.bbc.com/pidgin/sport-44214129"
-                              >
-                                World Cup 2018: Di top stars wey no dey go World Cup
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2018-06-14"
-                            >
-                              14th June 2018
-                            </time>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
-                        dir="ltr"
-                        role="listitem"
-                      >
-                        <div
-                          class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
-                        >
-                          <div
-                            class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
-                            dir="ltr"
-                          >
-                            <div
-                              class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
-                            >
-                              <div
-                                class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
-                              >
-                                <div
-                                  class="lazyload-placeholder"
-                                />
-                              </div>
-                              <div
-                                class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
-                              >
-                                <div
-                                  aria-hidden="true"
-                                  class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
-                                  dir="ltr"
+                                      Who go lead di Ninth National Assembly?
+                                    </span>
+                                  </a>
+                                </li>
+                                <li
+                                  class="StyledIndexAlso-xsqyvb-1 kZPHaK"
+                                  role="listitem"
                                 >
-                                  <div
-                                    class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                  <a
+                                    class="StyledIndexAlsosLink-xsqyvb-5 dwLQNJ"
+                                    href="/pidgin/tori-47603701"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MediaIcon-sc-10lpekz-0 PhotoMediaIcon-sc-10lpekz-3 eqyZnv"
-                                      focusable="false"
-                                      height="13px"
-                                      viewBox="0 0 32 26"
-                                      width="16px"
+                                    <span
+                                      class="IndexAlsosText-xsqyvb-4 gvRfTv"
                                     >
-                                      <path
-                                        d="M9,2V0H4V2H0V26H32V2ZM6.5,10A2.5,2.5,0,1,1,9,7.52,2.5,2.5,0,0,1,6.5,10ZM20,23a9,9,0,1,1,9-9A9,9,0,0,1,20,23Z"
-                                      />
-                                      <circle
-                                        cx="20"
-                                        cy="14.02"
-                                        r="5.5"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </div>
+                                      4 tins wey go determine who become di next Senate President, Speaker
+                                    </span>
+                                  </a>
+                                </li>
+                              </ul>
                             </div>
                           </div>
-                          <div
-                            class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
-                            dir="ltr"
-                          >
-                            <h3
-                              class="Headline-sc-1dvfmi3-3 hSJrur"
-                            >
-                              <a
-                                class="Link-sc-1dvfmi3-5 yQgSu"
-                                href="http://www.bbc.com/azeri"
-                              >
-                                Gallery promo
-                              </a>
-                            </h3>
-                            <time
-                              class="StyledTimestamp-um718p-0 kVWTyt"
-                              datetime="2019-08-07"
-                            >
-                              7th August 2019
-                            </time>
-                          </div>
                         </div>
-                      </li>
-                    </ul>
-                  </section>
-                  <section
-                    aria-labelledby="Most-Read"
-                    class="MostReadSection-sc-6bm912-1 gLMjih"
-                    role="region"
-                  >
-                    <div
-                      class="SectionLabelWrapper-sc-1x4gwjz-1 gKFUvc"
+                      </div>
+                    </section>
+                    <section
+                      aria-labelledby="Frequency-info"
+                      role="region"
                     >
                       <div
-                        class="Bar-sc-1x4gwjz-0 jsgdXU"
-                      />
-                      <h2
-                        class="Heading-sc-1x4gwjz-2 eZofTG"
+                        class="SectionLabelWrapper-sc-1x4gwjz-1 gKFUvc"
                       >
                         <div
-                          class="FlexColumn-wx5kdp-0 dgpsiS"
+                          class="Bar-sc-1x4gwjz-0 jsgdXU"
+                        />
+                        <h2
+                          class="Heading-sc-1x4gwjz-2 eZofTG"
                         >
-                          <span
-                            class="FlexRow-wx5kdp-2 dVBNyZ"
+                          <div
+                            class="FlexColumn-wx5kdp-0 dgpsiS"
                           >
                             <span
-                              class="Title-wx5kdp-4 jiurmA"
-                              dir="ltr"
-                              id="Most-Read"
+                              class="FlexRow-wx5kdp-2 dVBNyZ"
                             >
-                              De one we dem de read well well
+                              <span
+                                class="Title-wx5kdp-4 BeqZV"
+                                dir="ltr"
+                                id="Frequency-info"
+                              >
+                                2018 World Cup
+                              </span>
                             </span>
-                          </span>
-                        </div>
-                      </h2>
-                    </div>
-                    <div
-                      class="MarginWrapper-sc-6bm912-0 bmzrWW"
-                    >
-                      <ol
-                        class="GridComponent-nf79gm-0 gjgzxV TwoColumnGrid-sc-1ofyujo-0 ewnImn"
+                          </div>
+                        </h2>
+                      </div>
+                      <ul
+                        class="StoryPromoUl-sc-171lqjd-1 isCYWc GridComponent-nf79gm-0 gjgzxV"
                         dir="ltr"
                         role="list"
                       >
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                1
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                />
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-46729879"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Public Holidays wey go happun for 2019
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-05-21"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44416820"
                                 >
-                                  De one we dem update for: 
-                                  21st May 2019
-                                </time>
-                              </div>
+                                  Take dis predictor choose who go reach World Cup final
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 bLjXLm"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                2
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                >
+                                  <div
+                                    aria-hidden="true"
+                                    class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
+                                    dir="ltr"
+                                  >
+                                    <div
+                                      class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MediaIcon-sc-10lpekz-0 AudioMediaIcon-sc-10lpekz-2 jqcLqP"
+                                        focusable="false"
+                                        height="12px"
+                                        viewBox="0 0 13 12"
+                                        width="13px"
+                                      >
+                                        <path
+                                          d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                                        />
+                                        <path
+                                          d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50304653"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Liberia banks don run out of money
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-11-05"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="http://www.bbc.com/pidgin"
                                 >
-                                  De one we dem update for: 
-                                  5th November 2019
-                                </time>
-                              </div>
+                                  Audio promo
+                                </a>
+                              </h3>
+                              <p
+                                class="Summary-sc-1dvfmi3-4 eaCWBB"
+                              >
+                                Summary
+                              </p>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2019-08-06"
+                              >
+                                6th August 2019
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                3
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                />
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50298882"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-11-05"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44439411"
                                 >
-                                  De one we dem update for: 
-                                  5th November 2019
-                                </time>
-                              </div>
+                                  World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 bLjXLm"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                4
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                />
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50315150"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-11-06"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44425543"
                                 >
-                                  De one we dem update for: 
-                                  6th November 2019
-                                </time>
-                              </div>
+                                  Select your best ever African 11 players for World Cup
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                5
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                />
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50315157"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                How Balogun market fire kill Policeman for Lagos
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-11-06"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44425543"
                                 >
-                                  De one we dem update for: 
-                                  6th November 2019
-                                </time>
-                              </div>
+                                  Select your best ever African 11 players for World Cup as a feature
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 bXogUn"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                6
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                >
+                                  <div
+                                    aria-hidden="true"
+                                    class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
+                                    dir="ltr"
+                                  >
+                                    <div
+                                      class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MediaIcon-sc-10lpekz-0 VideoMediaIcon-sc-10lpekz-1 gUVBrE"
+                                        focusable="false"
+                                        height="12px"
+                                        viewBox="0 0 32 32"
+                                        width="12px"
+                                      >
+                                        <polygon
+                                          points="3,32 29,16 3,0"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50093818"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Labour, FG finally agree minimum wage salary adjustment
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-10-18"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44425543"
                                 >
-                                  De one we dem update for: 
-                                  18th October 2019
-                                </time>
-                              </div>
+                                  Select your best ever African 11 players for World Cup - Video
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 jmVRMD"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                7
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                />
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-50187218"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Naira Marley na 'Bad Influence'?
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-10-25"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="https://www.bbc.com/pidgin/sport-44214129"
                                 >
-                                  De one we dem update for: 
-                                  25th October 2019
-                                </time>
-                              </div>
+                                  World Cup 2018: Di top stars wey no dey go World Cup
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2018-06-14"
+                              >
+                                14th June 2018
+                              </time>
                             </div>
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="StoryPromoLi-sc-171lqjd-0 dqJaJG GridComponent-nf79gm-0 fxSOhP"
                           dir="ltr"
                           role="listitem"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 bXogUn"
+                              class="ImageGridItem-sc-1xk56cj-0 fNYKlW"
                               dir="ltr"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                              <div
+                                class="ImageContentsWrapper-sc-1dvfmi3-1 cinwNl"
                               >
-                                8
-                              </span>
+                                <div
+                                  class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+                                >
+                                  <div
+                                    class="lazyload-placeholder"
+                                  />
+                                </div>
+                                <div
+                                  class="ImageOverlayWrapper-sc-1dvfmi3-2 dqBekx"
+                                >
+                                  <div
+                                    aria-hidden="true"
+                                    class="StyledMediaIndicator-sc-1p6h86b-0 iRQPYq"
+                                    dir="ltr"
+                                  >
+                                    <div
+                                      class="FlexWrapper-sc-1p6h86b-1 fQsOMp"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MediaIcon-sc-10lpekz-0 PhotoMediaIcon-sc-10lpekz-3 eqyZnv"
+                                        focusable="false"
+                                        height="13px"
+                                        viewBox="0 0 32 26"
+                                        width="16px"
+                                      >
+                                        <path
+                                          d="M9,2V0H4V2H0V26H32V2ZM6.5,10A2.5,2.5,0,1,1,9,7.52,2.5,2.5,0,0,1,6.5,10ZM20,23a9,9,0,1,1,9-9A9,9,0,0,1,20,23Z"
+                                        />
+                                        <circle
+                                          cx="20"
+                                          cy="14.02"
+                                          r="5.5"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
                             </div>
                             <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
+                              class="TextGridItem-sc-1lkbq5i-0 jJWtYv"
                               dir="ltr"
                             >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-48347911"
+                              <h3
+                                class="Headline-sc-1dvfmi3-3 hSJrur"
                               >
-                                Tins you suppose know about Naira Marley
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-05-23"
+                                <a
+                                  class="Link-sc-1dvfmi3-5 yQgSu"
+                                  href="http://www.bbc.com/azeri"
                                 >
-                                  De one we dem update for: 
-                                  23rd May 2019
-                                </time>
-                              </div>
+                                  Gallery promo
+                                </a>
+                              </h3>
+                              <time
+                                class="StyledTimestamp-um718p-0 kVWTyt"
+                                datetime="2019-08-07"
+                              >
+                                7th August 2019
+                              </time>
                             </div>
                           </div>
                         </li>
-                        <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
-                          dir="ltr"
-                          role="listitem"
+                      </ul>
+                    </section>
+                    <section
+                      aria-labelledby="Most-Read"
+                      class="MostReadSection-sc-6bm912-1 gLMjih"
+                      role="region"
+                    >
+                      <div
+                        class="SectionLabelWrapper-sc-1x4gwjz-1 gKFUvc"
+                      >
+                        <div
+                          class="Bar-sc-1x4gwjz-0 jsgdXU"
+                        />
+                        <h2
+                          class="Heading-sc-1x4gwjz-2 eZofTG"
                         >
                           <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                            class="FlexColumn-wx5kdp-0 dgpsiS"
                           >
-                            <div
-                              class="TwoColumnWrapper-fs4y6m-0 jmVRMD"
-                              dir="ltr"
+                            <span
+                              class="FlexRow-wx5kdp-2 dVBNyZ"
                             >
                               <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
+                                class="Title-wx5kdp-4 BeqZV"
+                                dir="ltr"
+                                id="Most-Read"
                               >
-                                9
+                                De one we dem de read well well
                               </span>
-                            </div>
-                            <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
-                              dir="ltr"
-                            >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/sport-50312710"
-                              >
-                                Golden Eaglets crash out of Fifa U17 World Cup
-                              </a>
-                              <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
-                              >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-11-06"
-                                >
-                                  De one we dem update for: 
-                                  6th November 2019
-                                </time>
-                              </div>
-                            </div>
+                            </span>
                           </div>
-                        </li>
-                        <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                        </h2>
+                      </div>
+                      <div
+                        class="MarginWrapper-sc-6bm912-0 bmzrWW"
+                      >
+                        <ol
+                          class="GridComponent-nf79gm-0 gjgzxV TwoColumnGrid-sc-1ofyujo-0 ewnImn"
                           dir="ltr"
-                          role="listitem"
+                          role="list"
                         >
-                          <div
-                            class="ItemWrapper-u0d8kd-3 juBlKT"
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
                           >
                             <div
-                              class="TwoColumnWrapper-fs4y6m-0 bXogUn"
-                              dir="ltr"
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
                             >
-                              <span
-                                class="StyledSpan-fs4y6m-2 bbVUNN"
-                              >
-                                10
-                              </span>
-                            </div>
-                            <div
-                              class="StyledItem-u0d8kd-1 ihPUFl"
-                              dir="ltr"
-                            >
-                              <a
-                                class="StyledLink-u0d8kd-0 iVuzjN"
-                                href="/pidgin/tori-42945173"
-                              >
-                                Tiger nut drink fit wake up your sex drive - Nutritionist
-                              </a>
                               <div
-                                class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                                dir="ltr"
                               >
-                                <time
-                                  class="StyledTimestamp-um718p-0 kVWTyt"
-                                  datetime="2019-05-21"
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
                                 >
-                                  De one we dem update for: 
-                                  21st May 2019
-                                </time>
+                                  1
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-46729879"
+                                >
+                                  Public Holidays wey go happun for 2019
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-05-21"
+                                  >
+                                    De one we dem update for: 
+                                    21st May 2019
+                                  </time>
+                                </div>
                               </div>
                             </div>
-                          </div>
-                        </li>
-                      </ol>
-                    </div>
-                  </section>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 bLjXLm"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  2
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50304653"
+                                >
+                                  Liberia banks don run out of money
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-11-05"
+                                  >
+                                    De one we dem update for: 
+                                    5th November 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  3
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50298882"
+                                >
+                                  Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-11-05"
+                                  >
+                                    De one we dem update for: 
+                                    5th November 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 bLjXLm"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  4
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50315150"
+                                >
+                                  Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-11-06"
+                                  >
+                                    De one we dem update for: 
+                                    6th November 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 fpGgZU"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  5
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50315157"
+                                >
+                                  How Balogun market fire kill Policeman for Lagos
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-11-06"
+                                  >
+                                    De one we dem update for: 
+                                    6th November 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 bXogUn"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  6
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50093818"
+                                >
+                                  Labour, FG finally agree minimum wage salary adjustment
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-10-18"
+                                  >
+                                    De one we dem update for: 
+                                    18th October 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 jmVRMD"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  7
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-50187218"
+                                >
+                                  Naira Marley na 'Bad Influence'?
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-10-25"
+                                  >
+                                    De one we dem update for: 
+                                    25th October 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 bXogUn"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  8
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-48347911"
+                                >
+                                  Tins you suppose know about Naira Marley
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-05-23"
+                                  >
+                                    De one we dem update for: 
+                                    23rd May 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 jmVRMD"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  9
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/sport-50312710"
+                                >
+                                  Golden Eaglets crash out of Fifa U17 World Cup
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-11-06"
+                                  >
+                                    De one we dem update for: 
+                                    6th November 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                          <li
+                            class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                            dir="ltr"
+                            role="listitem"
+                          >
+                            <div
+                              class="ItemWrapper-u0d8kd-3 juBlKT"
+                            >
+                              <div
+                                class="TwoColumnWrapper-fs4y6m-0 bXogUn"
+                                dir="ltr"
+                              >
+                                <span
+                                  class="StyledSpan-fs4y6m-2 bbVUNN"
+                                >
+                                  10
+                                </span>
+                              </div>
+                              <div
+                                class="StyledItem-u0d8kd-1 ihPUFl"
+                                dir="ltr"
+                              >
+                                <a
+                                  class="StyledLink-u0d8kd-0 iVuzjN"
+                                  href="/pidgin/tori-42945173"
+                                >
+                                  Tiger nut drink fit wake up your sex drive - Nutritionist
+                                </a>
+                                <div
+                                  class="TimestampWrapper-u0d8kd-2 hlECaE"
+                                >
+                                  <time
+                                    class="StyledTimestamp-um718p-0 kVWTyt"
+                                    datetime="2019-05-21"
+                                  >
+                                    De one we dem update for: 
+                                    21st May 2019
+                                  </time>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                        </ol>
+                      </div>
+                    </section>
+                  </div>
                 </div>
               </main>
             </div>

--- a/src/app/pages/FrontPage/index.jsx
+++ b/src/app/pages/FrontPage/index.jsx
@@ -42,6 +42,7 @@ import withData from '#containers/PageHandlers/withData';
 
 export const StyledFrontPageMain = styled.main`
   background-color: ${C_GHOST};
+  z-index: 0;
 `;
 
 const StyledFrontPageWrapper = styled.div`

--- a/src/app/pages/FrontPage/index.jsx
+++ b/src/app/pages/FrontPage/index.jsx
@@ -21,7 +21,8 @@ import {
   GEL_MARGIN_ABOVE_400PX,
 } from '@bbc/gel-foundations/spacings';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
-import { StyledFrontPageMain } from '#app/components/Grid';
+import { C_GHOST } from '@bbc/psammead-styles/colours';
+import { group4WrapperMaxWidth } from '#app/components/Grid';
 import { frontPageDataPropTypes } from '#models/propTypes/frontPage';
 import { ServiceContext } from '#contexts/ServiceContext';
 import FrontPageSection from '#containers/FrontPageSection';
@@ -38,6 +39,19 @@ import withPageWrapper from '#containers/PageHandlers/withPageWrapper';
 import withLoading from '#containers/PageHandlers/withLoading';
 import withError from '#containers/PageHandlers/withError';
 import withData from '#containers/PageHandlers/withData';
+
+export const StyledFrontPageMain = styled.main`
+  background-color: ${C_GHOST};
+`;
+
+const StyledFrontPageWrapper = styled.div`
+  /* To centre page layout for Group 4+ */
+  margin: 0 auto;
+  width: 100%; /* Needed for IE11 */
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    max-width: ${group4WrapperMaxWidth};
+  }
+`;
 
 export const StyledFrontPageDiv = styled.div`
   /* To add GEL Margins */
@@ -103,28 +117,30 @@ const FrontPageContainer = ({ pageData, mostReadEndpointOverride }) => {
       />
       <LinkedData type="WebPage" seoTitle={seoTitle} />
       <StyledFrontPageMain role="main">
-        <VisuallyHiddenText id="content" tabIndex="-1" as="h1">
-          {offScreenText}
-        </VisuallyHiddenText>
-        <StyledFrontPageDiv>
-          {groups.map((group, index) => (
-            <Fragment key={group.title}>
-              {group.type === 'useful-links' && (
-                <MostReadContainer
-                  mostReadEndpointOverride={mostReadEndpointOverride}
-                  maxTwoColumns
-                />
-              )}
-              <FrontPageSection group={group} sectionNumber={index} />
-            </Fragment>
-          ))}
-          {!hasUsefulLinks && (
-            <MostReadContainer
-              mostReadEndpointOverride={mostReadEndpointOverride}
-              maxTwoColumns
-            />
-          )}
-        </StyledFrontPageDiv>
+        <StyledFrontPageWrapper>
+          <VisuallyHiddenText id="content" tabIndex="-1" as="h1">
+            {offScreenText}
+          </VisuallyHiddenText>
+          <StyledFrontPageDiv>
+            {groups.map((group, index) => (
+              <Fragment key={group.title}>
+                {group.type === 'useful-links' && (
+                  <MostReadContainer
+                    mostReadEndpointOverride={mostReadEndpointOverride}
+                    maxTwoColumns
+                  />
+                )}
+                <FrontPageSection group={group} sectionNumber={index} />
+              </Fragment>
+            ))}
+            {!hasUsefulLinks && (
+              <MostReadContainer
+                mostReadEndpointOverride={mostReadEndpointOverride}
+                maxTwoColumns
+              />
+            )}
+          </StyledFrontPageDiv>
+        </StyledFrontPageWrapper>
       </StyledFrontPageMain>
     </>
   );

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -992,7 +992,7 @@ exports[`Media Asset Page should render component 1`] = `
                           class="FlexRow-wx5kdp-2 dVBNyZ"
                         >
                           <span
-                            class="Title-wx5kdp-4 jiurmA"
+                            class="Title-wx5kdp-4 BeqZV"
                             dir="ltr"
                             id="related-content-heading"
                           >

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -3058,7 +3058,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;
@@ -6283,7 +6283,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -196,7 +196,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;
@@ -1702,7 +1702,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #222222;
-  background-color: #FFFFFF;
+  background-color: #FDFDFD;
   margin: 1rem 0;
   padding-right: 0.5rem;
   display: -webkit-box;


### PR DESCRIPTION
Resolves #5553 

**Overall change:** 
_Make front pages ghost-coloured._

**Code changes:**
- _Wrap frontpage content in a `div` inside of `main`._
- _Set background color of `main` to `#FDFDFD`._
- _Bump `psammead-section-label` to `5.0.0.`_
- _Update snapshots_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
