### PR TITLE
Smoke Test Failure: Make AMP ATI test more robust

### DIFF
--- a/cypress/support/commands/analytics.js
+++ b/cypress/support/commands/analytics.js
@@ -10,9 +10,10 @@ Cypress.Commands.add('hasNoscriptImgAtiUrl', atiUrl => {
 
 // Should be moved into integration/pages/index.js once all pages have ATI
 Cypress.Commands.add('hasAmpAnalyticsAtiUrl', atiUrl => {
-  cy.get('amp-analytics script[type="application/json"]')
-    .eq(0)
-    .should('contain', `${atiUrl}`);
+  cy.get('amp-analytics script[type="application/json"]').should(
+    'contain',
+    `${atiUrl}`,
+  );
 });
 
 // Should be moved into integration/pages/index.js once all pages have Chartbeat


### PR DESCRIPTION
**Overall change:** 
Since MAP Smoke tests have been enabled, the Simorgh deploy is failing due to failing ATI tests on AMP - `ATI should have an amp-analytics tag with the ati url`.

The test is looking for the existence of an `amp-analytics` script tag within the HTML, however, due to the way the MAP page is constructed, the chartbeat script is also present in the HTML and hence, the test fails. 

**Code changes:**
- Make test more robust - the order of the script in the HTML should not matter - just that the ATI URL is included.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
