### PR TITLE
 Disable Pidgin MAP smoke tests in Test / Live environments

### DIFF
--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -2909,7 +2909,7 @@ const genServices = {
             enabled: true,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         environments: {

--- a/cypress/support/config/services.js
+++ b/cypress/support/config/services.js
@@ -2898,11 +2898,11 @@ const genServices = {
         environments: {
           live: {
             paths: ['/pidgin/tori-50974590'], // CPS MAP with video clip
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/pidgin/23248703'], // CPS MAP with video clip
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/pidgin/23248703'], // CPS MAP with video clip


### PR DESCRIPTION
**Overall change:** 
E2Es and deployments to test and live are blocked by the Pidgin smoke test for MAPs. It is best to disable them all until we can determine the root cause, and fix later if required.

**Code changes:**
- Set `enabled: false` for Pidgin MAPs in test and live environments
- Set `smoke: false` for Pidgin MAP page type

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
