### PR TITLE
Temporarily disable av test while it is investigated

### DIFF
--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -162,7 +162,9 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
           });
         });
 
-        it('should render an iframe with a valid URL when a user clicks play', () => {
+        // temporarily disable this test until this issue is completed to investigate it:
+        // https://github.com/bbc/simorgh-infrastructure/issues/983
+        it.skip('should render an iframe with a valid URL when a user clicks play', () => {
           cy.window().then(win => {
             const body = win.SIMORGH_DATA.pageData;
             const media = getBlockData('video', body);


### PR DESCRIPTION
Related to https://github.com/bbc/simorgh-infrastructure/issues/983

**Overall change:**
Disables failing AV test to decrease noise while we investigate

```
articles - /scotland/articles/cm49v4x1r9lo - Canonical Canonical Tests for scotland articles Media Player: Canonical should render an iframe with a valid URL when a user clicks play:
      [31mAssertionError: Unexpected status code for https://polling.bbc.co.uk/ws/av-embeds/articles/cm49v4x1r9lo/p06p040v/en-GB: expected 500 to equal 200
```

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
