### PR TITLE
Updated getInitialData to accept an object of path/service

### DIFF
--- a/src/app/containers/App/App.jsx
+++ b/src/app/containers/App/App.jsx
@@ -82,24 +82,26 @@ export const App = ({ routes, location, initialData, bbcOrigin, history }) => {
         });
       });
 
-      route.getInitialData(location.pathname).then((data) => {
-        clearTimeout(loaderTimeout);
-        shouldSetFocus.current = true;
-        setState({
-          service: nextService,
-          variant: nextVariant,
-          id: nextId,
-          assetUri: nextAssetUri,
-          isAmp: nextIsAmp,
-          pageType: route.pageType,
-          loading: false,
-          pageData: path(['pageData'], data),
-          status: path(['status'], data),
-          error: path(['error'], data),
-          errorCode: null,
-          timeOnServer: path(['timeOnServer'], data),
+      route
+        .getInitialData({ path: location.pathname, service: nextService })
+        .then((data) => {
+          clearTimeout(loaderTimeout);
+          shouldSetFocus.current = true;
+          setState({
+            service: nextService,
+            variant: nextVariant,
+            id: nextId,
+            assetUri: nextAssetUri,
+            isAmp: nextIsAmp,
+            pageType: route.pageType,
+            loading: false,
+            pageData: path(['pageData'], data),
+            status: path(['status'], data),
+            error: path(['error'], data),
+            errorCode: null,
+            timeOnServer: path(['timeOnServer'], data),
+          });
         });
-      });
     }
   }, [routes, location.pathname]);
 

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -182,7 +182,10 @@ describe('App', () => {
 
           expect.assertions(3);
 
-          expect(route.getInitialData).toHaveBeenCalledWith(pathname);
+          expect(route.getInitialData).toHaveBeenCalledWith({
+            path: pathname,
+            service: 'news',
+          });
 
           // start data fetch and set loading to true
           expect(reactRouterConfig.renderRoutes).toHaveBeenNthCalledWith(

--- a/src/app/routes/article/getInitialData/index.js
+++ b/src/app/routes/article/getInitialData/index.js
@@ -13,7 +13,7 @@ const transformJson = pipe(
 );
 
 export default async (path) => {
-  const { json, ...rest } = await fetchPageData(path);
+  const { json, ...rest } = await fetchPageData({ path });
 
   return {
     ...rest,

--- a/src/app/routes/article/getInitialData/index.js
+++ b/src/app/routes/article/getInitialData/index.js
@@ -12,8 +12,8 @@ const transformJson = pipe(
   applyBlockPositioning,
 );
 
-export default async (path) => {
-  const { json, ...rest } = await fetchPageData({ path });
+export default async ({ path }) => {
+  const { json, ...rest } = await fetchPageData(path);
 
   return {
     ...rest,

--- a/src/app/routes/article/getInitialData/index.test.js
+++ b/src/app/routes/article/getInitialData/index.test.js
@@ -4,7 +4,7 @@ import articleJson from '#data/pidgin/articles/cwl08rd38l6o.json';
 fetch.mockResponse(JSON.stringify(articleJson));
 
 it('should return essential data for a page to render', async () => {
-  const { pageData } = await getInitialData('mock-article-path');
+  const { pageData } = await getInitialData({ path: 'mock-article-path' });
 
   expect(pageData.metadata.id).toEqual('urn:bbc:ares::article:cwl08rd38l6o');
   expect(pageData.promo.headlines.seoHeadline).toEqual(

--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -50,8 +50,8 @@ const transformJson = async (json) => {
   }
 };
 
-export default async (urlPath) => {
-  const { json, ...rest } = await fetchPageData(urlPath);
+export default async ({ path: pathname }) => {
+  const { json, ...rest } = await fetchPageData(pathname);
 
   return {
     ...rest,

--- a/src/app/routes/cpsAsset/getInitialData/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.test.js
@@ -8,7 +8,7 @@ describe('getInitialData', () => {
 
   it('should return essential data for a page to render', async () => {
     jest.spyOn(global, 'fetch').mockResponse(JSON.stringify(mapJson));
-    const { pageData } = await getInitialData('mock-map-path');
+    const { pageData } = await getInitialData({ path: 'mock-map-path' });
 
     expect(pageData.metadata.id).toEqual(
       'urn:bbc:ares::asset:pidgin/media-23256549',

--- a/src/app/routes/error/getInitialData/index.js
+++ b/src/app/routes/error/getInitialData/index.js
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router';
 
-export default (pathRegex) => (pathname) => {
+export default (pathRegex) => ({ path: pathname }) => {
   const { params } = matchPath(pathname, {
     path: pathRegex,
   });

--- a/src/app/routes/error/getInitialData/index.test.js
+++ b/src/app/routes/error/getInitialData/index.test.js
@@ -3,7 +3,7 @@ import { errorPagePath } from '../../utils/regex';
 
 it('should resolve with status 200 and errorCode', async () => {
   const expected = { status: 200, errorCode: 404 };
-  const actual = await getInitialData(errorPagePath)('/pidgin/404');
+  const actual = await getInitialData(errorPagePath)({ path: '/pidgin/404' });
 
   expect(expected).toEqual(actual);
 });

--- a/src/app/routes/home/getInitialData/index.js
+++ b/src/app/routes/home/getInitialData/index.js
@@ -14,7 +14,7 @@ const transformJson = pipe(
   filterGroupsWithoutStraplines,
 );
 
-export default async (path) => {
+export default async ({ path }) => {
   const { json, ...rest } = await fetchPageData(path);
 
   return {

--- a/src/app/routes/home/getInitialData/index.test.js
+++ b/src/app/routes/home/getInitialData/index.test.js
@@ -4,7 +4,7 @@ import frontPageJson from '#data/pidgin/frontpage/index.json';
 fetch.mockResponse(JSON.stringify(frontPageJson));
 
 it('should return essential data for a page to render', async () => {
-  const { pageData } = await getInitialData('mock-frontpage-path');
+  const { pageData } = await getInitialData({ path: 'mock-frontpage-path' });
 
   expect(pageData.metadata.language).toEqual('pcm');
   expect(pageData.metadata.summary).toEqual(

--- a/src/app/routes/index.test.jsx
+++ b/src/app/routes/index.test.jsx
@@ -68,7 +68,7 @@ it('should route to and render live radio page', async () => {
   fetch.mockResponse(JSON.stringify(liveRadioPageJson));
   const pathname = '/korean/bbc_korean_radio/liveradio';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -84,7 +84,7 @@ it('should route to and render the skeleton onDemand Radio page', async () => {
   fetch.mockResponse(JSON.stringify(onDemandRadioPageJson));
   const pathname = '/indonesia/bbc_indonesian_radio/w172x6r5000f38s';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -101,7 +101,7 @@ it('should route to and render an article page', async () => {
   fetch.mockResponse(JSON.stringify(articlePageJson));
   const pathname = '/persian/articles/c4vlle3q337o';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -117,7 +117,7 @@ it('should route to and render a front page', async () => {
   fetch.mockResponse(JSON.stringify(frontPageJson));
   const pathname = '/pidgin';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -133,7 +133,7 @@ it('should route to and render a media asset page', async () => {
   fetch.mockResponse(JSON.stringify(mediaAssetPageJson));
   const pathname = '/yoruba/media-23256797';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -150,7 +150,7 @@ it('should route to and render a media asset page', async () => {
   fetch.mockResponse(JSON.stringify(mediaAssetPageJson));
   const pathname = '/yoruba/media-23256797';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -169,7 +169,7 @@ it('should route to and render a legacy media asset page', async () => {
   fetch.mockResponse(JSON.stringify(legacyMediaAssetPage));
   const pathname = '/azeri/multimedia/2012/09/120919_georgia_prison_video';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -188,7 +188,7 @@ it('should route to and render a photo gallery page', async () => {
   fetch.mockResponse(JSON.stringify(photoGalleryPageJson));
   const pathname = '/indonesia/indonesia-41635759';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -205,7 +205,7 @@ it('should route to and render a story page', async () => {
   fetch.mockResponse(JSON.stringify(storyPageJson));
   const pathname = '/mundo/noticias-internacional-51266689';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -223,7 +223,7 @@ it.skip('should route to and render a feature index page', async () => {
   fetch.mockResponse(JSON.stringify(featureIndexPageJson));
   const pathname = '/afrique/48465371';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { pageData } = await getInitialData(pathname);
+  const { pageData } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageData,
@@ -239,7 +239,7 @@ it.skip('should route to and render a feature index page', async () => {
 it('should route to and render a 500 error page', async () => {
   const pathname = '/igbo/500';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { errorCode } = await getInitialData(pathname);
+  const { errorCode } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageType,
@@ -268,7 +268,7 @@ it('should fallback to and render a 500 error page if there is a problem with pa
 it('should route to and render a 404 error page', async () => {
   const pathname = '/igbo/404';
   const { getInitialData, pageType } = getMatchingRoute(pathname);
-  const { errorCode } = await getInitialData(pathname);
+  const { errorCode } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageType,
@@ -284,7 +284,7 @@ it('should render a 404 error page if a data fetch responds with a 404', async (
   fetch.mockResponse(null, { status: 404 });
   const pathname = '/pidgin/articles/cwl08rd38p6o';
   const { pageType, getInitialData } = getMatchingRoute(pathname);
-  const { status } = await getInitialData(pathname);
+  const { status } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageType,
@@ -300,7 +300,7 @@ it('should fallback to and render a 404 error page if no route match is found', 
   const pathname = '/a/path/that/does/not/exist';
   const { pageType, getInitialData } =
     getMatchingRoute(pathname) || routes[routes.length - 1];
-  const { errorCode } = await getInitialData(pathname);
+  const { errorCode } = await getInitialData({ path: pathname });
   const { getByText } = renderRouter({
     pathname,
     pageType,

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -26,7 +26,7 @@ const getEpisodeAvailableUntil = path([
   'availableUntil',
 ]);
 
-export default async (pathname) => {
+export default async ({ path: pathname }) => {
   const { json, ...rest } = await fetchPageData(pathname);
 
   return {

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -4,7 +4,9 @@ import onDemandRadioJson from '#data/pashto/bbc_pashto_radio/w172x8nvf4bchz5.jso
 fetch.mockResponse(JSON.stringify(onDemandRadioJson));
 
 it('should return essential data for a page to render', async () => {
-  const { pageData } = await getInitialData('mock-on-demand-radio-path');
+  const { pageData } = await getInitialData({
+    path: 'mock-on-demand-radio-path',
+  });
 
   expect(pageData.headline).toEqual('وروستي خبرونه');
   expect(pageData.episodeTitle).toEqual('04/02/2020 GMT');

--- a/src/app/routes/radio/getInitialData/index.js
+++ b/src/app/routes/radio/getInitialData/index.js
@@ -1,7 +1,7 @@
 import fetchPageData from '../../utils/fetchPageData';
 import addIdsToBlocks from './addIdsToBlocks';
 
-export default async (path) => {
+export default async ({ path }) => {
   const { json, ...rest } = await fetchPageData(path);
 
   return {

--- a/src/app/routes/radio/getInitialData/index.test.js
+++ b/src/app/routes/radio/getInitialData/index.test.js
@@ -4,7 +4,7 @@ import liveRadioJson from '#data/korean/bbc_korean_radio/liveradio.json';
 fetch.mockResponse(JSON.stringify(liveRadioJson));
 
 it('should return essential data for a page to render', async () => {
-  const { pageData } = await getInitialData('mock-live-radio-path');
+  const { pageData } = await getInitialData({ path: 'mock-live-radio-path' });
 
   expect(pageData.promo.name).toEqual('BBC 코리아 라디오');
   expect(pageData.metadata.language).toEqual('ko');

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -260,7 +260,7 @@ server
           routes,
           urlPath,
         );
-        const data = await route.getInitialData(url);
+        const data = await route.getInitialData({ path: url, service });
         const { status } = data;
         const bbcOrigin = headers['bbc-origin'];
 


### PR DESCRIPTION
A part of:
- https://github.com/bbc/simorgh/issues/4472
- https://github.com/bbc/simorgh/issues/5537

**Overall change:**
_Updated the getInitialData to accept an object of path and service, we needed this because we are starting to fetch data that is not the same value as the path. i,e most read page path is `$service/popular/read` whereas the data endpoint is `/$service/mostread.json`_

**Code changes:**

- _Updated `getInitialData` functions_
- _Updated unit tests_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
