### PR TITLE
Fix related content tests on MAP pages

### DIFF
--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -76,17 +76,16 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
       cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
         const numRelatedContentGroups = body.relatedContent.groups.length;
 
-        if (numRelatedContentGroups <= 0) {
-          return cy.log('Test skipped because no related content');
-        }
-        const assetURI =
-          body.relatedContent.groups[0].promos[0].locators.assetUri;
+        if (numRelatedContentGroups > 0) {
+          const assetURI =
+            body.relatedContent.groups[0].promos[0].locators.assetUri;
 
-        cy.get('div[class^="StoryPromoWrapper"]')
-          .find('h3')
-          .within(() => {
-            cy.get('a').should('have.attr', 'href').and('include', assetURI);
-          });
+          cy.get('div[class^="StoryPromoWrapper"]')
+            .find('h3')
+            .within(() => {
+              cy.get('a').should('have.attr', 'href').and('include', assetURI);
+            });
+        }
       });
     });
   });

--- a/cypress/integration/pages/mediaAssetPage/tests.js
+++ b/cypress/integration/pages/mediaAssetPage/tests.js
@@ -76,24 +76,17 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
       cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
         const numRelatedContentGroups = body.relatedContent.groups.length;
 
-        const requestPath = Cypress.env('currentPath');
-        const isLegacyAsset = requestPath.split('/').length > 5;
-        if (isLegacyAsset) {
-          return cy.log('Test skipped because legacy MAP');
-        }
-
         if (numRelatedContentGroups <= 0) {
           return cy.log('Test skipped because no related content');
         }
         const assetURI =
           body.relatedContent.groups[0].promos[0].locators.assetUri;
 
-        cy.get('li[class^="StoryPromoLi"] > div[class^="StoryPromoWrapper"]')
+        cy.get('div[class^="StoryPromoWrapper"]')
           .find('h3')
           .within(() => {
             cy.get('a').should('have.attr', 'href').and('include', assetURI);
           });
-        return cy.log('Not legacy MAP, has related content');
       });
     });
   });


### PR DESCRIPTION
**Overall change:**
Related Content Live E2E tests were failing due to changes to the Related Content component - if there is only a single related content item, there is no need to wrap it in a list

**Code changes:**
- Update the selector for finding the related content
- Remove the legacy MAP check, as this test also works on legacy media

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
