### PR TITLE
E2E URLs in local and test for Afrique, Portuguese/Brasil, Mundo and Japanese

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -211,12 +211,18 @@ module.exports = () => ({
             enabled: false,
           },
           test: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/afrique/region-23278969', // CPS MAP
+              '/afrique/nos_emissions/2016/06/160622_tc2_testmap1', // TC2 MAP
+            ],
+            enabled: true,
           },
           local: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/afrique/region-23278969', // CPS MAP
+              '/afrique/nos_emissions/2016/06/160622_tc2_testmap1', // TC2 MAP
+            ],
+            enabled: true,
           },
         },
         smoke: false,
@@ -1784,8 +1790,10 @@ module.exports = () => ({
             enabled: false,
           },
           test: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/japanese/video-23248670', // CPS MAP with video clip
+            ],
+            enabled: true,
           },
           local: {
             paths: ['/japanese/video-23248670'], // CPS MAP with video clip
@@ -2277,12 +2285,18 @@ module.exports = () => ({
             enabled: false,
           },
           test: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/mundo/media-23283126', // CPS MAP
+              '/mundo/noticias/2016/04/160427_tc2_testmap1', // TC2 MAP
+            ],
+            enabled: true,
           },
           local: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/mundo/media-23283126', // CPS MAP
+              '/mundo/noticias/2016/04/160427_tc2_testmap1', // TC2 MAP
+            ],
+            enabled: true,
           },
         },
         smoke: false,
@@ -3012,12 +3026,18 @@ module.exports = () => ({
             enabled: false,
           },
           test: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/portuguese/media-23282671', // CPS MAP
+              '/portuguese/revista/2016/05/160506_tc2_map_0605', // TC2 MAP
+            ],
+            enabled: true,
           },
           local: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/portuguese/media-23282671', // CPS MAP
+              '/portuguese/revista/2016/05/160506_tc2_map_0605', // TC2 MAP
+            ],
+            enabled: true,
           },
         },
         smoke: false,

