### PR TITLE
Adding Chartbeat to onDemand radio, updating values for liveRadio

### DIFF
--- a/src/app/containers/ChartbeatAnalytics/utils/index.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.js
@@ -33,7 +33,7 @@ export const getType = (pageType, shorthand = false) => {
     case 'MAP':
       return 'article-media-asset';
     case 'media':
-      return 'Live Radio';
+      return 'Radio';
     default:
       return null;
   }
@@ -64,10 +64,9 @@ export const buildSections = ({
     case 'media':
       return [
         serviceCap,
-        buildSectionItem(serviceCap, ''),
-        buildSectionItem(serviceCap, 'unknown'),
-        buildSectionItem(serviceCap, 'unknown'),
-        buildSectionItem(serviceCap, 'unknown'),
+        ...(pageType ? buildSectionItem(serviceCap, type) : []),
+        ...(addProducer ? buildSectionArr(serviceCap, producer, type) : []),
+        ...(chapter ? buildSectionArr(serviceCap, chapter, type) : []),
       ].join(', ');
     default:
       return [
@@ -89,10 +88,16 @@ export const getTitle = (pageType, pageData, brandName) => {
     case 'MAP':
       return path(['promo', 'headlines', 'headline'], pageData);
     case 'media':
-      return path(['name'], pageData);
+      return path(['pageTitle'], pageData);
     default:
       return null;
   }
+};
+
+const getRadioContentType = pageData => {
+  const contentType = path(['contentType'], pageData);
+  // workaround until contentType value is fixed by ARES
+  return contentType === 'player-live' ? contentType : 'player-episode';
 };
 
 export const getConfig = ({
@@ -123,6 +128,8 @@ export const getConfig = ({
   });
   const cookie = getSylphidCookie();
   const type = getType(pageType);
+  const contentType = type === 'Radio' ? getRadioContentType(data) : type;
+
   const currentPath = onClient() && window.location.pathname;
   return {
     domain,
@@ -130,9 +137,9 @@ export const getConfig = ({
     uid: chartbeatUID,
     title,
     virtualReferrer: referrer,
-    ...(isAmp && { contentType: type }),
+    ...(isAmp && { contentType }),
     ...(!isAmp && {
-      type,
+      type: contentType,
       useCanonical,
       path: currentPath,
     }),

--- a/src/app/containers/ChartbeatAnalytics/utils/index.test.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.test.js
@@ -63,8 +63,8 @@ describe('Chartbeat utilities', () => {
       },
       {
         type: 'media',
-        expectedDefaultType: 'Live Radio',
-        expectedShortType: 'Live Radio',
+        expectedDefaultType: 'Radio',
+        expectedShortType: 'Radio',
       },
       {
         type: null,
@@ -159,8 +159,7 @@ describe('Chartbeat utilities', () => {
         service: 'korean',
         pageType: 'media',
         description: 'should return expected section for live radio',
-        expected:
-          'Korean, Korean - , Korean - unknown, Korean - unknown, Korean - unknown',
+        expected: 'Korean, Korean - Radio',
       },
     ];
 
@@ -260,10 +259,19 @@ describe('Chartbeat utilities', () => {
     it('should return correct title when pageType is media (Live radio)', () => {
       const pageType = 'media';
       const pageData = {
-        name: 'Live Radio Page Title',
+        pageTitle: 'Live Radio Page Title',
       };
 
       expect(getTitle(pageType, pageData)).toBe('Live Radio Page Title');
+    });
+
+    it('should return correct title when pageType is media (onDemand radio)', () => {
+      const pageType = 'media';
+      const pageData = {
+        pageTitle: 'OnDemand Radio Page Title',
+      };
+
+      expect(getTitle(pageType, pageData)).toBe('OnDemand Radio Page Title');
     });
   });
 
@@ -385,7 +393,8 @@ describe('Chartbeat utilities', () => {
         platform: 'amp',
         pageType: 'media',
         data: {
-          name: 'Live Radio Page Title',
+          pageTitle: 'Live Radio Page Title',
+          contentType: 'player-live',
         },
         brandName: '',
         chartbeatDomain: 'korean.bbc.co.uk',
@@ -400,15 +409,46 @@ describe('Chartbeat utilities', () => {
         idSync: {
           bbc_hid: 'foobar',
         },
-        sections:
-          'Korean, Korean - , Korean - unknown, Korean - unknown, Korean - unknown',
+        sections: 'Korean, Korean - Radio',
         title: 'Live Radio Page Title',
-        contentType: 'Live Radio',
+        contentType: 'player-live',
         uid: 50924,
         virtualReferrer: `\${documentReferrer}`,
       };
 
       expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
     });
+  });
+
+  it('should return config for amp pages when page type is media (onDemand radio) and env is live', () => {
+    const fixtureData = {
+      isAmp: true,
+      platform: 'amp',
+      pageType: 'media',
+      data: {
+        pageTitle: 'OnDemand Radio Page Title',
+        contentType: 'player-episode',
+      },
+      brandName: '',
+      chartbeatDomain: 'korean.bbc.co.uk',
+      env: 'live',
+      service: 'korean',
+      origin: 'bbc.com',
+      previousPath: '/previous-path',
+    };
+
+    const expectedConfig = {
+      domain: 'korean.bbc.co.uk',
+      idSync: {
+        bbc_hid: 'foobar',
+      },
+      sections: 'Korean, Korean - Radio',
+      title: 'OnDemand Radio Page Title',
+      contentType: 'player-episode',
+      uid: 50924,
+      virtualReferrer: `\${documentReferrer}`,
+    };
+
+    expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
   });
 });

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -429,6 +429,9 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
           {"transport":{"beacon":false,"xhrpost":false,"image":true},"requests":{"pageview":"\${base}s=598343&s2=68&p=pashto.bbc_pashto_radio.w172x8nvf4bchz5.page&r=\${screenWidth}x\${screenHeight}x\${screenColorDepth}&re=\${availableScreenWidth}x\${availableScreenHeight}&hl=\${timestamp}&lng=\${browserLanguage}&x1=[urn:bbc:pips:w172x8nvf4bchz5]&x2=[amp]&x3=[news-pashto]&x4=[ps]&x5=[\${sourceUrl}]&x6=[\${documentReferrer}]&x7=[player-episode]&x8=[simorgh]&x9=[وروستي+خبرونه+-+BBC+News+پښتو]"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}
         </script>
       </amp-analytics>
+      <div>
+        chartbeat
+      </div>
       <main
         class="c0 c1"
         dir="rtl"
@@ -905,6 +908,9 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   <body>
     <div>
       <noscript />
+      <div>
+        chartbeat
+      </div>
       <main
         class="c0 c1"
         dir="rtl"
@@ -1114,6 +1120,9 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 
 <div>
   <noscript />
+  <div>
+    chartbeat
+  </div>
   <main
     class="c0 c1"
     dir="ltr"
@@ -1367,6 +1376,9 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 
 <div>
   <noscript />
+  <div>
+    chartbeat
+  </div>
   <main
     class="c0 c1"
     dir="ltr"

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -3,6 +3,7 @@ import { string, number, shape } from 'prop-types';
 import styled from 'styled-components';
 import MetadataContainer from '../../containers/Metadata';
 import ATIAnalytics from '../../containers/ATIAnalytics';
+import ChartbeatAnalytics from '../../containers/ChartbeatAnalytics';
 import Grid, { GelPageGrid } from '#app/components/Grid';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import HeadingBlock from '#containers/RadioPageBlocks/Blocks/Heading';
@@ -68,6 +69,7 @@ const OnDemandRadioPage = ({ pageData }) => {
   return (
     <>
       <ATIAnalytics data={pageData} />
+      <ChartbeatAnalytics data={pageData} />
       <MetadataContainer
         title={headline}
         lang={language}

--- a/src/integration/pages/liveRadioPage/__snapshots__/amharic.test.js.snap
+++ b/src/integration/pages/liveRadioPage/__snapshots__/amharic.test.js.snap
@@ -599,7 +599,7 @@ exports[`Given I am on the Amharic Live Radio page When I view the source code i
       </amp-analytics>
       <amp-analytics type="chartbeat">
         <script type="application/json">
-          {"vars":{"domain":"test.bbc.co.uk","sections":"Amharic, Amharic - , Amharic - unknown, Amharic - unknown, Amharic - unknown","uid":50924,"title":"ያድምጡ","virtualReferrer":"\${documentReferrer}","contentType":"Live Radio"}}
+          {"vars":{"domain":"test.bbc.co.uk","sections":"Amharic, Amharic - Radio","uid":50924,"title":"ያድምጡ - BBC News አማርኛ","virtualReferrer":"\${documentReferrer}","contentType":"player-live"}}
         </script>
       </amp-analytics>
       <main role="main"

--- a/src/integration/pages/liveRadioPage/__snapshots__/korean.test.js.snap
+++ b/src/integration/pages/liveRadioPage/__snapshots__/korean.test.js.snap
@@ -587,7 +587,7 @@ exports[`Given I am on the Korean Live Radio page When I view the source code in
       </amp-analytics>
       <amp-analytics type="chartbeat">
         <script type="application/json">
-          {"vars":{"domain":"test.bbc.co.uk","sections":"Korean, Korean - , Korean - unknown, Korean - unknown, Korean - unknown","uid":50924,"title":"BBC 코리아 라디오","virtualReferrer":"\${documentReferrer}","contentType":"Live Radio"}}
+          {"vars":{"domain":"test.bbc.co.uk","sections":"Korean, Korean - Radio","uid":50924,"title":"BBC 코리아 라디오 - BBC News 코리아","virtualReferrer":"\${documentReferrer}","contentType":"player-live"}}
         </script>
       </amp-analytics>
       <main role="main"


### PR DESCRIPTION
Resolves #6136

**Overall change:**
Adding Chartbeat for the onDemand Radio pages. Also updated values for the liveRadio pages

**Code changes:**

- Added Chartbeat component to onDemand Radio
- Updated the values for liveRadio/onDemand Chartbeat:
- Section was: 'Korean, Korean - , Korean - unknown, Korean - unknown, Korean - unknown',
- Section now: 'Korean, Korean - Radio',
- Type was 'Live Radio', type now 'player-live' or 'player-episode'
- Updated tests to reflect changes

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
