### PR TITLE
Disable live radio e2es

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -60,11 +60,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/afaanoromoo/bbc_afaanoromoo_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/afaanoromoo/bbc_afaanoromoo_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/afaanoromoo/bbc_afaanoromoo_radio/liveradio'],
@@ -191,11 +191,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
@@ -318,18 +318,18 @@ const genServices = {
         environments: {
           live: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
             enabled: true,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       mediaAssetPage: {
         environments: {
@@ -696,11 +696,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
@@ -832,11 +832,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
@@ -1015,11 +1015,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
@@ -1266,11 +1266,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
@@ -1402,11 +1402,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],
@@ -1644,11 +1644,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
@@ -1891,11 +1891,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/korean/bbc_korean_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/korean/bbc_korean_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/korean/bbc_korean_radio/liveradio'],
@@ -2022,11 +2022,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
@@ -2431,11 +2431,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
@@ -2614,11 +2614,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
@@ -2753,14 +2753,14 @@ const genServices = {
               '/persian/bbc_persian_radio/liveradio',
               '/persian/bbc_dari_radio/liveradio',
             ],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: [
               '/persian/bbc_persian_radio/liveradio',
               '/persian/bbc_dari_radio/liveradio',
             ],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: [
@@ -3611,11 +3611,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
@@ -3757,7 +3757,7 @@ const genServices = {
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       mediaAssetPage: {
         environments: {
@@ -3896,11 +3896,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
@@ -4032,11 +4032,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
@@ -4398,11 +4398,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
@@ -4982,11 +4982,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
@@ -5118,11 +5118,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],


### PR DESCRIPTION
Requires https://github.com/bbc/simorgh/pull/5847

**Overall change:** 
- Disable live radio E2Es apart from:
Smoke: Somali (LTR)
Non-Smoke: Arabic (RTL)

**Code changes:**
- Disable live radio paths in test & live environments
- Switch off amharic smoke test
- Switch on somali smoke test
- Enable arabic live radio paths in test & live environmens

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
