### PR TITLE
Move Social Embed translations into the correct block

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.js
+++ b/src/app/lib/config/services/afaanoromoo.js
@@ -155,6 +155,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            "Qabiyyeewwan maddawwan alaa irraa ta'aniif BBCn itti gaafatamaa miti.",
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -206,23 +223,6 @@ export const service = {
       ],
       copyrightText:
         "BBC. Qabiyyeewwan maddawwan alaa irraa ta'aniif BBCn itti gaafatamaa miti.",
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            "Qabiyyeewwan maddawwan alaa irraa ta'aniif BBCn itti gaafatamaa miti.",
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     navigation: [

--- a/src/app/lib/config/services/afrique.js
+++ b/src/app/lib/config/services/afrique.js
@@ -168,6 +168,24 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Légende vidéo, ',
+          text:
+            'Attention: le contenu externe peut contenir des messages publicitaires',
+        },
+        fallback: {
+          text: "Ce contenu n'est pas disponible",
+          linkText: 'Voir plus sur %provider_name%',
+          linkTextSuffixVisuallyHidden: ', lien externe',
+          warningText:
+            "La BBC n'est pas responsable du contenu des sites externes.",
+        },
+        skipLink: {
+          text: 'Ignorer %provider_name% publication',
+          endTextVisuallyHidden: 'Fin de %provider_name% publication',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -223,24 +241,6 @@ export const service = {
       ],
       copyrightText:
         "BBC. La BBC n'est pas responsable du contenu des sites externes.",
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Légende vidéo, ',
-          text:
-            'Attention: le contenu externe peut contenir des messages publicitaires',
-        },
-        fallback: {
-          text: "Ce contenu n'est pas disponible",
-          linkText: 'Voir plus sur %provider_name%',
-          linkTextSuffixVisuallyHidden: ', lien externe',
-          warningText:
-            "La BBC n'est pas responsable du contenu des sites externes.",
-        },
-        skipLink: {
-          text: 'Ignorer %provider_name% publication',
-          endTextVisuallyHidden: 'Fin de %provider_name% publication',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/amharic.js
+++ b/src/app/lib/config/services/amharic.js
@@ -151,6 +151,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText: 'ቢቢሲ ከሌሎች ድረ-ገጾች ለሚመጡ መረጃዎች ሀላፊነት አይወስድም.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -201,22 +217,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. ቢቢሲ ከሌሎች ድረ-ገጾች ለሚመጡ መረጃዎች ሀላፊነት አይወስድም.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText: 'ቢቢሲ ከሌሎች ድረ-ገጾች ለሚመጡ መረጃዎች ሀላፊነት አይወስድም.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_NOTO_SANS_ETHIOPIC_BOLD, F_NOTO_SANS_ETHIOPIC_REGULAR],
     navigation: [

--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -164,6 +164,22 @@ export const service = {
         nextRadioShow: 'البرنامج الإذاعي اللاحق',
         duration: 'المدة',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'التعليق على الفيديو، ',
+          text: 'تحذير: المحتوى من طرف ثالث قد يتضمن إعلانات',
+        },
+        fallback: {
+          text: 'المحتوى غير متاح',
+          linkText: '%provider_name% اطلع على المزيد في',
+          linkTextSuffixVisuallyHidden: '، خارجي',
+          warningText: 'بي بي سي ليست مسؤولة عن محتوى المواقع الخارجية.',
+        },
+        skipLink: {
+          text: 'أهمل %provider_name% مشاركة',
+          endTextVisuallyHidden: 'نهاية %provider_name% مشاركة',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -219,22 +235,6 @@ export const service = {
       ],
       copyrightText:
         'بي بي سي. بي بي سي ليست مسؤولة عن محتوى المواقع الخارجية.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'التعليق على الفيديو، ',
-          text: 'تحذير: المحتوى من طرف ثالث قد يتضمن إعلانات',
-        },
-        fallback: {
-          text: 'المحتوى غير متاح',
-          linkText: '%provider_name% اطلع على المزيد في',
-          linkTextSuffixVisuallyHidden: '، خارجي',
-          warningText: 'بي بي سي ليست مسؤولة عن محتوى المواقع الخارجية.',
-        },
-        skipLink: {
-          text: 'أهمل %provider_name% مشاركة',
-          endTextVisuallyHidden: 'نهاية %provider_name% مشاركة',
-        },
-      },
     },
     fonts: [F_NASSIM_ARABIC_REGULAR, F_NASSIM_ARABIC_BOLD],
     timezone: 'GMT',

--- a/src/app/lib/config/services/azeri.js
+++ b/src/app/lib/config/services/azeri.js
@@ -153,6 +153,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Videonun alt yazısı, ',
+          text: 'Xəbərdarlıq : Üçüncü tərəfin məzmununda reklam ola bilər',
+        },
+        fallback: {
+          text: 'Məzmun mövcud deyil',
+          linkText: 'Daha çoxu üçün %provider_name%',
+          linkTextSuffixVisuallyHidden: ', BBC-dən kənar',
+          warningText: 'BBC kənar saytların məzmununa məsul deyil.',
+        },
+        skipLink: {
+          text: 'Paylaşımını ötürün %provider_name%',
+          endTextVisuallyHidden: 'Paylaşımın sonu %provider_name%',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -203,22 +219,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. BBC kənar saytların məzmununa məsul deyil.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Videonun alt yazısı, ',
-          text: 'Xəbərdarlıq : Üçüncü tərəfin məzmununda reklam ola bilər',
-        },
-        fallback: {
-          text: 'Məzmun mövcud deyil',
-          linkText: 'Daha çoxu üçün %provider_name%',
-          linkTextSuffixVisuallyHidden: ', BBC-dən kənar',
-          warningText: 'BBC kənar saytların məzmununa məsul deyil.',
-        },
-        skipLink: {
-          text: 'Paylaşımını ötürün %provider_name%',
-          endTextVisuallyHidden: 'Paylaşımın sonu %provider_name%',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/baku',

--- a/src/app/lib/config/services/bengali.js
+++ b/src/app/lib/config/services/bengali.js
@@ -163,6 +163,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'ভিডিওর ক্যাপশান: ',
+          text: 'সতর্কবাণী: তৃতীয়পক্ষের কন্টেন্টে বিজ্ঞাপন থাকতে পারে',
+        },
+        fallback: {
+          text: 'ছবির কপিরাইট',
+          linkText: '%provider_name% -এ আরো দেখুন',
+          linkTextSuffixVisuallyHidden: ', বিবিসির বাইরের খবর',
+          warningText:
+            'বিবিসি। বাইরের কোন সাইটের তথ্যের জন্য বিবিসি দায়বদ্ধ নয়।',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -214,23 +231,6 @@ export const service = {
       ],
       copyrightText:
         'বিবিসি। বাইরের কোন সাইটের তথ্যের জন্য বিবিসি দায়বদ্ধ নয়।',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'ভিডিওর ক্যাপশান: ',
-          text: 'সতর্কবাণী: তৃতীয়পক্ষের কন্টেন্টে বিজ্ঞাপন থাকতে পারে',
-        },
-        fallback: {
-          text: 'ছবির কপিরাইট',
-          linkText: '%provider_name% -এ আরো দেখুন',
-          linkTextSuffixVisuallyHidden: ', বিবিসির বাইরের খবর',
-          warningText:
-            'বিবিসি। বাইরের কোন সাইটের তথ্যের জন্য বিবিসি দায়বদ্ধ নয়।',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_SHONAR_BANGLA_BOLD, F_SHONAR_BANGLA_REGULAR],
     timezone: 'Asia/Dhaka',

