### PR TITLE
add missing Simp link for ‘Ad Choices/ Do not sell my info’ in Footer

### DIFF
--- a/src/app/lib/config/services/serbian.js
+++ b/src/app/lib/config/services/serbian.js
@@ -90,6 +90,12 @@ export const service = {
           href: 'https://www.bbc.com/serbian/lat/institutional-43543431',
           text: 'Kontaktirajte BBC',
         },
+        {
+          href:
+            'https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/',
+          text: 'AdChoices / Do Not Sell My Info',
+          lang: 'en-GB',
+        },
       ],
       copyrightText: 'BBC. BBC nije odgovoran za sadržaj drugih sajtova.',
     },

--- a/src/app/lib/config/services/ukchina.js
+++ b/src/app/lib/config/services/ukchina.js
@@ -79,6 +79,12 @@ export const service = {
           href: 'https://www.bbc.com/contact/',
           text: '联络BBC',
         },
+        {
+          href:
+            'https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/',
+          text: 'AdChoices / Do Not Sell My Info',
+          lang: 'en-GB',
+        },
       ],
       copyrightText: 'BBC. BBC对外部网站内容不负责任。',
     },

--- a/src/app/lib/config/services/zhongwen.js
+++ b/src/app/lib/config/services/zhongwen.js
@@ -82,6 +82,12 @@ export const service = {
           href: 'https://www.bbc.com/contact/',
           text: '联络BBC',
         },
+        {
+          href:
+            'https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/',
+          text: 'AdChoices / Do Not Sell My Info',
+          lang: 'en-GB',
+        },
       ],
       copyrightText: 'BBC. BBC对外部网站内容不负责任。',
     },


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh-infrastructure/issues/910

**Overall change:** 
_Added missing link to ukchina simp, zhongwen simp, serbian lat footer._

**Code changes:**
- Added missing link to ukchina simp, zhongwen simp, serbian lat footer

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