--- a/data/afrique/cpsAssets/region-23278969.json
+++ b/data/afrique/cpsAssets/region-23278969.json
@@ -1,0 +1,222 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "They may be tiny, but us humans could learn a thing or two from ants.",
+        "embedding": true,
+        "format": "video",
+        "id": "p01k6msm",
+        "imageCopyright": "BBC",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "They may be tiny, but us humans could learn a thing or two from ants."
+        },
+        "title": "Five things ants can teach us about management",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1540218932000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 191,
+            "durationISO8601": "PT3M11S",
+            "types": ["Original"],
+            "versionId": "p01k6msp",
+            "warnings": {
+              "long": "Contains strong language and adult humour.",
+              "short": "Contains strong language and adult humour."
+            }
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "African French is the generic name of the varieties of a French language spoken by an estimated 430 million people in Africa spread across 29 francophone countries.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Africa is thus the continent with the most French speakers in the world. In each of the francophone African countries, French is spoken with local variations in pronunciation and vocabulary. ",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "There are many different varieties of African French, but they can be broadly grouped into four categories:",
+        "type": "paragraph"
+      },
+      {
+        "items": [
+          {
+            "markupType": "candy_xml",
+            "text": "<link><caption>the French spoken by people in West and Central Africa - spoken altogether by about 75 million people, as either a first or second language.</caption><altText>wikipedia</altText><url href=\"https://en.wikipedia.org/wiki/African_French\" platform=\"highweb\"/></link>",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "items": [
+          {
+            "markupType": "candy_xml",
+            "text": "<bold><italic> the French variety spoken by Maghrebis and Berbers in Northwest Africa (see Maghreb French), which has about 36 million first and second language speakers.</italic></bold>",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "items": [
+          {
+            "markupType": "candy_xml",
+            "text": "<bold>the French variety spoken in Djibouti in the Horn of Africa.</bold>",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "items": [
+          {
+            "markupType": "candy_xml",
+            "text": "<italic>the French variety spoken by Creoles in the Indian Ocean (Réunion, Mauritius and Seychelles), which has around 1.6 million first and second language speakers. The French spoken in this region is not to be confused with the French-based creole languages, which are also spoken in the area.</italic>",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "TEST test 123 !\"£$%%^&*()<>?/",
+        "type": "heading"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Afrique test page",
+        "type": "paragraph"
+      },
+      {
+        "altText": "map",
+        "caption": "map test caption {}:@~<>?[]-=+_",
+        "copyrightHolder": "Wikipedia",
+        "height": 549,
+        "href": "http://b.files.bbci.co.uk/61C9/test/_63733052_300px-francophone_africa.png",
+        "id": "63733052",
+        "path": "/cpsdevpb/61C9/test/_63733052_300px-francophone_africa.png",
+        "positionHint": "full-width",
+        "subType": "body",
+        "type": "image",
+        "width": 976
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "afrique.africa.media_asset.23278969.page",
+      "cps_asset_id": "23278969",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph", "list", "heading", "image"],
+    "createdBy": "afrique-v6",
+    "firstPublished": 1585037532000,
+    "id": "urn:bbc:ares::asset:afrique/region-23278969",
+    "includeComments": false,
+    "language": "fr",
+    "lastPublished": 1585037535000,
+    "lastUpdated": 1585037549603,
+    "locators": {
+      "assetId": "23278969",
+      "assetUri": "/afrique/region-23278969",
+      "cpsUrn": "urn:bbc:content:assetUri:afrique/region-23278969",
+      "curie": "http://www.bbc.co.uk/asset/3ffb6bb9-a7fd-0747-8695-d219c4a67389"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1585037532000,
+    "type": "MAP",
+    "version": "v1.1.8"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Afrique test video clip - They may be tiny, but us humans could learn a thing or two from ants.",
+      "shortHeadline": "Afrique test video clip - Five things ants can teach us about management"
+    },
+    "id": "urn:bbc:ares::asset:afrique/region-23278969",
+    "language": "fr",
+    "locators": {
+      "assetId": "23278969",
+      "assetUri": "/afrique/region-23278969",
+      "cpsUrn": "urn:bbc:content:assetUri:afrique/region-23278969",
+      "curie": "http://www.bbc.co.uk/asset/3ffb6bb9-a7fd-0747-8695-d219c4a67389"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "They may be tiny, but us humans could learn a thing or two from ants.",
+      "embedding": true,
+      "format": "video",
+      "id": "p01k6msm",
+      "imageCopyright": "BBC",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01k6mtv.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "They may be tiny, but us humans could learn a thing or two from ants."
+      },
+      "title": "Five things ants can teach us about management",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1540218932000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 191,
+          "durationISO8601": "PT3M11S",
+          "types": ["Original"],
+          "versionId": "p01k6msp",
+          "warnings": {
+            "long": "Contains strong language and adult humour.",
+            "short": "Contains strong language and adult humour."
+          }
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "afrique ants",
+    "timestamp": 1585037532000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Afrique",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/afrique/region"
+    },
+    "site": {
+      "name": "Afrique",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/afrique"
+    }
+  }
+}

--- a/data/afrique/legacyAssets/nos_emissions/2016/06/160622_tc2_testmap1.json
+++ b/data/afrique/legacyAssets/nos_emissions/2016/06/160622_tc2_testmap1.json
@@ -1,0 +1,158 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/afrique/meta/dps/junk/2016/06/emp/160622_tc2_testmap1.emp.xml",
+        "id": "17697658",
+        "image": {
+          "altText": "",
+          "copyrightHolder": "",
+          "height": 360,
+          "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/02/26/150226142623_netball_640x360_bbc.jpg",
+          "id": "17697658",
+          "path": "/amz/worldservice/test/assets/images/2015/02/26/150226142623_netball_640x360_bbc.jpg",
+          "subType": "thumbnail",
+          "type": "image",
+          "width": 640
+        },
+        "live": false,
+        "playlist": [
+          {
+            "bitrate": "168000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_lo.mp4"
+          },
+          {
+            "bitrate": "320000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_med.mp4"
+          },
+          {
+            "bitrate": "904000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_hi.mp4"
+          }
+        ],
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Le camerounais Richard Bona sort dans les prochains jours son nouvel album &quot;Héritage&quot;. C'est un opus qui retrace la riche tradition de l'Afrique et des Caraïbes, notamment Cuba. Ata Ahli Ahebla a rencontré le chanteur.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17697658", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "afrique",
+    "firstPublished": 1466612374000,
+    "id": "urn:bbc:ares::asset:afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+    "includeComments": false,
+    "language": "fr",
+    "lastPublished": 1466612374000,
+    "lastUpdated": 1585904544832,
+    "locators": {
+      "assetId": "17697658",
+      "assetUri": "/afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/e9916696-3894-11e6-abd9-7341006d6ea2"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1466612374000,
+    "type": "MAP",
+    "version": "v1.1.10"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "\"Héritage\", le nouvel album de Richard Bona",
+      "shortHeadline": "\"Héritage\", le nouvel album de Richard Bona"
+    },
+    "id": "urn:bbc:ares::asset:afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "Getty",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "id": "d5e219",
+      "path": "/amz/worldservice/test/assets/images/2014/11/27/141127145732_scotland_tax_144x81_getty.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "fr",
+    "locators": {
+      "assetId": "17697658",
+      "assetUri": "/afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:afrique/nos_emissions/2016/06/160622_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/e9916696-3894-11e6-abd9-7341006d6ea2"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/afrique/meta/dps/junk/2016/06/emp/160622_tc2_testmap1.emp.xml",
+      "id": "17697658",
+      "image": {
+        "altText": "",
+        "copyrightHolder": "",
+        "height": 360,
+        "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/02/26/150226142623_netball_640x360_bbc.jpg",
+        "id": "17697658",
+        "path": "/amz/worldservice/test/assets/images/2015/02/26/150226142623_netball_640x360_bbc.jpg",
+        "subType": "thumbnail",
+        "type": "image",
+        "width": 640
+      },
+      "live": false,
+      "playlist": [
+        {
+          "bitrate": "168000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_lo.mp4"
+        },
+        {
+          "bitrate": "320000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_med.mp4"
+        },
+        {
+          "bitrate": "904000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/afrique/dps/junk/2016/06/hd_cps_sot_1800_24_2_105_5256622_toprores_160622_tc2_testmap1_16x9_hi.mp4"
+        }
+      ],
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "Le camerounais Richard Bona sort dans les prochains jours son nouvel album \"Héritage\". C'est un opus qui retrace la riche tradition de l'Afrique et des Caraïbes, notamment Cuba. Ata Ahli Ahebla a rencontré le chanteur.",
+    "timestamp": 1466612374000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Nos émissions",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/afrique/nos_emissions"
+    },
+    "site": {
+      "name": "BBCAfrique.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/afrique"
+    }
+  }
+}

--- a/data/mundo/cpsAssets/media-23283126.json
+++ b/data/mundo/cpsAssets/media-23283126.json
@@ -1,0 +1,195 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": false,
+        "caption": "Some audio from a supermarket checkout in Birmingham",
+        "embedding": false,
+        "format": "audio",
+        "id": "p01m7d07",
+        "imageCopyright": "Getty Images",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01mt2kt.jpg",
+        "subType": "clip",
+        "synopses": {
+          "short": "Some audio from a supermarket checkout in Birmingham"
+        },
+        "title": "Birmingham checkout",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1555067395000,
+            "availableTerritories": {
+              "nonUk": true,
+              "uk": true,
+              "world": false
+            },
+            "duration": 127,
+            "durationISO8601": "PT2M7S",
+            "types": ["Original"],
+            "versionId": "p01m7d09",
+            "warnings": {
+              "long": "Contains some strong language.",
+              "short": "Contains some strong language."
+            }
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "role": "introduction",
+        "text": "This is an introduction to the Mundo test MAP",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "<bold>Así lo asegura la Organización de Naciones Unidas al 30 de marzo.</bold>",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Eso quiere decir que son 1.500 millones de estudiantes sin clases en 165 países del mundo debido al coronavirus.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "Si eres una de esas personas que se ha quedado sin clases o si estás con ganas de aprender algo nuevo en tu tiempo libre, <bold>internet está lleno de cursos online en todas las áreas de especialización.</bold>",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Algunos incluso son dictados por las mejores universidades del mundo y de forma gratuita, aunque la mayoría están exclusivamente en inglés y es usual tener que para obtener un certificado oficial.",
+        "type": "paragraph"
+      },
+      { "markupType": "plain_text", "text": "Crosshead", "type": "crosshead" },
+      {
+        "altText": "Colourful studying",
+        "caption": "Do you like school?",
+        "copyrightHolder": "Getty/ BBC",
+        "height": 549,
+        "href": "http://b.files.bbci.co.uk/5B25/test/_63733332__111437543_197389d9-800f-4763-8654-aa30c04220e4.png",
+        "id": "63733332",
+        "path": "/cpsdevpb/5B25/test/_63733332__111437543_197389d9-800f-4763-8654-aa30c04220e4.png",
+        "positionHint": "full-width",
+        "subType": "body",
+        "type": "image",
+        "width": 976
+      },
+      {
+        "markupType": "plain_text",
+        "text": "A continuación, los 24 disponibles en cinco prestigiosos centros, sobre temas tan variados como negocios, matemáticas y paternidad, y que incluye el curso más exitoso en la historia de Yale: La ciencia del bienestar.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "mundo.media.media_asset.23283126.page",
+      "cps_asset_id": "23283126",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": ["media", "paragraph", "crosshead", "image"],
+    "createdBy": "mundo-v6",
+    "firstPublished": 1585748681000,
+    "id": "urn:bbc:ares::asset:mundo/media-23283126",
+    "includeComments": false,
+    "language": "es",
+    "lastPublished": 1585748681000,
+    "lastUpdated": 1585748692679,
+    "locators": {
+      "assetId": "23283126",
+      "assetUri": "/mundo/media-23283126",
+      "cpsUrn": "urn:bbc:content:assetUri:mundo/media-23283126",
+      "curie": "http://www.bbc.co.uk/asset/22720ea0-aaf8-8749-afa1-a0b36a632a71"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1585748681000,
+    "type": "MAP",
+    "version": "v1.1.10"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Mundo test MAP !\"£$%^&*(){}[]:@;'~#?/>.<,|\\\\",
+      "shortHeadline": "Mundo test MAP !\"£$%^&*(){}[]:@;'~#?/>.<,|\\\\"
+    },
+    "id": "urn:bbc:ares::asset:mundo/media-23283126",
+    "indexImage": {
+      "altText": "England star Fran Kirby",
+      "copyrightHolder": "Getty Images",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/0D05/test/_63733330_p01mt2kt.jpg",
+      "id": "63733330",
+      "path": "/cpsdevpb/0D05/test/_63733330_p01mt2kt.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "language": "es",
+    "locators": {
+      "assetId": "23283126",
+      "assetUri": "/mundo/media-23283126",
+      "cpsUrn": "urn:bbc:content:assetUri:mundo/media-23283126",
+      "curie": "http://www.bbc.co.uk/asset/22720ea0-aaf8-8749-afa1-a0b36a632a71"
+    },
+    "media": {
+      "advertising": false,
+      "caption": "Some audio from a supermarket checkout in Birmingham",
+      "embedding": false,
+      "format": "audio",
+      "id": "p01m7d07",
+      "imageCopyright": "Getty Images",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01mt2kt.jpg",
+      "subType": "clip",
+      "synopses": {
+        "short": "Some audio from a supermarket checkout in Birmingham"
+      },
+      "title": "Birmingham checkout",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1555067395000,
+          "availableTerritories": { "nonUk": true, "uk": true, "world": false },
+          "duration": 127,
+          "durationISO8601": "PT2M7S",
+          "types": ["Original"],
+          "versionId": "p01m7d09",
+          "warnings": {
+            "long": "Contains some strong language.",
+            "short": "Contains some strong language."
+          }
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "test",
+    "timestamp": 1585748681000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Media",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/mundo/media"
+    },
+    "site": {
+      "name": "BBC Mundo",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/mundo"
+    }
+  }
+}

--- a/data/mundo/legacyAssets/noticias/2016/04/160427_tc2_testmap1.json
+++ b/data/mundo/legacyAssets/noticias/2016/04/160427_tc2_testmap1.json
@@ -1,0 +1,198 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/mundo/meta/dps/junk/2016/04/emp/160427_tc2_testmap1.emp.xml",
+        "id": "17697143",
+        "image": {
+          "altText": "video",
+          "copyrightHolder": "",
+          "height": 360,
+          "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/11/11/141111124420_bbc_generic_video_640x360_bbc_nocredit.jpg",
+          "id": "17697143",
+          "path": "/amz/worldservice/test/assets/images/2014/11/11/141111124420_bbc_generic_video_640x360_bbc_nocredit.jpg",
+          "subType": "thumbnail",
+          "type": "image",
+          "width": 640
+        },
+        "live": false,
+        "playlist": [
+          {
+            "bitrate": "168000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_lo.mp4"
+          },
+          {
+            "bitrate": "320000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_med.mp4"
+          },
+          {
+            "bitrate": "904000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_hi.mp4"
+          }
+        ],
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Un golazo. Es la mejor manera de definir la acrobacia del jugador del Socuéllamos, Javi Gómez, durante la jornada de tercera división del futbol español.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Transcurrían los 20 minutos del primer tiempo entre el Socuéllamos y el Toledo, este domingo, cuando Gómez recibió un pase largo desde la defensa de su equipo.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Entonces decidió arremeter, cometer la hazaña: recibió de pecho, se levantó por los aires y, a por lo menos 40 metros del arco contrario, hizo una chilena, pero no fua una acrobacia normal: fue una apuesta a la fortuna vestida de malabar, que afortunadamente terminó en gol.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Perdón, en un golazo.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Todos los hinchas celebraron como cuando se conquista una copa.&quot;Cuando hice la jugada pensé: 'Que sea lo que Dios quiera'&quot;, le dijo Gómez al programa &quot;Fuera de Tiempo&quot; de la radio española.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Ese gol representó la victoria del Socuéllamos y le dio a este equipo de Ciudad Real la posibilidad de acceder a la fase final del torneo.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "&quot;Lo del gol es anecdótico, lo importante es que el Socuéllamos se mete en puestos para la final a tres jornadas y ha podido ser de esta manera&quot;, explicó Gómez.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Desde ya, muchos analistas y hasta el mismo club ya nominan la chilena de Gómez como uno de las mejores anotaciones del año en España y que tendrá su puesto dentro de los nominados al premio Puskas de la FIFA, que reconoce los mejores goles del año.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Imágenes Cortesía Castilla-La Mancha TV.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17697143", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "mundo",
+    "firstPublished": 1461774694000,
+    "id": "urn:bbc:ares::asset:mundo/noticias/2016/04/160427_tc2_testmap1",
+    "includeComments": false,
+    "language": "es",
+    "lastPublished": 1461774694000,
+    "lastUpdated": 1585904698821,
+    "locators": {
+      "assetId": "17697143",
+      "assetUri": "/mundo/noticias/2016/04/160427_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:mundo/noticias/2016/04/160427_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/0d4450a2-0c95-11e6-82cc-6442e881520c"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1461774694000,
+    "type": "MAP",
+    "version": "v1.1.10"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "De chilena y desde 40 metros: ¿es este el mejor gol del año?",
+      "shortHeadline": "De chilena y desde 40 metros: ¿es este el mejor gol del año?"
+    },
+    "id": "urn:bbc:ares::asset:mundo/noticias/2016/04/160427_tc2_testmap1",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "BBC",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_144x81_bbc_nocredit.jpg",
+      "id": "d5e220",
+      "path": "/amz/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_144x81_bbc_nocredit.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "es",
+    "locators": {
+      "assetId": "17697143",
+      "assetUri": "/mundo/noticias/2016/04/160427_tc2_testmap1",
+      "cpsUrn": "urn:bbc:content:assetUri:mundo/noticias/2016/04/160427_tc2_testmap1",
+      "curie": "http://www.bbc.co.uk/asset/0d4450a2-0c95-11e6-82cc-6442e881520c"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/mundo/meta/dps/junk/2016/04/emp/160427_tc2_testmap1.emp.xml",
+      "id": "17697143",
+      "image": {
+        "altText": "video",
+        "copyrightHolder": "",
+        "height": 360,
+        "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2014/11/11/141111124420_bbc_generic_video_640x360_bbc_nocredit.jpg",
+        "id": "17697143",
+        "path": "/amz/worldservice/test/assets/images/2014/11/11/141111124420_bbc_generic_video_640x360_bbc_nocredit.jpg",
+        "subType": "thumbnail",
+        "type": "image",
+        "width": 640
+      },
+      "live": false,
+      "playlist": [
+        {
+          "bitrate": "168000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_lo.mp4"
+        },
+        {
+          "bitrate": "320000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_med.mp4"
+        },
+        {
+          "bitrate": "904000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/mundo/dps/junk/2016/04/hd_cps_sot_1800_24_2_105_5256622_toprores_160427_tc2_testmap1_16x9_hi.mp4"
+        }
+      ],
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "De chilena y desde 40 metros: ¿es este el mejor gol del año?",
+    "timestamp": 1461774694000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Noticias",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/mundo/noticias"
+    },
+    "site": {
+      "name": "BBCMundo.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/mundo"
+    }
+  }
+}

--- a/data/portuguese/cpsAssets/media-23282671.json
+++ b/data/portuguese/cpsAssets/media-23282671.json
@@ -1,0 +1,236 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "advertising": true,
+        "caption": "How do Germans remember the World Wars?",
+        "embedding": true,
+        "format": "video",
+        "id": "p01kdbns",
+        "imageCopyright": "BBC",
+        "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+        "subType": "clip",
+        "synopses": {
+          "long": "Can people in today's Germany mourn their dead without whitewashing their country's past? We ask three Germans, ahead of the 100th anniversary of the end of World War One.",
+          "medium": "Can people in today's Germany mourn their dead without whitewashing their country's past?",
+          "short": "Remembrance Day: How Germans remember the World Wars"
+        },
+        "title": "How Germans remember the World Wars",
+        "type": "media",
+        "versions": [
+          {
+            "availableFrom": 1541761851000,
+            "availableTerritories": {
+              "nonUk": false,
+              "uk": true,
+              "world": false
+            },
+            "duration": 162,
+            "durationISO8601": "PT2M42S",
+            "types": ["Original"],
+            "versionId": "p01kdbnv",
+            "warnings": {
+              "long": "Contains some strong language.",
+              "short": "Contains some strong language."
+            }
+          }
+        ]
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Já ouviu falar da cabra gnu, do macaco de orelhas vermelhas ou do monstro de Gila?",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Eles podem ser os futuros ícones da conservação ambiental, de acordo com um estudo.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Os cientistas acreditam que estes animais pouco conhecidos são fundamentais para arrecadar dinheiro para proteger ecossistemas vulneráveis.",
+        "type": "paragraph"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "As imagens de tigres e elefantes, que têm grande apelo junto ao público, são frequentemente selecionadas para campanhas de arrecadação de fundos.",
+        "type": "paragraph"
+      },
+      { "markupType": "plain_text", "text": "Heading", "type": "heading" },
+      {
+        "markupType": "plain_text",
+        "text": "text text text text",
+        "type": "paragraph"
+      },
+      {
+        "altText": "Two photos of nice animals",
+        "caption": "Nice animals",
+        "copyrightHolder": "Getty Images",
+        "height": 549,
+        "href": "http://b.files.bbci.co.uk/6A61/test/_63733272__110989783_animals-comp.jpg",
+        "id": "63733272",
+        "path": "/cpsdevpb/6A61/test/_63733272__110989783_animals-comp.jpg",
+        "positionHint": "full-width",
+        "subType": "body",
+        "type": "image",
+        "width": 976
+      },
+      {
+        "markupType": "plain_text",
+        "text": "Subheading",
+        "type": "subheading"
+      },
+      {
+        "items": [
+          {
+            "markupType": "plain_text",
+            "text": "Conheça as 'superfrutas' encontradas na Mata Atlântica que pesquisadores tentam salvar da extinção",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "items": [
+          {
+            "markupType": "plain_text",
+            "text": "Por que Greta Thunberg pode estar errada sobre estarmos diante da 'sexta extinção em massa na Terra'",
+            "type": "listItem"
+          }
+        ],
+        "numbered": false,
+        "type": "list"
+      },
+      {
+        "markupType": "candy_xml",
+        "text": "<italic>Mas essa abordagem tem sido criticada por negligenciar muitas outras espécies que precisam da nossa ajuda.</italic>",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "portuguese.media.media_asset.23282671.page",
+      "cps_asset_id": "23282671",
+      "cps_asset_type": "map"
+    },
+    "blockTypes": [
+      "media",
+      "paragraph",
+      "heading",
+      "image",
+      "subheading",
+      "list"
+    ],
+    "createdBy": "brasil-v6",
+    "firstPublished": 1585672938000,
+    "id": "urn:bbc:ares::asset:portuguese/media-23282671",
+    "includeComments": false,
+    "language": "pt-BR",
+    "lastPublished": 1585672938000,
+    "lastUpdated": 1585672950185,
+    "locators": {
+      "assetId": "23282671",
+      "assetUri": "/portuguese/media-23282671",
+      "cpsUrn": "urn:bbc:content:assetUri:portuguese/media-23282671",
+      "curie": "http://www.bbc.co.uk/asset/a9601e04-929a-c74b-8198-cdbdfd3f046e"
+    },
+    "options": {
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false
+    },
+    "tags": {},
+    "timestamp": 1585672938000,
+    "type": "MAP",
+    "version": "v1.1.10"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Brasil/Portuguese test MAP",
+      "shortHeadline": "Brasil/Portuguese test MAP"
+    },
+    "id": "urn:bbc:ares::asset:portuguese/media-23282671",
+    "indexImage": {
+      "altText": "Description of picture (ALT TEXT)",
+      "copyrightHolder": "BBC",
+      "height": 576,
+      "href": "http://b.files.bbci.co.uk/1C41/test/_63733270_p01kdbpk.jpg",
+      "id": "63733270",
+      "path": "/cpsdevpb/1C41/test/_63733270_p01kdbpk.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 1024
+    },
+    "language": "pt-BR",
+    "locators": {
+      "assetId": "23282671",
+      "assetUri": "/portuguese/media-23282671",
+      "cpsUrn": "urn:bbc:content:assetUri:portuguese/media-23282671",
+      "curie": "http://www.bbc.co.uk/asset/a9601e04-929a-c74b-8198-cdbdfd3f046e"
+    },
+    "media": {
+      "advertising": true,
+      "caption": "How do Germans remember the World Wars?",
+      "embedding": true,
+      "format": "video",
+      "id": "p01kdbns",
+      "imageCopyright": "BBC",
+      "imageUrl": "ichef.test.bbci.co.uk/images/ic/$recipe/p01kdbpk.jpg",
+      "subType": "clip",
+      "synopses": {
+        "long": "Can people in today's Germany mourn their dead without whitewashing their country's past? We ask three Germans, ahead of the 100th anniversary of the end of World War One.",
+        "medium": "Can people in today's Germany mourn their dead without whitewashing their country's past?",
+        "short": "Remembrance Day: How Germans remember the World Wars"
+      },
+      "title": "How Germans remember the World Wars",
+      "type": "media",
+      "versions": [
+        {
+          "availableFrom": 1541761851000,
+          "availableTerritories": {
+            "nonUk": false,
+            "uk": true,
+            "world": false
+          },
+          "duration": 162,
+          "durationISO8601": "PT2M42S",
+          "types": ["Original"],
+          "versionId": "p01kdbnv",
+          "warnings": {
+            "long": "Contains some strong language.",
+            "short": "Contains some strong language."
+          }
+        }
+      ]
+    },
+    "passport": { "taggings": [] },
+    "summary": "Can people in today's Germany mourn their dead without whitewashing their country's past?",
+    "timestamp": 1585672938000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Media",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/portuguese/media"
+    },
+    "site": {
+      "name": "BBC Brasil",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/portuguese"
+    }
+  }
+}

