### PR TITLE
Use 'timeOnServer' instead of client time for Radio Schedules

### DIFF
--- a/src/app/containers/RadioSchedule/Canonical/index.jsx
+++ b/src/app/containers/RadioSchedule/Canonical/index.jsx
@@ -18,6 +18,7 @@ import RadioSchedule from '@bbc/psammead-radio-schedule';
 import SectionLabel from '@bbc/psammead-section-label';
 import { Link } from '@bbc/psammead-story-promo';
 import { ServiceContext } from '#contexts/ServiceContext';
+import { RequestContext } from '#contexts/RequestContext';
 import processRadioSchedule from '../utilities/processRadioSchedule';
 import webLogger from '#lib/logger.web';
 
@@ -65,6 +66,8 @@ const CanonicalRadioSchedule = ({ endpoint }) => {
   const { service, script, dir, timezone, locale, radioSchedule } = useContext(
     ServiceContext,
   );
+  const { timeOnServer } = useContext(RequestContext);
+
   const header = pathOr(null, ['header'], radioSchedule);
   const frequenciesPageUrl = pathOr(
     null,
@@ -81,7 +84,11 @@ const CanonicalRadioSchedule = ({ endpoint }) => {
     const handleResponse = async response => {
       const radioScheduleData = await response.json();
 
-      const schedules = processRadioSchedule(radioScheduleData, service);
+      const schedules = processRadioSchedule(
+        radioScheduleData,
+        service,
+        timeOnServer,
+      );
       setRadioSchedule(schedules);
     };
 

--- a/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
+++ b/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import findLastIndex from 'ramda/src/findLastIndex';
 import propSatisfies from 'ramda/src/propSatisfies';
 import pathOr from 'ramda/src/pathOr';
@@ -22,13 +21,11 @@ const getLink = (state, program, service) => {
     : `${url}/${program.broadcast.pid}`;
 };
 
-export default (radioScheduleData, service) => {
-  const currentTime = parseInt(moment.utc().format('x'), 10);
-
+export default (radioScheduleData, service, currentServerTime) => {
   // finding latest program, that may or may not still be live. this is because there isn't
   // always a live program, in which case we show the most recently played program on demand.
   const latestProgramIndex = findLastIndex(
-    propSatisfies(time => time < currentTime, 'publishedTimeStart'),
+    propSatisfies(time => time < currentServerTime, 'publishedTimeStart'),
   )(radioScheduleData.schedules);
 
   const radioSchedules = radioScheduleData.schedules;
@@ -47,7 +44,7 @@ export default (radioScheduleData, service) => {
     schedulesToShow &&
     schedulesToShow.map(program => {
       const currentState = getProgramState(
-        currentTime,
+        currentServerTime,
         program.publishedTimeStart,
         program.publishedTimeEnd,
         service,

--- a/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
+++ b/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
@@ -21,11 +21,11 @@ const getLink = (state, program, service) => {
     : `${url}/${program.broadcast.pid}`;
 };
 
-export default (radioScheduleData, service, currentServerTime) => {
+export default (radioScheduleData, service, currentTime) => {
   // finding latest program, that may or may not still be live. this is because there isn't
   // always a live program, in which case we show the most recently played program on demand.
   const latestProgramIndex = findLastIndex(
-    propSatisfies(time => time < currentServerTime, 'publishedTimeStart'),
+    propSatisfies(time => time < currentTime, 'publishedTimeStart'),
   )(radioScheduleData.schedules);
 
   const radioSchedules = radioScheduleData.schedules;
@@ -44,7 +44,7 @@ export default (radioScheduleData, service, currentServerTime) => {
     schedulesToShow &&
     schedulesToShow.map(program => {
       const currentState = getProgramState(
-        currentServerTime,
+        currentTime,
         program.publishedTimeStart,
         program.publishedTimeEnd,
         service,

--- a/src/app/containers/RadioSchedule/utilities/testHelpers.jsx
+++ b/src/app/containers/RadioSchedule/utilities/testHelpers.jsx
@@ -22,6 +22,7 @@ const RadioSchedulesWithContext = ({
       pageType="frontPage"
       service={service}
       pathname={`/${service}`}
+      timeOnServer={Date.now()}
     >
       <ServiceContextProvider service={service}>
         <RadioScheduleContainer />


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5606

**More Context: This is an investigation to see if the server time will suffice to determine radio programs as there is a chance that the client device time might be wrong**

**Overall change:** 
_Use the server time to determine radio schedule programs._

**Code changes:**
- _Destructured `timeOnServer` from the `RequestContext`._
- _Passed that into `processRadioSchedule`._
- _Updated tests._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [x] This PR requires manual testing
