### PR TITLE
Increase media play timeout to 20 seconds

### DIFF
--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -71,7 +71,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
                         // `timeout` only applies to the methods chained below.
                         // `its()` benefits from this, and will wait up to 8s
                         // for the mediaPlayer instance to become available.
-                        timeout: 8000,
+                        timeout: 20000,
                       })
                         .its('embeddedMedia.playerInstances.mediaPlayer')
                         .invoke('currentTime')

--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -178,7 +178,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
                         // `timeout` only applies to the methods chained below.
                         // `its()` benefits from this, and will wait up to 8s
                         // for the mediaPlayer instance to become available.
-                        timeout: 8000,
+                        timeout: 20000,
                       })
                         .its('embeddedMedia.playerInstances.mediaPlayer')
                         .invoke('currentTime')
@@ -200,7 +200,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
                     // `timeout` only applies to the methods chained below.
                     // `its()` benefits from this, and will wait up to 8s
                     // for the mediaPlayer instance to become available.
-                    timeout: 8000,
+                    timeout: 20000,
                   })
                     .its(
                       'embeddedMedia.playerInstances.mediaPlayer._settings.ui.subtitles.enabled',

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -54,7 +54,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
             'div[class^="StyledVideoContainer"] iframe[class^="StyledIframe"]',
           ).then($iframe => {
             cy.wrap($iframe.prop('contentWindow'), {
-              timeout: 8000,
+              timeout: 20000,
             })
               .its('embeddedMedia.playerInstances.mediaPlayer.ready')
               .should('eq', true);
@@ -70,7 +70,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
               .then(inner => cy.wrap(inner.contents().find(playButton)).click())
               .then(() => {
                 cy.wrap(iframe.prop('contentWindow'), {
-                  timeout: 8000,
+                  timeout: 20000,
                 })
                   .its('embeddedMedia.playerInstances.mediaPlayer')
                   .invoke('currentTime')


### PR DESCRIPTION
**Overall change:** 
There are a number of tests failing due to being unable to play media. Increase the timeout from 8 to 20 seconds to see if this improves stability.

**Code changes:**
- Increase timeout to 20000ms for media asset pages
- Increase timeout to 20000ms for articles
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
