### PR TITLE
Now showing multimedia as chapter type for ATI legacy MAPS

### DIFF
--- a/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/cpsAssetPage/buildParams.js
@@ -25,7 +25,7 @@ export const buildCpsAssetPageATIParams = (
 
   const getChapter1 = pageIdentifier => {
     const chapter = pageIdentifier.split('.')[1];
-    if (['media_asset', 'multimedia'].includes(chapter)) {
+    if (['media_asset'].includes(chapter)) {
       return null;
     }
     return chapter;


### PR DESCRIPTION
Resolves #5927

**Overall change:** 
Legacy MAPs should show 'multimedia' in ATI Analytics if 'multimedia' is the chapter value
**Code changes:**
Removed 'multimedia' from the excluded list for ATI Analytics chapter name

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**
- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [ ] This PR requires manual testing