--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -166,6 +166,24 @@ export const service = {
         nextRadioShow: 'နောက် ရေဒီယိုအစီအစဉ်',
         duration: 'ကြာမြင့်ချိန်',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'ဗီဒီယို ပုံစာ - ',
+          text:
+            'သတိပေးချက်- ဘီဘီစီပြင်ပ ဝက်ဆိုက်များမှ ဖော်ပြချက်များတွင် ကြော်ငြာများပါနိုင်ပါသည်။',
+        },
+        fallback: {
+          text: 'ကြည့်ရန် မရနိုင်သေးပါ။',
+          linkText: '%provider_name% တွင် နောက်ထပ်ကြည့်နိုင်ပါသည်။',
+          linkTextSuffixVisuallyHidden: ' ပြင်ပစာမျက်နှာ',
+          warningText:
+            'ပြင်ပဝက်ဆိုက်များတွင် ပါဝင်သော အကြောင်းအရာများအတွက် ဘီဘီစီက တာဝန်မယူပါ။',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -214,24 +232,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. ပြင်ပဝက်ဆိုက်များတွင် ပါဝင်သော အကြောင်းအရာများအတွက် ဘီဘီစီက တာဝန်မယူပါ။',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'ဗီဒီယို ပုံစာ - ',
-          text:
-            'သတိပေးချက်- ဘီဘီစီပြင်ပ ဝက်ဆိုက်များမှ ဖော်ပြချက်များတွင် ကြော်ငြာများပါနိုင်ပါသည်။',
-        },
-        fallback: {
-          text: 'ကြည့်ရန် မရနိုင်သေးပါ။',
-          linkText: '%provider_name% တွင် နောက်ထပ်ကြည့်နိုင်ပါသည်။',
-          linkTextSuffixVisuallyHidden: ' ပြင်ပစာမျက်နှာ',
-          warningText:
-            'ပြင်ပဝက်ဆိုက်များတွင် ပါဝင်သော အကြောင်းအရာများအတွက် ဘီဘီစီက တာဝန်မယူပါ။',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_PADAUK_BOLD, F_PADAUK_REGULAR],
     timezone: 'GMT',

