### PR TITLE
Fix Storybook Moment stories for RTL services to have correct direction

### DIFF
--- a/src/app/lib/utilities/moment/index.stories.jsx
+++ b/src/app/lib/utilities/moment/index.stories.jsx
@@ -457,7 +457,7 @@ const Table = styled.table`
   }
 `;
 
-const ShowMoment = ({ name, locale, moments }) => {
+const ShowMoment = ({ dir, lang, locale, moments, name }) => {
   return (
     <Table>
       <tbody>
@@ -471,7 +471,9 @@ const ShowMoment = ({ name, locale, moments }) => {
           <tr key={index}>
             <td>{what}</td>
             <td>{method('en-gb')}</td>
-            <td>{method(locale)}</td>
+            <td dir={dir} lang={lang}>
+              {method(locale)}
+            </td>
           </tr>
         ))}
       </tbody>
@@ -480,6 +482,8 @@ const ShowMoment = ({ name, locale, moments }) => {
 };
 
 ShowMoment.propTypes = {
+  dir: string.isRequired,
+  lang: string.isRequired,
   name: string.isRequired,
   moments: arrayOf(
     shape({
@@ -506,6 +510,8 @@ Object.keys(services).forEach((service) => {
     .filter((variant) => services[service][variant].datetimeLocale)
     .forEach((variant) => {
       const serviceName = capitalizeService(service);
+      const { dir } = services[service][variant];
+      const { lang } = services[service][variant];
       const serviceLocale = services[service][variant].datetimeLocale;
       const storyTitle = `${serviceName} - ${serviceLocale} ${
         variant !== 'default' ? `(${variant})` : ''
@@ -513,6 +519,8 @@ Object.keys(services).forEach((service) => {
 
       editorialStories.add(storyTitle, () => (
         <ShowMoment
+          dir={dir}
+          lang={lang}
           name={serviceName}
           locale={serviceLocale}
           moments={methods.filter((method) =>
@@ -524,6 +532,8 @@ Object.keys(services).forEach((service) => {
       developerStories.add(storyTitle, () => {
         return (
           <ShowMoment
+            dir={dir}
+            lang={lang}
             name={serviceName}
             locale={serviceLocale}
             moments={methods}

--- a/src/app/lib/utilities/moment/index.stories.jsx
+++ b/src/app/lib/utilities/moment/index.stories.jsx
@@ -510,9 +510,9 @@ Object.keys(services).forEach((service) => {
     .filter((variant) => services[service][variant].datetimeLocale)
     .forEach((variant) => {
       const serviceName = capitalizeService(service);
-      const { dir } = services[service][variant];
-      const { lang } = services[service][variant];
-      const serviceLocale = services[service][variant].datetimeLocale;
+      const { dir, lang, datetimeLocale: serviceLocale } = services[service][
+        variant
+      ];
       const storyTitle = `${serviceName} - ${serviceLocale} ${
         variant !== 'default' ? `(${variant})` : ''
       }`;


### PR DESCRIPTION
No ticket

**Overall change:**
Ensure Arabic, Pashto, Persian, Urdu moment locales appear correctly in storybook (right-to-left)

**Code changes:**

- Add dir & lang attributes onto moment locale table cell


Before:
https://bbc.github.io/simorgh/?path=/story/moment-locales-developer-view--arabic-ar
https://bbc.github.io/simorgh/?path=/story/moment-locales-developer-view--pashto-ps
https://bbc.github.io/simorgh/?path=/story/moment-locales-developer-view--persian-fa
https://bbc.github.io/simorgh/?path=/story/moment-locales-developer-view--urdu-ur

After:
http://localhost:9001/?path=/story/moment-locales-developer-view--arabic-ar
http://localhost:9001/?path=/story/moment-locales-developer-view--pashto-ps
http://localhost:9001/?path=/story/moment-locales-developer-view--persian-fa
http://localhost:9001/?path=/story/moment-locales-developer-view--urdu-ur
The locale columns for these examples are all right-to-left
<img width="150" alt="Screenshot developer view" src="https://user-images.githubusercontent.com/3028997/79308120-ee637380-7eef-11ea-9aee-42366320ca09.png">

Same with the editorial view:
http://localhost:9001/?path=/story/moment-locales-editorial-view--arabic-ar
<img width="400" alt="Screenshot editorial view" src="https://user-images.githubusercontent.com/3028997/79308193-0affab80-7ef0-11ea-8bf9-9e4548cd40f3.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
