### PR TITLE
pass service to embed url

### DIFF
--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/__snapshots__/index.test.jsx.snap
@@ -63,7 +63,7 @@ exports[`MediaPageBlocks AudioPlayer should render correctly for amp 1`] = `
               layout="fill"
               sandbox="allow-scripts allow-same-origin"
               scrolling="no"
-              src="https://polling.test.bbc.co.uk/ws/av-embeds/media/externalId/id/ko/amp"
+              src="https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/externalId/id/ko/amp"
               title="Audio player"
             >
               <amp-img
@@ -147,7 +147,7 @@ exports[`MediaPageBlocks AudioPlayer should render correctly for canonical 1`] =
         allowfullscreen=""
         class="c3"
         scrolling="no"
-        src="https://polling.test.bbc.co.uk/ws/av-embeds/media/externalId/id/ko"
+        src="https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/externalId/id/ko"
         title="Audio player"
       />
       <noscript />
@@ -219,7 +219,7 @@ exports[`MediaPageBlocks AudioPlayer when externalId is bbc_oromo_radio it is ov
               layout="fill"
               sandbox="allow-scripts allow-same-origin"
               scrolling="no"
-              src="https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_afaanoromoo_radio/id/om/amp"
+              src="https://polling.test.bbc.co.uk/ws/av-embeds/media/afaanoromoo/bbc_afaanoromoo_radio/id/om/amp"
               title="Audio player"
             >
               <amp-img
@@ -303,7 +303,7 @@ exports[`MediaPageBlocks AudioPlayer when externalId is bbc_oromo_radio it is ov
         allowfullscreen=""
         class="c3"
         scrolling="no"
-        src="https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_afaanoromoo_radio/id/om"
+        src="https://polling.test.bbc.co.uk/ws/av-embeds/media/afaanoromoo/bbc_afaanoromoo_radio/id/om"
         title="Audio player"
       />
       <noscript />

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
@@ -17,8 +17,12 @@ const staticAssetsPath = `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN}${pr
 
 const audioPlaceholderImageSrc = `${staticAssetsPath}images/amp_audio_placeholder.png`;
 
+const LIVE_RADIO_ASSET_ID = 'liveradio';
+
+const isLiveRadio = (assetId) => assetId === LIVE_RADIO_ASSET_ID;
+
 const getMediaInfo = (assetId) => ({
-  title: assetId === 'liveradio' ? 'Live radio' : 'On-demand radio',
+  title: isLiveRadio(assetId) ? 'Live radio' : 'On-demand radio',
   type: 'audio',
 });
 
@@ -75,8 +79,12 @@ const AudioPlayer = ({
 
   if (!isValidPlatform || !masterBrand || !assetId) return null; // potential for logging here
 
+  const mediaId = isLiveRadio(assetId)
+    ? `${masterBrand}/${assetId}/${lang}` // liveradio
+    : `${service}/${masterBrand}/${assetId}/${lang}`; // ondemand
+
   const embedUrl = getEmbedUrl({
-    mediaId: `${masterBrand}/${assetId}/${lang}`,
+    mediaId,
     type: 'media',
     isAmp,
     queryString: location.search,

--- a/src/app/pages/OnDemandRadioPage/index.test.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.test.jsx
@@ -149,7 +149,7 @@ describe('OnDemand Radio Page ', () => {
       .getAttribute('src');
 
     expect(audioPlayerIframeSrc).toEqual(
-      'https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_korean_radio/w3cszwcg/ko',
+      'https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/bbc_korean_radio/w3cszwcg/ko',
     );
   });
 
@@ -172,7 +172,7 @@ describe('OnDemand Radio Page ', () => {
       .getAttribute('src');
 
     expect(audioPlayerIframeSrc).toEqual(
-      'https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_korean_radio/w3cszwcg/ko/amp',
+      'https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/bbc_korean_radio/w3cszwcg/ko/amp',
     );
   });
 


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/5953

**Overall change:**
Add the service to the on-demand radio episode embed url.

**Code changes:**

- Adds a function `isLiveRadio` to determine audio type is live radio or on-demand
- Adds the service to `mediaId` if is on-demand so the embed url is correct for on-demand embeds to render

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
