### PR TITLE
Removing additional logic for player-episode

### DIFF
--- a/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/radioPage/buildParams.js
@@ -26,8 +26,7 @@ export const buildRadioATIParams = (
   return {
     appName: atiAnalyticsAppName,
     contentId: isLiveRadio ? id : getContentId('pips'),
-    // workaround until ARES have corrected onDemand contentType to player-episode
-    contentType: isLiveRadio ? contentType : 'player-episode',
+    contentType,
     language,
     pageIdentifier,
     pageTitle,

--- a/src/app/containers/ChartbeatAnalytics/utils/index.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.js
@@ -98,11 +98,7 @@ export const getTitle = ({ pageType, pageData, brandName, title }) => {
   }
 };
 
-const getRadioContentType = pageData => {
-  const contentType = path(['contentType'], pageData);
-  // workaround until contentType value is fixed by ARES
-  return contentType === 'player-live' ? contentType : 'player-episode';
-};
+const getRadioContentType = pageData => path(['contentType'], pageData);
 
 export const getConfig = ({
   isAmp,


### PR DESCRIPTION
Resolves #6444

**Overall change:**
Ares returned the incorrect value for onDemand's contentType (player-onDemand instead of player-episode). This has been fixed so there is no longer a need for the logic to change the value of contentType for onDemand pages.

**Code changes:**

- Removed hardcoded 'player-epsiode' value for contentType

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
