### PR TITLE
add link to CSP maintenance doc

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -3,6 +3,9 @@ import getRouteProps from '#app/routes/utils/fetchPageData/utils/getRouteProps';
 import routes from '#app/routes';
 import getOriginContext from '#contexts/RequestContext/getOriginContext';
 
+/* Guidelines to follow when updating the CSP Header can be found here: 
+https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/updating-csp.md */
+
 const directives = {
   connectSrc: {
     ampLive: [


### PR DESCRIPTION
No Issue

a [doc](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/updating-csp.md) that outlines how we should maintain our CSP Headers in both `simorgh` and `mozart-routing` has been created by James Donohue. This PR adds a link to that doc in the `cspHeader` file for easy access for people who will be updating this file in the future, especially for the first time.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
