### PR TITLE
Adding Chartbeat tests for Canonical and AMP MAPs

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -42,6 +42,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         });
       }
     });
+
     describe('AMP Status', () => {
       it('should return a 200 response', () => {
         cy.testResponseCodeAndType(

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -38,7 +38,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
     describe('Chartbeat', () => {
       if (envConfig.chartbeatEnabled) {
         it('should have chartbeat config UID', () => {
-          cy.hasAmpChartbeatConfigUid(0);
+          cy.hasAmpChartbeatConfigUid();
         });
       }
     });

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -34,6 +34,14 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         }
       });
     });
+
+    describe('Chartbeat', () => {
+      if (envConfig.chartbeatEnabled) {
+        it('should have chartbeat config UID', () => {
+          cy.hasAmpChartbeatConfigUid(0);
+        });
+      }
+    });
     describe('AMP Status', () => {
       it('should return a 200 response', () => {
         cy.testResponseCodeAndType(

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -80,6 +80,17 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
         }
       });
     });
+
+    describe('Chartbeat', () => {
+      if (envConfig.chartbeatEnabled) {
+        it('should have a script with src value set to chartbeat source', () => {
+          cy.hasScriptWithChartbeatSrc();
+        });
+        it('should have chartbeat config set to window object', () => {
+          cy.hasGlobalChartbeatConfig();
+        });
+      }
+    });
   });
 
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.

--- a/cypress/support/commands/analytics.js
+++ b/cypress/support/commands/analytics.js
@@ -29,8 +29,9 @@ Cypress.Commands.add('hasGlobalChartbeatConfig', () => {
 });
 
 // Should be moved into integration/pages/index.js once all pages have Chartbeat
-Cypress.Commands.add('hasAmpChartbeatConfigUid', (position = 1) => {
-  cy.get('amp-analytics script[type="application/json"]')
-    .eq(position)
-    .should('contain', '50924');
+Cypress.Commands.add('hasAmpChartbeatConfigUid', () => {
+  cy.get('amp-analytics script[type="application/json"]').should(
+    'contain',
+    '50924',
+  );
 });

--- a/cypress/support/commands/analytics.js
+++ b/cypress/support/commands/analytics.js
@@ -29,8 +29,8 @@ Cypress.Commands.add('hasGlobalChartbeatConfig', () => {
 });
 
 // Should be moved into integration/pages/index.js once all pages have Chartbeat
-Cypress.Commands.add('hasAmpChartbeatConfigUid', () => {
+Cypress.Commands.add('hasAmpChartbeatConfigUid', (position = 1) => {
   cy.get('amp-analytics script[type="application/json"]')
-    .eq(1)
+    .eq(position)
     .should('contain', '50924');
 });


### PR DESCRIPTION
Resolves #5788

**Overall change:** 
Adding tests for Chartbeat on Canonical and AMP MAPs

**Code changes:**
Added tests for Chartbeat

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
