### PR TITLE
Remove the 'should play media' MAP / Live Radio tests as they are unstable and causing test failures

### DIFF
--- a/cypress/integration/pages/liveRadio/helper.js
+++ b/cypress/integration/pages/liveRadio/helper.js
@@ -1,20 +1,18 @@
 import envConfig from '../../../support/config/envs';
 
 // the externalId `bbc_oromo_radio` is overriden to `bbc_afaanoromoo` in production code
-const getMappedServiceId = externalId =>
+const getBrandId = externalId =>
   externalId === 'bbc_oromo_radio' ? 'bbc_afaanoromoo_radio' : externalId;
 
-export const getEmbedUrl = (body, language) => {
-  const { id, externalId } = body.content.blocks[2];
-  const mediaId = getMappedServiceId(externalId);
+export default (body, language) => {
+  const { externalId } = body.content.blocks[2];
+  const brandId = getBrandId(externalId);
 
   return [
     envConfig.avEmbedBaseUrl,
     'ws/av-embeds/media',
-    mediaId,
-    id,
+    brandId,
+    'liveradio',
     language,
   ].join('/');
 };
-
-export default getEmbedUrl;

--- a/cypress/integration/pages/liveRadio/helper.js
+++ b/cypress/integration/pages/liveRadio/helper.js
@@ -1,5 +1,20 @@
+import envConfig from '../../../support/config/envs';
+
 // the externalId `bbc_oromo_radio` is overriden to `bbc_afaanoromoo` in production code
 const getMappedServiceId = externalId =>
   externalId === 'bbc_oromo_radio' ? 'bbc_afaanoromoo_radio' : externalId;
 
-export default getMappedServiceId;
+export const getEmbedUrl = (body, language) => {
+  const { id, externalId } = body.content.blocks[2];
+  const mediaId = getMappedServiceId(externalId);
+
+  return [
+    envConfig.avEmbedBaseUrl,
+    'ws/av-embeds/media',
+    mediaId,
+    id,
+    language,
+  ].join('/');
+};
+
+export default getEmbedUrl;

--- a/cypress/integration/pages/liveRadio/testsForAMPOnly.js
+++ b/cypress/integration/pages/liveRadio/testsForAMPOnly.js
@@ -1,6 +1,6 @@
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import envConfig from '../../../support/config/envs';
-import { getEmbedUrl } from './helper';
+import getEmbedUrl from './helper';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.

--- a/cypress/integration/pages/liveRadio/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/liveRadio/testsForCanonicalOnly.js
@@ -1,6 +1,6 @@
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import envConfig from '../../../support/config/envs';
-import { getEmbedUrl } from './helper';
+import getEmbedUrl from './helper';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.

--- a/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForAMPOnly.js
@@ -16,12 +16,22 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   variant,
 }) =>
   describe(`testsThatFollowSmokeTestConfigForAMPOnly for ${service} ${pageType}`, () => {
-    it('should render a media player', () => {
-      cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-        const language = appConfig[config[service].name][variant].lang;
-        const embedUrl = getEmbedUrl(body, language);
+    describe('Media Player', () => {
+      const language = appConfig[config[service].name][variant].lang;
+      let embedUrl;
 
+      beforeEach(() => {
+        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
+          embedUrl = getEmbedUrl(body, language);
+        });
+      });
+
+      it('should be rendered', () => {
         cy.get(`amp-iframe[src*="${embedUrl}"]`).should('be.visible');
+      });
+
+      it('embed URL should be reachable', () => {
+        cy.testResponseCodeAndType(embedUrl, 200, 'text/html');
       });
     });
 

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -1,7 +1,7 @@
 import config from '../../../support/config/services';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import envConfig from '../../../support/config/envs';
-import { hasMedia, getEmbedUrl } from './helpers';
+import { getEmbedUrl } from './helpers';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -16,47 +16,22 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
   variant,
 }) =>
   describe(`testsThatFollowSmokeTestConfigForCanonicalOnly for ${service} ${pageType}`, () => {
-    it('should render a media player', () => {
-      cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-        const language = appConfig[config[service].name][variant].lang;
-        const embedUrl = getEmbedUrl(body, language);
+    describe('Media Player', () => {
+      const language = appConfig[config[service].name][variant].lang;
+      let embedUrl;
 
+      beforeEach(() => {
+        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
+          embedUrl = getEmbedUrl(body, language);
+        });
+      });
+
+      it('should be rendered', () => {
         cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
       });
-    });
 
-    it('should play media', () => {
-      cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-        const canPlayMedia = hasMedia(body);
-
-        if (!canPlayMedia) throw new Error('No media detected');
-
-        // Ensure media player is ready
-        cy.get(
-          'div[class^="StyledVideoContainer"] iframe[class^="StyledIframe"]',
-        ).then($iframe => {
-          cy.wrap($iframe.prop('contentWindow'), {
-            timeout: 30000,
-          })
-            .its('embeddedMedia.playerInstances.mediaPlayer.ready')
-            .should('eq', true);
-        });
-
-        const playButton = 'button.p_cta';
-
-        cy.get('iframe').then(iframe => {
-          cy.wrap(iframe.contents().find('iframe'))
-            .should(inner => expect(inner.contents().find(playButton)).to.exist)
-            .then(inner => cy.wrap(inner.contents().find(playButton)).click())
-            .then(() => {
-              cy.wrap(iframe.prop('contentWindow'), {
-                timeout: 45000,
-              })
-                .its('embeddedMedia.playerInstances.mediaPlayer')
-                .invoke('currentTime')
-                .should('be.gt', 0);
-            });
-        });
+      it('embed URL should be reachable', () => {
+        cy.testResponseCodeAndType(embedUrl, 200, 'text/html');
       });
     });
 


### PR DESCRIPTION
**Overall change:** 
- Remove the 'should play media' tests which click the play button on Live Radio / MAP pages
- Instead, check that the embedURL of the media player iframe on Live Radio / MAP pages is reachable (i.e returns a 200 status)

**Code changes:**
- Adding a helper to get the embedUrl of the LiveRadio media player

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
