### PR TITLE
Ensure slack notifications go to the simorgh-alerts channel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
     CI = true
   }
   parameters {
-    string(name: 'SLACK_CHANNEL', defaultValue: '#si_repo-simorgh', description: 'The Slack channel where the build status is posted.')
+    string(name: 'SLACK_CHANNEL', defaultValue: '#simorgh-alerts', description: 'The Slack channel where the build status is posted.')
     booleanParam(name: 'SKIP_OOH_CHECK', defaultValue: false, description: 'Allow Simorgh deployment to LIVE outside the set Out of Hours (O.O.H) time span.')
   }
   stages {


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Ensures build notifications go to the simorgh-alerts slack channel

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