--- a/src/app/lib/config/services/gahuza.js
+++ b/src/app/lib/config/services/gahuza.js
@@ -158,6 +158,22 @@ export const service = {
         nextRadioShow: 'Ikiganiro ca radiyo gikurikira',
         duration: 'Umwanya bimara',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Insiguro ya video, ',
+          text: "Uragaba: Ibitangwa n'izindi mbuga bishobora kubamwo gutangaza",
+        },
+        fallback: {
+          text: 'Ibi ntibiboneka',
+          linkText: 'Raba ibindi kuri %provider_name%',
+          linkTextSuffixVisuallyHidden: ', bivuye ahandi',
+          warningText: 'BBC ntibazwa ibivuye ku zindi mbuga.',
+        },
+        skipLink: {
+          text: 'Tambuka %provider_name% ubutumwa',
+          endTextVisuallyHidden: 'Impera ya %provider_name% ubutumwa',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -208,22 +224,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. BBC ntibazwa ibivuye ku zindi mbuga.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Insiguro ya video, ',
-          text: "Uragaba: Ibitangwa n'izindi mbuga bishobora kubamwo gutangaza",
-        },
-        fallback: {
-          text: 'Ibi ntibiboneka',
-          linkText: 'Raba ibindi kuri %provider_name%',
-          linkTextSuffixVisuallyHidden: ', bivuye ahandi',
-          warningText: 'BBC ntibazwa ibivuye ku zindi mbuga.',
-        },
-        skipLink: {
-          text: 'Tambuka %provider_name% ubutumwa',
-          endTextVisuallyHidden: 'Impera ya %provider_name% ubutumwa',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/gujarati.js
+++ b/src/app/lib/config/services/gujarati.js
@@ -159,6 +159,22 @@ export const service = {
         nextRadioShow: 'આગામી રેડિયો શો',
         duration: 'અવધિ',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'વીડિયો કૅપ્શન ',
+          text: 'થર્ડ પાર્ટી કન્ટેટમાં જાહેરખબર હોય શકે છે',
+        },
+        fallback: {
+          text: 'આ કન્ટેન્ટ ઉપલબ્ધ નથી',
+          linkText: '%provider_name% પર વધુ મેળવો',
+          linkTextSuffixVisuallyHidden: ' બહારની સામગ્રી',
+          warningText: 'બહારની વેબસાઇટ્સની સામગ્રી માટે બીબીસી જવાબદાર નથી.',
+        },
+        skipLink: {
+          text: 'બદલો %provider_name% કન્ટેન્ટ',
+          endTextVisuallyHidden: '%provider_name% કન્ટેન્ટ પૂર્ણ',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -208,22 +224,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. બહારની વેબસાઇટ્સની સામગ્રી માટે બીબીસી જવાબદાર નથી.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'વીડિયો કૅપ્શન ',
-          text: 'થર્ડ પાર્ટી કન્ટેટમાં જાહેરખબર હોય શકે છે',
-        },
-        fallback: {
-          text: 'આ કન્ટેન્ટ ઉપલબ્ધ નથી',
-          linkText: '%provider_name% પર વધુ મેળવો',
-          linkTextSuffixVisuallyHidden: ' બહારની સામગ્રી',
-          warningText: 'બહારની વેબસાઇટ્સની સામગ્રી માટે બીબીસી જવાબદાર નથી.',
-        },
-        skipLink: {
-          text: 'બદલો %provider_name% કન્ટેન્ટ',
-          endTextVisuallyHidden: '%provider_name% કન્ટેન્ટ પૂર્ણ',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Kolkata',

--- a/src/app/lib/config/services/hausa.js
+++ b/src/app/lib/config/services/hausa.js
@@ -160,6 +160,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Bayanan bidiyo ',
+          text: 'Gargadi: Ana iya samun talla wanda ba na BBC ba ne',
+        },
+        fallback: {
+          text: 'Babu karin bayanai',
+          linkText: 'Ci gaba da duba %provider_name%',
+          linkTextSuffixVisuallyHidden: ', adireshin waje',
+          warningText:
+            'BBC ba za ta dauki alhakin abubuwan da wasu shafukan daban suka wallafa ba.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -214,23 +231,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC ba za ta dauki alhakin abubuwan da wasu shafukan daban suka wallafa ba. ',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Bayanan bidiyo ',
-          text: 'Gargadi: Ana iya samun talla wanda ba na BBC ba ne',
-        },
-        fallback: {
-          text: 'Babu karin bayanai',
-          linkText: 'Ci gaba da duba %provider_name%',
-          linkTextSuffixVisuallyHidden: ', adireshin waje',
-          warningText:
-            'BBC ba za ta dauki alhakin abubuwan da wasu shafukan daban suka wallafa ba.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/hindi.js
+++ b/src/app/lib/config/services/hindi.js
@@ -165,6 +165,23 @@ export const service = {
         nextRadioShow: 'अगला रेडियो शो',
         duration: 'अवधि',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'वीडियो कैप्शन ',
+          text: 'चेतावनी: तीसरे पक्ष की सामग्री में विज्ञापन हो सकते हैं.',
+        },
+        fallback: {
+          text: 'सामग्री् उपलब्ध नहीं है',
+          linkText: 'सोशल नेटवर्क पर और देखिए',
+          linkTextSuffixVisuallyHidden: ' बाहरी सामग्री',
+          warningText:
+            'बाहरी साइटों की सामग्री के लिए बीबीसी ज़िम्मेदार नहीं है.',
+        },
+        skipLink: {
+          text: 'छोड़िए %provider_name% पोस्ट',
+          endTextVisuallyHidden: 'पोस्ट %provider_name% समाप्त',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -215,23 +232,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. बाहरी साइटों की सामग्री के लिए बीबीसी ज़िम्मेदार नहीं है.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'वीडियो कैप्शन ',
-          text: 'चेतावनी: तीसरे पक्ष की सामग्री में विज्ञापन हो सकते हैं.',
-        },
-        fallback: {
-          text: 'सामग्री् उपलब्ध नहीं है',
-          linkText: 'सोशल नेटवर्क पर और देखिए',
-          linkTextSuffixVisuallyHidden: ' बाहरी सामग्री',
-          warningText:
-            'बाहरी साइटों की सामग्री के लिए बीबीसी ज़िम्मेदार नहीं है.',
-        },
-        skipLink: {
-          text: 'छोड़िए %provider_name% पोस्ट',
-          endTextVisuallyHidden: 'पोस्ट %provider_name% समाप्त',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Kolkata',

--- a/src/app/lib/config/services/igbo.js
+++ b/src/app/lib/config/services/igbo.js
@@ -164,6 +164,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            'BBC anaghị ahụta maka ọdịnaya nke saịtị ndị dị na mpụga.s',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     mostRead: {
       header: 'Akachasị Gụọ',
@@ -231,23 +248,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC anaghị ahụta maka ọdịnaya nke saịtị ndị dị na mpụga.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            'BBC anaghị ahụta maka ọdịnaya nke saịtị ndị dị na mpụga.s',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     timezone: 'Africa/Lagos',
   },

--- a/src/app/lib/config/services/indonesia.js
+++ b/src/app/lib/config/services/indonesia.js
@@ -155,6 +155,23 @@ export const service = {
         nextRadioShow: 'Siaran radio berikutnya',
         duration: 'Durasi',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Keterangan video, ',
+          text: 'Peringatan: Konten pihak ketiga mungkin berisi iklan',
+        },
+        fallback: {
+          text: 'Konten tidak tersedia',
+          linkText: 'Lihat lebih banyak di %provider_name%',
+          linkTextSuffixVisuallyHidden: ', eksternal',
+          warningText:
+            'BBC tidak bertanggung jawab atas konten dari situs eksternal',
+        },
+        skipLink: {
+          text: 'Hentikan %provider_name% pesan',
+          endTextVisuallyHidden: 'Lompati %provider_name% pesan',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -207,23 +224,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC tidak bertanggung jawab atas konten dari situs eksternal.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Keterangan video, ',
-          text: 'Peringatan: Konten pihak ketiga mungkin berisi iklan',
-        },
-        fallback: {
-          text: 'Konten tidak tersedia',
-          linkText: 'Lihat lebih banyak di %provider_name%',
-          linkTextSuffixVisuallyHidden: ', eksternal',
-          warningText:
-            'BBC tidak bertanggung jawab atas konten dari situs eksternal',
-        },
-        skipLink: {
-          text: 'Hentikan %provider_name% pesan',
-          endTextVisuallyHidden: 'Lompati %provider_name% pesan',
-        },
-      },
     },
     fonts: [],
     navigation: [

--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -151,6 +151,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText: 'BBCは外部サイトの内容に責任を負いません。',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -200,22 +216,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. BBCは外部サイトの内容に責任を負いません。',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText: 'BBCは外部サイトの内容に責任を負いません。',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Tokyo',

--- a/src/app/lib/config/services/korean.js
+++ b/src/app/lib/config/services/korean.js
@@ -149,6 +149,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            'BBC는 외부 인터넷 사이트 및 콘텐츠에 대한 책임을 지지않습니다.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -201,23 +218,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC는 외부 인터넷 사이트 및 콘텐츠에 대한 책임을 지지않습니다.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            'BBC는 외부 인터넷 사이트 및 콘텐츠에 대한 책임을 지지않습니다.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     navigation: [

--- a/src/app/lib/config/services/kyrgyz.js
+++ b/src/app/lib/config/services/kyrgyz.js
@@ -163,6 +163,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Видеонун түшүндүрмөсү, ',
+          text: 'Эскертүү: Жарнамалар болушу ыктымал',
+        },
+        fallback: {
+          text: 'Баракча ачылбайт',
+          linkText: '%provider_name% баракчадан көбүрөк пост окуу',
+          linkTextSuffixVisuallyHidden: ', Би-Би-Сиден тышкары баракча',
+          warningText:
+            'Би-Би-Си сырткы интернет сайттардын мазмуну үчүн жооптуу эмес.',
+        },
+        skipLink: {
+          text: '%provider_name% баракчаны өткөрүп жиберүү, пост',
+          endTextVisuallyHidden: '%provider_name% посттун аягы',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -214,23 +231,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. Би-Би-Си сырткы интернет сайттардын мазмуну үчүн жооптуу эмес.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Видеонун түшүндүрмөсү, ',
-          text: 'Эскертүү: Жарнамалар болушу ыктымал',
-        },
-        fallback: {
-          text: 'Баракча ачылбайт',
-          linkText: '%provider_name% баракчадан көбүрөк пост окуу',
-          linkTextSuffixVisuallyHidden: ', Би-Би-Сиден тышкары баракча',
-          warningText:
-            'Би-Би-Си сырткы интернет сайттардын мазмуну үчүн жооптуу эмес.',
-        },
-        skipLink: {
-          text: '%provider_name% баракчаны өткөрүп жиберүү, пост',
-          endTextVisuallyHidden: '%provider_name% посттун аягы',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/marathi.js
+++ b/src/app/lib/config/services/marathi.js
@@ -159,6 +159,23 @@ export const service = {
         nextRadioShow: 'पुढचा रेडिओ शो',
         duration: 'वेळ',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            'बीबीसी बाह्य इंटरनेट साइट्सच्या सामग्रीसाठी बीबीसी जबाबदार नाही. बाह्य लिंक्सबद्दल आम्हाल काय वाटतं? इथे वाचा.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -205,23 +222,6 @@ export const service = {
       ],
       copyrightText:
         'बीबीसी बाह्य इंटरनेट साइट्सच्या सामग्रीसाठी बीबीसी जबाबदार नाही.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            'बीबीसी बाह्य इंटरनेट साइट्सच्या सामग्रीसाठी बीबीसी जबाबदार नाही. बाह्य लिंक्सबद्दल आम्हाल काय वाटतं? इथे वाचा.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Kolkata',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -163,6 +163,24 @@ export const service = {
         nextRadioShow: 'Próximo programa',
         duration: 'Duración',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Título del video: ',
+          text:
+            'Advertencia: El contenido de sitios externos y terceras partes puede contener publicidad',
+        },
+        fallback: {
+          text: 'Contenido no disponible',
+          linkText: 'Ver más en %provider_name%',
+          linkTextSuffixVisuallyHidden: ', externo',
+          warningText:
+            'La BBC no se hace responsable del contenido de sitios externos.',
+        },
+        skipLink: {
+          text: 'Saltar contenido de %provider_name%',
+          endTextVisuallyHidden: 'Fin del contenido de %provider_name%',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -213,24 +231,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. La BBC no se hace responsable del contenido de sitios externos.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Título del video: ',
-          text:
-            'Advertencia: El contenido de sitios externos y terceras partes puede contener publicidad',
-        },
-        fallback: {
-          text: 'Contenido no disponible',
-          linkText: 'Ver más en %provider_name%',
-          linkTextSuffixVisuallyHidden: ', externo',
-          warningText:
-            'La BBC no se hace responsable del contenido de sitios externos.',
-        },
-        skipLink: {
-          text: 'Saltar contenido de %provider_name%',
-          endTextVisuallyHidden: 'Fin del contenido de %provider_name%',
-        },
-      },
     },
     fonts: [
       F_REITH_SANS_BOLD,

--- a/src/app/lib/config/services/nepali.js
+++ b/src/app/lib/config/services/nepali.js
@@ -159,6 +159,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'भिडिओ क्याप्शन सुरु हुँदैछ, ',
+          text: 'चेतावनी: तीसरे पक्ष की सामग्री में विज्ञापन हो सकते हैं.',
+        },
+        fallback: {
+          text: 'सामग्री उपलब्ध नहीं है',
+          linkText: '%provider_name% पर और देखिए',
+          linkTextSuffixVisuallyHidden: ', बाह्य सामग्री',
+          warningText:
+            'बीबीसी। अन्य वेबसाइटका सामग्रीहरूका लागि बीबीसी जिम्मेवार छैन।',
+        },
+        skipLink: {
+          text: 'छोड़िए %provider_name% पोस्ट',
+          endTextVisuallyHidden: 'पोस्ट %provider_name% समाप्त',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -209,23 +226,6 @@ export const service = {
       ],
       copyrightText:
         '२०१९ बीबीसी। अन्य वेबसाइटका सामग्रीहरूका लागि बीबीसी जिम्मेवार छैन।',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'भिडिओ क्याप्शन सुरु हुँदैछ, ',
-          text: 'चेतावनी: तीसरे पक्ष की सामग्री में विज्ञापन हो सकते हैं.',
-        },
-        fallback: {
-          text: 'सामग्री उपलब्ध नहीं है',
-          linkText: '%provider_name% पर और देखिए',
-          linkTextSuffixVisuallyHidden: ', बाह्य सामग्री',
-          warningText:
-            'बीबीसी। अन्य वेबसाइटका सामग्रीहरूका लागि बीबीसी जिम्मेवार छैन।',
-        },
-        skipLink: {
-          text: 'छोड़िए %provider_name% पोस्ट',
-          endTextVisuallyHidden: 'पोस्ट %provider_name% समाप्त',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Kathmandu',

--- a/src/app/lib/config/services/pashto.js
+++ b/src/app/lib/config/services/pashto.js
@@ -166,6 +166,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'د ویډیو تشریح ',
+          text: 'خبرداری:‌ ښايي درېیمګړي ته اړوند منځپانګه کې اعلانونه وي',
+        },
+        fallback: {
+          text: 'منځپانګه نه شته',
+          linkText: 'په %provider_name% کې نور وګورئ',
+          linkTextSuffixVisuallyHidden: ' بهرنی',
+          warningText:
+            ' بي بي سي. بي بي‌ سي‌ د نورو ویبپاڼو د محتوا مسوله نه ده.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -219,23 +236,6 @@ export const service = {
         },
       ],
       copyrightText: 'بي بي سي. بي بي‌ سي‌ د نورو ویبپاڼو د محتوا مسوله نه ده.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'د ویډیو تشریح ',
