### PR TITLE
Remove query string

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -42,7 +42,10 @@ const fetchMarkup = async (url) => {
   }
 };
 
-const convertInclude = async ({ href, type, ...rest }) => {
+const convertInclude = async ({ href: fullHref, type, ...rest }) => {
+  // We want to strip and remove the GET parameters from the include href
+  const [href] = fullHref.split('?');
+
   const supportedTypes = {
     indepthtoolkit: 'idt1',
     idt2: 'idt2',
@@ -63,7 +66,6 @@ const convertInclude = async ({ href, type, ...rest }) => {
 
   // This determines if the type is supported and returns the include type name
   const includeType = supportedTypes[typeExtraction];
-
   if (!includeType) {
     return null;
   }

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -10,10 +10,7 @@ const buildIncludeUrl = (href, type) => {
     vj: '',
   };
 
-  const strippedHref = href.split('?')[0];
-  const withTrailingHref = href.startsWith('/')
-    ? strippedHref
-    : `/${strippedHref}`;
+  const withTrailingHref = href.startsWith('/') ? href : `/${href}`;
 
   return `${process.env.SIMORGH_INCLUDES_BASE_URL}${withTrailingHref}${resolvers[type]}`;
 };
@@ -45,12 +42,15 @@ const fetchMarkup = async (url) => {
   }
 };
 
-const convertInclude = async ({ href, type, ...rest }) => {
+const convertInclude = async ({ href: hrefWithParams, type, ...rest }) => {
   const supportedTypes = {
     indepthtoolkit: 'idt1',
     idt2: 'idt2',
     include: 'vj',
   };
+
+  // This strips the GET query params from the href
+  const href = hrefWithParams && hrefWithParams.split('?')[0];
 
   // This determines if the href has a leading '/'
   const hrefTypePostion = () => (href.indexOf('/') === 0 ? 1 : 0);

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -10,7 +10,10 @@ const buildIncludeUrl = (href, type) => {
     vj: '',
   };
 
-  const withTrailingHref = href.startsWith('/') ? href : `/${href}`;
+  const strippedHref = href.split('?')[0];
+  const withTrailingHref = href.startsWith('/')
+    ? strippedHref
+    : `/${strippedHref}`;
 
   return `${process.env.SIMORGH_INCLUDES_BASE_URL}${withTrailingHref}${resolvers[type]}`;
 };
@@ -42,10 +45,7 @@ const fetchMarkup = async (url) => {
   }
 };
 
-const convertInclude = async ({ href: fullHref, type, ...rest }) => {
-  // We want to strip and remove the GET parameters from the include href
-  const [href] = fullHref.split('?');
-
+const convertInclude = async ({ href, type, ...rest }) => {
   const supportedTypes = {
     indepthtoolkit: 'idt1',
     idt2: 'idt2',

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.test.js
@@ -120,6 +120,35 @@ describe('convertInclude', () => {
     );
   });
 
+  it('should convert an include block to an idt1 block with no query params in href', async () => {
+    fetch.mockResponse(() => Promise.resolve(idt1Markup));
+    const input = {
+      required: false,
+      tile: 'A quiz!',
+      href: 'indepthtoolkit?foo=bar',
+      platform: 'highweb',
+      type: 'include',
+    };
+    const expected = {
+      type: 'include',
+      model: {
+        href: 'indepthtoolkit',
+        required: false,
+        tile: 'A quiz!',
+        platform: 'highweb',
+        type: 'idt1',
+        html: idt1Markup,
+      },
+    };
+    expect(await convertInclude(input)).toEqual(expected);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://foobar.com/includes/indepthtoolkit',
+      {
+        timeout: 3000,
+      },
+    );
+  });
+
   it('should convert an include block to an idt2 block with no / in href', async () => {
     fetch.mockResponse(() => Promise.resolve(idt2Markup));
     const input = {


### PR DESCRIPTION
Resolves bbc/simorgh-infrastructure#946

**Overall change:**
Removes the `GET` parameters from the includes URL, as they could potentially mislead a developer into believing they were somehow manipulating the response, when they were not.

**Code changes:**

- Split the include URL on the `?` character, and return the first index (the main include URL)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
