### PR TITLE
Log correct routing info in server log when visiting a live radio / on demand radio page

### DIFF
--- a/src/app/routes/liveRadio/getInitialData/index.js
+++ b/src/app/routes/liveRadio/getInitialData/index.js
@@ -19,6 +19,7 @@ export default async ({ path: pathname }) => {
   const liveRadioDataPath = overrideRendererOnTest(pathname);
   const { json, ...rest } = await fetchPageData(liveRadioDataPath);
   const contentData = path(['content'], json);
+  const pageType = { metadata: { type: 'Live Radio' } };
 
   return {
     ...rest,
@@ -32,6 +33,7 @@ export default async ({ path: pathname }) => {
         pageTitle: getPageTitle(json),
         contentType: getContentType(json),
         pageIdentifier: getPageIdentifier(json),
+        ...pageType,
       },
     }),
   };

--- a/src/app/routes/liveRadio/getInitialData/index.js
+++ b/src/app/routes/liveRadio/getInitialData/index.js
@@ -19,7 +19,6 @@ export default async ({ path: pathname }) => {
   const liveRadioDataPath = overrideRendererOnTest(pathname);
   const { json, ...rest } = await fetchPageData(liveRadioDataPath);
   const contentData = path(['content'], json);
-  const pageType = { metadata: { type: 'Live Radio' } };
 
   return {
     ...rest,
@@ -33,7 +32,6 @@ export default async ({ path: pathname }) => {
         pageTitle: getPageTitle(json),
         contentType: getContentType(json),
         pageIdentifier: getPageIdentifier(json),
-        ...pageType,
       },
     }),
   };