-          text: 'خبرداری:‌ ښايي درېیمګړي ته اړوند منځپانګه کې اعلانونه وي',
-        },
-        fallback: {
-          text: 'منځپانګه نه شته',
-          linkText: 'په %provider_name% کې نور وګورئ',
-          linkTextSuffixVisuallyHidden: ' بهرنی',
-          warningText:
-            ' بي بي سي. بي بي‌ سي‌ د نورو ویبپاڼو د محتوا مسوله نه ده.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_NASSIM_PASHTO_REGULAR, F_NASSIM_PASHTO_BOLD],
     timezone: 'GMT',

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -176,6 +176,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'توضیح ویدئو، ',
+          text: 'هشدار: محتوای مربوط به طرف ثالث ممکن است شامل آگهی باشد',
+        },
+        fallback: {
+          text: 'محتوا در دسترس نیست',
+          linkText: 'در %provider_name% بیشتر ببینید',
+          linkTextSuffixVisuallyHidden: '، لینک خارجی',
+          warningText: ' بی بی سی. بی بی سی مسئول محتوای سایت های دیگر نیست.',
+        },
+        skipLink: {
+          text: 'بگذر از پست %provider_name%',
+          endTextVisuallyHidden: 'پایان پست %provider_name%',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -227,22 +243,6 @@ export const service = {
         },
       ],
       copyrightText: 'بی بی سی. بی بی سی مسئول محتوای سایت های دیگر نیست.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'توضیح ویدئو، ',
