### PR TITLE
Social Embed - bug fixes

### DIFF
--- a/src/app/containers/SocialEmbed/index.jsx
+++ b/src/app/containers/SocialEmbed/index.jsx
@@ -54,7 +54,7 @@ const SocialEmbedContainer = ({ blocks }) => {
 
   const id = path(['id'], model);
   const href = path(['href'], model);
-  if (!id || !href) return null;
+  if (!href) return null;
 
   const oEmbed = path(['embed', 'oembed'], model);
 

--- a/src/app/containers/SocialEmbed/index.jsx
+++ b/src/app/containers/SocialEmbed/index.jsx
@@ -61,7 +61,7 @@ const SocialEmbedContainer = ({ blocks }) => {
   const {
     fallback: fallbackTranslations,
     skipLink: skipLinkTranslations,
-    captionTranslations,
+    caption: captionTranslations,
   } = createTranslations({ translations, index });
 
   const fallback = {

--- a/src/app/models/propTypes/socialEmbed/index.js
+++ b/src/app/models/propTypes/socialEmbed/index.js
@@ -6,10 +6,13 @@ const socialEmbedBlockPropTypes = {
       type: string.isRequired,
       indexOfType: number.isRequired,
       model: shape({
-        id: string.isRequired,
+        // `id` is provided by Ares on the basis it knows how to extract it
+        // from the URL. For unsupported providers (e.g. Facebook), this will
+        // not be supplied - for that reason it is no required.
+        id: string,
         href: string.isRequired,
-        // 'embed' is optional, however if it is included it
-        // must contain 'oembed' and 'oembed.html' properties.
+        // 'embed' is not required, however if it is included it must contain
+        // 'oembed' and 'oembed.html' properties.
         embed: shape({
           oembed: shape({
             html: string.isRequired,

--- a/src/app/models/propTypes/socialEmbed/index.js
+++ b/src/app/models/propTypes/socialEmbed/index.js
@@ -8,7 +8,7 @@ const socialEmbedBlockPropTypes = {
       model: shape({
         // `id` is provided by Ares on the basis it knows how to extract it
         // from the URL. For unsupported providers (e.g. Facebook), this will
-        // not be supplied - for that reason it is no required.
+        // not be supplied - for that reason it is not required.
         id: string,
         href: string.isRequired,
         // 'embed' is not required, however if it is included it must contain


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/6344.

Blocks https://github.com/bbc/simorgh/issues/6099.

**Overall change:**
This PR fixes two little bugs:

- An undefined `caption` for YouTube embeds, due to an error in destructing.
- Unsupported providers not rendering a fallback due to over-guarding.

**Code changes:**

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- ~~[ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)~~
- ~~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- ~~[ ] This PR requires manual testing~~
