### PR TITLE
Removed Swahili test MAP URL

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -3922,7 +3922,7 @@ const genServices = {
           },
           test: {
             paths: [
-              '/swahili/media-23268999', // CPS MAP with live stream
+              // '/swahili/media-23268999', // CPS MAP with live stream
               // '/swahili/michezo/2016/07/160713_tc2_testmap2', // TC2 MAP with audio clip
             ],
             enabled: true,


### PR DESCRIPTION

**Overall change:** 
I wanted to chaneg the media to a video clip instead of a stream so we can still run the test but I cannot access CPS now... I could before with zscaler.

Instead I have commented out the URL for E2E Swahili MAP on test
**Code changes:**
Commented out URL

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

