### PR TITLE
Add logging to diagnose E2E failures

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -48,17 +48,6 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
 
       if (pageType !== 'errorPage404') {
         it('should include the canonical URL', () => {
-          // ============================================================================
-          const deleteMessage = `DEBUG CANONICAL URL: ${JSON.stringify(
-            envConfig,
-          )}; APP_ENV: ${Cypress.env('APP_ENV')}; CurrentPath: ${Cypress.env(
-            'currentPath',
-          )}`;
-
-          // eslint-disable-next-line no-console
-          console.log(deleteMessage);
-          cy.log(deleteMessage);
-          // ============================================================================
           cy.get('head link[rel="canonical"]').should(
             'have.attr',
             'href',
@@ -156,17 +145,6 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
                 'content',
                 ogType,
               );
-              // ============================================================================
-              const deleteMessage = `DEBUG SHARED METADATA: ${JSON.stringify(
-                envConfig,
-              )}; APP_ENV: ${Cypress.env(
-                'APP_ENV',
-              )}; CurrentPath: ${Cypress.env('currentPath')}`;
-
-              // eslint-disable-next-line no-console
-              console.log(deleteMessage);
-              cy.log(deleteMessage);
-              // ============================================================================
               cy.get('meta[property="og:url"]').should(
                 'have.attr',
                 'content',

--- a/src/app/contexts/RequestContext/getOriginContext/index.js
+++ b/src/app/contexts/RequestContext/getOriginContext/index.js
@@ -1,26 +1,37 @@
+import nodeLogger from '#lib/logger.node';
+
+const logger = nodeLogger(__filename);
+
 const getOriginContext = bbcOrigin => {
   let origin = 'https://www.bbc.co.uk';
   let isUK = true;
 
+  let logPrefix = 'origin=default';
+
   if (bbcOrigin) {
+    logPrefix = 'origin=bbcOrigin';
     origin = bbcOrigin;
   } else if (
     process &&
     process.env &&
     process.env.SIMORGH_APP_ENV === 'local'
   ) {
+    logPrefix = 'origin=process.env.SIMORGH_BASE_URL';
     origin = process.env.SIMORGH_BASE_URL;
   } else if (
     typeof window !== 'undefined' &&
     window.location &&
     window.location.origin
   ) {
+    logPrefix = 'origin=window.location.origin';
     origin = window.location.origin; // eslint-disable-line prefer-destructuring
   }
 
   if (origin.includes('.com')) {
     isUK = false;
   }
+
+  logger.debug(`${logPrefix}: ${origin}; isUK: ${isUK}`);
 
   return {
     origin,

--- a/src/app/contexts/RequestContext/getOriginContext/index.js
+++ b/src/app/contexts/RequestContext/getOriginContext/index.js
@@ -31,7 +31,7 @@ const getOriginContext = bbcOrigin => {
     isUK = false;
   }
 
-  logger.debug(`${logPrefix}: ${origin}; isUK: ${isUK}`);
+  logger.info(`${logPrefix}: ${origin}; isUK: ${isUK}`);
 
   return {
     origin,


### PR DESCRIPTION
**Overall change:** 
Some of the E2Es are failing because the URL in some of the page headers on AMP is `www.stage.bbc.com` instead of `www.test.bbc.com`
Adding logging to the area of the code which sets the URL to diagnose the problem

**Code changes:**
- Add logging to `getOriginContext` within `RequestContext`
- Remove logging from cypress test code, as it is not appearing in output 

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
