### PR TITLE
Fix transparent images

### DIFF
--- a/src/app/containers/ImageWithPlaceholder/index.jsx
+++ b/src/app/containers/ImageWithPlaceholder/index.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { string, number, bool, node } from 'prop-types';
+import styled from 'styled-components';
 import LazyLoad from 'react-lazyload';
 import ImagePlaceholder from '@bbc/psammead-image-placeholder';
 import Image, { AmpImg } from '@bbc/psammead-image';
@@ -7,11 +8,15 @@ import { RequestContext } from '#contexts/RequestContext';
 
 const LAZYLOAD_OFFSET = 250; // amount of pixels below the viewport to begin loading the image
 
+const ImageWithBackground = styled.div`
+  background: white;
+`;
+
 const renderImage = (imageToRender, lazyLoad, fallback) =>
   lazyLoad ? (
     <>
       <LazyLoad offset={LAZYLOAD_OFFSET} once>
-        {imageToRender}
+        <ImageWithBackground>{imageToRender}</ImageWithBackground>
       </LazyLoad>
       {fallback && <noscript>{imageToRender}</noscript>}
     </>


### PR DESCRIPTION
Resolves #6429

**Overall change:**
Adds a wrapper around the rendered lazy-loaded image, that adds `background: #ffffff` to prevent the image placeholder appearing through a transparent image.

**Code changes:**

- Adds a new `div` wrapper with `background: #ffffff` property

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
