### PR TITLE
[Tech Debt] Replace deprecated wait() with waitFor()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8017,7 +8017,7 @@
     },
     "diffable-html": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-4.0.0.tgz",
+      "resolved": "https://npm.morph.int.tools.bbc.co.uk/diffable-html/-/diffable-html-4.0.0.tgz",
       "integrity": "sha512-keJdgy2qBkdrrnwP1YE6e834d4Y+mV0aRFzk8w7WzyAJVbQVfcJltSmUWB3r/NOoO/0jt7RdJlvy5ioyqvmQcw==",
       "dev": true,
       "requires": {
@@ -13957,7 +13957,7 @@
     },
     "jest-serializer-html": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-7.0.0.tgz",
+      "resolved": "https://npm.morph.int.tools.bbc.co.uk/jest-serializer-html/-/jest-serializer-html-7.0.0.tgz",
       "integrity": "sha512-o3S2j/5yA9emV8+QRHqJ41SznW5cZ1PXIAk+aSToJffdhuaiSoDsa4IgqV8lNOHPp4cP0LNT7k5KjXjD+l6SGg==",
       "dev": true,
       "requires": {

--- a/src/app/containers/RadioSchedule/Canonical/index.test.jsx
+++ b/src/app/containers/RadioSchedule/Canonical/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import fetchMock from 'fetch-mock';
-import { render, wait } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { matchSnapshotAsync } from '@bbc/psammead-test-helpers';
 import '@testing-library/jest-dom/extend-expect';
 import arabicRadioScheduleData from '#data/arabic/bbc_arabic_radio/schedule.json';
@@ -55,7 +55,7 @@ describe('Canonical RadioSchedule', () => {
         <RadioScheduleWithContext initialData={initialData} />,
       );
 
-      await wait(() => {
+      await waitFor(() => {
         expect(container.querySelectorAll('li').length).toEqual(4);
       });
     });
@@ -70,7 +70,7 @@ describe('Canonical RadioSchedule', () => {
       const { container } = render(
         <RadioScheduleWithContext initialData={initialData} />,
       );
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });
@@ -85,7 +85,7 @@ describe('Canonical RadioSchedule', () => {
       const { container } = render(
         <RadioScheduleWithContext initialData={initialData} />,
       );
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });
@@ -103,7 +103,7 @@ describe('Canonical RadioSchedule', () => {
       fetchMock.mock(endpoint, arabicRadioScheduleData);
       const { container } = render(<RadioScheduleWithContext />);
 
-      await wait(() => {
+      await waitFor(() => {
         expect(container.querySelectorAll('li').length).toEqual(4);
       });
     });
@@ -113,7 +113,7 @@ describe('Canonical RadioSchedule', () => {
         schedules: arabicRadioScheduleData.schedules.slice(0, 2),
       });
       const { container } = render(<RadioScheduleWithContext />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });
@@ -123,7 +123,7 @@ describe('Canonical RadioSchedule', () => {
         schedules: [],
       });
       const { container } = render(<RadioScheduleWithContext />);
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });
@@ -133,7 +133,7 @@ describe('Canonical RadioSchedule', () => {
 
       const { container } = render(<RadioScheduleWithContext />);
 
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });
@@ -145,7 +145,7 @@ describe('Canonical RadioSchedule', () => {
 
       const { container } = render(<RadioScheduleWithContext />);
 
-      await wait(() => {
+      await waitFor(() => {
         expect(container).toBeEmpty();
       });
     });

--- a/src/app/containers/RadioSchedule/index.test.jsx
+++ b/src/app/containers/RadioSchedule/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import RadioSchedulesWithContext from './utilities/testHelpers';
 import arabicRadioScheduleData from '#data/arabic/bbc_arabic_radio/schedule.json';
@@ -14,7 +14,7 @@ describe('RadioScheduleData', () => {
     const { container } = render(
       <RadioSchedulesWithContext service="arabic" />,
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(container).toBeEmpty();
     });
   });
@@ -24,7 +24,7 @@ describe('RadioScheduleData', () => {
     const { container } = render(
       <RadioSchedulesWithContext service="arabic" radioScheduleToggle />,
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(container.querySelectorAll('li').length).toEqual(4);
     });
   });
@@ -34,7 +34,7 @@ describe('RadioScheduleData', () => {
     const { container } = render(
       <RadioSchedulesWithContext service="arabic" radioScheduleToggle isAmp />,
     );
-    await wait(() => {
+    await waitFor(() => {
       expect(container).toBeEmpty();
     });
   });

--- a/src/app/pages/FrontPage/index.test.jsx
+++ b/src/app/pages/FrontPage/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { render, wait, waitForElement } from '@testing-library/react';
+import { render, waitFor, waitForElement } from '@testing-library/react';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
@@ -163,7 +163,7 @@ describe('Front Page', () => {
       expect(langSpan.getAttribute('lang')).toEqual('en-GB');
       expect(langSpan.textContent).toEqual('BBC News');
 
-      await wait();
+      await waitFor(() => {});
     });
 
     it('should render front page sections', async () => {
@@ -176,7 +176,7 @@ describe('Front Page', () => {
       sections.forEach(section => {
         expect(section.getAttribute('role')).toEqual('region');
       });
-      await wait();
+      await waitFor(() => {});
     });
   });
 });


### PR DESCRIPTION
Resolves N/A

**Overall change:**
testing-library-react has deprecated the `wait()` method and replaced it with `waitFor()` with a now required callback.

https://testing-library.com/docs/dom-testing-library/api-async#wait-deprecated-use-waitfor-instead

![image](https://user-images.githubusercontent.com/14273378/80840126-805bc380-8bf4-11ea-9bdb-6a45a1dd3f20.png)


This PR replaces all occurrences of `wait()` with waitFor()

**Code changes:**

- Replace `wait()` with `waitFor()`

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
