### PR TITLE
Fix merge conflict within on-demand audio by renaming imageUrl -> thumbnailImageUrl

### DIFF
--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.jsx
@@ -8,7 +8,7 @@ const AudioObject = ({
   shortSynopsis,
   durationISO8601,
   embedUrl,
-  imageUrl,
+  placeholderImageUrl,
   releaseDateTimeStamp,
 }) => {
   const metadata = {
@@ -17,7 +17,7 @@ const AudioObject = ({
     name: promoBrandTitle,
     description: shortSynopsis,
     duration: durationISO8601,
-    thumbnailUrl: imageUrl,
+    thumbnailUrl: placeholderImageUrl,
     uploadDate: new Date(releaseDateTimeStamp).toISOString(),
     embedURL: embedUrl,
   };
@@ -34,7 +34,7 @@ AudioObject.propTypes = {
   shortSynopsis: string,
   durationISO8601: string,
   embedUrl: string,
-  imageUrl: string,
+  placeholderImageUrl: string,
   releaseDateTimeStamp: number,
 };
 
@@ -43,7 +43,7 @@ AudioObject.defaultProps = {
   shortSynopsis: '',
   durationISO8601: '',
   embedUrl: '',
-  imageUrl: '',
+  placeholderImageUrl: '',
   releaseDateTimeStamp: null,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.jsx
@@ -8,7 +8,7 @@ const AudioObject = ({
   shortSynopsis,
   durationISO8601,
   embedUrl,
-  placeholderImageUrl,
+  thumbnailImageUrl,
   releaseDateTimeStamp,
 }) => {
   const metadata = {
@@ -17,7 +17,7 @@ const AudioObject = ({
     name: promoBrandTitle,
     description: shortSynopsis,
     duration: durationISO8601,
-    thumbnailUrl: placeholderImageUrl,
+    thumbnailUrl: thumbnailImageUrl,
     uploadDate: new Date(releaseDateTimeStamp).toISOString(),
     embedURL: embedUrl,
   };
@@ -34,7 +34,7 @@ AudioObject.propTypes = {
   shortSynopsis: string,
   durationISO8601: string,
   embedUrl: string,
-  placeholderImageUrl: string,
+  thumbnailImageUrl: string,
   releaseDateTimeStamp: number,
 };
 
@@ -43,7 +43,7 @@ AudioObject.defaultProps = {
   shortSynopsis: '',
   durationISO8601: '',
   embedUrl: '',
-  placeholderImageUrl: '',
+  thumbnailImageUrl: '',
   releaseDateTimeStamp: null,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.test.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.test.jsx
@@ -8,7 +8,8 @@ const props = {
   durationISO8601: 'PT29M30S',
   embedUrl:
     'https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/externalId/id/ko?morph_env=live',
-  imageUrl: 'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
+  placeholderImageUrl:
+    'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
   releaseDateTimeStamp: 1587655800000,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.test.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/AudioObject.test.jsx
@@ -8,8 +8,7 @@ const props = {
   durationISO8601: 'PT29M30S',
   embedUrl:
     'https://polling.test.bbc.co.uk/ws/av-embeds/media/korean/externalId/id/ko?morph_env=live',
-  placeholderImageUrl:
-    'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
+  thumbnailImageUrl: 'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
   releaseDateTimeStamp: 1587655800000,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
@@ -63,7 +63,7 @@ const AudioPlayer = ({
   promoBrandTitle,
   shortSynopsis,
   durationISO8601,
-  imageUrl,
+  placeholderImageUrl,
   releaseDateTimeStamp,
 }) => {
   const { liveRadioOverrides, lang, translations, service } = useContext(
@@ -142,7 +142,7 @@ const AudioPlayer = ({
           shortSynopsis={shortSynopsis}
           durationISO8601={durationISO8601}
           embedUrl={embedUrl}
-          imageUrl={imageUrl}
+          placeholderImageUrl={placeholderImageUrl}
           releaseDateTimeStamp={releaseDateTimeStamp}
         />
       )}
@@ -158,7 +158,7 @@ AudioPlayer.propTypes = {
   promoBrandTitle: string,
   shortSynopsis: string,
   durationISO8601: string,
-  imageUrl: string,
+  placeholderImageUrl: string,
   releaseDateTimeStamp: number,
 };
 
@@ -170,7 +170,7 @@ AudioPlayer.defaultProps = {
   promoBrandTitle: '',
   shortSynopsis: '',
   durationISO8601: '',
-  imageUrl: '',
+  placeholderImageUrl: '',
   releaseDateTimeStamp: null,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.jsx
@@ -63,7 +63,7 @@ const AudioPlayer = ({
   promoBrandTitle,
   shortSynopsis,
   durationISO8601,
-  placeholderImageUrl,
+  thumbnailImageUrl,
   releaseDateTimeStamp,
 }) => {
   const { liveRadioOverrides, lang, translations, service } = useContext(
@@ -142,7 +142,7 @@ const AudioPlayer = ({
           shortSynopsis={shortSynopsis}
           durationISO8601={durationISO8601}
           embedUrl={embedUrl}
-          placeholderImageUrl={placeholderImageUrl}
+          thumbnailImageUrl={thumbnailImageUrl}
           releaseDateTimeStamp={releaseDateTimeStamp}
         />
       )}
@@ -158,7 +158,7 @@ AudioPlayer.propTypes = {
   promoBrandTitle: string,
   shortSynopsis: string,
   durationISO8601: string,
-  placeholderImageUrl: string,
+  thumbnailImageUrl: string,
   releaseDateTimeStamp: number,
 };
 
@@ -170,7 +170,7 @@ AudioPlayer.defaultProps = {
   promoBrandTitle: '',
   shortSynopsis: '',
   durationISO8601: '',
-  placeholderImageUrl: '',
+  thumbnailImageUrl: '',
   releaseDateTimeStamp: null,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.test.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.test.jsx
@@ -20,7 +20,8 @@ const defaultAudioPlayerProps = {
   promoBrandTitle: 'ماښامنۍ خپرونه',
   shortSynopsis: 'د بي بي سي ورلډ سروس څخه پروګرام کول',
   durationISO8601: 'PT29M30S',
-  imageUrl: 'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
+  placeholderImageUrl:
+    'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
   releaseDateTimeStamp: 1587655800000,
 };
 

--- a/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.test.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/AudioPlayer/index.test.jsx
@@ -20,8 +20,7 @@ const defaultAudioPlayerProps = {
   promoBrandTitle: 'ماښامنۍ خپرونه',
   shortSynopsis: 'د بي بي سي ورلډ سروس څخه پروګرام کول',
   durationISO8601: 'PT29M30S',
-  placeholderImageUrl:
-    'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
+  thumbnailImageUrl: 'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
   releaseDateTimeStamp: 1587655800000,
 };
 

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -37,7 +37,7 @@ const renderEpisode = ({
   episodeAvailableUntil,
   promoBrandTitle,
   shortSynopsis,
-  placeholderImageUrl,
+  thumbnailImageUrl,
   durationISO8601,
   releaseDateTimeStamp,
 }) => {
@@ -53,7 +53,7 @@ const renderEpisode = ({
           id={episodeId}
           promoBrandTitle={promoBrandTitle}
           shortSynopsis={shortSynopsis}
-          placeholderImageUrl={placeholderImageUrl}
+          thumbnailImageUrl={thumbnailImageUrl}
           durationISO8601={durationISO8601}
           releaseDateTimeStamp={releaseDateTimeStamp}
         />
@@ -82,7 +82,7 @@ const OnDemandRadioPage = ({ pageData }) => {
     releaseDateTimeStamp,
     promoBrandTitle,
     durationISO8601,
-    placeholderImageUrl,
+    thumbnailImageUrl,
   } = pageData;
   const { dir } = useContext(ServiceContext);
 
@@ -146,7 +146,7 @@ const OnDemandRadioPage = ({ pageData }) => {
             episodeAvailableUntil,
             promoBrandTitle,
             shortSynopsis,
-            placeholderImageUrl,
+            thumbnailImageUrl,
             durationISO8601,
             releaseDateTimeStamp,
           })}

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -37,7 +37,7 @@ const renderEpisode = ({
   episodeAvailableUntil,
   promoBrandTitle,
   shortSynopsis,
-  imageUrl,
+  placeholderImageUrl,
   durationISO8601,
   releaseDateTimeStamp,
 }) => {
@@ -53,7 +53,7 @@ const renderEpisode = ({
           id={episodeId}
           promoBrandTitle={promoBrandTitle}
           shortSynopsis={shortSynopsis}
-          imageUrl={imageUrl}
+          placeholderImageUrl={placeholderImageUrl}
           durationISO8601={durationISO8601}
           releaseDateTimeStamp={releaseDateTimeStamp}
         />
@@ -82,7 +82,7 @@ const OnDemandRadioPage = ({ pageData }) => {
     releaseDateTimeStamp,
     promoBrandTitle,
     durationISO8601,
-    imageUrl,
+    placeholderImageUrl,
   } = pageData;
   const { dir } = useContext(ServiceContext);
 
@@ -146,7 +146,7 @@ const OnDemandRadioPage = ({ pageData }) => {
             episodeAvailableUntil,
             promoBrandTitle,
             shortSynopsis,
-            imageUrl,
+            placeholderImageUrl,
             durationISO8601,
             releaseDateTimeStamp,
           })}

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -44,7 +44,7 @@ const getDurationISO8601 = path([
   0,
   'durationISO8601',
 ]);
-const getPlaceholderImageUrl = json =>
+const getThumbnailImageUrl = json =>
   getPlaceholderImageUrlUtil(path(['promo', 'media', 'imageUrl'], json));
 
 export default async ({ path: pathname }) => {
@@ -73,7 +73,7 @@ export default async ({ path: pathname }) => {
         pageIdentifier: getPageIdentifier(json),
         promoBrandTitle: getPromoBrandTitle(json),
         durationISO8601: getDurationISO8601(json),
-        placeholderImageUrl: getPlaceholderImageUrl(json),
+        thumbnailImageUrl: getThumbnailImageUrl(json),
         ...pageType,
       },
     }),

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -1,7 +1,7 @@
 import path from 'ramda/src/path';
 import fetchPageData from '../../utils/fetchPageData';
 import overrideRendererOnTest from '../../utils/overrideRendererOnTest';
-import getPlaceholderImageUrl from '../../utils/getPlaceholderImageUrl';
+import getPlaceholderImageUrlUtil from '../../utils/getPlaceholderImageUrl';
 
 const getBrandTitle = path(['metadata', 'title']);
 const getLanguage = path(['metadata', 'language']);
@@ -44,8 +44,8 @@ const getDurationISO8601 = path([
   0,
   'durationISO8601',
 ]);
-const getImageUrl = json =>
-  getPlaceholderImageUrl(path(['promo', 'media', 'imageUrl'], json));
+const getPlaceholderImageUrl = json =>
+  getPlaceholderImageUrlUtil(path(['promo', 'media', 'imageUrl'], json));
 
 export default async ({ path: pathname }) => {
   const onDemandRadioDataPath = overrideRendererOnTest(pathname);
@@ -73,7 +73,7 @@ export default async ({ path: pathname }) => {
         pageIdentifier: getPageIdentifier(json),
         promoBrandTitle: getPromoBrandTitle(json),
         durationISO8601: getDurationISO8601(json),
-        imageUrl: getImageUrl(json),
+        placeholderImageUrl: getPlaceholderImageUrl(json),
         ...pageType,
       },
     }),

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -24,7 +24,7 @@ describe('Get initial data for on demand radio', () => {
     expect(pageData.metadata.type).toEqual('On Demand Radio');
     expect(pageData.promoBrandTitle).toEqual('ماښامنۍ خپرونه');
     expect(pageData.durationISO8601).toEqual('PT29M30S');
-    expect(pageData.imageUrl).toEqual(
+    expect(pageData.placeholderImageUrl).toEqual(
       'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
     );
   });

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -24,7 +24,7 @@ describe('Get initial data for on demand radio', () => {
     expect(pageData.metadata.type).toEqual('On Demand Radio');
     expect(pageData.promoBrandTitle).toEqual('ماښامنۍ خپرونه');
     expect(pageData.durationISO8601).toEqual('PT29M30S');
-    expect(pageData.placeholderImageUrl).toEqual(
+    expect(pageData.thumbnailImageUrl).toEqual(
       'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
     );
   });


### PR DESCRIPTION
Resolves a merge conflict between https://github.com/bbc/simorgh/issues/6337 & https://github.com/bbc/simorgh/pull/6461

**Overall change:**

The upcoming [On-demand audio episode image PR] (https://github.com/bbc/simorgh/pull/6471) refers to the episode image  as `imageUrl`, from the page's `getInitialData` function, through to when it's rendered.

The recently merged [On-demand audio structured data PR for the same page ](https://github.com/bbc/simorgh/pull/6461) also makes use of the variable `imageUrl`, for the thumbnailUrl that is used in the schema.org audio object.

The value of these two `imageUrl` instances is different: the structured data version parses the url through a /getPlaceholderImageUrl` util, the episode image version is just the raw string taken from the ARES response.

In order to fix this impending merge conflict, this PR renames all of the structured data `imageUrl` -> to `thumbnailImageUrl`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
