### PR TITLE
Bump psammead-radio-schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3442,6 +3442,11 @@
         "@bbc/psammead-styles": "^4.3.0"
       }
     },
+    "@bbc/psammead-live-label": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-live-label/-/psammead-live-label-1.0.0.tgz",
+      "integrity": "sha512-OXc5rSOVm1vDbtberaHUYMorwI92zeaT4hhe9iR3SEN5M6PGsGhwCrrGyBmoj8VStzqTbv0bvE5YvZcsJS4kjA=="
+    },
     "@bbc/psammead-locales": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@bbc/psammead-locales/-/psammead-locales-4.1.4.tgz",
@@ -3512,14 +3517,15 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "0.1.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-0.1.0-alpha.20.tgz",
-      "integrity": "sha512-NvHQupbPP+UEcdOFDRcAgOYN3oqA/9E6MvXAQGUMna+thQI62SWXyoSxfu10szCcERbrygm3G1busDOBAWRR+Q==",
+      "version": "0.1.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-0.1.0-alpha.25.tgz",
+      "integrity": "sha512-ovd0ovGiSMs3xYJKcLKBQwL2G5CDv7PxTEk6iJjYD4huHLfREIQogycjDn+SXiXhBpSg+tsu9zjTWWNcNsmCGA==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.13.0",
+        "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.3.0",
-        "@bbc/psammead-timestamp-container": "^2.7.7"
+        "@bbc/psammead-timestamp-container": "^2.7.9"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@bbc/psammead-most-read": "^2.0.3",
     "@bbc/psammead-navigation": "^6.0.6",
     "@bbc/psammead-paragraph": "^2.2.26",
-    "@bbc/psammead-radio-schedule": "0.1.0-alpha.20",
+    "@bbc/psammead-radio-schedule": "0.1.0-alpha.25",
     "@bbc/psammead-rich-text-transforms": "^2.0.0",
     "@bbc/psammead-script-link": "^1.0.11",
     "@bbc/psammead-section-label": "^5.0.2",

--- a/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Canonical RadioSchedule contains four programs for a service with a radio schedule 1`] = `<div />`;
+
 exports[`Canonical RadioSchedule renders correctly for a service with a radio schedule and page frequency URL 1`] = `
 .c15 {
   vertical-align: middle;


### PR DESCRIPTION
Resolves #5964 

**Overall change:** 
_Bump psammead-radio-schedule to version `0.1.0-alpha.25`._

**Code changes:**
- _Update `package.json` and `package-lock.json`_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
