### PR TITLE
Remove Most Read e2e test

### DIFF
--- a/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
@@ -1,9 +1,5 @@
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
-import useAppToggles from '../../../support/helpers/useAppToggles';
-
-// Limiting to two services
-const serviceHasMostRead = service => ['pidgin', 'yoruba'].includes(service);
 
 export const testsThatAlwaysRunForCanonicalOnly = ({ service, pageType }) => {
   describe(`No testsToAlwaysRunForCanonicalOnly to run for ${service} ${pageType}`, () => {});
@@ -18,17 +14,6 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
     it('should not have an AMP attribute', () => {
       cy.get('html').should('not.have.attr', 'amp');
     });
-    // Once the most read is implemented for amp and all other pages this test will be moved to testforallpages
-    if (serviceHasMostRead(service)) {
-      it('should contain most read component if the toggle is enabled', () => {
-        if (useAppToggles.mostRead) {
-          // For testing most read renders when ARES endpoint returns correctly.
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(2000); // wait for 2 seconds
-          cy.get('[data-e2e="most-read"]').should('be.visible');
-        }
-      });
-    }
   });
 
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.

--- a/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/frontPage/testsForCanonicalOnly.js
@@ -3,13 +3,13 @@
 import useAppToggles from '../../../support/helpers/useAppToggles';
 
 // Limiting to two services
-const serviceHasMostRead = service => ['persian', 'yoruba'].includes(service);
+const serviceHasMostRead = service => ['pidgin', 'yoruba'].includes(service);
 
 export const testsThatAlwaysRunForCanonicalOnly = ({ service, pageType }) => {
   describe(`No testsToAlwaysRunForCanonicalOnly to run for ${service} ${pageType}`, () => {});
 };
 
-// For testing feastures that may differ across services but share a common logic e.g. translated strings.
+// For testing features that may differ across services but share a common logic e.g. translated strings.
 export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   service,
   pageType,
@@ -23,6 +23,8 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
       it('should contain most read component if the toggle is enabled', () => {
         if (useAppToggles.mostRead) {
           // For testing most read renders when ARES endpoint returns correctly.
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(2000); // wait for 2 seconds
           cy.get('[data-e2e="most-read"]').should('be.visible');
         }
       });


### PR DESCRIPTION
Resolves #5726

**Overall change:** 
The Most Read e2e test is failing on live and we think it is because the component needs to fetch data on the client before being rendered, so the e2e is trying to target it when it is not on the page yet. 

Since the page is not broken if this component doesn't render, we've decided to remove it and make sure to treat Chromatic checks as important.

**Code changes:**
- Remove Most Read e2e test

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added labels to this PR for the relevant pod(s) affected by these changes
- [X] I have assigned this PR to the Simorgh project

**Testing:**
- [X] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [X] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
