### PR TITLE
Changed Tigrinya cookie title within config/services to match cypress' assertion

### DIFF
--- a/src/app/lib/config/services/tigrinya.js
+++ b/src/app/lib/config/services/tigrinya.js
@@ -113,7 +113,7 @@ export const service = {
           rejectUrl: 'https://www.bbc.co.uk/usingthebbc/your-data-matters',
         },
         cookie: {
-          title: "ኩኪስ' ንምጥቃም ከም ዝተሰማማዕኩም ኣፍልጡና",
+          title: "ኩኪስ' ንምጥቃም ከም ዝተሰማማዕኩም ኣፍልጡና",
           description: {
             uk: {
               first: 'ኣብ መርበብ ሓበሬታና ዝበለጸ ኣገልግሎት መታን ክትረኽቡ ኢና ',


### PR DESCRIPTION
**Overall change:**
Incredibly,

<img width="396" alt="Screenshot 2020-04-17 at 15 24 35" src="https://user-images.githubusercontent.com/9042672/79579651-c3c81500-80bf-11ea-8733-92108e540d1f.png">

The first string is what we have in the codebase for `cookie.title` within `src/app/lib/config/services/tigrinya.js`, the second string is what Cypress is asserting against. 

This is causing e2es to fail in live and test.

**Code changes:**

- Replaced the existing cookie title with what Cypress is expecting.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project
