### PR TITLE
A simplification of the route used for the cpsAsset index

### DIFF
--- a/src/app/routes/cpsAsset/index.js
+++ b/src/app/routes/cpsAsset/index.js
@@ -9,7 +9,7 @@ import {
   PhotoGalleryPage,
   StoryPage,
 } from '#pages';
-import { cpsAssetPagePath, legacyAssetPagePath } from '../utils/regex';
+import { catchAllServicePath } from '../utils/regex';
 import {
   FEATURE_INDEX_PAGE,
   MEDIA_ASSET_PAGE,
@@ -34,7 +34,7 @@ const CpsAsset = (props) => {
 };
 
 export default {
-  path: [cpsAssetPagePath, legacyAssetPagePath],
+  path: [catchAllServicePath],
   exact: true,
   component: memo(CpsAsset, pageIsSame),
   getInitialData,

--- a/src/app/routes/utils/regex/index.js
+++ b/src/app/routes/utils/regex/index.js
@@ -11,6 +11,7 @@ import {
   getRadioAndTVRegex,
   getErrorPageRegex,
   getLegacyAssetRegex,
+  getCatchAllServicePath,
 } from './utils';
 
 const allServices = Object.keys(services);
@@ -32,6 +33,9 @@ export const frontPageManifestPath = getManifestRegex(allServices);
 
 export const cpsAssetPagePath = getCpsAssetRegex(allServices);
 export const cpsAssetPageDataPath = `${cpsAssetPagePath}.json`;
+
+export const catchAllServicePath = getCatchAllServicePath(allServices);
+export const catchAllServiceDataPath = `${catchAllServicePath}.json`;
 
 export const liveRadioPath = getLiveRadioRegex(allServices);
 export const liveRadioDataPath = `${liveRadioPath}.json`;

--- a/src/app/routes/utils/regex/index.js
+++ b/src/app/routes/utils/regex/index.js
@@ -6,11 +6,9 @@ import {
   getFrontPageRegex,
   getSwRegex,
   getManifestRegex,
-  getCpsAssetRegex,
   getLiveRadioRegex,
   getRadioAndTVRegex,
   getErrorPageRegex,
-  getLegacyAssetRegex,
   getCatchAllServicePath,
 } from './utils';
 
@@ -31,9 +29,6 @@ export const frontPageDataPath = `${frontPagePath}.json`;
 export const frontPageSwPath = getSwRegex(allServices);
 export const frontPageManifestPath = getManifestRegex(allServices);
 
-export const cpsAssetPagePath = getCpsAssetRegex(allServices);
-export const cpsAssetPageDataPath = `${cpsAssetPagePath}.json`;
-
 export const catchAllServicePath = getCatchAllServicePath(allServices);
 export const catchAllServiceDataPath = `${catchAllServicePath}.json`;
 
@@ -45,6 +40,3 @@ export const radioAndTvDataPath = `${radioAndTvPath}.json`;
 
 export const errorPagePath = getErrorPageRegex(allServices);
 export const mostReadDataRegexPath = `/:service(${serviceRegex})/${mostRead}:variant(${variantRegex})?.json`;
-
-export const legacyAssetPagePath = getLegacyAssetRegex(allServices);
-export const legacyAssetPageDataPath = `${legacyAssetPagePath}.json`;

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -4,17 +4,15 @@ import {
   articleDataPath,
   articleSwPath,
   articleManifestPath,
+  catchAllServicePath,
+  catchAllServiceDataPath,
   frontPagePath,
   frontPageDataPath,
   frontPageManifestPath,
   frontPageSwPath,
-  cpsAssetPagePath,
-  cpsAssetPageDataPath,
   liveRadioPath,
   radioAndTvPath,
   mostReadDataRegexPath,
-  legacyAssetPagePath,
-  legacyAssetPageDataPath,
 } from './index';
 
 jest.mock('#server/utilities/serviceConfigs', () => ({
@@ -289,8 +287,8 @@ describe('liveRadioRegexPathsArray', () => {
   shouldNotMatchInvalidRoutes(invalidRoutes, liveRadioPath);
 });
 
-describe('cpsAssetPagePath', () => {
-  const validRoutes = [
+describe('catchAllServicePath', () => {
+  const validCpsRoutes = [
     '/pidgin/12345678',
     '/pidgin/12345678.amp',
     '/pidgin/tori-49450859',
@@ -306,26 +304,21 @@ describe('cpsAssetPagePath', () => {
     '/zhongwen/simp/test-12345678.amp',
   ];
 
-  shouldMatchValidRoutes(validRoutes, cpsAssetPagePath);
+  shouldMatchValidRoutes(validCpsRoutes, catchAllServicePath);
 
-  // According to CPS a valid assetUri should have 8 digits or more and CPS index is optional
-  const inValidRoutes = [
-    '/pidgin/1234567',
-    '/pidgin/12345678/.amp',
-    '/blah/12345678',
-    '/pidgin/test-494859',
-    '/blah/test-49450859',
-    '/pidgin/test-49450859/.amp',
-    '/pidgin/test-49450859/',
-    '/pidgin/test-494859.amp',
-    // Below are legacy asset routes - should not match CPS routes
+  const validLegacyAssetRoutes = [
     '/sinhala/sri_lanka/2015/02/150218_mahinda_rally_sl',
     '/hausa/multimedia/2014/05/140528_hip_hop_40years_gallery',
+    '/zhongwen/simp/multimedia/2016/05/160511_vid_cultural_revolution_explainer',
   ];
-  shouldNotMatchInvalidRoutes(inValidRoutes, cpsAssetPagePath);
+
+  shouldMatchValidRoutes(validLegacyAssetRoutes, catchAllServicePath);
+
+  const inValidRoutes = ['/blah/12345678', '/blah/test-49450859'];
+  shouldNotMatchInvalidRoutes(inValidRoutes, catchAllServiceDataPath);
 });
 
-describe('cpsAssetPageDataPath', () => {
+describe('catchAllServiceDataPath', () => {
   const validRoutes = [
     '/pidgin/12345678.json',
     '/pidgin/test-49450859.json',
@@ -335,55 +328,15 @@ describe('cpsAssetPageDataPath', () => {
     '/zhongwen/trad/test-12345678.json',
   ];
 
-  shouldMatchValidRoutes(validRoutes, cpsAssetPageDataPath);
+  shouldMatchValidRoutes(validRoutes, catchAllServiceDataPath);
 
-  // According to CPS a valid assetUri should have 8 digits or more and CPS index is optional
-  const inValidRoutes = [
-    '/pidgin/1234567.json',
-    '/pidgin/12345678',
-    '/pidgin/test-494859.json',
-    '/blah/test-49450859.json',
-    '/pidgin/test-49450859',
-    '/pidgin/test-49450859/.json',
-    '/pidgin/test-494859.amp.json',
-    // Below are legacy asset routes - should not match CPS routes
-    '/sinhala/sri_lanka/2015/02/150218_mahinda_rally_sl.json',
-    '/hausa/multimedia/2014/05/140528_hip_hop_40years_gallery.json',
-  ];
-  shouldNotMatchInvalidRoutes(inValidRoutes, cpsAssetPageDataPath);
-});
-
-describe('legacyAssetPagePath', () => {
-  const validRoutes = [
-    '/sinhala/sri_lanka/2015/02/150218_mahinda_rally_sl',
-    '/hausa/multimedia/2014/05/140528_hip_hop_40years_gallery',
-    '/zhongwen/simp/multimedia/2016/05/160511_vid_cultural_revolution_explainer',
-  ];
-
-  shouldMatchValidRoutes(validRoutes, legacyAssetPagePath);
-
-  const inValidRoutes = [
-    // Must be a 4 digit year after category
-    '/sinhala/category/15/02/150218_mahinda_rally_sl',
-    // Asset URI begin with a 6 digit date
-    '/hausa/multimedia/2014/05/hip_hop_40years_gallery',
-  ];
-  shouldNotMatchInvalidRoutes(inValidRoutes, legacyAssetPagePath);
-});
-
-describe('legacyAssetPageDataPath', () => {
-  const validRoutes = [
+  const validLegacyAssetRoutes = [
     '/sinhala/sri_lanka/2015/02/150218_mahinda_rally_sl.json',
     '/hausa/multimedia/2014/05/140528_hip_hop_40years_gallery.json',
   ];
 
-  shouldMatchValidRoutes(validRoutes, legacyAssetPageDataPath);
+  shouldMatchValidRoutes(validLegacyAssetRoutes, catchAllServiceDataPath);
 
-  const inValidRoutes = [
-    // Must be a 4 digit year after category
-    '/sinhala/category/15/02/150218_mahinda_rally_sl.json',
-    // Asset URI begin with a 6 digit date
-    '/hausa/multimedia/2014/05/hip_hop_40years_gallery.json',
-  ];
-  shouldNotMatchInvalidRoutes(inValidRoutes, legacyAssetPageDataPath);
+  const inValidRoutes = ['/blah/test-49450859.json'];
+  shouldNotMatchInvalidRoutes(inValidRoutes, catchAllServiceDataPath);
 });

--- a/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
@@ -6,6 +6,8 @@ exports[`regex utils snapshots should create expected regex from getArticleRegex
 
 exports[`regex utils snapshots should create expected regex from getArticleSwRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|erthyglau|sgeulachdan)/sw.js"`;
 
+exports[`regex utils snapshots should create expected regex from getCatchAllServicePath 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?:pathparam(.{0,}):amp(.amp)?"`;
+
 exports[`regex utils snapshots should create expected regex from getCpsAssetRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/:assetUri([a-z-_]{0,}[0-9]{8,}):amp(.amp)?"`;
 
 exports[`regex utils snapshots should create expected regex from getErrorPageRegex 1`] = `"/:service(news|persian|igbo)/:errorCode(404|500):variant(/simp|/trad|/cyr|/lat)?"`;

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -8,7 +8,7 @@ const articleLocalRegex = 'articles|erthyglau|sgeulachdan';
 const mediaIdRegex = '[a-z0-9]+';
 const mediaServiceIdRegex = 'bbc_[a-z]+_radio|bbc_[a-z]+_tv';
 const errorCodeRegex = '404|500';
-const anyCharsRegex = '*{0,}';
+const anyCharsRegex = '.{0,}';
 
 const getServiceRegex = (services) => services.join('|');
 

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -8,6 +8,7 @@ const articleLocalRegex = 'articles|erthyglau|sgeulachdan';
 const mediaIdRegex = '[a-z0-9]+';
 const mediaServiceIdRegex = 'bbc_[a-z]+_radio|bbc_[a-z]+_tv';
 const errorCodeRegex = '404|500';
+const anyCharsRegex = '*{0,}';
 
 const getServiceRegex = (services) => services.join('|');
 
@@ -64,4 +65,9 @@ export const getRadioAndTVRegex = (services) => {
 export const getErrorPageRegex = (services) => {
   const serviceRegex = getServiceRegex(services);
   return `/:service(${serviceRegex})/:errorCode(${errorCodeRegex}):variant(${variantRegex})?`;
+};
+
+export const getCatchAllServicePath = (services) => {
+  const serviceRegex = getServiceRegex(services);
+  return `/:service(${serviceRegex}):variant(${variantRegex})?:pathparam(${anyCharsRegex}):amp(${ampRegex})?`;
 };


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Replaces the legacy and CPS routes with a catch all route

**Code changes:**

- Replaces the legacy and CPS routes with a catch all route
- Updates tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
