### PR TITLE
Skipping canonical e2e script switching test

### DIFF
--- a/cypress/integration/specialFeatures/scriptSwitching/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/scriptSwitching/testsForCanonicalOnly.js
@@ -18,7 +18,8 @@ export default ({
   variant,
   otherVariant,
 }) => {
-  describe(`Script Switching - ${serviceId} - ${pageType} - ${path}`, () => {
+  describe.skip(`Script Switching - ${serviceId} - ${pageType} - ${path}`, () => {
+    // This test suite is being skipped due to flakey failing within our build pipeline. Being investigated here https://github.com/bbc/simorgh/issues/6399
     beforeEach(() => {
       cy.clearCookies();
       visitPage(path, pageType);
@@ -67,7 +68,6 @@ export default ({
         `Asserting script switch button, url and document lang have changed after clicking script switcher to ${variant}`,
       );
       allVariantAssertions(serviceName, variant);
-    }).skip();
-    // This test suite is being skipped due to flakey failing within our build pipeline
+    });
   });
 };

--- a/cypress/integration/specialFeatures/scriptSwitching/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/scriptSwitching/testsForCanonicalOnly.js
@@ -67,6 +67,7 @@ export default ({
         `Asserting script switch button, url and document lang have changed after clicking script switcher to ${variant}`,
       );
       allVariantAssertions(serviceName, variant);
-    });
+    }).skip();
+    // This test suite is being skipped due to flakey failing within our build pipeline
   });
 };


### PR DESCRIPTION


**Overall change:**
Skipping the ScriptSwitching test suite due to it causing flakey fails during build

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
