### PR TITLE
add metadata to most read pageData

### DIFF
--- a/src/app/routes/mostRead/getInitialData/index.js
+++ b/src/app/routes/mostRead/getInitialData/index.js
@@ -4,11 +4,12 @@ import { getMostReadEndpoint } from '#lib/utilities/getMostReadUrls';
 export default async ({ service, variant }) => {
   const mostReadUrl = getMostReadEndpoint({ service, variant }).split('.')[0];
   const { json, ...rest } = await fetchPageData(mostReadUrl);
+  const pageTypeMeta = { metadata: { type: 'mostRead' } };
 
   return {
     ...rest,
     ...(json && {
-      pageData: json,
+      pageData: { ...json, ...pageTypeMeta },
     }),
   };
 };


### PR DESCRIPTION
Resolves #6362

**Overall change:**
_Add pageType meta to the most read pageData, so that it is logged out on the server correctly._

**Code changes:**

- _Add metadata object to pageData, because our server handles pageType logging with this function `pageType: pathOr('Error', ['pageData', 'metadata', 'type'], data),`_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
