### PR TITLE
[POC] Add fake api for F&T, modify getInitialData to fetch secondary col data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10824,28 +10824,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -10856,14 +10856,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -10874,42 +10874,42 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "optional": true,
@@ -10919,28 +10919,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "optional": true,
@@ -10950,14 +10950,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -10974,7 +10974,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "optional": true,
@@ -10989,14 +10989,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -11006,7 +11006,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
           "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "optional": true,
@@ -11016,7 +11016,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -11027,21 +11027,21 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -11051,14 +11051,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -11068,14 +11068,14 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
           "optional": true,
@@ -11086,7 +11086,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "optional": true,
@@ -11096,7 +11096,7 @@
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
           "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
           "dev": true,
           "optional": true,
@@ -11106,14 +11106,14 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
           "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
           "dev": true,
           "optional": true,
@@ -11125,7 +11125,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
           "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "dev": true,
           "optional": true,
@@ -11144,7 +11144,7 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
           "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "optional": true,
@@ -11155,7 +11155,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
           "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "optional": true,
@@ -11165,14 +11165,14 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
           "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "optional": true,
@@ -11184,7 +11184,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -11197,21 +11197,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -11221,21 +11221,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -11246,21 +11246,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
           "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -11273,7 +11273,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "optional": true,
@@ -11289,7 +11289,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "optional": true,
@@ -11299,49 +11299,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -11353,7 +11353,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -11363,7 +11363,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -11373,14 +11373,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
@@ -11396,14 +11396,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -11413,14 +11413,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true

--- a/src/app/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/containers/CpsFeaturesAnalysis/index.jsx
@@ -41,8 +41,4 @@ FeaturesAnalysis.propTypes = {
   content: arrayOf(shape(storyItem)),
 };
 
-FeaturesAnalysis.defaultProps = {
-  content: featuresAnalysis, // TODO: rm this https://github.com/bbc/simorgh/issues/5765
-};
-
 export default FeaturesAnalysis;

--- a/src/app/containers/CpsTopStories/index.jsx
+++ b/src/app/containers/CpsTopStories/index.jsx
@@ -41,8 +41,4 @@ TopStories.propTypes = {
   content: arrayOf(shape(storyItem)),
 };
 
-TopStories.defaultProps = {
-  content: topStories, // TODO: rm this https://github.com/bbc/simorgh/issues/5765
-};
-
 export default TopStories;

