### PR TITLE
refactor front page composition

### DIFF
--- a/src/app/pages/FrontPage/index.jsx
+++ b/src/app/pages/FrontPage/index.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/aria-role */
 import React, { Fragment, useContext } from 'react';
-import pipe from 'ramda/src/pipe';
 import { string } from 'prop-types';
 import path from 'ramda/src/path';
 import findIndex from 'ramda/src/findIndex';
@@ -31,14 +30,6 @@ import LinkedData from '#containers/LinkedData';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
 
-// Page Handlers
-import withVariant from '#containers/PageHandlers/withVariant';
-import withContexts from '#containers/PageHandlers/withContexts';
-import withPageWrapper from '#containers/PageHandlers/withPageWrapper';
-import withLoading from '#containers/PageHandlers/withLoading';
-import withError from '#containers/PageHandlers/withError';
-import withData from '#containers/PageHandlers/withData';
-
 export const StyledFrontPageDiv = styled.div`
   /* To add GEL Margins */
   margin: 0 ${GEL_MARGIN_BELOW_400PX};
@@ -67,7 +58,7 @@ export const StyledFrontPageDiv = styled.div`
   }
 `;
 
-const FrontPageContainer = ({ pageData, mostReadEndpointOverride }) => {
+const FrontPage = ({ pageData, mostReadEndpointOverride }) => {
   const {
     product,
     serviceLocalizedName,
@@ -130,22 +121,13 @@ const FrontPageContainer = ({ pageData, mostReadEndpointOverride }) => {
   );
 };
 
-FrontPageContainer.propTypes = {
+FrontPage.propTypes = {
   pageData: frontPageDataPropTypes.isRequired,
   mostReadEndpointOverride: string,
 };
 
-FrontPageContainer.defaultProps = {
+FrontPage.defaultProps = {
   mostReadEndpointOverride: null,
 };
 
-const EnhancedFrontPageContainer = pipe(
-  withData,
-  withError,
-  withLoading,
-  withPageWrapper,
-  withContexts,
-  withVariant,
-)(FrontPageContainer);
-
-export default EnhancedFrontPageContainer;
+export default FrontPage;

--- a/src/app/pages/FrontPage/index.stories.jsx
+++ b/src/app/pages/FrontPage/index.stories.jsx
@@ -17,7 +17,7 @@ import { service as thaiConfig } from '#lib/config/services/thai';
 import { service as yorubaConfig } from '#lib/config/services/yoruba';
 import { service as punjabiConfig } from '#lib/config/services/punjabi';
 import { service as serbianConfig } from '#lib/config/services/serbian';
-import FrontPage from '.';
+import { FrontPage } from '..';
 
 const serviceDataSets = {
   news: { default: newsData },

--- a/src/app/pages/FrontPage/index.test.jsx
+++ b/src/app/pages/FrontPage/index.test.jsx
@@ -6,7 +6,7 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 import frontPageDataPidgin from '#data/pidgin/frontpage/index-light';
 import pidginMostReadData from '#data/pidgin/mostRead';
 import getInitialData from '#app/routes/home/getInitialData';
-import FrontPageContainer from './index';
+import { FrontPage } from '..';
 
 const requestContextData = {
   isAmp: false,
@@ -20,7 +20,7 @@ const FrontPageWithContext = props => (
   <ToggleContextProvider>
     <RequestContextProvider {...requestContextData}>
       <ServiceContextProvider service="pidgin">
-        <FrontPageContainer {...props} />
+        <FrontPage {...props} />
       </ServiceContextProvider>
     </RequestContextProvider>
   </ToggleContextProvider>
@@ -46,12 +46,12 @@ jest.mock('uuid', () => {
   };
 });
 
-jest.mock('../../containers/ChartbeatAnalytics', () => {
+jest.mock('#containers/ChartbeatAnalytics', () => {
   const ChartbeatAnalytics = () => <div>chartbeat</div>;
   return ChartbeatAnalytics;
 });
 
-jest.mock('../../containers/PageHandlers/withVariant', () => Component => {
+jest.mock('#containers/PageHandlers/withVariant', () => Component => {
   const VariantContainer = props => (
     <div id="VariantContainer">
       <Component {...props} />
@@ -61,7 +61,7 @@ jest.mock('../../containers/PageHandlers/withVariant', () => Component => {
   return VariantContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withContexts', () => Component => {
+jest.mock('#containers/PageHandlers/withContexts', () => Component => {
   const DataContainer = props => (
     <div id="ContextsContainer">
       <Component {...props} />
@@ -71,7 +71,7 @@ jest.mock('../../containers/PageHandlers/withContexts', () => Component => {
   return DataContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withPageWrapper', () => Component => {
+jest.mock('#containers/PageHandlers/withPageWrapper', () => Component => {
   const PageWrapperContainer = props => (
     <div id="PageWrapperContainer">
       <Component {...props} />
@@ -81,7 +81,7 @@ jest.mock('../../containers/PageHandlers/withPageWrapper', () => Component => {
   return PageWrapperContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withLoading', () => Component => {
+jest.mock('#containers/PageHandlers/withLoading', () => Component => {
   const LoadingContainer = props => (
     <div id="LoadingContainer">
       <Component {...props} />
@@ -91,7 +91,7 @@ jest.mock('../../containers/PageHandlers/withLoading', () => Component => {
   return LoadingContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withError', () => Component => {
+jest.mock('#containers/PageHandlers/withError', () => Component => {
   const ErrorContainer = props => (
     <div id="ErrorContainer">
       <Component {...props} />
@@ -101,7 +101,7 @@ jest.mock('../../containers/PageHandlers/withError', () => Component => {
   return ErrorContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withData', () => Component => {
+jest.mock('#containers/PageHandlers/withData', () => Component => {
   const DataContainer = props => (
     <div id="DataContainer">
       <Component {...props} />
@@ -111,7 +111,7 @@ jest.mock('../../containers/PageHandlers/withData', () => Component => {
   return DataContainer;
 });
 
-jest.mock('../../containers/PageHandlers/withContexts', () => Component => {
+jest.mock('#containers/PageHandlers/withContexts', () => Component => {
   const ContextsContainer = props => (
     <div id="ContextsContainer">
       <Component {...props} />

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -224,6 +224,25 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding: 0;
 }
 
+.c41 {
+  padding: 0.5rem 0 1rem;
+}
+
+.c41:first-child {
+  padding-top: 0;
+}
+
+.c41:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c39 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
 .c25 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -256,25 +275,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 
 .c27 figure {
   padding-bottom: 0;
-}
-
-.c41 {
-  padding: 0.5rem 0 1rem;
-}
-
-.c41:first-child {
-  padding-top: 0;
-}
-
-.c41:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c39 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
 }
 
 .c31 {
@@ -792,6 +792,30 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
+@media (max-width:62.9375rem) {
+  .c41 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c41 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c41 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c41:first-child {
+    padding-top: 1rem;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c25 {
     font-size: 1rem;
@@ -846,30 +870,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   .c27 {
     padding-top: 0.5rem;
     margin-top: 2rem;
-  }
-}
-
-@media (max-width:62.9375rem) {
-  .c41 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c41 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c41 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c41:first-child {
-    padding-top: 1rem;
   }
 }
 
@@ -1730,6 +1730,25 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding: 0;
 }
 
+.c43 {
+  padding: 0.5rem 0 1rem;
+}
+
+.c43:first-child {
+  padding-top: 0;
+}
+
+.c43:last-child {
+  padding-bottom: 0;
+  border: none;
+}
+
+.c41 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
 .c27 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -1762,25 +1781,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 
 .c29 figure {
   padding-bottom: 0;
-}
-
-.c43 {
-  padding: 0.5rem 0 1rem;
-}
-
-.c43:first-child {
-  padding-top: 0;
-}
-
-.c43:last-child {
-  padding-bottom: 0;
-  border: none;
-}
-
-.c41 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
 }
 
 .c33 {
@@ -2316,6 +2316,30 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
+@media (max-width:62.9375rem) {
+  .c43 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c43 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c43 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c43:first-child {
+    padding-top: 1rem;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c27 {
     font-size: 1rem;
@@ -2370,30 +2394,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   .c29 {
     padding-top: 0.5rem;
     margin-top: 2rem;
-  }
-}
-
-@media (max-width:62.9375rem) {
-  .c43 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c43 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width:63rem) {
-  .c43 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c43:first-child {
-    padding-top: 1rem;
   }
 }
 

--- a/src/app/pages/index.js
+++ b/src/app/pages/index.js
@@ -1,5 +1,6 @@
 import pipe from 'ramda/src/pipe';
 import _ArticlePage from './ArticlePage';
+import _FrontPage from './FrontPage';
 import _MediaAssetPage from './MediaAssetPage';
 import _PhotoGalleryPage from './PhotoGalleryPage';
 import _RadioPage from './RadioPage';
@@ -23,6 +24,7 @@ export const ArticlePage = pipe(
   applyBasicPageHandlers,
   withVariant,
 )(_ArticlePage);
+export const FrontPage = pipe(applyBasicPageHandlers, withVariant)(_FrontPage);
 export const MediaAssetPage = applyBasicPageHandlers(_MediaAssetPage);
 export const PhotoGalleryPage = applyBasicPageHandlers(_PhotoGalleryPage);
 export const RadioPage = applyBasicPageHandlers(_RadioPage);

--- a/src/app/routes/cpsAsset/index.js
+++ b/src/app/routes/cpsAsset/index.js
@@ -1,7 +1,6 @@
 import path from 'ramda/src/path';
 import getInitialData from './getInitialData';
-import { MediaAssetPage, PhotoGalleryPage, StoryPage } from '#pages';
-import FrontPage from '#pages/FrontPage';
+import { MediaAssetPage, PhotoGalleryPage, StoryPage, FrontPage } from '#pages';
 import ErrorPage from '#pages/Error';
 import { cpsAssetPagePath, legacyAssetPagePath } from '../utils/regex';
 import {

--- a/src/app/routes/home/index.js
+++ b/src/app/routes/home/index.js
@@ -1,4 +1,4 @@
-import FrontPage from '#pages/FrontPage';
+import { FrontPage } from '#pages';
 import getInitialData from './getInitialData';
 import { frontPagePath } from '../utils/regex';
 


### PR DESCRIPTION
Related to https://github.com/bbc/simorgh/issues/5482

**Overall change:** 
Refactors the front page component to apply page handlers in `pages/index.js` like all other pages.

**Code changes:**
- Removes page handler HOCs from the front page component
- Applies page handler HOCs in `pages/index.js`
- Updates routes in all affected files

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
