### PR TITLE
update radioSchedule config with placeholders for header and frequencies link text

### DIFF
--- a/src/app/lib/config/services/afrique.js
+++ b/src/app/lib/config/services/afrique.js
@@ -174,6 +174,8 @@ export const service = {
       hasRadioSchedule: true,
       frequenciesPageUrl:
         '/afrique/institutionelles/2010/12/000000_schedules_frequencies_afrique',
+      frequenciesPageLabel: 'Radio Frequencies Link Label',
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -172,6 +172,8 @@ export const service = {
       hasRadioSchedule: true,
       frequenciesPageUrl:
         '/arabic/institutional/2011/01/000000_frequencies_radio',
+      frequenciesPageLabel: 'Radio Frequencies Link Label',
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/hausa.js
+++ b/src/app/lib/config/services/hausa.js
@@ -166,6 +166,8 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       frequenciesPageUrl: '/hausa/institutional/2011/11/000001_mitocinmu',
+      frequenciesPageLabel: 'Radio Frequencies Link Label',
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/korean.js
+++ b/src/app/lib/config/services/korean.js
@@ -154,6 +154,7 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/pashto.js
+++ b/src/app/lib/config/services/pashto.js
@@ -172,6 +172,8 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       frequenciesPageUrl: '/pashto/institutional/2012/03/000001_frequencies',
+      frequenciesPageLabel: 'Radio Frequencies Link Label',
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -181,6 +181,7 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/somali.js
+++ b/src/app/lib/config/services/somali.js
@@ -173,6 +173,7 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {

--- a/src/app/lib/config/services/swahili.js
+++ b/src/app/lib/config/services/swahili.js
@@ -168,6 +168,7 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
+      header: 'BBC News Radio',
     },
     footer: {
       trustProjectLink: {


### PR DESCRIPTION
Resolves #5810

**Overall change:** 
_Updated the respective radio schedule services with `header` and `frequenciesPageLabel` placeholders
```
frequenciesPageLabel: 'Radio Frequencies Link Label'
header: 'BBC News Radio'
```
._

**Code changes:**
- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
