### PR TITLE
Fix most read bug on IE

### DIFF
--- a/src/app/containers/MostRead/Canonical/index.jsx
+++ b/src/app/containers/MostRead/Canonical/index.jsx
@@ -164,7 +164,11 @@ const CanonicalMostRead = ({
           maxTwoColumns={maxTwoColumns}
         >
           {items.map((item, i) => (
-            <MostReadItemWrapper dir={dir} key={item.id}>
+            <MostReadItemWrapper
+              dir={dir}
+              key={item.id}
+              maxTwoColumns={maxTwoColumns}
+            >
               <MostReadRank
                 service={service}
                 script={script}

--- a/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/FrontPage/__snapshots__/index.test.jsx.snap
@@ -750,7 +750,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                         role="list"
                       >
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -791,7 +791,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -832,7 +832,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -873,7 +873,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -914,7 +914,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -955,7 +955,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -996,7 +996,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -1037,7 +1037,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -1078,7 +1078,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >
@@ -1119,7 +1119,7 @@ exports[`Front Page snapshots should render a pidgin frontpage correctly 1`] = `
                           </div>
                         </li>
                         <li
-                          class="GridComponent-nf79gm-0 bvkVj StyledGrid-u0d8kd-4 ereTEa"
+                          class="GridComponent-nf79gm-0 cvevRu StyledGrid-u0d8kd-4 ereTEa"
                           dir="ltr"
                           role="listitem"
                         >


### PR DESCRIPTION
🐛 🛠 

**Overall change:** 
_We've forgotten to pass the maxTwoColumns prop in one of our most read components, this is currently only affecting IE._

Currently on LIVE:
![image](https://user-images.githubusercontent.com/30599794/76426500-0dc42980-63a3-11ea-9d7f-34ec580955ac.png)

Local fix: 
![image](https://user-images.githubusercontent.com/30599794/76427143-db66fc00-63a3-11ea-9b07-f2545c35b139.png)



**Code changes:**
- _update most read container to pass maxTwoColumns prop to mostReadItemWrapper_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
