### PR TITLE
Remove Snyk badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/bbc/simorgh.svg?branch=latest)](https://travis-ci.org/bbc/simorgh)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cbca275e184057982f27/test_coverage)](https://codeclimate.com/github/bbc/simorgh/test_coverage)
-[![Known Vulnerabilities](https://snyk.io/test/github/bbc/simorgh/badge.svg)](https://snyk.io/test/github/bbc/simorgh)
 [![dependencies Status](https://david-dm.org/bbc/simorgh/status.svg)](https://david-dm.org/bbc/simorgh)
 [![devDependencies Status](https://david-dm.org/bbc/simorgh/dev-status.svg)](https://david-dm.org/bbc/simorgh?type=dev)
 [![Maintainability](https://api.codeclimate.com/v1/badges/cbca275e184057982f27/maintainability)](https://codeclimate.com/github/bbc/simorgh/maintainability)


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh-infrastructure/issues/814

**Overall change:** 
Remove link to Snyk badge from `README.md`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [no] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [Na] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`) 
- [no] This PR requires manual testing
