### PR TITLE
Gahuza, Urdu, Swahili, Tamil - MAPs failing on Test E2Es

### DIFF
--- a/3rdPartyCypress/cypress/support/index.js
+++ b/3rdPartyCypress/cypress/support/index.js
@@ -1,5 +1,5 @@
 import './commands';
 
 Cypress.Screenshot.defaults({
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: true,
 });

--- a/3rdPartyCypress/cypress/support/index.js
+++ b/3rdPartyCypress/cypress/support/index.js
@@ -1,5 +1,5 @@
 import './commands';
 
 Cypress.Screenshot.defaults({
-  screenshotOnRunFailure: true,
+  screenshotOnRunFailure: false,
 });

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -549,7 +549,7 @@ const genServices = {
             // '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP
           ],
         },
-        smoke: false,
+        smoke: true,
       },
       photoGalleryPage: {
         paths: {
@@ -2069,7 +2069,7 @@ const genServices = {
             // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
           ],
         },
-        smoke: false,
+        smoke: true,
       },
       photoGalleryPage: {
         paths: {
@@ -2142,7 +2142,7 @@ const genServices = {
             // '/tamil/global/2016/08/160822_tc2_testmap1', // TC2 MAP
           ],
         },
-        smoke: false,
+        smoke: true,
       },
       photoGalleryPage: {
         paths: {
@@ -2630,7 +2630,7 @@ const genServices = {
             // '/urdu/sport/2016/09/160902_tc2_testmap2', // TC2 MAP
           ],
         },
-        smoke: false,
+        smoke: true,
       },
       photoGalleryPage: {
         paths: {

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -541,15 +541,15 @@ const genServices = {
             // '/gahuza/video/2015/12/151201_100womenburundi', // TC2 MAP
           ],
           test: [
-            '/gahuza/amakuru-23257470', // CPS MAP
+            // '/gahuza/amakuru-23257470', // CPS MAP
             // '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP
           ],
           local: [
-            '/gahuza/amakuru-23257470', // CPS MAP
+            // '/gahuza/amakuru-23257470', // CPS MAP
             // '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP
           ],
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         paths: {
@@ -2061,15 +2061,15 @@ const genServices = {
             // '/swahili/medianuai/2016/05/160517_apatae_fatacky', // TC2 MAP
           ],
           test: [
-            '/swahili/media-23268999', // CPS MAP with audio clip
+            // '/swahili/media-23268999', // CPS MAP with audio clip
             // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
           ],
           local: [
-            '/swahili/media-23268999', // CPS MAP with audio clip
+            // '/swahili/media-23268999', // CPS MAP with audio clip
             // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
           ],
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         paths: {
@@ -2134,15 +2134,15 @@ const genServices = {
             // '/tamil/global/2014/07/140713_animalsvideo', // TC2 MAP
           ],
           test: [
-            '/tamil/india-23268994', // CPS MAP
+            // '/tamil/india-23268994', // CPS MAP
             // '/tamil/global/2016/08/160822_tc2_testmap1', // TC2 MAP
           ],
           local: [
-            '/tamil/india-23268994', // CPS MAP
+            // '/tamil/india-23268994', // CPS MAP
             // '/tamil/global/2016/08/160822_tc2_testmap1', // TC2 MAP
           ],
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         paths: {
@@ -2622,15 +2622,15 @@ const genServices = {
             // '/urdu/multimedia/2014/11/141104_hindu_riaz_kq', // TC2 MAP
           ],
           test: [
-            '/urdu/world-23268929', // CPS MAP
+            // '/urdu/world-23268929', // CPS MAP
             // '/urdu/sport/2016/09/160902_tc2_testmap2', // TC2 MAP
           ],
           local: [
-            '/urdu/world-23268929', // CPS MAP
+            // '/urdu/world-23268929', // CPS MAP
             // '/urdu/sport/2016/09/160902_tc2_testmap2', // TC2 MAP
           ],
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         paths: {

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -545,7 +545,7 @@ const genServices = {
             // '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP
           ],
           local: [
-            // '/gahuza/amakuru-23257470', // CPS MAP
+            '/gahuza/amakuru-23257470', // CPS MAP
             // '/gahuza/amakuru/2016/02/160215_map_amakuru_test1', // TC2 MAP
           ],
         },
@@ -2065,7 +2065,7 @@ const genServices = {
             // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
           ],
           local: [
-            // '/swahili/media-23268999', // CPS MAP with audio clip
+            '/swahili/media-23268999', // CPS MAP with audio clip
             // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
           ],
         },
@@ -2138,7 +2138,7 @@ const genServices = {
             // '/tamil/global/2016/08/160822_tc2_testmap1', // TC2 MAP
           ],
           local: [
-            // '/tamil/india-23268994', // CPS MAP
+            '/tamil/india-23268994', // CPS MAP
             // '/tamil/global/2016/08/160822_tc2_testmap1', // TC2 MAP
           ],
         },
@@ -2626,7 +2626,7 @@ const genServices = {
             // '/urdu/sport/2016/09/160902_tc2_testmap2', // TC2 MAP
           ],
           local: [
-            // '/urdu/world-23268929', // CPS MAP
+            '/urdu/world-23268929', // CPS MAP
             // '/urdu/sport/2016/09/160902_tc2_testmap2', // TC2 MAP
           ],
         },


### PR DESCRIPTION
**Overall change:** 
- Simorgh Test E2Es are failing for Gahuza, Urdu, Swahili, Tamil
- It's not currently clear whether we are unable to play the media, or whether the media is not playing as expected. 

**Code changes:**
- Temporarily add MAPs to the Cypress Smoke Tests so that they run in CI

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
