### PR TITLE
Remove stage env from cypress config

### DIFF
--- a/cypress/support/config/envs.js
+++ b/cypress/support/config/envs.js
@@ -21,17 +21,6 @@ const config = {
     standaloneErrorPages: false,
     alwaysCheckForFallback: true,
   },
-  stage: {
-    baseUrl: 'https://www.stage.bbc.com',
-    dataUrl: 'https://www.stage.bbc.com',
-    assetUrl: 'https://news.test.files.bbci.co.uk/include/articles/public',
-    assetOrigin: 'https://news.test.files.bbci.co.uk',
-    atiUrl: 'https://logws1363.ati-host.net?',
-    chartbeatEnabled: true,
-    avEmbedBaseUrl: 'https://polling.bbc.co.uk',
-    standaloneErrorPages: false,
-    alwaysCheckForFallback: true,
-  },
   local: {
     baseUrl: 'http://localhost:7080',
     dataUrl: 'http://localhost:7080',


### PR DESCRIPTION
No ticket

**Overall change:** 
Our application has three env configs, local test and live. We should only run cypress on these and not against stage.

**Code changes:**
- Remove cypress stage config


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
