### PR TITLE
position footer at bottom of page for OD and live radio

### DIFF
--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -266,6 +266,10 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @supports (display:grid) {
@@ -533,6 +537,10 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @supports (display:grid) {
@@ -965,6 +973,10 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @supports (display:grid) {
@@ -1189,6 +1201,10 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @supports (display:grid) {

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -24,6 +24,7 @@ const getEpisodeAvailability = (availableFrom, availableUntil) => {
 
 const StyledGelPageGrid = styled(GelPageGrid)`
   width: 100%;
+  flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 
 const renderEpisode = (

--- a/src/app/pages/RadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/RadioPage/__snapshots__/index.test.jsx.snap
@@ -249,6 +249,10 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @supports (display:grid) {
@@ -494,6 +498,10 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 
 .c1 {
   width: 100%;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c7 {

--- a/src/app/pages/RadioPage/index.jsx
+++ b/src/app/pages/RadioPage/index.jsx
@@ -12,6 +12,7 @@ import { ServiceContext } from '../../contexts/ServiceContext';
 
 const StyledGelPageGrid = styled(GelPageGrid)`
   width: 100%;
+  flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 
 const RadioPage = ({ pageData }) => {

--- a/src/integration/pages/liveRadioPage/__snapshots__/amharic.test.js.snap
+++ b/src/integration/pages/liveRadioPage/__snapshots__/amharic.test.js.snap
@@ -604,7 +604,7 @@ exports[`Given I am on the Amharic Live Radio page When I view the source code i
       </amp-analytics>
       <main role="main"
             dir="ltr"
-            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 hzCstj"
+            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 cPPVag"
       >
         <div dir="ltr"
              class="GridComponent-nf79gm-0 kMhoTR"
@@ -1238,7 +1238,7 @@ exports[`Given I am on the Amharic Live Radio page When I view the source code i
       </noscript>
       <main role="main"
             dir="ltr"
-            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 hzCstj"
+            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 cPPVag"
       >
         <div dir="ltr"
              class="GridComponent-nf79gm-0 kMhoTR"

--- a/src/integration/pages/liveRadioPage/__snapshots__/korean.test.js.snap
+++ b/src/integration/pages/liveRadioPage/__snapshots__/korean.test.js.snap
@@ -592,7 +592,7 @@ exports[`Given I am on the Korean Live Radio page When I view the source code in
       </amp-analytics>
       <main role="main"
             dir="ltr"
-            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 hzCstj"
+            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 cPPVag"
       >
         <div dir="ltr"
              class="GridComponent-nf79gm-0 kMhoTR"
@@ -1216,7 +1216,7 @@ exports[`Given I am on the Korean Live Radio page When I view the source code in
       </noscript>
       <main role="main"
             dir="ltr"
-            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 hzCstj"
+            class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1539sby-0 cPPVag"
       >
         <div dir="ltr"
              class="GridComponent-nf79gm-0 kMhoTR"


### PR DESCRIPTION
https://github.com/bbc/simorgh/issues/6190

**Overall change:**
Position footer at bottom of page for OD and live radio

**Code changes:**

- flex-grow: 1 to space out header/main content/footer

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
