### PR TITLE
Update russian live label

### DIFF
--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -168,7 +168,7 @@ export const service = {
         },
         listen: 'Слушать',
         watch: 'Смотреть',
-        liveLabel: 'Прямой эфир',
+        liveLabel: 'LIVE',
         nextLabel: 'Дальше',
         previousRadioShow: 'Предыдущая передача',
         nextRadioShow: 'Следующая передача',


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Updates a Russian translation

**Code changes:**

- Changes the Russian LIVE label to say LIVE

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
