### PR TITLE
feat: add top stories

### DIFF
--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -109,6 +109,7 @@ const StoryPromoContainer = ({
   lazyLoadImage,
   dir,
   displayImage,
+  displaySummary,
 }) => {
   const {
     script,
@@ -164,7 +165,7 @@ const StoryPromoContainer = ({
           </Link>
         </Headline>
       )}
-      {summary && displayImage && (
+      {summary && displaySummary && (
         <Summary
           script={script}
           service={service}
@@ -235,6 +236,7 @@ StoryPromoContainer.propTypes = {
   lazyLoadImage: bool,
   dir: oneOf(['ltr', 'rtl']),
   displayImage: bool,
+  displaySummary: bool,
 };
 
 StoryPromoContainer.defaultProps = {
@@ -242,6 +244,7 @@ StoryPromoContainer.defaultProps = {
   lazyLoadImage: true,
   dir: 'ltr',
   displayImage: true,
+  displaySummary: true,
 };
 
 export default StoryPromoContainer;

--- a/src/app/containers/TopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/TopStories/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CpsRelatedContent should render Top Stories components when given appropriate data 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="top-stories-heading"
+    class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-shj2ec-0 kvTGYD"
+    role="region"
+  >
+    <div
+      class="GridItemConstrainedLarge-sc-12lwanc-4 Wrapper-shj2ec-0 kvTGYD"
+    >
+      <div
+        class="SectionLabelWrapper-sc-1x4gwjz-1 iLMrCu StyledSectionLabel-shj2ec-1 gLFyEX"
+      >
+        <div
+          class="Bar-sc-1x4gwjz-0 jsgdXU"
+        />
+        <h2
+          class="Heading-sc-1x4gwjz-2 eZofTG"
+        >
+          <div
+            class="FlexColumn-wx5kdp-0 dgpsiS"
+          >
+            <span
+              class="FlexRow-wx5kdp-2 dVBNyZ"
+            >
+              <span
+                class="Title-wx5kdp-4 BeqZV"
+                dir="ltr"
+                id="top-stories-heading"
+              >
+                Top Stories
+              </span>
+            </span>
+          </div>
+        </h2>
+      </div>
+      <ul
+        class="StoryPromoUl-sc-171lqjd-1 isCYWc"
+        role="list"
+      >
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          role="listitem"
+        >
+          <div
+            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
+          >
+            <div
+              class="TextGridItem-sc-1lkbq5i-0 gCyGvI"
+              dir="ltr"
+            >
+              <h3
+                class="Headline-sc-1dvfmi3-3 gejHzT"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-5 yQgSu"
+                  href="/mundo/noticias-internacional-51939501"
+                >
+                  China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-4 hTsuvP"
+              >
+                Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="2020-03-18"
+              >
+                18th March 2020
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="StoryPromoLi-sc-171lqjd-0 dqJaJG"
+          role="listitem"
+        >
+          <div
+            class="StoryPromoWrapper-sc-1dvfmi3-0 buBJys"
+          >
+            <div
+              class="TextGridItem-sc-1lkbq5i-0 gCyGvI"
+              dir="ltr"
+            >
+              <h3
+                class="Headline-sc-1dvfmi3-3 gejHzT"
+              >
+                <a
+                  class="Link-sc-1dvfmi3-5 yQgSu"
+                  href="/pidgin/tori-51945757"
+                >
+                  Nigeria don get five new cases of Coronavirus - See how e happun
+                </a>
+              </h3>
+              <p
+                class="Summary-sc-1dvfmi3-4 hTsuvP"
+              >
+                Nigeria Health say di patients from UK and America travel come di kontri.
+              </p>
+              <time
+                class="StyledTimestamp-um718p-0 kVWTyt"
+                datetime="2020-03-18"
+              >
+                58 minutes wey don pass
+              </time>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/src/app/containers/TopStories/index.jsx
+++ b/src/app/containers/TopStories/index.jsx
@@ -1,0 +1,84 @@
+import React, { useContext } from 'react';
+import { arrayOf, shape, node } from 'prop-types';
+import SectionLabel from '@bbc/psammead-section-label';
+import styled from 'styled-components';
+import { StoryPromoLi, StoryPromoUl } from '@bbc/psammead-story-promo-list';
+import { GEL_GROUP_3_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
+import {
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+} from '@bbc/gel-foundations/spacings';
+
+import topStories from '#pages/StoryPage/topStories.json';
+import { storyItem } from '#models/propTypes/storyItem';
+import { ServiceContext } from '#contexts/ServiceContext';
+import { GridItemConstrainedLarge } from '#lib/styledGrid';
+import StoryPromo from '../StoryPromo';
+
+const Wrapper = styled(GridItemConstrainedLarge)`
+  margin-bottom: ${GEL_SPACING_DBL};
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    margin-bottom: ${GEL_SPACING_TRPL};
+  }
+`;
+
+const StyledSectionLabel = styled(SectionLabel)`
+  margin-top: 0;
+`;
+
+// const refineTopStory = topStory => {
+//   return Object.entries(topStory).reduce(
+//     (obj, [key, value]) =>
+//       !['timestamp'].includes(key) ? { ...obj, [key]: value } : obj,
+//     {},
+//   );
+// };
+
+const TopStories = ({ content }) => {
+  const { script, service, dir } = useContext(ServiceContext);
+  const a11yAttributes = {
+    as: 'section',
+    role: 'region',
+    'aria-labelledby': 'top-stories-heading',
+  };
+  const TopStoriesWrapper = ({ children }) => (
+    <Wrapper {...a11yAttributes}>{children}</Wrapper>
+  );
+  TopStoriesWrapper.propTypes = {
+    children: node.isRequired,
+  };
+  if (!topStories.length) return null;
+
+  return (
+    <TopStoriesWrapper>
+      <Wrapper>
+        <StyledSectionLabel
+          script={script}
+          service={service}
+          dir={dir}
+          labelId="top-stories-heading"
+        >
+          Top Stories
+        </StyledSectionLabel>
+
+        <StoryPromoUl>
+          {content.map(item => (
+            <StoryPromoLi key={item.id || item.uri}>
+              <StoryPromo item={item} dir={dir} displayImage={false} />
+            </StoryPromoLi>
+          ))}
+        </StoryPromoUl>
+      </Wrapper>
+    </TopStoriesWrapper>
+  );
+};
+
+TopStories.propTypes = {
+  content: arrayOf(shape(storyItem)),
+};
+
+TopStories.defaultProps = {
+  content: topStories, // @TODO: rm this
+};
+
+export default TopStories;

--- a/src/app/containers/TopStories/index.stories.jsx
+++ b/src/app/containers/TopStories/index.stories.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import TopStories from '.';
+import topStories from '#pages/StoryPage/topStories.json';
+import topStoriesRtl from '#pages/StoryPage/topStoriesRtl.json';
+import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import { RequestContextProvider } from '#contexts/RequestContext';
+
+const getTopStories = platform => ({ service, dir, data }) => (
+  <div dir={dir}>
+    {/* The above simulates dir being added at the page level */}
+    <ServiceContextProvider service={service}>
+      <RequestContextProvider
+        bbcOrigin="https://www.test.bbc.com"
+        isAmp={platform === 'amp'}
+        pageType="STY"
+        pathname="/"
+        service={service}
+      >
+        <TopStories content={data} />
+      </RequestContextProvider>
+    </ServiceContextProvider>
+  </div>
+);
+
+const canonicalTopStories = getTopStories('canonical');
+const ampTopStories = getTopStories('amp');
+
+storiesOf('Containers|Top Stories/Canonical', module)
+  .addParameters({ chromatic: { disable: true } })
+  .add('igbo (ltr)', () =>
+    canonicalTopStories({
+      service: 'igbo',
+      dir: 'ltr',
+      data: topStories,
+    }),
+  )
+  .add('arabic (rtl)', () =>
+    canonicalTopStories({
+      service: 'arabic',
+      dir: 'rtl',
+      data: topStoriesRtl,
+    }),
+  );
+
+storiesOf('Containers|Top Stories/AMP', module)
+  .addParameters({ chromatic: { disable: true } })
+  .addDecorator(AmpDecorator)
+  .add('igbo (ltr) - amp', () =>
+    ampTopStories({
+      service: 'igbo',
+      dir: 'ltr',
+      data: topStories,
+    }),
+  )
+  .add('arabic (rtl) - amp', () =>
+    ampTopStories({
+      service: 'arabic',
+      dir: 'rtl',
+      data: topStoriesRtl,
+    }),
+  );

--- a/src/app/containers/TopStories/index.test.jsx
+++ b/src/app/containers/TopStories/index.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { RequestContextProvider } from '#contexts/RequestContext';
+
+import TopStories from '.';
+import topStories from '#pages/StoryPage/topStories.json';
+
+// eslint-disable-next-line react/prop-types
+const renderTopStories = ({
+  content = topStories,
+  bbcOrigin = 'https://www.test.bbc.co.uk',
+} = {}) => {
+  return render(
+    <ServiceContextProvider service="pidgin">
+      <RequestContextProvider
+        bbcOrigin={bbcOrigin}
+        isAmp={false}
+        pageType="STY"
+        pathname="/pidgin/tori-49450859"
+        service="pidgin"
+        statusCode={200}
+      >
+        <TopStories content={content} enableGridWrapper />
+      </RequestContextProvider>
+    </ServiceContextProvider>,
+  );
+};
+
+describe('CpsRelatedContent', () => {
+  it('should render Top Stories components when given appropriate data', () => {
+    // Ensure fixture still has top stories
+    expect(topStories.length).toBe(2);
+
+    const { asFragment } = renderTopStories();
+
+    expect(document.querySelectorAll(`li[class^='StoryPromoLi']`).length).toBe(
+      topStories.length,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should have a section with a "region" role (a11y) and [aria-labelledby="top-stories-heading"]', () => {
+    renderTopStories();
+    expect(
+      document.querySelectorAll(
+        `section[role='region'][aria-labelledby="top-stories-heading"]`,
+      ).length,
+    ).toBe(1);
+  });
+
+  it('should have an [id] #top-stories-heading', () => {
+    renderTopStories();
+    expect(document.querySelector(`#top-stories-heading`)).toBeTruthy();
+  });
+});

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -154,6 +154,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   transition: visibility 0.2s linear;
 }
 
+.c53 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
 .c28 {
   padding-top: 56.25%;
   position: relative;
@@ -244,6 +254,84 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding: 0;
 }
 
+.c49 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+  width: 100%;
+}
+
+.c49 >div {
+  vertical-align: middle;
+}
+
+.c49 >div {
+  display: inline-block;
+  vertical-align: initial;
+}
+
+.c49 svg {
+  margin: 0;
+}
+
+.c48 {
+  position: relative;
+}
+
+.c50 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  display: inline;
+}
+
+.c52 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.c51 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c51:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c51:hover,
+.c51:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c51:visited {
+  color: #6E6E73;
+}
+
 .c25 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -284,6 +372,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 .c33 {
+  margin-top: 0;
+}
+
+.c46 {
+  margin-bottom: 1rem;
+}
+
+.c47 {
   margin-top: 0;
 }
 
@@ -330,10 +426,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   flex-grow: 1;
 }
 
-.c45 {
+.c54 {
   background: #ECEAE7;
   margin-bottom: 1.5rem;
   padding: 1rem;
+}
+
+.c45 {
+  margin-bottom: 1.5rem;
 }
 
 .c29 {
@@ -570,6 +670,20 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 @media (min-width:63rem) {
   .c20 {
     padding: 0.5rem 0 0;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c53 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c53 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
   }
 }
 
@@ -817,6 +931,80 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
+@media (min-width:37.5rem) {
+  .c49 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c49 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c49 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+    grid-column: 1 / span 6;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c48 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c50 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c50 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c52 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c52 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c52 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:63rem) {
+  .c52 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c25 {
     font-size: 1rem;
@@ -910,6 +1098,42 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
+@media (max-width:63rem) {
+  .c46 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c46 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c46 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c46 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c46 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c46 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 @media (min-width:37.5rem) {
   .c8 {
     font-size: 0.875rem;
@@ -925,6 +1149,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 @media (min-width:63rem) {
   .c44 {
     margin-top: 2rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c45 {
+    padding: 1rem;
   }
 }
 
@@ -1458,26 +1688,134 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                 <div
                   class="c45"
                 >
-                  <h2>
-                    This is a component in the second column
-                  </h2>
+                  <section
+                    aria-labelledby="top-stories-heading"
+                    class="c46"
+                    role="region"
+                  >
+                    <div
+                      class="c46"
+                    >
+                      <div
+                        class="c32 c47"
+                      >
+                        <div
+                          class="c34"
+                        />
+                        <h2
+                          class="c35"
+                        >
+                          <div
+                            class="c36"
+                          >
+                            <span
+                              class="c37"
+                            >
+                              <span
+                                class="c38"
+                                dir="ltr"
+                                id="top-stories-heading"
+                              >
+                                Top Stories
+                              </span>
+                            </span>
+                          </div>
+                        </h2>
+                      </div>
+                      <ul
+                        class="c39"
+                        role="list"
+                      >
+                        <li
+                          class="c41"
+                          role="listitem"
+                        >
+                          <div
+                            class="c48"
+                          >
+                            <div
+                              class="c49"
+                              dir="ltr"
+                            >
+                              <h3
+                                class="c50"
+                              >
+                                <a
+                                  class="c51"
+                                  href="/mundo/noticias-internacional-51939501"
+                                >
+                                  China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
+                                </a>
+                              </h3>
+                              <p
+                                class="c52"
+                              >
+                                Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.
+                              </p>
+                              <time
+                                class="c53"
+                                datetime="2020-03-18"
+                              >
+                                18th March 2020
+                              </time>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="c41"
+                          role="listitem"
+                        >
+                          <div
+                            class="c48"
+                          >
+                            <div
+                              class="c49"
+                              dir="ltr"
+                            >
+                              <h3
+                                class="c50"
+                              >
+                                <a
+                                  class="c51"
+                                  href="/pidgin/tori-51945757"
+                                >
+                                  Nigeria don get five new cases of Coronavirus - See how e happun
+                                </a>
+                              </h3>
+                              <p
+                                class="c52"
+                              >
+                                Nigeria Health say di patients from UK and America travel come di kontri.
+                              </p>
+                              <time
+                                class="c53"
+                                datetime="2020-03-18"
+                              >
+                                one hour wey don pass
+                              </time>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </section>
                 </div>
                 <div
-                  class="c45"
+                  class="c54"
                 >
                   <h2>
                     This is a component in the second column
                   </h2>
                 </div>
                 <div
-                  class="c45"
+                  class="c54"
                 >
                   <h2>
                     This is a component in the second column
                   </h2>
                 </div>
                 <div
-                  class="c45"
+                  class="c54"
                 >
                   <h2>
                     This is a component in the second column
@@ -1661,6 +1999,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding-bottom: 1rem;
 }
 
+.c55 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #6E6E73;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
 .c30 {
   padding-top: 56.25%;
   position: relative;
@@ -1751,6 +2099,84 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding: 0;
 }
 
+.c51 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+  width: 100%;
+}
+
+.c51 >div {
+  vertical-align: middle;
+}
+
+.c51 >div {
+  display: inline-block;
+  vertical-align: initial;
+}
+
+.c51 svg {
+  margin: 0;
+}
+
+.c50 {
+  position: relative;
+}
+
+.c52 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+  display: inline;
+}
+
+.c54 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.c53 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c53:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.c53:hover,
+.c53:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c53:visited {
+  color: #6E6E73;
+}
+
 .c27 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -1791,6 +2217,14 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 .c35 {
+  margin-top: 0;
+}
+
+.c48 {
+  margin-bottom: 1rem;
+}
+
+.c49 {
   margin-top: 0;
 }
 
@@ -1841,10 +2275,14 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   flex-grow: 1;
 }
 
-.c47 {
+.c56 {
   background: #ECEAE7;
   margin-bottom: 1.5rem;
   padding: 1rem;
+}
+
+.c47 {
+  margin-bottom: 1.5rem;
 }
 
 .c31 {
@@ -2098,6 +2536,20 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c55 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c55 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .c0 {
     padding: 0 1rem;
@@ -2342,6 +2794,80 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
+@media (min-width:37.5rem) {
+  .c51 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c51 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c51 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3 / span 4;
+    grid-column: 1 / span 6;
+  }
+}
+
+@supports (grid-template-columns:fit-content(200px)) {
+  .c50 {
+    display: grid;
+    grid-template-columns: repeat(6,1fr);
+    grid-column-gap: 0.5rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c52 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c52 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:20rem) and (max-width:37.4375rem) {
+  .c54 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c54 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width:37.4375rem) {
+  .c54 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width:63rem) {
+  .c54 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c27 {
     font-size: 1rem;
@@ -2435,6 +2961,42 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
+@media (max-width:63rem) {
+  .c48 {
+    grid-column: 1 / span 6;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c48 {
+    grid-column: 3 / span 6;
+  }
+}
+
+@media (min-width:80rem) {
+  .c48 {
+    grid-column: 6 / span 12;
+  }
+}
+
+@media (max-width:25rem) {
+  .c48 {
+    padding: 0 0.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:62.9375rem) {
+  .c48 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c48 {
+    margin-bottom: 1.5rem;
+  }
+}
+
 @media (min-width:37.5rem) {
   .c8 {
     font-size: 0.875rem;
@@ -2456,6 +3018,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 @media (min-width:63rem) {
   .c46 {
     margin-top: 2rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c47 {
+    padding: 1rem;
   }
 }
 
@@ -3211,26 +3779,134 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                     <div
                       class="c47"
                     >
-                      <h2>
-                        This is a component in the second column
-                      </h2>
+                      <section
+                        aria-labelledby="top-stories-heading"
+                        class="c48"
+                        role="region"
+                      >
+                        <div
+                          class="c48"
+                        >
+                          <div
+                            class="c34 c49"
+                          >
+                            <div
+                              class="c36"
+                            />
+                            <h2
+                              class="c37"
+                            >
+                              <div
+                                class="c38"
+                              >
+                                <span
+                                  class="c39"
+                                >
+                                  <span
+                                    class="c40"
+                                    dir="ltr"
+                                    id="top-stories-heading"
+                                  >
+                                    Top Stories
+                                  </span>
+                                </span>
+                              </div>
+                            </h2>
+                          </div>
+                          <ul
+                            class="c41"
+                            role="list"
+                          >
+                            <li
+                              class="c43"
+                              role="listitem"
+                            >
+                              <div
+                                class="c50"
+                              >
+                                <div
+                                  class="c51"
+                                  dir="ltr"
+                                >
+                                  <h3
+                                    class="c52"
+                                  >
+                                    <a
+                                      class="c53"
+                                      href="/mundo/noticias-internacional-51939501"
+                                    >
+                                      China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
+                                    </a>
+                                  </h3>
+                                  <p
+                                    class="c54"
+                                  >
+                                    Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.
+                                  </p>
+                                  <time
+                                    class="c55"
+                                    datetime="2020-03-18"
+                                  >
+                                    18th March 2020
+                                  </time>
+                                </div>
+                              </div>
+                            </li>
+                            <li
+                              class="c43"
+                              role="listitem"
+                            >
+                              <div
+                                class="c50"
+                              >
+                                <div
+                                  class="c51"
+                                  dir="ltr"
+                                >
+                                  <h3
+                                    class="c52"
+                                  >
+                                    <a
+                                      class="c53"
+                                      href="/pidgin/tori-51945757"
+                                    >
+                                      Nigeria don get five new cases of Coronavirus - See how e happun
+                                    </a>
+                                  </h3>
+                                  <p
+                                    class="c54"
+                                  >
+                                    Nigeria Health say di patients from UK and America travel come di kontri.
+                                  </p>
+                                  <time
+                                    class="c55"
+                                    datetime="2020-03-18"
+                                  >
+                                    one hour wey don pass
+                                  </time>
+                                </div>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </section>
                     </div>
                     <div
-                      class="c47"
+                      class="c56"
                     >
                       <h2>
                         This is a component in the second column
                       </h2>
                     </div>
                     <div
-                      class="c47"
+                      class="c56"
                     >
                       <h2>
                         This is a component in the second column
                       </h2>
                     </div>
                     <div
-                      class="c47"
+                      class="c56"
                     >
                       <h2>
                         This is a component in the second column

--- a/src/app/pages/StoryPage/index.jsx
+++ b/src/app/pages/StoryPage/index.jsx
@@ -20,6 +20,7 @@ import image from '#containers/Image';
 import MediaPlayer from '#containers/CpsAssetMediaPlayer';
 import Blocks from '#containers/Blocks';
 import CpsRelatedContent from '#containers/CpsRelatedContent';
+import TopStories from '#containers/TopStories';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import cpsAssetPagePropTypes from '../../models/propTypes/cpsAssetPage';
 import fauxHeadline from '#containers/FauxHeadline';
@@ -105,6 +106,18 @@ const StoryPage = ({ pageData }) => {
     padding: ${GEL_SPACING_DBL};
   `;
 
+  /**
+   * this should be the defacto wrapper for OJs
+   * as it displays a conditional padding, which
+   * works well for mobile view.
+   */
+  const ResponsiveComponentWrapper = styled.div`
+    margin-bottom: ${GEL_SPACING_TRPL};
+    @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+      padding: ${GEL_SPACING_DBL};
+    }
+  `;
+
   const gridColumns = {
     group0: 8,
     group1: 8,
@@ -186,9 +199,9 @@ const StoryPage = ({ pageData }) => {
           <CpsRelatedContent content={relatedContent} />
         </Grid>
         <GridSecondaryColumn item columns={gridColsSecondary}>
-          <ComponentWrapper>
-            <h2>This is a component in the second column</h2>
-          </ComponentWrapper>
+          <ResponsiveComponentWrapper>
+            <TopStories />
+          </ResponsiveComponentWrapper>
           <ComponentWrapper>
             <h2>This is a component in the second column</h2>
           </ComponentWrapper>

--- a/src/app/pages/StoryPage/topStories.json
+++ b/src/app/pages/StoryPage/topStories.json
@@ -1,0 +1,122 @@
+[
+    {
+        "headlines": {
+            "headline": "China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos"
+        },
+        "locators": {
+            "assetUri": "/mundo/noticias-internacional-51939501",
+            "cpsUrn": "urn:bbc:content:assetUri:mundo/noticias-internacional-51939501",
+            "assetId": "51939501"
+        },
+        "summary": "Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.",
+        "timestamp": 1584489449000,
+        "language": "es",
+        "byline": {
+            "name": "Redacción  ",
+            "title": "BBC News Mundo",
+            "persons": [
+                {
+                    "name": "Redacción",
+                    "function": "BBC News Mundo"
+                }
+            ]
+        },
+        "passport": {
+            "category": {
+                "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
+                "categoryName": "News"
+            },
+            "campaigns": [
+                {
+                    "campaignId": "5a988e4739461b000e9dabfc",
+                    "campaignName": "WS - Update me"
+                }
+            ],
+            "taggings": []
+        },
+        "cpsType": "STY",
+        "indexImage": {
+            "id": "111335312",
+            "subType": "index",
+            "href": "http://c.files.bbci.co.uk/5369/production/_111335312_gettyimages-1004465280.jpg",
+            "path": "/cpsprodpb/5369/production/_111335312_gettyimages-1004465280.jpg",
+            "height": 549,
+            "width": 976,
+            "altText": "Una mujer china recibe una vacuna.",
+            "caption": "China es uno de los países que más se ha implicado en la búsqueda tanto de una vacuna como de métodos de detección del nuevo coronavirus.",
+            "copyrightHolder": "Getty Images"
+        },
+        "options": {
+            "isBreakingNews": false,
+            "isFactCheck": false
+        },
+        "prominence": "standard",
+        "relatedItems": [
+            {
+                "headlines": {
+                    "headline": "Estados Unidos comienza a probar en humanos la primera vacuna contra el coronavirus"
+                },
+                "locators": {
+                    "assetUri": "/mundo/noticias-51921073",
+                    "cpsUrn": "urn:bbc:content:assetUri:/mundo/noticias-51921073"
+                },
+                "summary": "Un total de 45 voluntarios sanos participarán en un ensayo clínico financiado por el gobierno federal.",
+                "timestamp": 1584402419000,
+                "language": "es",
+                "cpsType": "STY",
+                "id": "urn:bbc:ares::asset:mundo/noticias-51921073",
+                "type": "cps"
+            }
+        ],
+        "id": "urn:bbc:ares::asset:mundo/noticias-internacional-51939501",
+        "type": "cps"
+    },
+    {
+        "headlines": {
+            "headline": "Nigeria don get five new cases of Coronavirus - See how e happun"
+        },
+        "locators": {
+            "assetUri": "/pidgin/tori-51945757",
+            "cpsUrn": "urn:bbc:content:assetUri:pidgin/tori-51945757",
+            "assetId": "51945757"
+        },
+        "summary": "Nigeria Health say di patients from UK and America travel come di kontri.",
+        "timestamp": 1584531167000,
+        "language": "pcm",
+        "passport": {
+            "category": {
+                "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
+                "categoryName": "News"
+            },
+            "campaigns": [
+                {
+                    "campaignId": "5a988e2939461b000e9dabf8",
+                    "campaignName": "WS - Educate me"
+                },
+                {
+                    "campaignId": "5a988e3e39461b000e9dabfb",
+                    "campaignName": "WS - Keep me on trend"
+                }
+            ],
+            "taggings": []
+        },
+        "cpsType": "STY",
+        "indexImage": {
+            "id": "111336814",
+            "subType": "index",
+            "href": "http://c.files.bbci.co.uk/A387/production/_111336814_39ac4483-c830-4858-85fb-ad8e2608afb4.jpg",
+            "path": "/cpsprodpb/A387/production/_111336814_39ac4483-c830-4858-85fb-ad8e2608afb4.jpg",
+            "height": 549,
+            "width": 976,
+            "altText": "NCDC Oga and Nigeria Health Minister",
+            "copyrightHolder": "BBC"
+        },
+        "options": {
+            "isBreakingNews": false,
+            "isFactCheck": false
+        },
+        "prominence": "standard",
+        "id": "urn:bbc:ares::asset:pidgin/tori-51945757",
+        "type": "cps"
+    }
+]

--- a/src/app/pages/StoryPage/topStoriesRtl.json
+++ b/src/app/pages/StoryPage/topStoriesRtl.json
@@ -1,0 +1,103 @@
+[
+    {
+      "headlines": {
+        "shortHeadline": "\"اعتدل في جلستك يا رجل\"",
+        "headline": "\"اعتدل في جلستك يا رجل\""
+      },
+      "locators": {
+        "assetUri": "/arabic/media-49580542",
+        "cpsUrn": "urn:bbc:content:assetUri:arabic/media-49580542",
+        "curie": "http://www.bbc.co.uk/asset/16dcfb1b-f237-104a-b885-69e758171253"
+      },
+      "summary": "زعيم مجلس العموم والعضو البارز في حزب المحافظين جاكوب ريس موغ يستلقي خلال جلسة بالبرلمان البريطاني أثناء كلمات لنواب معارضين لقرار رئيس الوزراء تعليق البرلمان.",
+      "timestamp": 1580745507000,
+      "passport": {
+        "category": {
+          "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
+          "categoryName": "News"
+        },
+        "campaigns": [
+          {
+            "campaignId": "5a988e3e39461b000e9dabfb",
+            "campaignName": "WS - Keep me on trend"
+          }
+        ]
+      },
+      "media": {
+        "id": "p07mf8wy",
+        "subType": "clip",
+        "format": "video",
+        "title": "\"اعتدل في جلستك يا رجل\"",
+        "synopses": {
+          "short": "\"اعتدل في جلستك يا رجل\"",
+          "long": "استلقى زعيم مجلس العموم والعضو البارز في حزب المحافظين جاكوب ريس موغ خلال جلسة بالبرلمان البريطاني أثناء كلمات لنواب معارضين لقرار رئيس الوزراء تعليق البرلمان.\n \nصوت النواب البريطانيون بواقع 328 صوتا مقابل 301 لصالح فرض سيطرتهم على جدول أعمال مجلس العموم، وهو ما يتيح لهم سن قانون بتأجيل تاريخ خروج بريطانيا من الاتحاد الأوروبي (بريكست). ورد رئيس الوزراء، بوريس جونسون، بأنه سيدعو لإجراء انتخابات عامة مبكرة إذا أقر النواب مقترح التأجيل.",
+          "medium": "زعيم مجلس العموم والعضو البارز في حزب المحافظين جاكوب ريس موغ يستلقي خلال جلسة بالبرلمان البريطاني أثناء كلمات لنواب معارضين لقرار رئيس الوزراء تعليق البرلمان."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07mfb6b.jpg",
+        "embedding": true,
+        "advertising": true,
+        "caption": "\"اعتدل في جلستك يا رجل\"",
+        "versions": [
+          {
+            "versionId": "p07mf8x2",
+            "types": [
+              "Original"
+            ],
+            "duration": 36,
+            "durationISO8601": "PT36S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true
+            },
+            "availableFrom": 1567610367
+          }
+        ],
+        "type": "media"
+      },
+      "indexImage": {
+        "id": "108611199",
+        "subType": "index",
+        "href": "http://c.files.bbci.co.uk/18327/production/_108611199_p07mfb6b.jpg",
+        "path": "/cpsprodpb/18327/production/_108611199_p07mfb6b.jpg",
+        "height": 549,
+        "width": 976,
+        "altText": "\"اعتدل في جلستك يا رجل\"",
+        "caption": "\"اعتدل في جلستك يا رجل\"",
+        "copyrightHolder": "BBC",
+        "type": "image"
+      },
+      "id": "urn:bbc:ares::asset:arabic/media-49580542",
+      "type": "cps"
+    },
+    {
+      "headlines": {
+        "shortHeadline": "بالصور: كيرك دوغلاس يحتفل بعيد ميلاده المئة",
+        "headline": "بالصور: كيرك دوغلاس يحتفل بعيد ميلاده المئة"
+      },
+      "locators": {
+        "assetUri": "/arabic/art-and-culture-38260491",
+        "cpsUrn": "urn:bbc:content:assetUri:arabic/art-and-culture-38260491",
+        "curie": "http://www.bbc.co.uk/asset/bc8c6f47-cc26-1a49-8bd8-fc679131aa17"
+      },
+      "summary": "مجموعة منتقاة من الصور لنجم هوليود كيرك دوغلاس بمناسبة مرور مئة عام عام على مولده",
+      "timestamp": 1580745507000,
+      "passport": {
+        "taggings": []
+      },
+      "indexImage": {
+        "id": "92909541",
+        "subType": "index",
+        "href": "http://c.files.bbci.co.uk/38FE/production/_92909541_77.jpg",
+        "path": "/cpsprodpb/38FE/production/_92909541_77.jpg",
+        "height": 371,
+        "width": 660,
+        "altText": "كيرك دوغلاس",
+        "caption": "كيرك دوغلاس وأولاده",
+        "copyrightHolder": "Getty Images",
+        "type": "image"
+      },
+      "id": "urn:bbc:ares::asset:arabic/art-and-culture-38260491",
+      "type": "cps"
+    }
+  ] 


### PR DESCRIPTION
Resolves #5700

**Overall change:** 
- _Add TopStories container to Secondary Column._
- _Add fixture data for populating its content_

**Code changes:**
- _A `displaySummary` prop has been added to the StoryPromo Wrapper Component within Simorgh. Prior to this, the summary was only shown when a summary exists, and `displayImage` is `true`. Now, with the prop, it's explicit. This change is needed because the Top Stories contain no images, and yet, we need to show the summary._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