-          text: 'هشدار: محتوای مربوط به طرف ثالث ممکن است شامل آگهی باشد',
-        },
-        fallback: {
-          text: 'محتوا در دسترس نیست',
-          linkText: 'در %provider_name% بیشتر ببینید',
-          linkTextSuffixVisuallyHidden: '، لینک خارجی',
-          warningText: ' بی بی سی. بی بی سی مسئول محتوای سایت های دیگر نیست.',
-        },
-        skipLink: {
-          text: 'بگذر از پست %provider_name%',
-          endTextVisuallyHidden: 'پایان پست %provider_name%',
-        },
-      },
     },
     timezone: 'GMT',
     fonts: [F_NASSIM_PERSIAN_REGULAR, F_NASSIM_PERSIAN_BOLD],

--- a/src/app/lib/config/services/pidgin.js
+++ b/src/app/lib/config/services/pidgin.js
@@ -161,6 +161,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText: 'De external site no concern BBC.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     mostRead: {
       header: 'De one we dem de read well well',
@@ -243,22 +259,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. De external site no concern BBC.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText: 'De external site no concern BBC.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     timezone: 'Africa/Lagos',
   },

--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -166,6 +166,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Legenda do vídeo, ',
+          text: 'Alerta: Conteúdo de terceiros pode conter publicidade',
+        },
+        fallback: {
+          text: 'Conteúdo não disponível',
+          linkText: 'Veja mais em %provider_name%',
+          linkTextSuffixVisuallyHidden: ', externo',
+          warningText:
+            'A BBC não se responsabiliza pelo conteúdo de sites externos.',
+        },
+        skipLink: {
+          text: 'Pule %provider_name% post',
+          endTextVisuallyHidden: 'Final de %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -216,23 +233,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. A BBC não se responsabiliza pelo conteúdo de sites externos.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Legenda do vídeo, ',
-          text: 'Alerta: Conteúdo de terceiros pode conter publicidade',
-        },
-        fallback: {
-          text: 'Conteúdo não disponível',
-          linkText: 'Veja mais em %provider_name%',
-          linkTextSuffixVisuallyHidden: ', externo',
-          warningText:
-            'A BBC não se responsabiliza pelo conteúdo de sites externos.',
-        },
-        skipLink: {
-          text: 'Pule %provider_name% post',
-          endTextVisuallyHidden: 'Final de %provider_name% post',
-        },
-      },
     },
     fonts: [
       F_REITH_SANS_BOLD,

--- a/src/app/lib/config/services/punjabi.js
+++ b/src/app/lib/config/services/punjabi.js
@@ -150,6 +150,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText: 'ਬਾਹਰੀ ਸਾਈਟਾਂ ਦੀ ਸਮਗਰੀ ਲਈ ਬੀਬੀਸੀ ਜ਼ਿੰਮੇਵਾਰ ਨਹੀਂ ਹੈ',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -225,22 +241,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. ਬਾਹਰੀ ਸਾਈਟਾਂ ਦੀ ਸਮਗਰੀ ਲਈ ਬੀਬੀਸੀ ਜ਼ਿੰਮੇਵਾਰ ਨਹੀਂ ਹੈ',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText: 'ਬਾਹਰੀ ਸਾਈਟਾਂ ਦੀ ਸਮਗਰੀ ਲਈ ਬੀਬੀਸੀ ਜ਼ਿੰਮੇਵਾਰ ਨਹੀਂ ਹੈ',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Kolkata',

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -174,6 +174,23 @@ export const service = {
         nextRadioShow: 'Следующая передача',
         duration: 'Продолжительность',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Подпись к видео, ',
+          text: 'Внимание: Контент других сайтов может содержать рекламу.',
+        },
+        fallback: {
+          text: 'Контент недоступен',
+          linkText: 'Смотреть еще в %provider_name%',
+          linkTextSuffixVisuallyHidden: ', внешняя ссылка',
+          warningText:
+            'Би-би-си на несет ответственности за содержание других сайтов.',
+        },
+        skipLink: {
+          text: 'Пропустить контент из %provider_name%',
+          endTextVisuallyHidden: 'Контент из %provider_name% окончен',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -224,23 +241,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. Би-би-си на несет ответственности за содержание других сайтов.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Подпись к видео, ',
-          text: 'Внимание: Контент других сайтов может содержать рекламу.',
-        },
-        fallback: {
-          text: 'Контент недоступен',
-          linkText: 'Смотреть еще в %provider_name%',
-          linkTextSuffixVisuallyHidden: ', внешняя ссылка',
-          warningText:
-            'Би-би-си на несет ответственности за содержание других сайтов.',
-        },
-        skipLink: {
-          text: 'Пропустить контент из %provider_name%',
-          endTextVisuallyHidden: 'Контент из %provider_name% окончен',
-        },
-      },
     },
     fonts: [
       F_REITH_SANS_BOLD,

--- a/src/app/lib/config/services/sinhala.js
+++ b/src/app/lib/config/services/sinhala.js
@@ -164,6 +164,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'වීඩියෝ ශීර්ෂ වැකිය, ',
+          text:
+            'අනතුරු ඇඟවීමයි: බීබීසී නොවන වාර්තාවල වෙළෙඳ දැන්වීම් අඩංගු විය හැකිය',
+        },
+        fallback: {
+          text: 'මෙහි අන්තර්ගතය නැත',
+          linkText: 'වැඩිදුරටත් %provider_name% බලන්න',
+          linkTextSuffixVisuallyHidden: ', බාහිර',
+          warningText: 'බාහිර වෙබ් අඩවිවල අන්තර්ගතයට බීබීසී වගකියනු නොලැබේ.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -209,23 +226,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. බාහිර වෙබ් අඩවිවල අන්තර්ගතයට බීබීසී වගකියනු නොලැබේ.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'වීඩියෝ ශීර්ෂ වැකිය, ',
-          text:
-            'අනතුරු ඇඟවීමයි: බීබීසී නොවන වාර්තාවල වෙළෙඳ දැන්වීම් අඩංගු විය හැකිය',
-        },
-        fallback: {
-          text: 'මෙහි අන්තර්ගතය නැත',
-          linkText: 'වැඩිදුරටත් %provider_name% බලන්න',
-          linkTextSuffixVisuallyHidden: ', බාහිර',
-          warningText: 'බාහිර වෙබ් අඩවිවල අන්තර්ගතයට බීබීසී වගකියනු නොලැබේ.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_ISKOOLA_POTA_BBC_BOLD, F_ISKOOLA_POTA_BBC_REGULAR],
     timezone: 'GMT',

--- a/src/app/lib/config/services/somali.js
+++ b/src/app/lib/config/services/somali.js
@@ -168,6 +168,24 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Qoraalka Muuqaalka ',
+          text:
+            'Digniin: Macluumaadka dad kale waxaa laga yaabaa inay ku jiraan xayaysiin',
+        },
+        fallback: {
+          text: 'Macluumaadkan lama heli karo',
+          linkText: 'Faahfaahin ka eeg %provider_name%',
+          linkTextSuffixVisuallyHidden: ', bogag kale',
+          warningText:
+            'BBC masuul kama ahan macluumadka bogagga kale ee dibadda.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -220,24 +238,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC masuul kama ahan macluumadka bogagga kale ee dibadda.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Qoraalka Muuqaalka ',
-          text:
-            'Digniin: Macluumaadka dad kale waxaa laga yaabaa inay ku jiraan xayaysiin',
-        },
-        fallback: {
-          text: 'Macluumaadkan lama heli karo',
-          linkText: 'Faahfaahin ka eeg %provider_name%',
-          linkTextSuffixVisuallyHidden: ', bogag kale',
-          warningText:
-            'BBC masuul kama ahan macluumadka bogagga kale ee dibadda.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Africa/Mogadishu',

--- a/src/app/lib/config/services/swahili.js
+++ b/src/app/lib/config/services/swahili.js
@@ -163,6 +163,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Maelezo ya video, ',
+          text: 'Onyo: Imetoka kwingine na inaweza kuwa na matangazo',
+        },
+        fallback: {
+          text: 'Haipatikani tena',
+          linkText: 'Tazama zaidi katika %provider_name%',
+          linkTextSuffixVisuallyHidden: ', ya nje',
+          warningText: 'BBC haihusiki na taarifa za kutoka mitandao ya nje.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -215,22 +231,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. BBC haihusiki na taarifa za kutoka mitandao ya nje.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Maelezo ya video, ',
-          text: 'Onyo: Imetoka kwingine na inaweza kuwa na matangazo',
-        },
-        fallback: {
-          text: 'Haipatikani tena',
-          linkText: 'Tazama zaidi katika %provider_name%',
-          linkTextSuffixVisuallyHidden: ', ya nje',
-          warningText: 'BBC haihusiki na taarifa za kutoka mitandao ya nje.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Africa/Nairobi',

--- a/src/app/lib/config/services/tamil.js
+++ b/src/app/lib/config/services/tamil.js
@@ -166,6 +166,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'காணொளிக் குறிப்பு ',
+          text: 'எச்சரிக்கை: வெளியார் தகவல்களில் விளம்பரங்கள் இருக்கலாம்',
+        },
+        fallback: {
+          text: 'தகவல் இல்லை',
+          linkText: 'மேலதிக விவரங்களைக் காண %provider_name%',
+          linkTextSuffixVisuallyHidden: ', வெளி இணைப்பு',
+          warningText:
+            'வெளியார் இணைய தளங்களின் உள்ளடக்கத்துக்கு பிபிசி பொறுப்பாகாது.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -217,23 +234,6 @@ export const service = {
       ],
       copyrightText:
         'பிபிசி. வெளியார் இணைய தளங்களின் உள்ளடக்கத்துக்கு பிபிசி பொறுப்பாகாது.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'காணொளிக் குறிப்பு ',