--- a/data/portuguese/legacyAssets/revista/2016/05/160506_tc2_map_0605.json
+++ b/data/portuguese/legacyAssets/revista/2016/05/160506_tc2_map_0605.json
@@ -1,0 +1,158 @@
+{
+  "content": {
+    "blocks": [
+      {
+        "aspectRatio": "16:9",
+        "format": "video",
+        "href": "http://a.files.bbci.co.uk/worldservice/test/portuguese/meta/dps/junk/2016/05/emp/160506_tc2_map_0605.emp.xml",
+        "id": "17697275",
+        "image": {
+          "altText": "",
+          "copyrightHolder": "",
+          "height": 360,
+          "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_640x360_bbc_nocredit.jpg",
+          "id": "17697275",
+          "path": "/amz/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_640x360_bbc_nocredit.jpg",
+          "subType": "thumbnail",
+          "type": "image",
+          "width": 640
+        },
+        "live": false,
+        "playlist": [
+          {
+            "bitrate": "168000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_lo.mp4"
+          },
+          {
+            "bitrate": "320000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_med.mp4"
+          },
+          {
+            "bitrate": "904000",
+            "format": "mp4",
+            "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_hi.mp4"
+          }
+        ],
+        "subType": "primary",
+        "type": "legacyMedia"
+      },
+      {
+        "markupType": "plain_text",
+        "text": "A primeira mensagem chegou por e-mail, de forma anônima, há mais de um ano: &quot;Olá, aqui é o fulano. Interessam alguns dados?&quot; &quot;Estamos muito interessados&quot;, respondeu Bastian Obermayer, repórter do jornal alemão Suddeutsche Zeitung. &quot;Há algumas precondições. Minha vida corre perigo&quot;, alertou a fonte, segundo confirmou à BBC Frederik Obermaier, outro repórter do jornal alemão. Leia também: Panama Papers: em seis pontos, como offshores podem esconder bilhões de origem ilegal Siga a BBC Brasil no Facebook e no Twitter &quot;A única coisa que não podemos revelar é o idioma em que se deu o diálogo original&quot;, desculpou-se Obermaier, um dos integrantes da equipe de investigação que recebeu os chamados Panama Papers, o maior vazamento de documentos confidenciais da história.",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "metadata": {
+    "analyticsLabels": { "cps_asset_id": "17697275", "cps_asset_type": "map" },
+    "blockTypes": ["legacyMedia", "paragraph"],
+    "createdBy": "portuguese",
+    "firstPublished": 1462537207000,
+    "id": "urn:bbc:ares::asset:portuguese/revista/2016/05/160506_tc2_map_0605",
+    "includeComments": false,
+    "language": "pt-BR",
+    "lastPublished": 1462537207000,
+    "lastUpdated": 1585590833664,
+    "locators": {
+      "assetId": "17697275",
+      "assetUri": "/portuguese/revista/2016/05/160506_tc2_map_0605",
+      "cpsUrn": "urn:bbc:content:assetUri:portuguese/revista/2016/05/160506_tc2_map_0605",
+      "curie": "http://www.bbc.co.uk/asset/8ed065a2-1384-11e6-9f7e-020733e45519"
+    },
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowRightHandSide": true,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "suitableForSyndication": false
+    },
+    "tags": {},
+    "timestamp": 1462537207000,
+    "type": "MAP",
+    "version": "v1.1.10"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "map 'Minha vida corre perigo': a troca de e-mails que desencadeou os Panama Papers",
+      "shortHeadline": "map 'Minha vida corre perigo': a troca de e-mails que desencadeou os Panama Papers"
+    },
+    "id": "urn:bbc:ares::asset:portuguese/revista/2016/05/160506_tc2_map_0605",
+    "indexImage": {
+      "altText": "",
+      "copyrightHolder": "BBC",
+      "height": 81,
+      "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/02/26/150226142623_netball_144x81_bbc.jpg",
+      "id": "d5e212",
+      "path": "/amz/worldservice/test/assets/images/2015/02/26/150226142623_netball_144x81_bbc.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 144
+    },
+    "language": "pt-BR",
+    "locators": {
+      "assetId": "17697275",
+      "assetUri": "/portuguese/revista/2016/05/160506_tc2_map_0605",
+      "cpsUrn": "urn:bbc:content:assetUri:portuguese/revista/2016/05/160506_tc2_map_0605",
+      "curie": "http://www.bbc.co.uk/asset/8ed065a2-1384-11e6-9f7e-020733e45519"
+    },
+    "media": {
+      "aspectRatio": "16:9",
+      "format": "video",
+      "href": "http://a.files.bbci.co.uk/worldservice/test/portuguese/meta/dps/junk/2016/05/emp/160506_tc2_map_0605.emp.xml",
+      "id": "17697275",
+      "image": {
+        "altText": "",
+        "copyrightHolder": "",
+        "height": 360,
+        "href": "http://a.files.bbci.co.uk/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_640x360_bbc_nocredit.jpg",
+        "id": "17697275",
+        "path": "/amz/worldservice/test/assets/images/2015/01/26/150126145000_house_of_parliament_640x360_bbc_nocredit.jpg",
+        "subType": "thumbnail",
+        "type": "image",
+        "width": 640
+      },
+      "live": false,
+      "playlist": [
+        {
+          "bitrate": "168000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_lo.mp4"
+        },
+        {
+          "bitrate": "320000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_med.mp4"
+        },
+        {
+          "bitrate": "904000",
+          "format": "mp4",
+          "url": "https://wsodprogrf.akamaized.net/portuguese/dps/junk/2016/05/hd_audio_r4_pips_only_1241_15_3_105_5349369_toprores_160506_tc2_map_0605_16x9_hi.mp4"
+        }
+      ],
+      "subType": "primary",
+      "type": "legacyMedia"
+    },
+    "passport": { "taggings": [] },
+    "summary": "Fonte que revelou escândalo global de suspeitas de lavagem de dinheiro e evasão fiscal exigiu apenas medidas de segurança para ceder material sigiloso.",
+    "timestamp": 1462537207000,
+    "type": "cps"
+  },
+  "relatedContent": {
+    "groups": [],
+    "section": {
+      "name": "Revista",
+      "subType": "index",
+      "type": "simple",
+      "uri": "/portuguese/revista"
+    },
+    "site": {
+      "name": "BBCBrasil.com",
+      "subType": "site",
+      "type": "simple",
+      "uri": "/portuguese"
+    }
+  }
+}


### PR DESCRIPTION
Added URLs to settings file for local and test E2Es to fun for Afrique, Portuguese/Brasil, Mundo and Japanese.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
Run on local and test, only fails on the related content StoryPromo bug we have spoken about.
