### PR TITLE
Add data attribute to Most Read

### DIFF
--- a/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
@@ -23,7 +23,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       it('should contain most read component if the toggle is enabled', () => {
         if (useAppToggles.mostRead) {
           // For testing most read renders when ARES endpoint returns correctly.
-          cy.get('[aria-labelledby="Most-Read"]').should('be.visible');
+          cy.get('[data-e2e="most-read"]').should('be.visible');
         }
       });
     }

--- a/src/app/containers/MostRead/Canonical/index.jsx
+++ b/src/app/containers/MostRead/Canonical/index.jsx
@@ -45,6 +45,7 @@ const MarginWrapper = styled.div`
 const MostReadSection = styled.section.attrs(() => ({
   role: 'region',
   'aria-labelledby': 'Most-Read',
+  'data-e2e': 'most-read',
 }))``;
 
 const ConstrainedMostReadSection = styled(MostReadSection)`

--- a/src/app/containers/MostRead/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MostRead/__snapshots__/index.test.jsx.snap
@@ -481,6 +481,7 @@ exports[`MostReadContainerCanonical Assertion should render most read correctly 
 <section
   aria-labelledby="Most-Read"
   class=""
+  data-e2e="most-read"
   role="region"
 >
   <div

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -37,6 +37,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
     <section
       aria-labelledby="Most-Read"
       class="MostReadSection-sc-6bm912-1 ConstrainedMostReadSection-sc-6bm912-2 cswDPl"
+      data-e2e="most-read"
       role="region"
     >
       <div
@@ -575,6 +576,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
     <section
       aria-labelledby="Most-Read"
       class="MostReadSection-sc-6bm912-1 ConstrainedMostReadSection-sc-6bm912-2 cswDPl"
+      data-e2e="most-read"
       role="region"
     >
       <div

--- a/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
@@ -718,6 +718,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                   <section
                     aria-labelledby="Most-Read"
                     class="MostReadSection-sc-6bm912-1 gLMjih"
+                    data-e2e="most-read"
                     role="region"
                   >
                     <div


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Add data attribute to Most Read to look for elements using data attributes instead of `aria-label`.

**Code changes:**
- Add `data-e2e` attribute to Most Read section
- Update Most Read e2e to look for the elements using the `data-e2e` attribute
- Update snapshots

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added labels to this PR for the relevant pod(s) affected by these changes
- [X] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [X] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [X] This PR requires manual testing