-          text: 'எச்சரிக்கை: வெளியார் தகவல்களில் விளம்பரங்கள் இருக்கலாம்',
-        },
-        fallback: {
-          text: 'தகவல் இல்லை',
-          linkText: 'மேலதிக விவரங்களைக் காண %provider_name%',
-          linkTextSuffixVisuallyHidden: ', வெளி இணைப்பு',
-          warningText:
-            'வெளியார் இணைய தளங்களின் உள்ளடக்கத்துக்கு பிபிசி பொறுப்பாகாது.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_LATHA_BOLD, F_LATHA_REGULAR],
     timezone: 'GMT',

--- a/src/app/lib/config/services/telugu.js
+++ b/src/app/lib/config/services/telugu.js
@@ -160,6 +160,22 @@ export const service = {
         nextRadioShow: 'తర్వాత రేడియో షో',
         duration: 'వ్యవధి',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText: 'ఇతర వెబ్‌సైట్లలో సమాచారానికి బీబీసీ బాధ్యత వహించదు.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -210,22 +226,6 @@ export const service = {
       ],
       copyrightText:
         ' BBC. ఇతర వెబ్‌సైట్లలో సమాచారానికి బీబీసీ బాధ్యత వహించదు.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText: 'ఇతర వెబ్‌సైట్లలో సమాచారానికి బీబీసీ బాధ్యత వహించదు.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_MALLANNA_REGULAR],
     timezone: 'Asia/Kolkata',

