### PR TITLE
Implement logging of a structured event object

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -238,16 +238,20 @@ server
     },
   )
   .get('/*', cspInjectFun, async ({ url, headers, path: urlPath }, res) => {
-    logger.info(`Path: [${urlPath}] URL: [${url}]`);
+    logger.info(
+      JSON.stringify({
+        event: 'ssr_request_received',
+        url,
+        urlPath,
+        headers,
+      }),
+    );
 
     try {
       const { service, isAmp, route, variant } = getRouteProps(routes, urlPath);
       const data = await route.getInitialData(url);
       const { status } = data;
       const bbcOrigin = headers['bbc-origin'];
-
-      // Temp log to test upstream change
-      logger.info(`Headers: ${JSON.stringify(headers, null, 2)}`);
 
       data.path = urlPath;
       data.timeOnServer = Date.now();
@@ -270,8 +274,18 @@ server
         throw new Error('unknown result');
       }
     } catch ({ message, status }) {
+      logger.error(
+        JSON.stringify({
+          event: 'ssr_request_failed',
+          status: status || 500,
+          message,
+          url,
+          urlPath,
+          headers,
+        }),
+      );
+
       // Return an internal server error for any uncaught errors
-      logger.error(`status: ${status || 500} - ${message}`);
       res.status(500).send(message);
     }
   });


### PR DESCRIPTION
Resolves N/A

**Overall change:** 
Looking to improve our logging strategy and to ensure that logs are easily parseable in sumo logic to aid in debugging problems.

Instead of just logging any random message and a value, i propose we start using a standardises log event structure. This even will always container and event name in a set format, making it easier to locate and match events to ares of the code base.

The event can then be populated with any values that we think are necessary for when parsing these logs.

if we find this format useful, I'd propose a migration of all of our current logging events to this new structure. We can improve our logger so the logger itself with construct the event and stringify the object. We can then add new/improve any docs around our logging strategy,

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [N/A] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [n/A] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [N/A] This PR requires manual testing
