### PR TITLE
Add external_vpid to supported CPS block types

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/index.js
@@ -23,6 +23,10 @@ const handleMissingType = (block, json, assetType) =>
     assetType,
   });
 
+// Pass external_vpid blocks through to be filtered by processUnavailableMedia
+// eslint-disable-next-line camelcase
+const external_vpid = block => block;
+
 const typesToConvert = {
   crosshead: subheadline,
   heading: subheadline,
@@ -31,6 +35,7 @@ const typesToConvert = {
   paragraph,
   list,
   media,
+  external_vpid,
   version,
   legacyMedia,
   include,


### PR DESCRIPTION
Resolves #6262

**Overall change:**
`external_vpid` is a valid block type which tells us the media asset is no longer available. This PR adds `external_vpid` to the supported block types.

**Code changes:**
- Add a pass through function to support `external_vpid` as a valid CPS block type

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
