### PR TITLE
Removing console.log statement, fixing test that relies on it

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/subheadline/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/subheadline/index.js
@@ -1,5 +1,8 @@
+import nodeLogger from '#lib/logger.node';
 import convertParagraph from '../paragraph';
 import { blockBase } from '#app/models/blocks';
+
+const logger = nodeLogger(__filename);
 
 const convertToSubheadline = async block => {
   const typesArray = ['crosshead', 'heading', 'subheading'];
@@ -9,7 +12,7 @@ const convertToSubheadline = async block => {
       blocks: [innerParagraph],
     });
   }
-  console.log(`Incorrect block type ${block.type}`);
+  logger.error(`Incorrect block type ${block.type}`);
   return null;
 };
 

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/subheadline/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/subheadline/index.test.js
@@ -1,3 +1,4 @@
+import loggerMock from '#testHelpers/loggerMock';
 import convertToSubheadline from '.';
 import { optimoSubheadline } from '../../utils/helpers';
 
@@ -53,8 +54,6 @@ describe('convertToSubheadline', () => {
   });
 
   it(`should not convert a non-heading CPS block to Optimo format`, async () => {
-    const originalConsoleLog = global.console.log;
-    global.console.log = jest.fn();
     const input = {
       model: {
         copyrightHolder: 'Joe Maher',
@@ -67,9 +66,8 @@ describe('convertToSubheadline', () => {
     };
 
     expect(await convertToSubheadline(input)).toBeNull();
-    expect(global.console.log).toHaveBeenCalledWith(
+    expect(loggerMock.error).toHaveBeenCalledWith(
       'Incorrect block type rawImage',
     );
-    global.console.log = originalConsoleLog;
   });
 });


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:** 
Removing console.log statement from subheadline code

**Code changes:**
Removed console.log
Added loggerMock to replace the console.log

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
