### PR TITLE
[Tech Debt] Replace deprecated waitForElement() with waitFor()

### DIFF
--- a/src/app/contexts/ServiceContext/index.test.jsx
+++ b/src/app/contexts/ServiceContext/index.test.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { cleanup, render, waitForElement } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import services from '#server/utilities/serviceConfigs';
 
 // Unmock service context which is mocked globally in jest-setup.js
@@ -39,7 +39,7 @@ describe('ServiceContextProvider', () => {
           </ServiceContextProvider>,
         );
 
-        await waitForElement(() => container.querySelector('span'));
+        await waitFor(() => container.querySelector('span'));
 
         expect(container.firstChild.innerHTML).toEqual(
           services[service][variant].brandName,

--- a/src/app/contexts/utils/withContext/index.test.jsx
+++ b/src/app/contexts/utils/withContext/index.test.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { cleanup, render, waitForElement } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import withContext from '.';
 
 const NewContext = React.createContext({});
@@ -28,7 +28,7 @@ describe('withContext', () => {
       </ContextProviderWithData>,
     );
 
-    await waitForElement(() => container.querySelector('span'));
+    await waitFor(() => container.querySelector('span'));
 
     expect(container.firstChild.innerHTML).toEqual('dummy text');
   });
@@ -50,7 +50,7 @@ describe('withContext', () => {
       </ContextProviderWithData>,
     );
 
-    await waitForElement(() => container.querySelector('span'));
+    await waitFor(() => container.querySelector('span'));
 
     expect(container.firstChild.innerHTML).toEqual('dummy text');
   });

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  render,
-  waitForDomChange,
-  waitForElement,
-} from '@testing-library/react';
+import { render, waitForDomChange, waitFor } from '@testing-library/react';
 import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import ArticlePage from '.';
 import { RequestContextProvider } from '#contexts/RequestContext';
@@ -92,7 +88,7 @@ it('should render a rtl article (persian) with most read correctly', async () =>
     </Context>,
   );
 
-  await waitForElement(() => container.querySelector('#Most-Read'));
+  await waitFor(() => container.querySelector('#Most-Read'));
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();
@@ -108,7 +104,7 @@ it('should render a ltr article (pidgin) with most read correctly', async () => 
     </Context>,
   );
 
-  await waitForElement(() => container.querySelector('#Most-Read'));
+  await waitFor(() => container.querySelector('#Most-Read'));
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();

--- a/src/app/pages/FrontPage/index.test.jsx
+++ b/src/app/pages/FrontPage/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { render, wait, waitForElement } from '@testing-library/react';
+import { render, wait, waitFor } from '@testing-library/react';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
@@ -136,7 +136,7 @@ describe('Front Page', () => {
 
       // Waiting to ensure most read data is loaded and element is rendered
       // The data is loaded separately which was previously causing snapshots to fail
-      await waitForElement(() => container.querySelector('#Most-Read'));
+      await waitFor(() => container.querySelector('#Most-Read'));
 
       expect(container).toMatchSnapshot();
     });


### PR DESCRIPTION
Resolves N/A

**Overall change:**
testing-library-react has deprecated the waitForElement() method and replaced it with waitFor() with a now required callback.

https://testing-library.com/docs/dom-testing-library/api-async#waitforelement-deprecated-use-find-queries-or-waitfor

**Code changes:**

- Replaced deprecated `waitForElement()` with `waitFor`

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
