### PR TITLE
Bump psammead-navigation to 6.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,9 +3482,9 @@
       }
     },
     "@bbc/psammead-navigation": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-navigation/-/psammead-navigation-6.0.5.tgz",
-      "integrity": "sha512-AJer0RqOKgdjzyHmP/ZW33Q1ZB63QEX37tZP6jpa4Y6Hud8C0HHS+YYs60E7JQcUJ+5n3cZrnDqtlRsJZdFmKw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-navigation/-/psammead-navigation-6.0.6.tgz",
+      "integrity": "sha512-wmQk8kjS8/f8f36eZ92lPz6VBC3t2BDO+7S6aY7dD3rJJWsRQ593aRGMZmi+GJyd3buKHRTDUg5AgA1TomUNEQ==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.13.0",
@@ -13921,7 +13921,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@bbc/psammead-media-indicator": "^4.0.4",
     "@bbc/psammead-media-player": "^2.7.5",
     "@bbc/psammead-most-read": "^2.0.3",
-    "@bbc/psammead-navigation": "^6.0.5",
+    "@bbc/psammead-navigation": "^6.0.6",
     "@bbc/psammead-paragraph": "^2.2.26",
     "@bbc/psammead-radio-schedule": "0.1.0-alpha.20",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",

--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -591,10 +591,10 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   .c18 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -503,10 +503,10 @@ exports[`Header should render correctly for WS frontPage 1`] = `
   .c18 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -1501,10 +1501,10 @@ exports[`Header should render correctly for WS radio page 1`] = `
   .c18 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -2499,10 +2499,10 @@ exports[`Header should render correctly for news article 1`] = `
   .c18 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;

--- a/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
@@ -102,10 +102,10 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   .c6 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;

--- a/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
@@ -114,10 +114,10 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
   .c6 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;

--- a/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -309,10 +309,10 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   .c10 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -1001,10 +1001,10 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   .c9 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -1661,10 +1661,10 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   .c9 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -2393,10 +2393,10 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   .c6 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -3038,10 +3038,10 @@ exports[`Navigation Container should correctly render canonical navigation on no
   .c6 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;
@@ -3660,10 +3660,10 @@ exports[`Navigation Container should correctly render canonical navigation on no
   .c6 {
     white-space: nowrap;
     overflow-x: scroll;
-    -webkit-scroll-behavior: smooth;
-    -moz-scroll-behavior: smooth;
-    -ms-scroll-behavior: smooth;
-    scroll-behavior: smooth;
+    -webkit-scroll-behavior: auto;
+    -moz-scroll-behavior: auto;
+    -ms-scroll-behavior: auto;
+    scroll-behavior: auto;
     -webkit-overflow-scrolling: touch;
     -webkit-scrollbar-width: none;
     -moz-scrollbar-width: none;


### PR DESCRIPTION
Resolves #2999

**Overall change:** 
Bumping @bbc/psammead-navigation to resolve accessibility issue

**Code changes:**
- Bump @bbc/psammead-navigation to 6.0.6

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
