### PR TITLE
Adding ATI Analytics for onDemand Radio

### DIFF
--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
@@ -26,7 +26,8 @@ export const buildRadioATIParams = (
   return {
     appName: atiAnalyticsAppName,
     contentId: isLiveRadio ? id : getContentId('pips'),
-    contentType,
+    // workaround until ARES have corrected onDemand contentType to player-episode
+    contentType: isLiveRadio ? contentType : 'player-episode',
     language,
     pageIdentifier,
     pageTitle,

--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
@@ -15,9 +15,17 @@ export const buildRadioATIParams = (
 
   const { id, language, pageTitle, pageIdentifier, contentType } = pageData;
 
+  const isLiveRadio = contentType === 'player-live';
+
+  const getContentId = (assetType) => {
+    const guid = id.split('/').pop();
+    const contentId = `urn:bbc:${assetType}:`.concat(guid);
+    return contentId;
+  };
+
   return {
     appName: atiAnalyticsAppName,
-    contentId: id,
+    contentId: isLiveRadio ? id : getContentId('pips'),
     contentType,
     language,
     pageIdentifier,

--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
@@ -17,7 +17,7 @@ export const buildRadioATIParams = (
 
   const isLiveRadio = contentType === 'player-live';
 
-  const getContentId = (assetType) => {
+  const getContentId = assetType => {
     const guid = id.split('/').pop();
     const contentId = `urn:bbc:${assetType}:`.concat(guid);
     return contentId;

--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.test.js
@@ -7,12 +7,20 @@ analyticsUtils.getPublishedDatetime = jest
   .fn()
   .mockReturnValue('1970-01-01T00:00:00.000Z');
 
-const radio = {
+const liveRadio = {
   id: 'id',
   language: 'language',
   pageIdentifier: 'pageIdentifier',
   pageTitle: 'pageTitle',
   contentType: 'player-live',
+};
+
+const onDemandRadio = {
+  id: 'id',
+  language: 'language',
+  pageIdentifier: 'pageIdentifier',
+  pageTitle: 'pageTitle',
+  contentType: 'player-episode',
 };
 
 const requestContext = {
@@ -29,7 +37,7 @@ const serviceContext = {
   service: 'service',
 };
 
-const validURLParams = {
+const validLiveRadioURLParams = {
   appName: serviceContext.atiAnalyticsAppName,
   contentId: 'id',
   contentType: 'player-live',
@@ -43,16 +51,43 @@ const validURLParams = {
   service: 'service',
 };
 
+const validOnDemandURLParams = {
+  appName: serviceContext.atiAnalyticsAppName,
+  contentId: 'urn:bbc:pips:id',
+  contentType: 'player-episode',
+  language: 'language',
+  pageIdentifier: 'pageIdentifier',
+  pageTitle: 'pageTitle',
+  producerId: serviceContext.atiAnalyticsProducerId,
+  statsDestination: requestContext.statsDestination,
+  libraryVersion: analyticsUtils.LIBRARY_VERSION,
+  platform: requestContext.platform,
+  service: 'service',
+};
+
 describe('buildRadioATIParams', () => {
-  it('should return the right object', () => {
-    const result = buildRadioATIParams(radio, requestContext, serviceContext);
-    expect(result).toEqual(validURLParams);
+  it('should return the right object for live radio', () => {
+    const result = buildRadioATIParams(
+      liveRadio,
+      requestContext,
+      serviceContext,
+    );
+    expect(result).toEqual(validLiveRadioURLParams);
+  });
+
+  it('should return the right object for onDemand radio', () => {
+    const result = buildRadioATIParams(
+      onDemandRadio,
+      requestContext,
+      serviceContext,
+    );
+    expect(result).toEqual(validOnDemandURLParams);
   });
 });
 
 describe('buildRadioATIUrl', () => {
-  it('should return the right url', () => {
-    const result = buildRadioATIUrl(radio, requestContext, serviceContext);
+  it('should return the right url for live radio', () => {
+    const result = buildRadioATIUrl(liveRadio, requestContext, serviceContext);
     expect(result).toEqual(
       [
         's=598285',
@@ -68,6 +103,33 @@ describe('buildRadioATIUrl', () => {
         'x4=[language]',
         'x5=[http://localhost/]',
         'x7=[player-live]',
+        'x8=[simorgh]',
+        'x9=[pageTitle]',
+      ].join('&'),
+    );
+  });
+
+  it('should return the right url for onDemand radio', () => {
+    const result = buildRadioATIUrl(
+      onDemandRadio,
+      requestContext,
+      serviceContext,
+    );
+    expect(result).toEqual(
+      [
+        's=598285',
+        's2=atiAnalyticsProducerId',
+        'p=pageIdentifier',
+        'r=0x0x24x24',
+        're=1024x768',
+        'hl=00-00-00',
+        'lng=en-US',
+        'x1=[urn:bbc:pips:id]',
+        'x2=[responsive]',
+        'x3=[atiAnalyticsAppName]',
+        'x4=[language]',
+        'x5=[http://localhost/]',
+        'x7=[player-episode]',
         'x8=[simorgh]',
         'x9=[pageTitle]',
       ].join('&'),

--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.test.js
@@ -66,7 +66,7 @@ const validOnDemandURLParams = {
 };
 
 describe('buildRadioATIParams', () => {
-  it('should return the right object for live radio', () => {
+  it('should return the correct object for live radio', () => {
     const result = buildRadioATIParams(
       liveRadio,
       requestContext,
@@ -75,7 +75,7 @@ describe('buildRadioATIParams', () => {
     expect(result).toEqual(validLiveRadioURLParams);
   });
 
-  it('should return the right object for onDemand radio', () => {
+  it('should return the correct object for onDemand radio', () => {
     const result = buildRadioATIParams(
       onDemandRadio,
       requestContext,
@@ -86,7 +86,7 @@ describe('buildRadioATIParams', () => {
 });
 
 describe('buildRadioATIUrl', () => {
-  it('should return the right url for live radio', () => {
+  it('should return the correct url for live radio', () => {
     const result = buildRadioATIUrl(liveRadio, requestContext, serviceContext);
     expect(result).toEqual(
       [
@@ -109,7 +109,7 @@ describe('buildRadioATIUrl', () => {
     );
   });
 
-  it('should return the right url for onDemand radio', () => {
+  it('should return the correct url for onDemand radio', () => {
     const result = buildRadioATIUrl(
       onDemandRadio,
       requestContext,

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -422,6 +422,13 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 }
 
 <div>
+      <amp-analytics>
+        <script
+          type="application/json"
+        >
+          {"transport":{"beacon":false,"xhrpost":false,"image":true},"requests":{"pageview":"\${base}s=598343&s2=68&p=pashto.bbc_pashto_radio.w172x8nvf4bchz5.page&r=\${screenWidth}x\${screenHeight}x\${screenColorDepth}&re=\${availableScreenWidth}x\${availableScreenHeight}&hl=\${timestamp}&lng=\${browserLanguage}&x1=[urn:bbc:pips:w172x8nvf4bchz5]&x2=[amp]&x3=[news-pashto]&x4=[ps]&x5=[\${sourceUrl}]&x6=[\${documentReferrer}]&x7=[player-ondemand]&x8=[simorgh]&x9=[وروستي+خبرونه+-+BBC+News+پښتو]"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}
+        </script>
+      </amp-analytics>
       <main
         class="c0 c1"
         dir="rtl"
@@ -897,6 +904,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   </head>
   <body>
     <div>
+      <noscript />
       <main
         class="c0 c1"
         dir="rtl"
@@ -1105,6 +1113,7 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 }
 
 <div>
+  <noscript />
   <main
     class="c0 c1"
     dir="ltr"
@@ -1357,6 +1366,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 }
 
 <div>
+  <noscript />
   <main
     class="c0 c1"
     dir="ltr"

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -426,7 +426,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
         <script
           type="application/json"
         >
-          {"transport":{"beacon":false,"xhrpost":false,"image":true},"requests":{"pageview":"\${base}s=598343&s2=68&p=pashto.bbc_pashto_radio.w172x8nvf4bchz5.page&r=\${screenWidth}x\${screenHeight}x\${screenColorDepth}&re=\${availableScreenWidth}x\${availableScreenHeight}&hl=\${timestamp}&lng=\${browserLanguage}&x1=[urn:bbc:pips:w172x8nvf4bchz5]&x2=[amp]&x3=[news-pashto]&x4=[ps]&x5=[\${sourceUrl}]&x6=[\${documentReferrer}]&x7=[player-ondemand]&x8=[simorgh]&x9=[وروستي+خبرونه+-+BBC+News+پښتو]"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}
+          {"transport":{"beacon":false,"xhrpost":false,"image":true},"requests":{"pageview":"\${base}s=598343&s2=68&p=pashto.bbc_pashto_radio.w172x8nvf4bchz5.page&r=\${screenWidth}x\${screenHeight}x\${screenColorDepth}&re=\${availableScreenWidth}x\${availableScreenHeight}&hl=\${timestamp}&lng=\${browserLanguage}&x1=[urn:bbc:pips:w172x8nvf4bchz5]&x2=[amp]&x3=[news-pashto]&x4=[ps]&x5=[\${sourceUrl}]&x6=[\${documentReferrer}]&x7=[player-episode]&x8=[simorgh]&x9=[وروستي+خبرونه+-+BBC+News+پښتو]"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}
         </script>
       </amp-analytics>
       <main

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { string, number, shape } from 'prop-types';
 import styled from 'styled-components';
 import MetadataContainer from '../../containers/Metadata';
+import ATIAnalytics from '../../containers/ATIAnalytics';
 import Grid, { GelPageGrid } from '#app/components/Grid';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import HeadingBlock from '#containers/RadioPageBlocks/Blocks/Heading';
@@ -66,6 +67,7 @@ const OnDemandRadioPage = ({ pageData }) => {
 
   return (
     <>
+      <ATIAnalytics data={pageData} />
       <MetadataContainer
         title={headline}
         lang={language}

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -8,7 +8,15 @@ const getHeadline = path(['promo', 'headlines', 'headline']);
 const getShortSynopsis = path(['promo', 'media', 'synopses', 'short']);
 const getSummary = path(['content', 'blocks', '0', 'synopses', 'short']);
 const getEpisodeId = path(['content', 'blocks', '0', 'id']);
+const getId = path(['metadata', 'id']);
 const getMasterBrand = path(['metadata', 'createdBy']);
+const getContentType = path(['metadata', 'analyticsLabels', 'contentType']);
+const getPageTitle = path(['metadata', 'analyticsLabels', 'pageTitle']);
+const getPageIdentifier = path([
+  'metadata',
+  'analyticsLabels',
+  'pageIdentifier',
+]);
 const getEpisodeAvailableFrom = path([
   'content',
   'blocks',
@@ -38,11 +46,15 @@ export default async ({ path: pathname }) => {
         episodeTitle: getEpisodeTitle(json),
         headline: getHeadline(json),
         shortSynopsis: getShortSynopsis(json),
+        id: getId(json),
         summary: getSummary(json),
+        contentType: getContentType(json),
         episodeId: getEpisodeId(json),
         masterBrand: getMasterBrand(json),
         episodeAvailableFrom: getEpisodeAvailableFrom(json),
         episodeAvailableUntil: getEpisodeAvailableUntil(json),
+        pageTitle: getPageTitle(json),
+        pageIdentifier: getPageIdentifier(json),
       },
     }),
   };


### PR DESCRIPTION
Resolves #6134

**Overall change:**
Adding ATI Analytics to onDemand radio page

**Code changes:**

- Passing through additional values from getInitialData, required by ATI
- Added ATI component to onDemand Radio page
- Added logic to ATI Analytics radio/buildParams to return correct contentId for onDemand radio as served from pips.
- Updated tests to reflect changes

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