--- a/src/app/pages/StoryPage/index.jsx
+++ b/src/app/pages/StoryPage/index.jsx
@@ -79,25 +79,22 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
     featuresAndAnalysis || secondaryColState.featuresAndAnalysis;
 
   useEffect(() => {
-    const abortController = new AbortController();
-    const signal = abortController.signal;
+    let isSubscribed = true;
 
     const fetchAditionalData = async () => {
-      const data = await fetchPageData('/mundo/testdata', { signal: signal });
+      const data = await fetchPageData('/mundo/testdata');
       const { json } = data;
       if (json) {
-        setSecondaryColState(json);
+        // Only setstate if still subscribed to promise/component is mounted
+        isSubscribed ? setSecondaryColState(json) : null;
       }
     };
 
     if (!topStories && !featuresAndAnalysis) {
-      console.log('fetching data');
       fetchAditionalData();
     }
 
-    return () => {
-      abortController.abort;
-    };
+    return () => (isSubscribed = false); // unsubscribe to promise when cleaningup useEffect
   }, [pageData]);
 
   const componentsToRender = {

--- a/src/app/pages/StoryPage/index.jsx
+++ b/src/app/pages/StoryPage/index.jsx
@@ -37,7 +37,11 @@ import categoryType from './categoryMap/index';
 import Include from '#containers/Include';
 import { ServiceContext } from '#contexts/ServiceContext';
 
-const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
+const StoryPage = ({
+  pageData,
+  mostReadEndpointOverride,
+  secondaryColumData,
+}) => {
   const { dir } = useContext(ServiceContext);
   const title = path(['promo', 'headlines', 'headline'], pageData);
   const category = path(
@@ -62,6 +66,9 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
   const firstPublished = getFirstPublished(pageData);
   const lastPublished = getLastPublished(pageData);
   const aboutTags = getAboutTags(pageData);
+  const {
+    additonalData: { featuresAndAnalysis, topStories },
+  } = pageData;
 
   const componentsToRender = {
     fauxHeadline,
@@ -212,10 +219,10 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
           parentColumns={gridColumns}
         >
           <ResponsiveComponentWrapper>
-            <TopStories />
+            <TopStories content={topStories} />
           </ResponsiveComponentWrapper>
           <ResponsiveComponentWrapper>
-            <FeaturesAnalysis />
+            <FeaturesAnalysis content={featuresAndAnalysis} />
           </ResponsiveComponentWrapper>
           <ComponentWrapper>
             <MostReadContainer

--- a/src/app/pages/StoryPage/index.jsx
+++ b/src/app/pages/StoryPage/index.jsx
@@ -37,11 +37,7 @@ import categoryType from './categoryMap/index';
 import Include from '#containers/Include';
 import { ServiceContext } from '#contexts/ServiceContext';
 
-const StoryPage = ({
-  pageData,
-  mostReadEndpointOverride,
-  secondaryColumData,
-}) => {
+const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
   const { dir } = useContext(ServiceContext);
   const title = path(['promo', 'headlines', 'headline'], pageData);
   const category = path(

--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -16,6 +16,7 @@ import addAnalyticsCounterName from './addAnalyticsCounterName';
 import convertToOptimoBlocks from './convertToOptimoBlocks';
 import processUnavailableMedia from './processUnavailableMedia';
 import { MEDIA_ASSET_PAGE, STORY_PAGE } from '#app/routes/utils/pageTypes';
+import onClient from '../../../lib/utilities/onClient';
 
 const formatPageData = pipe(
   addAnalyticsCounterName,
@@ -68,14 +69,17 @@ const getAdditionalData = async (pageData) => {
 
 export default async ({ path: pathname }) => {
   const { json, ...rest } = await fetchPageData(pathname);
-  //   const { json: data } = await fetchPageData('/mundo/testdata');
+  let pageData = await transformJson(json);
 
-  const additonalData = await getAdditionalData(json);
+  if (!onClient()) {
+    const additionalData = await getAdditionalData(json);
+    pageData = { ...(await transformJson(json)), additionalData };
+  }
 
   return {
     ...rest,
     ...(json && {
-      pageData: { ...(await transformJson(json)), additonalData },
+      pageData,
     }),
   };
 };

--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -67,12 +67,12 @@ const handleError = (e) => {
   };
 };
 
-const fetchData = (pathname) => {
+const fetchData = (pathname, options = {}) => {
   const url = getUrl(pathname);
 
   logger.info(DATA_REQUEST_RECEIVED, { url });
 
-  return fetch(url).then(handleResponse(url)).catch(handleError);
+  return fetch(url, options).then(handleResponse(url)).catch(handleError);
 };
 
 export default fetchData;

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -51,6 +51,245 @@ class LoggerStream {
     logger.info(message.substring(0, message.lastIndexOf('\n')));
   }
 }
+const secondaryColumData = {
+  featuresAndAnalysis: [
+    {
+      headlines: {
+        shortHeadline: 'STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?',
+        headline: 'STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?',
+      },
+      locators: {
+        assetUri: '/igbo/afirika-23252735',
+        cpsUrn: 'urn:bbc:content:assetUri:igbo/afirika-23252735',
+        curie:
+          'http://www.bbc.co.uk/asset/954b3c17-7900-9342-aa1a-6857067770d7',
+      },
+      summary:
+        'This is a test asset used in Simorgh, please do not edit it without asking.',
+      timestamp: 1580745507000,
+      byline: {
+        name: 'By Andrew Overtyped Marr',
+        title: 'BBC News - Overtyped',
+        persons: [
+          {
+            name: 'Andrew Marr',
+            function: 'BBC News',
+            thumbnail:
+              'http://wwwpreview.test.newsonline.tc.nca.bbc.co.uk/media/images/50002000/jpg/_50002170_andrew_marr_112_bbc.jpg',
+          },
+        ],
+      },
+      passport: {
+        category: {
+          categoryId:
+            'http://www.bbc.co.uk/ontologies/applicationlogic-news/News',
+          categoryName: 'News',
+        },
+        campaigns: [
+          {
+            campaignId: '5ad86270c93a9f000eecb255',
+            campaignName: 'Amuse me',
+          },
+        ],
+      },
+      indexImage: {
+        id: '63724372',
+        subType: 'index',
+        href:
+          'http://b.files.bbci.co.uk/6ACE/test/_63724372_gettyimages-1098075358.jpg',
+        path: '/cpsdevpb/6ACE/test/_63724372_gettyimages-1098075358.jpg',
+        height: 549,
+        width: 976,
+        altText: 'Some people at the NTA awards',
+        copyrightHolder: 'Joe Maher',
+        type: 'image',
+      },
+      id: 'urn:bbc:ares::asset:igbo/afirika-23252735',
+      type: 'cps',
+    },
+    {
+      headlines: {
+        shortHeadline: 'Zimbabwe eferela Robert Mugabe aka',
+        headline: 'Robert Mugabe: Zimbabwe eferela nwa amadi a aka',
+      },
+      locators: {
+        assetUri: '/igbo/afirika-49666505',
+        cpsUrn: 'urn:bbc:content:assetUri:igbo/afirika-49666505',
+        curie:
+          'http://www.bbc.co.uk/asset/40af9483-cf8c-254f-b5f8-af1fa2a74436',
+      },
+      summary:
+        "Gọọmentị nakwa ndị Zimbabwe pụtara n'igwe iji kwanyere aka chịburu ha bụ Robert Mugabe ugwu ikpeazụ ya na Harare.",
+      timestamp: 1580745507000,
+      passport: {
+        category: {
+          categoryId:
+            'http://www.bbc.co.uk/ontologies/applicationlogic-news/Feature',
+          categoryName: 'Feature',
+        },
+        campaigns: [
+          {
+            campaignId: '5a988e3e39461b000e9dabfb',
+            campaignName: 'WS - Keep me on trend',
+          },
+        ],
+      },
+      indexImage: {
+        id: '108810335',
+        subType: 'index',
+        href:
+          'http://c.files.bbci.co.uk/D035/production/_108810335_mugabe2.jpg',
+        path: '/cpsprodpb/D035/production/_108810335_mugabe2.jpg',
+        height: 549,
+        width: 976,
+        altText:
+          "Ndị mmadụ na-agụ egwu iji kwanyere Robert Mugabe ugwu n'akwamozu ya.",
+        caption:
+          "Ndị mmadụ na-agụ egwu iji kwanyere Robert Mugabe ugwu n'akwamozu ya.",
+        copyrightHolder: 'BBC',
+        type: 'image',
+      },
+      id: 'urn:bbc:ares::asset:igbo/afirika-49666505',
+      type: 'cps',
+    },
+  ],
+  topStories: [
+    {
+      headlines: {
+        headline:
+          'China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos',
+      },
+      locators: {
+        assetUri: '/mundo/noticias-internacional-51939501',
+        cpsUrn:
+          'urn:bbc:content:assetUri:mundo/noticias-internacional-51939501',
+        assetId: '51939501',
+      },
+      summary:
+        'Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.',
+      timestamp: 1580745507000,
+      language: 'es',
+      byline: {
+        name: 'Redacción  ',
+        title: 'BBC News Mundo',
+        persons: [
+          {
+            name: 'Redacción',
+            function: 'BBC News Mundo',
+          },
+        ],
+      },
+      passport: {
+        category: {
+          categoryId:
+            'http://www.bbc.co.uk/ontologies/applicationlogic-news/News',
+          categoryName: 'News',
+        },
+        campaigns: [
+          {
+            campaignId: '5a988e4739461b000e9dabfc',
+            campaignName: 'WS - Update me',
+          },
+        ],
+        taggings: [],
+      },
+      cpsType: 'STY',
+      indexImage: {
+        id: '111335312',
+        subType: 'index',
+        href:
+          'http://c.files.bbci.co.uk/5369/production/_111335312_gettyimages-1004465280.jpg',
+        path:
+          '/cpsprodpb/5369/production/_111335312_gettyimages-1004465280.jpg',
+        height: 549,
+        width: 976,
+        altText: 'Una mujer china recibe una vacuna.',
+        caption:
+          'China es uno de los países que más se ha implicado en la búsqueda tanto de una vacuna como de métodos de detección del nuevo coronavirus.',
+        copyrightHolder: 'Getty Images',
+      },
+      options: {
+        isBreakingNews: false,
+        isFactCheck: false,
+      },
+      prominence: 'standard',
+      relatedItems: [
+        {
+          headlines: {
+            headline:
+              'Estados Unidos comienza a probar en humanos la primera vacuna contra el coronavirus',
+          },
+          locators: {
+            assetUri: '/mundo/noticias-51921073',
+            cpsUrn: 'urn:bbc:content:assetUri:/mundo/noticias-51921073',
+          },
+          summary:
+            'Un total de 45 voluntarios sanos participarán en un ensayo clínico financiado por el gobierno federal.',
+          timestamp: 1584402419000,
+          language: 'es',
+          cpsType: 'STY',
+          id: 'urn:bbc:ares::asset:mundo/noticias-51921073',
+          type: 'cps',
+        },
+      ],
+      id: 'urn:bbc:ares::asset:mundo/noticias-internacional-51939501',
+      type: 'cps',
+    },
+    {
+      headlines: {
+        headline:
+          'Nigeria don get five new cases of Coronavirus - See how e happun',
+      },
+      locators: {
+        assetUri: '/pidgin/tori-51945757',
+        cpsUrn: 'urn:bbc:content:assetUri:pidgin/tori-51945757',
+        assetId: '51945757',
+      },
+      summary:
+        'Nigeria Health say di patients from UK and America travel come di kontri.',
+      timestamp: 1580745507000,
+      language: 'pcm',
+      passport: {
+        category: {
+          categoryId:
+            'http://www.bbc.co.uk/ontologies/applicationlogic-news/News',
+          categoryName: 'News',
+        },
+        campaigns: [
+          {
+            campaignId: '5a988e2939461b000e9dabf8',
+            campaignName: 'WS - Educate me',
+          },
+          {
+            campaignId: '5a988e3e39461b000e9dabfb',
+            campaignName: 'WS - Keep me on trend',
+          },
+        ],
+        taggings: [],
+      },
+      cpsType: 'STY',
+      indexImage: {
+        id: '111336814',
+        subType: 'index',
+        href:
+          'http://c.files.bbci.co.uk/A387/production/_111336814_39ac4483-c830-4858-85fb-ad8e2608afb4.jpg',
+        path:
+          '/cpsprodpb/A387/production/_111336814_39ac4483-c830-4858-85fb-ad8e2608afb4.jpg',
+        height: 549,
+        width: 976,
+        altText: 'NCDC Oga and Nigeria Health Minister',
+        copyrightHolder: 'BBC',
+      },
+      options: {
+        isBreakingNews: false,
+        isFactCheck: false,
+      },
+      prominence: 'standard',
+      id: 'urn:bbc:ares::asset:pidgin/tori-51945757',
+      type: 'cps',
+    },
+  ],
+};
 
 const constructDataFilePath = ({
   pageType,
@@ -246,6 +485,9 @@ server
       });
     },
   )
+  .get('/:service/testdata.json', async ({ params }, res) => {
+    res.status(200).send(secondaryColumData);
+  })
   .get(
     '/*',
     injectCspHeaderProdBuild,

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -486,6 +486,7 @@ server
     },
   )
   .get('/:service/testdata.json', async ({ params }, res) => {
+    res.set('Cache-Control', 'public, max-age=31557600'); // testing the app respects the cache
     res.status(200).send(secondaryColumData);
   })
   .get(


### PR DESCRIPTION
Related to: https://github.com/bbc/simorgh/issues/6252

**Overall change:**
Amends the CpsAsset get initial data function, by detecting the asset type (after fetching the page data) and then calls a function top fetch additional data required to render a page for a given asset type.

**Code changes:**

- Adds an endpoint to the express server to fetch the fixture data
- Adds new function to getInitialData to detect the asset type
- Adds a new function to fetch any additional data for a given asset type
- returns both the standard PageData and any additional fetch data.
- Grabs the new additional data from the pageData object and passes it to the Feature and Analysis and Top Stories components replacing the fixture data previously used.

**Pros**
- Not a big breaking change
- Will fetch data and render components on the server
- Will working out of the box with client side rendering

**Cons**
- Blocks page rendering based on additional data requests (No so bad for SSR, Worse for CSR)
- Has to check the page type to determine whether additional data should be fetched.

> Blocks page rendering based on additional data requests (No so bad for SSR, Worse for CSR)

This is a big concern of mine, to get around this we could ensure we only fetch additional data when on the server and then when it comes to CSR we could fetch data within the components, which would not block the page rendering.

However that means defining the data fetch logic and URL's in multiple locations and will introduce issues with content reflowing.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