--- a/src/app/lib/config/services/thai.js
+++ b/src/app/lib/config/services/thai.js
@@ -155,6 +155,23 @@ export const service = {
         nextRadioShow: 'รายการวิทยุถัดไป',
         duration: 'ความยาว',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'คำบรรยายวิดีโอ ',
+          text: 'คำเตือน:เนื้อหาภายนอกอาจมีโฆษณา',
+        },
+        fallback: {
+          text: 'ไม่มีเนื้อหานี้',
+          linkText: 'ดูเพิ่มเติมที่ %provider_name%',
+          linkTextSuffixVisuallyHidden: ' ลิงก์จากภายนอก',
+          warningText:
+            'บีบีซี. บีบีซีไม่มีส่วนรับผิดชอบต่อเนื้อหาของเว็บไซต์ภายนอก. นโยบายของเราเรื่องการเชื่อมต่อไปยังลิงก์ภายนอก.',
+        },
+        skipLink: {
+          text: 'ข้าม %provider_name% โพสต์ ',
+          endTextVisuallyHidden: 'สิ้นสุด %provider_name% โพสต์',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -235,23 +252,6 @@ export const service = {
       ],
       copyrightText:
         'บีบีซี. บีบีซีไม่มีส่วนรับผิดชอบต่อเนื้อหาของเว็บไซต์ภายนอก.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'คำบรรยายวิดีโอ ',
-          text: 'คำเตือน:เนื้อหาภายนอกอาจมีโฆษณา',
-        },
-        fallback: {
-          text: 'ไม่มีเนื้อหานี้',
-          linkText: 'ดูเพิ่มเติมที่ %provider_name%',
-          linkTextSuffixVisuallyHidden: ' ลิงก์จากภายนอก',
-          warningText:
-            'บีบีซี. บีบีซีไม่มีส่วนรับผิดชอบต่อเนื้อหาของเว็บไซต์ภายนอก. นโยบายของเราเรื่องการเชื่อมต่อไปยังลิงก์ภายนอก.',
-        },
-        skipLink: {
-          text: 'ข้าม %provider_name% โพสต์ ',
-          endTextVisuallyHidden: 'สิ้นสุด %provider_name% โพสต์',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Bangkok',

--- a/src/app/lib/config/services/tigrinya.js
+++ b/src/app/lib/config/services/tigrinya.js
@@ -151,6 +151,23 @@ export const service = {
         nextRadioShow: 'ዝቕጽል ፈነወ ራድዮ',
         duration: 'ዕምሪ ፈነወ',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            'BBC는 외부 인터넷 사이트 및 콘텐츠에 대한 책임을 지지않습니다.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -201,23 +218,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. ቢቢሲ፡ ንትሕዝቶ ካልኦት መርበባት ሓበሬታ ሓላፍነት ኣይወስድን።',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            'BBC는 외부 인터넷 사이트 및 콘텐츠에 대한 책임을 지지않습니다.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_NOTO_SANS_ETHIOPIC_BOLD, F_NOTO_SANS_ETHIOPIC_REGULAR],
     navigation: [

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -162,6 +162,24 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video altyazısı: ',
+          text:
+            'Uyarı: Üçüncü tarafların sağladığı içerikte reklam bulunabilir.',
+        },
+        fallback: {
+          text: 'İçerik bulunamadı',
+          linkText: 'Daha fazlası için %provider_name%',
+          linkTextSuffixVisuallyHidden: ' Dış Link',
+          warningText:
+            'BBC, link verilen internet sitelerinin içeriğinden sorumlu değildir.',
+        },
+        skipLink: {
+          text: '%provider_name% paylaşımını geçin',
+          endTextVisuallyHidden: '%provider_name% paylaşımının sonu',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -208,24 +226,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC, link verilen internet sitelerinin içeriğinden sorumlu değildir.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video altyazısı: ',
-          text:
-            'Uyarı: Üçüncü tarafların sağladığı içerikte reklam bulunabilir.',
-        },
-        fallback: {
-          text: 'İçerik bulunamadı',
-          linkText: 'Daha fazlası için %provider_name%',
-          linkTextSuffixVisuallyHidden: ' Dış Link',
-          warningText:
-            'BBC, link verilen internet sitelerinin içeriğinden sorumlu değildir.',
-        },
-        skipLink: {
-          text: '%provider_name% paylaşımını geçin',
-          endTextVisuallyHidden: '%provider_name% paylaşımının sonu',
-        },
-      },
     },
     fonts: [
       F_REITH_SANS_BOLD,

--- a/src/app/lib/config/services/ukrainian.js
+++ b/src/app/lib/config/services/ukrainian.js
@@ -162,6 +162,22 @@ export const service = {
         nextRadioShow: 'Наступна радіопрограма',
         duration: 'Тривалість',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Підпис до відео, ',
+          text: 'Увага: інші сайти можуть містити рекламу',
+        },
+        fallback: {
+          text: 'Контент недоступний',
+          linkText: 'Дивіться більше у %provider_name%',
+          linkTextSuffixVisuallyHidden: ', зовнішнє посилання',
+          warningText: 'ВВС не несе відповідальності за контент інших сайтів.',
+        },
+        skipLink: {
+          text: 'Пропустити %provider_name% допис',
+          endTextVisuallyHidden: 'Кінець %provider_name% допису',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -208,22 +224,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. ВВС не несе відповідальності за контент інших сайтів.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Підпис до відео, ',
-          text: 'Увага: інші сайти можуть містити рекламу',
-        },
-        fallback: {
-          text: 'Контент недоступний',
-          linkText: 'Дивіться більше у %provider_name%',
-          linkTextSuffixVisuallyHidden: ', зовнішнє посилання',
-          warningText: 'ВВС не несе відповідальності за контент інших сайтів.',
-        },
-        skipLink: {
-          text: 'Пропустити %provider_name% допис',
-          endTextVisuallyHidden: 'Кінець %provider_name% допису',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/urdu.js
+++ b/src/app/lib/config/services/urdu.js
@@ -155,6 +155,23 @@ export const service = {
         nextRadioShow: 'اگلا ریڈیو پروگرام',
         duration: 'دورانیہ',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'ویڈیو کیپشن, ',
+          text: 'تنبیہ: دیگر مواد میں اشتہار موجود ہو سکتے ہیں',
+        },
+        fallback: {
+          text: 'مواد دستیاب نہیں ہے',
+          linkText: '%provider_name% مزید دیکھنے کے لیے',
+          linkTextSuffixVisuallyHidden: ', بیرونی مواد',
+          warningText:
+            ' بی بی سی. بی بی سی بیرونی سائٹس پر شائع شدہ مواد کی ذمہ دار نہیں ہے.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -207,23 +224,6 @@ export const service = {
       ],
       copyrightText:
         'بی بی سی. بی بی سی بیرونی ویب سائٹس کے مواد کا ذمہ دار نہیں',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'ویڈیو کیپشن, ',
-          text: 'تنبیہ: دیگر مواد میں اشتہار موجود ہو سکتے ہیں',
-        },
-        fallback: {
-          text: 'مواد دستیاب نہیں ہے',
-          linkText: '%provider_name% مزید دیکھنے کے لیے',
-          linkTextSuffixVisuallyHidden: ', بیرونی مواد',
-          warningText:
-            ' بی بی سی. بی بی سی بیرونی سائٹس پر شائع شدہ مواد کی ذمہ دار نہیں ہے.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [F_NASSIM_URDU_REGULAR, F_NASSIM_URDU_BOLD],
     timezone: 'Asia/Karachi',

--- a/src/app/lib/config/services/uzbek.js
+++ b/src/app/lib/config/services/uzbek.js
@@ -163,6 +163,22 @@ export const service = {
         nextRadioShow: 'Кейинги радио дастур',
         duration: 'Давомийлиги',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Видео тагсўзи, ',
+          text: 'Огоҳлантириш:Учинчи манба материалида реклама бўлиши мумкин',
+        },
+        fallback: {
+          text: 'Бу материалга кириш имконсиз',
+          linkText: 'Кўпроқ кўринг %provider_name%',
+          linkTextSuffixVisuallyHidden: ', ташқи',
+          warningText: 'Би-би-си ташқи сайтлар мазмуни учун масъул эмас.',
+        },
+        skipLink: {
+          text: 'Ўтказиб юборинг %provider_name% пост ',
+          endTextVisuallyHidden: 'Охири %provider_name% пост',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -209,22 +225,6 @@ export const service = {
         },
       ],
       copyrightText: 'BBC. Би-би-си ташқи сайтлар мазмуни учун масъул эмас.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Видео тагсўзи, ',
-          text: 'Огоҳлантириш:Учинчи манба материалида реклама бўлиши мумкин',
-        },
-        fallback: {
-          text: 'Бу материалга кириш имконсиз',
-          linkText: 'Кўпроқ кўринг %provider_name%',
-          linkTextSuffixVisuallyHidden: ', ташқи',
-          warningText: 'Би-би-си ташқи сайтлар мазмуни учун масъул эмас.',
-        },
-        skipLink: {
-          text: 'Ўтказиб юборинг %provider_name% пост ',
-          endTextVisuallyHidden: 'Охири %provider_name% пост',
-        },
-      },
     },
     fonts: [],
     timezone: 'GMT',

