### PR TITLE
Update log levels for external_vpid errors

### DIFF
--- a/src/app/lib/utilities/logging/index.js
+++ b/src/app/lib/utilities/logging/index.js
@@ -9,10 +9,10 @@ export const logMediaError = ({ logger, mediaBlock, url }) => {
   const { statusCode } = mediaBlock;
   switch (statusCode) {
     case 404:
-      logger.warn(MEDIA_ASSET_REVOKED, { url, mediaBlock });
+      logger.info(MEDIA_ASSET_REVOKED, { url, mediaBlock });
       break;
     case 410:
-      logger.warn(MEDIA_ASSET_EXPIRED, { url, mediaBlock });
+      logger.info(MEDIA_ASSET_EXPIRED, { url, mediaBlock });
       break;
     default:
       logger.error(MEDIA_METADATA_UNAVAILABLE, { url, mediaBlock });

--- a/src/app/routes/cpsAsset/getInitialData/processUnavailableMedia/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/processUnavailableMedia/index.test.js
@@ -132,7 +132,7 @@ describe('processUnavailableMedia', () => {
       },
     };
     processUnavailableMedia(pageData);
-    expect(loggerMock.warn).toHaveBeenCalledWith(MEDIA_ASSET_REVOKED, {
+    expect(loggerMock.info).toHaveBeenCalledWith(MEDIA_ASSET_REVOKED, {
       url: 'mock-uri',
       mediaBlock: {
         statusCode: 404,
@@ -152,7 +152,7 @@ describe('processUnavailableMedia', () => {
       },
     };
     processUnavailableMedia(pageData);
-    expect(loggerMock.warn).toHaveBeenCalledWith(MEDIA_ASSET_EXPIRED, {
+    expect(loggerMock.info).toHaveBeenCalledWith(MEDIA_ASSET_EXPIRED, {
       url: 'mock-uri',
       mediaBlock: {
         statusCode: 410,


### PR DESCRIPTION
Resolves #6262

**Overall change:**
Update log levels to `info` for _expired_ and _revoked_ `external_vpid` blocks

**Code changes:**
- Change log levels to info for expired and revoked
- Update tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