--- a/src/app/routes/liveRadio/getInitialData/index.test.js
+++ b/src/app/routes/liveRadio/getInitialData/index.test.js
@@ -16,7 +16,6 @@ describe('Get initial data for live radio', () => {
     const { pageData } = await getInitialData({ path: 'mock-live-radio-path' });
     expect(pageData.name).toEqual('BBC 코리아 라디오');
     expect(pageData.language).toEqual('ko');
-    expect(pageData.metadata.type).toEqual('Live Radio');
     expect(pageData.summary).toEqual(
       '세계와 한반도 뉴스를 공정하고 객관적으로 전달해 드립니다',
     );

--- a/src/app/routes/liveRadio/getInitialData/index.test.js
+++ b/src/app/routes/liveRadio/getInitialData/index.test.js
@@ -16,6 +16,7 @@ describe('Get initial data for live radio', () => {
     const { pageData } = await getInitialData({ path: 'mock-live-radio-path' });
     expect(pageData.name).toEqual('BBC 코리아 라디오');
     expect(pageData.language).toEqual('ko');
+    expect(pageData.metadata.type).toEqual('Live Radio');
     expect(pageData.summary).toEqual(
       '세계와 한반도 뉴스를 공정하고 객관적으로 전달해 드립니다',
     );

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -38,6 +38,7 @@ const getEpisodeAvailableUntil = path([
 export default async ({ path: pathname }) => {
   const onDemandRadioDataPath = overrideRendererOnTest(pathname);
   const { json, ...rest } = await fetchPageData(onDemandRadioDataPath);
+  const pageType = { metadata: { type: 'On Demand Radio' } };
 
   return {
     ...rest,
@@ -57,6 +58,7 @@ export default async ({ path: pathname }) => {
         episodeAvailableUntil: getEpisodeAvailableUntil(json),
         pageTitle: getPageTitle(json),
         pageIdentifier: getPageIdentifier(json),
+        ...pageType,
       },
     }),
   };

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -38,7 +38,6 @@ const getEpisodeAvailableUntil = path([
 export default async ({ path: pathname }) => {
   const onDemandRadioDataPath = overrideRendererOnTest(pathname);
   const { json, ...rest } = await fetchPageData(onDemandRadioDataPath);
-  const pageType = { metadata: { type: 'On Demand Radio' } };
 
   return {
     ...rest,
@@ -58,7 +57,6 @@ export default async ({ path: pathname }) => {
         episodeAvailableUntil: getEpisodeAvailableUntil(json),
         pageTitle: getPageTitle(json),
         pageIdentifier: getPageIdentifier(json),
-        ...pageType,
       },
     }),
   };

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -21,7 +21,6 @@ describe('Get initial data for on demand radio', () => {
     expect(pageData.episodeTitle).toEqual('04/02/2020 GMT');
     expect(pageData.summary).toEqual('د نړۍ وروستي خبرونه');
     expect(pageData.language).toEqual('ps');
-    expect(pageData.metadata.type).toEqual('On Demand Radio');
   });
 
   it('should override renderer on test', async () => {

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -21,6 +21,7 @@ describe('Get initial data for on demand radio', () => {
     expect(pageData.episodeTitle).toEqual('04/02/2020 GMT');
     expect(pageData.summary).toEqual('د نړۍ وروستي خبرونه');
     expect(pageData.language).toEqual('ps');
+    expect(pageData.metadata.type).toEqual('On Demand Radio');
   });
 
   it('should override renderer on test', async () => {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -2,7 +2,7 @@ import express from 'express';
 import compression from 'compression';
 import expressStaticGzip from 'express-static-gzip';
 import path from 'path';
-import paths from 'ramda/src/paths';
+import pathOr from 'ramda/src/pathOr';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
@@ -223,16 +223,6 @@ if (process.env.SIMORGH_APP_ENV === 'local') {
  * Application env routes
  */
 
-export const getPageType = data => {
-  const { pageData } = data;
-  const [metadataType, contentType] = paths(
-    [['metadata', 'type'], ['contentType']],
-    pageData,
-  );
-
-  return metadataType || contentType || 'Unknown';
-};
-
 server
   .get([articleSwPath, frontPageSwPath], (req, res) => {
     const swPath = `${__dirname}/public/sw.js`;
@@ -294,7 +284,7 @@ server
         logger.info(ROUTING_INFORMATION, {
           url,
           status,
-          pageType: getPageType(data),
+          pageType: pathOr('Error', ['pageData', 'metadata', 'type'], data),
         });
 
         if (result.redirectUrl) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -2,7 +2,7 @@ import express from 'express';
 import compression from 'compression';
 import expressStaticGzip from 'express-static-gzip';
 import path from 'path';
-import pathOr from 'ramda/src/pathOr';
+import paths from 'ramda/src/paths';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
@@ -223,6 +223,16 @@ if (process.env.SIMORGH_APP_ENV === 'local') {
  * Application env routes
  */
 
+export const getPageType = data => {
+  const { pageData } = data;
+  const [metadataType, contentType] = paths(
+    [['metadata', 'type'], ['contentType']],
+    pageData,
+  );
+
+  return metadataType || contentType || 'Unknown';
+};
+
 server
   .get([articleSwPath, frontPageSwPath], (req, res) => {
     const swPath = `${__dirname}/public/sw.js`;
@@ -284,7 +294,7 @@ server
         logger.info(ROUTING_INFORMATION, {
           url,
           status,
-          pageType: pathOr('Error', ['pageData', 'metadata', 'type'], data),
+          pageType: getPageType(data),
         });
 
         if (result.redirectUrl) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -2,7 +2,7 @@ import express from 'express';
 import compression from 'compression';
 import expressStaticGzip from 'express-static-gzip';
 import path from 'path';
-import pathOr from 'ramda/src/pathOr';
+import paths from 'ramda/src/paths';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
@@ -223,6 +223,16 @@ if (process.env.SIMORGH_APP_ENV === 'local') {
  * Application env routes
  */
 
+export const getPageType = data => {
+  const { pageData } = data;
+  const [metadataType, contentType] = paths(
+    [['metadata', 'type'], ['contentType']],
+    pageData,
+  );
+
+  return metadataType || contentType || 'Unknown';
+};
+
 server
   .get([articleSwPath, frontPageSwPath], (req, res) => {
     const swPath = `${__dirname}/public/sw.js`;
@@ -284,7 +294,7 @@ server
         logger.info(ROUTING_INFORMATION, {
           url,
           status,
-          pageType: pathOr('Unknown', ['pageData', 'metadata', 'type'], data),
+          pageType: getPageType(data),
         });
 
         if (result.redirectUrl) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -2,7 +2,7 @@ import express from 'express';
 import compression from 'compression';
 import expressStaticGzip from 'express-static-gzip';
 import path from 'path';
-import paths from 'ramda/src/paths';
+import pathOr from 'ramda/src/pathOr';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
@@ -223,16 +223,6 @@ if (process.env.SIMORGH_APP_ENV === 'local') {
  * Application env routes
  */
 
-export const getPageType = data => {
-  const { pageData } = data;
-  const [metadataType, contentType] = paths(
-    [['metadata', 'type'], ['contentType']],
-    pageData,
-  );
-
-  return metadataType || contentType || 'Unknown';
-};
-
 server
   .get([articleSwPath, frontPageSwPath], (req, res) => {
     const swPath = `${__dirname}/public/sw.js`;
@@ -294,7 +284,7 @@ server
         logger.info(ROUTING_INFORMATION, {
           url,
           status,
-          pageType: getPageType(data),
+          pageType: pathOr('Unknown', ['pageData', 'metadata', 'type'], data),
         });
 
         if (result.redirectUrl) {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -284,7 +284,7 @@ server
         logger.info(ROUTING_INFORMATION, {
           url,
           status,
-          pageType: pathOr('Error', ['pageData', 'metadata', 'type'], data),
+          pageType: pathOr('Unknown', ['pageData', 'metadata', 'type'], data),
         });
 
         if (result.redirectUrl) {

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -16,6 +16,7 @@ dotenv.config({ path: './envConfig/local.env' });
 const path = require('path');
 const express = require('express');
 const server = require('./index').default;
+const { getPageType } = require('./index');
 
 const sendFileSpy = jest.spyOn(express.response, 'sendFile');
 
@@ -974,5 +975,20 @@ describe('Server HTTP Headers', () => {
     });
 
     // It should turn the message around at the end of the line and send it back again (Currently untested)
+  });
+});
+
+describe('getPageType', () => {
+  it('should return metadata type', () => {
+    const data = { pageData: { metadata: { type: 'metadataType' } } };
+    expect(getPageType(data)).toBe('metadataType');
+  });
+  it('should return content type if metadata type does not exist', () => {
+    const data = { pageData: { contentType: 'contentType' } };
+    expect(getPageType(data)).toBe('contentType');
+  });
+  it('should return Unknown if metadata type and content type do no exist', () => {
+    const data = { pageData: {} };
+    expect(getPageType(data)).toBe('Unknown');
   });
 });

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -16,7 +16,6 @@ dotenv.config({ path: './envConfig/local.env' });
 const path = require('path');
 const express = require('express');
 const server = require('./index').default;
-const { getPageType } = require('./index');
 
 const sendFileSpy = jest.spyOn(express.response, 'sendFile');
 
@@ -975,20 +974,5 @@ describe('Server HTTP Headers', () => {
     });
 
     // It should turn the message around at the end of the line and send it back again (Currently untested)
-  });
-});
-
-describe('getPageType', () => {
-  it('should return metadata type', () => {
-    const data = { pageData: { metadata: { type: 'metadataType' } } };
-    expect(getPageType(data)).toBe('metadataType');
-  });
-  it('should return content type if metadata type does not exist', () => {
-    const data = { pageData: { contentType: 'contentType' } };
-    expect(getPageType(data)).toBe('contentType');
-  });
-  it('should return Unknown if metadata type and content type do no exist', () => {
-    const data = { pageData: {} };
-    expect(getPageType(data)).toBe('Unknown');
   });
 });


### PR DESCRIPTION
Resolves #6277, #6276

**Overall change:**
We are logging basic routing information for a URL, such as status and page type to the server log, however, `pagedata.metadata.type` is not always available.
This fix adds `metadata.type` to Live Radio and On Demand Radio pages

**Code changes:**
- Set the `metadata.type` in initial data, so that it appears in the logs correctly as per: https://github.com/bbc/simorgh/blob/4e7caf0d2f77d9ba2f361aed65bf90520f4ba33f/src/server/index.jsx#L287
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