--- a/src/app/lib/config/services/vietnamese.js
+++ b/src/app/lib/config/services/vietnamese.js
@@ -152,6 +152,22 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Chụp lại video, ',
+          text: 'Cảnh báo: Nội dung bên thứ ba có thể có quảng cáo',
+        },
+        fallback: {
+          text: 'Nội dung không có',
+          linkText: 'Xem thêm ở %provider_name%',
+          linkTextSuffixVisuallyHidden: ', bên ngoài',
+          warningText: 'BBC không chịu trách nhiệm nội dung các trang ngoài.',
+        },
+        skipLink: {
+          text: 'Bỏ qua %provider_name% tin',
+          endTextVisuallyHidden: 'Cuối %provider_name% tin',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -203,22 +219,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC không chịu trách nhiệm nội dung các trang ngoài.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Chụp lại video, ',
-          text: 'Cảnh báo: Nội dung bên thứ ba có thể có quảng cáo',
-        },
-        fallback: {
-          text: 'Nội dung không có',
-          linkText: 'Xem thêm ở %provider_name%',
-          linkTextSuffixVisuallyHidden: ', bên ngoài',
-          warningText: 'BBC không chịu trách nhiệm nội dung các trang ngoài.',
-        },
-        skipLink: {
-          text: 'Bỏ qua %provider_name% tin',
-          endTextVisuallyHidden: 'Cuối %provider_name% tin',
-        },
-      },
     },
     fonts: [],
     timezone: 'Asia/Ho_Chi_Minh',

--- a/src/app/lib/config/services/yoruba.js
+++ b/src/app/lib/config/services/yoruba.js
@@ -160,6 +160,23 @@ export const service = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Video caption, ',
+          text: 'Warning: Third party content may contain adverts',
+        },
+        fallback: {
+          text: 'Content is not available',
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          warningText:
+            'BBC kò mọ̀ nípa àwọn ohun tí ó wà ní àwọn ojú òpó tí ó wà ní ìta.',
+        },
+        skipLink: {
+          text: 'Skip %provider_name% post',
+          endTextVisuallyHidden: 'End of %provider_name% post',
+        },
+      },
     },
     brandSVG,
     mostRead: {
@@ -210,23 +227,6 @@ export const service = {
       ],
       copyrightText:
         'BBC. BBC kò mọ̀ nípa àwọn ohun tí ó wà ní àwọn ojú òpó tí ó wà ní ìta.',
-      socialEmbed: {
-        caption: {
-          textPrefixVisuallyHidden: 'Video caption, ',
-          text: 'Warning: Third party content may contain adverts',
-        },
-        fallback: {
-          text: 'Content is not available',
-          linkText: 'View content on %provider_name%',
-          linkTextSuffixVisuallyHidden: ', external',
-          warningText:
-            'BBC kò mọ̀ nípa àwọn ohun tí ó wà ní àwọn ojú òpó tí ó wà ní ìta.',
-        },
-        skipLink: {
-          text: 'Skip %provider_name% post',
-          endTextVisuallyHidden: 'End of %provider_name% post',
-        },
-      },
     },
     fonts: [],
     timezone: 'Africa/Lagos',


### PR DESCRIPTION
No issue.

### Overall change:
This change moves all translations relating to Social Embeds into the correct block - `translations`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- ~~[ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~~
- ~~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- ~~[ ] This PR requires manual testing~~
