### PR TITLE
Add Kyrgyz Social Embed focussed test asset

### DIFF
--- a/data/kyrgyz/cpsAssets/23292889.json
+++ b/data/kyrgyz/cpsAssets/23292889.json
@@ -1,0 +1,202 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares::asset:kyrgyz/23292889",
+    "locators": {
+      "assetUri": "/kyrgyz/23292889",
+      "cpsUrn": "urn:bbc:content:assetUri:kyrgyz/23292889",
+      "curie": "http://www.bbc.co.uk/asset/bb9390aa-4b35-e448-b295-cbd7369fe457",
+      "assetId": "23292889"
+    },
+    "type": "STY",
+    "createdBy": "kyrgyz-v6",
+    "language": "ky",
+    "lastUpdated": 1588086814630,
+    "firstPublished": 1587739877000,
+    "lastPublished": 1587739877000,
+    "timestamp": 1587739877000,
+    "options": {
+      "isIgorSeoTagsEnabled": false,
+      "includeComments": false,
+      "allowRightHandSide": true,
+      "isFactCheck": false,
+      "allowDateStamp": true,
+      "suitableForSyndication": true,
+      "hasNewsTracker": false,
+      "allowRelatedStoriesBox": true,
+      "isKeyContent": false,
+      "allowHeadline": true,
+      "allowAdvertising": true,
+      "hasContentWarning": false,
+      "isBreakingNews": false,
+      "allowPrintingSharingLinks": true
+    },
+    "analyticsLabels": {
+      "cps_asset_type": "sty",
+      "counterName": "kyrgyz.story.23292889.page",
+      "cps_asset_id": "23292889"
+    },
+    "passport": { "taggings": [] },
+    "tags": {},
+    "version": "v1.2.0",
+    "blockTypes": ["image", "paragraph", "crosshead", "social_embed"],
+    "includeComments": false
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "63734037",
+        "subType": "body",
+        "href": "http://b.files.bbci.co.uk/11D53/test/_63734037_socialmedia.jpg",
+        "path": "/cpsdevpb/11D53/test/_63734037_socialmedia.jpg",
+        "height": 351,
+        "width": 624,
+        "altText": "social media",
+        "caption": "Social media",
+        "copyrightHolder": "BBC",
+        "positionHint": "full-width",
+        "type": "image"
+      },
+      {
+        "text": "This is a test STY for social embeds.",
+        "role": "introduction",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Social embed content galore.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      { "text": "Instagram", "markupType": "plain_text", "type": "crosshead" },
+      {
+        "href": "https://www.instagram.com/p/BWp1s3lH06h/?hl=en",
+        "source": "instagram",
+        "embed": {
+          "oembed": {
+            "version": "1.0",
+            "title": "17 JUL: A Kyrgyz student's protest video against marrying young has gone viral in Central Asia and beyond. In it, she dances to a famous 70s tune, saying Kyrgyz brides are barely surviving. Marriages are often arranged, but no-one asks young people's opinions, she says. Find out more: bbc.in/kyrgyzbrides #Kyrgyz #Kyrgyzstan #Brides #Marriage #BBCShorts #BBC #BBCNews @bbcnews",
+            "author_name": "bbcnews",
+            "author_url": "https://www.instagram.com/bbcnews",
+            "provider_name": "Instagram",
+            "provider_url": "https://www.instagram.com",
+            "thumbnail_url": "https://scontent-lhr8-1.cdninstagram.com/v/t51.2885-15/e15/s640x640/20065264_116037709030321_6204254926801993728_n.jpg?_nc_ht=scontent-lhr8-1.cdninstagram.com&_nc_cat=101&_nc_ohc=bNlV9NVIfMgAX8aT4I8&oh=2b9ae7d3f326dfabb282b8fc2bf2310a&oe=5EA55EB5",
+            "thumbnail_width": 640,
+            "thumbnail_height": 640,
+            "html": "<blockquote class=\"instagram-media\" data-instgrm-captioned data-instgrm-permalink=\"https://www.instagram.com/p/BWp1s3lH06h/?utm_source=ig_embed&amp;utm_campaign=loading\" data-instgrm-version=\"12\" style=\" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);\"><div style=\"padding:16px;\"> <a href=\"https://www.instagram.com/p/BWp1s3lH06h/?utm_source=ig_embed&amp;utm_campaign=loading\" style=\" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;\" target=\"_blank\"> <div style=\" display: flex; flex-direction: row; align-items: center;\"> <div style=\"background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;\"></div> <div style=\"display: flex; flex-direction: column; flex-grow: 1; justify-content: center;\"> <div style=\" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;\"></div> <div style=\" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;\"></div></div></div><div style=\"padding: 19% 0;\"></div> <div style=\"display:block; height:50px; margin:0 auto 12px; width:50px;\"><svg width=\"50px\" height=\"50px\" viewBox=\"0 0 60 60\" version=\"1.1\" xmlns=\"https://www.w3.org/2000/svg\" xmlns:xlink=\"https://www.w3.org/1999/xlink\"><g stroke=\"none\" stroke-width=\"1\" fill=\"none\" fill-rule=\"evenodd\"><g transform=\"translate(-511.000000, -20.000000)\" fill=\"#000000\"><g><path d=\"M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631\"></path></g></g></g></svg></div><div style=\"padding-top: 8px;\"> <div style=\" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;\"> View this post on Instagram</div></div><div style=\"padding: 12.5% 0;\"></div> <div style=\"display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;\"><div> <div style=\"background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);\"></div> <div style=\"background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;\"></div> <div style=\"background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);\"></div></div><div style=\"margin-left: 8px;\"> <div style=\" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;\"></div> <div style=\" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)\"></div></div><div style=\"margin-left: auto;\"> <div style=\" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);\"></div> <div style=\" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);\"></div> <div style=\" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);\"></div></div></div></a> <p style=\" margin:8px 0 0 0; padding:0 4px;\"> <a href=\"https://www.instagram.com/p/BWp1s3lH06h/?utm_source=ig_embed&amp;utm_campaign=loading\" style=\" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;\" target=\"_blank\">17 JUL: A Kyrgyz student&#39;s protest video against marrying young has gone viral in Central Asia and beyond. In it, she dances to a famous 70s tune, saying Kyrgyz brides are barely surviving. Marriages are often arranged, but no-one asks young people&#39;s opinions, she says. Find out more: bbc.in/kyrgyzbrides #Kyrgyz #Kyrgyzstan #Brides #Marriage #BBCShorts #BBC #BBCNews @bbcnews</a></p> <p style=\" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;\">A post shared by <a href=\"https://www.instagram.com/bbcnews/?utm_source=ig_embed&amp;utm_campaign=loading\" style=\" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;\" target=\"_blank\"> BBC News</a> (@bbcnews) on <time style=\" font-family:Arial,sans-serif; font-size:14px; line-height:17px;\" datetime=\"2017-07-17T16:05:01+00:00\">Jul 17, 2017 at 9:05am PDT</time></p></div></blockquote>",
+            "width": 658
+          },
+          "fallback_image": {
+            "fallback_image_width": 599,
+            "fallback_image_height": 977,
+            "alt_text": "Instagram post by bbcnews: 17 JUL: A Kyrgyz student's protest video against marrying young has gone viral in Central Asia and beyond. In it, she dances to a famous 70s tune, saying Kyrgyz brides are barely surviving. Marriages are often arranged, but no-one asks young people's opinions, she says. Find out more: bbc.in/kyrgyzbrides #Kyrgyz #Kyrgyzstan #Brides #Marriage #BBCShorts #BBC #BBCNews @bbcnews"
+          }
+        },
+        "id": "BWp1s3lH06h",
+        "type": "social_embed"
+      },
+      { "text": "YouTube", "markupType": "plain_text", "type": "crosshead" },
+      {
+        "href": "https://www.youtube.com/watch?v=UqdIoCjy1CM",
+        "source": "youtube",
+        "embed": {
+          "oembed": {
+            "version": "1.0",
+            "title": "Coronavirus: la exitosa estrategia de Corea del Sur contra el covid-19 | BBC Mundo",
+            "author_name": "BBC News Mundo",
+            "author_url": "https://www.youtube.com/user/BBCMundo",
+            "provider_name": "YouTube",
+            "provider_url": "https://www.youtube.com/",
+            "thumbnail_url": "https://i.ytimg.com/vi/UqdIoCjy1CM/hqdefault.jpg",
+            "thumbnail_width": 480,
+            "thumbnail_height": 360,
+            "html": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/UqdIoCjy1CM?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>",
+            "width": 480,
+            "height": 270
+          },
+          "fallback_image": {
+            "fallback_image_width": 500,
+            "fallback_image_height": 269,
+            "alt_text": "YouTube post by BBC News Mundo: Coronavirus: la exitosa estrategia de Corea del Sur contra el covid-19 | BBC Mundo"
+          }
+        },
+        "id": "UqdIoCjy1CM",
+        "type": "social_embed"
+      },
+      { "text": "Twitter", "markupType": "plain_text", "type": "crosshead" },
+      {
+        "href": "https://twitter.com/bbckyrgyz/status/1253664751588126722",
+        "source": "twitter",
+        "embed": {
+          "oembed": {
+            "version": "1.0",
+            "author_name": "BBC News Кыргыз",
+            "author_url": "https://twitter.com/bbckyrgyz",
+            "provider_name": "Twitter",
+            "provider_url": "https://twitter.com",
+            "url": "https://twitter.com/bbckyrgyz/status/1253664751588126722",
+            "html": "<blockquote class=\"twitter-tweet\"><p lang=\"ru\" dir=\"ltr\">Москва: “Тез жардам” чакыргандан корккон, оорусун жашырган мигранттар <a href=\"https://t.co/rwbq3qELMm\">https://t.co/rwbq3qELMm</a></p>&mdash; BBC News Кыргыз (@bbckyrgyz) <a href=\"https://twitter.com/bbckyrgyz/status/1253664751588126722?ref_src=twsrc%5Etfw\">April 24, 2020</a></blockquote>\n",
+            "width": 550
+          },
+          "fallback_image": {
+            "fallback_image_width": 465,
+            "fallback_image_height": 544,
+            "alt_text": "Twitter post by BBC News Кыргыз: Москва: “Тез жардам” чакыргандан корккон, оорусун жашырган мигранттар https://t.co/rwbq3qELMm"
+          }
+        },
+        "id": "1253664751588126722",
+        "type": "social_embed"
+      },
+      { "text": "Facebook", "markupType": "plain_text", "type": "crosshead" },
+      {
+        "href": "https://www.facebook.com/228735667216/posts/10157712846517217/?sfnsn=scwspmo&extid=ixkwkArH1fy0g2GP",
+        "source": "facebook",
+        "type": "social_embed"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": {
+      "shortHeadline": "Test STY for social embeds",
+      "headline": "Test STY for social embeds"
+    },
+    "locators": {
+      "assetUri": "/kyrgyz/23292889",
+      "cpsUrn": "urn:bbc:content:assetUri:kyrgyz/23292889",
+      "curie": "http://www.bbc.co.uk/asset/bb9390aa-4b35-e448-b295-cbd7369fe457",
+      "assetId": "23292889"
+    },
+    "summary": "A test STY for social embeds",
+    "timestamp": 1587739877000,
+    "language": "ky",
+    "passport": { "taggings": [] },
+    "indexImage": {
+      "id": "63734035",
+      "subType": "index",
+      "href": "http://b.files.bbci.co.uk/CF33/test/_63734035_socialmedia.jpg",
+      "path": "/cpsdevpb/CF33/test/_63734035_socialmedia.jpg",
+      "height": 351,
+      "width": 624,
+      "altText": "social media",
+      "caption": "Social media",
+      "copyrightHolder": "BBC",
+      "type": "image"
+    },
+    "id": "urn:bbc:ares::asset:kyrgyz/23292889",
+    "type": "cps"
+  },
+  "relatedContent": {
+    "section": {
+      "subType": "index",
+      "name": "Башталгыч бет",
+      "uri": "/kyrgyz/front_page",
+      "type": "simple"
+    },
+    "site": {
+      "subType": "site",
+      "name": "BBC Кыргыз",
+      "uri": "/kyrgyz",
+      "type": "simple"
+    },
+    "groups": []
+  }
+}


### PR DESCRIPTION
No issue.

**Overall change:**

Add a Social Embed focussed test asset, which includes:

- An enriched Instagram embed.
- An enriched YouTube embed.
- An enriched Twitter embed.
- An unsupported provider (Facebook) embed.

Where enriched means it includes oEmbed data from Embedephant.

**Code changes:**

- Add `kyrgyz/cspAssets/23292889.json`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- ~~[ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~~
- ~~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- ~~[ ] This PR requires manual testing~~
