### PR TITLE
add more valid vj include types

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -47,7 +47,6 @@ const convertInclude = async ({ href, type, ...rest }) => {
     indepthtoolkit: 'idt1',
     idt2: 'idt2',
     include: 'vj',
-    edp: 'vj',
     'news/special': 'vj',
     'market-data': 'vj',
     'smallprox/include': 'vj',

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -47,6 +47,10 @@ const convertInclude = async ({ href, type, ...rest }) => {
     indepthtoolkit: 'idt1',
     idt2: 'idt2',
     include: 'vj',
+    edp: 'vj',
+    'news/special': 'vj',
+    'market-data': 'vj',
+    'smallprox/include': 'vj',
   };
 
   // This determines if the href has a leading '/'

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.test.js
@@ -150,6 +150,36 @@ describe('convertInclude', () => {
     );
   });
 
+  it('should fetch and convert an include block to a vj block with no / in href', async () => {
+    fetch.mockResponse(() => Promise.resolve(vjMarkup));
+    const input = {
+      required: false,
+      tile: 'Include from VisJo',
+      href: 'news/special/111-222-333-444-555',
+      platform: 'highweb',
+      type: 'include',
+    };
+    const expected = {
+      type: 'include',
+      model: {
+        href: 'news/special/111-222-333-444-555',
+        required: false,
+        tile: 'Include from VisJo',
+        platform: 'highweb',
+        type: 'vj',
+        html: vjMarkup,
+      },
+    };
+    expect(await convertInclude(input)).toEqual(expected);
+    expect(fetch).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://foobar.com/includes/news/special/111-222-333-444-555',
+      {
+        timeout: 3000,
+      },
+    );
+  });
+
   it('should convert an include block to an idt2 block with html set to null when fetch returns with status other than 200', async () => {
     jest.mock('#lib/logger.web', () => jest.fn());
     fetch.mockResponse(() => Promise.resolve({ status: 304 }));


### PR DESCRIPTION
Resolves #6138

**Overall change:**
_Adds other valid vj include types._ ie,
- `news/special`
- `market-data`
- `smallprox/include`
- ~`edp`~ (removed support for this)

**Code changes:**

- _Add valid vj includes as supported types in preprocessor._

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added labels to this PR for the relevant pod(s) affected by these changes
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
