### PR TITLE
Updating asset from V1 to V2

### DIFF
--- a/data/afaanoromoo/bbc_afaanoromoo_radio/w3cszx1y.json
+++ b/data/afaanoromoo/bbc_afaanoromoo_radio/w3cszx1y.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx1y",
-    "locators": {},
+    "locators": { "pid": "w3cszx1y", "brandPid": "w13xttnw" },
     "type": "WSRADIO",
     "createdBy": "bbc_oromo_radio",
     "language": "om",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1588318279115,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
+    "timestamp": 1582565117000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Oduu BBC Afaan Oromoo - BBC News Afaan Oromoo",
       "pageIdentifier": "Afaan Oromoo.bbc_oromo_radio.w3cszx1y.page",
       "producerId": "2",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "AFAAN_OROMOO"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.2.1",
     "blockTypes": ["media"],
-    "title": "Oduu BBC Afaan Oromoo"
+    "title": "Oduu BBC Afaan Oromoo",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -36,33 +37,14 @@
         "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvgbm",
-            "types": ["Original"],
-            "duration": 883,
-            "durationISO8601": "PT14M43S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586120670000,
-            "availableFrom": 1583517870000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Oduu BBC Afaan Oromoo"
-    },
-    "locators": {
-      "pid": "w3cszx1y"
-    },
+    "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+    "locators": { "pid": "w3cszx1y", "brandPid": "w13xttnw" },
     "media": {
       "id": "w3cszx1y",
       "subType": "episode",
@@ -75,23 +57,8 @@
       "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvgbm",
-          "types": ["Original"],
-          "duration": 883,
-          "durationISO8601": "PT14M43S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586120670000,
-          "availableFrom": 1583517870000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
@@ -101,46 +68,42 @@
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "w13xttnw",
-      "title": "Oduu BBC Afaan Oromoo"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx1y"
+    "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx1y",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Afaan oromoo",
-      "uri": "/afaan oromoo"
+      "uri": "/afaan oromoo",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx46"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0lbw", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx46",
+              "id": "w3ct0lbw",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgdw",
+                  "versionId": "w4hqw56f",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -150,11 +113,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586034270000,
-                  "availableFrom": 1583431470000
+                  "availableUntil": 1591909470000,
+                  "availableFrom": 1589306670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -164,36 +127,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx46"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lbw",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx6g"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0l8m", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx6g",
+              "id": "w3ct0l8m",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgh4",
+                  "versionId": "w4hqw545",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -203,11 +161,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585947870000,
-                  "availableFrom": 1583345070000
+                  "availableUntil": 1591823070000,
+                  "availableFrom": 1589220270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -217,36 +175,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx6g"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l8m",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx5b"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0l7g", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx5b",
+              "id": "w3ct0l7g",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgg0",
+                  "versionId": "w4hqw530",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -256,11 +209,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585861470000,
-                  "availableFrom": 1583258670000
+                  "availableUntil": 1591563870000,
+                  "availableFrom": 1588961070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -270,36 +223,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx5b"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l7g",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx32"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0l9q", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx32",
+              "id": "w3ct0l9q",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgcr",
+                  "versionId": "w4hqw558",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -309,11 +257,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585775070000,
-                  "availableFrom": 1583172270000
+                  "availableUntil": 1591477470000,
+                  "availableFrom": 1588874670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -323,36 +271,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx32"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l9q",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx1x"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0lcz", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx1x",
+              "id": "w3ct0lcz",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgbl",
+                  "versionId": "w4hqw57j",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -362,11 +305,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585515870000,
-                  "availableFrom": 1582913070000
+                  "availableUntil": 1591391070000,
+                  "availableFrom": 1588788270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -376,36 +319,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx1x"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lcz",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx45"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0lbv", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx45",
+              "id": "w3ct0lbv",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgdv",
+                  "versionId": "w4hqw56d",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -415,11 +353,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585429470000,
-                  "availableFrom": 1582826670000
+                  "availableUntil": 1591304670000,
+                  "availableFrom": 1588701870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -429,36 +367,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx45"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lbv",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx6f"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0l8l", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx6f",
+              "id": "w3ct0l8l",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "04/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgh3",
+                  "versionId": "w4hqw544",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -468,11 +401,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585343070000,
-                  "availableFrom": 1582740270000
+                  "availableUntil": 1591218270000,
+                  "availableFrom": 1588615470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -482,36 +415,31 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx6f"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l8l",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Oduu BBC Afaan Oromoo"
-            },
-            "locators": {
-              "pid": "w3cszx59"
-            },
+            "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
+            "locators": { "pid": "w3ct0l7f", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3cszx59",
+              "id": "w3ct0l7f",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "01/05/2020 GMT",
               "synopses": {
-                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
-                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
+                "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
+                "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvgfz",
+                  "versionId": "w4hqw52z",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -521,11 +449,11 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585256670000,
-                  "availableFrom": 1582653870000
+                  "availableUntil": 1590959070000,
+                  "availableFrom": 1588356270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
@@ -535,13 +463,12 @@
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnw",
-              "title": "Oduu BBC Afaan Oromoo"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx59"
+            "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l7f",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/afrique/bbc_afrique_radio/w172x601yx5z2n1.json
+++ b/data/afrique/bbc_afrique_radio/w172x601yx5z2n1.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5z2n1",
-    "locators": {},
+    "locators": { "pid": "w172x601yx5z2n1", "brandPid": "p03p35rt" },
     "type": "WSRADIO",
     "createdBy": "bbc_afrique_radio",
     "language": "fr",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582529718000,
     "lastPublished": 1582529718000,
+    "timestamp": 1582529718000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Le Journal - BBC News Afrique",
       "pageIdentifier": "afrique.bbc_afrique_radio.w172x601yx5z2n1.page",
       "producerId": "3",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "AFRIQUE"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Le Journal"
+    "title": "Le Journal",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "Le premier rendez-vous d'information de la soirée.",
           "medium": "Le premier rendez-vous d'information de la soirée."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshbpq04f4kql",
-            "types": ["Original"],
-            "duration": 600,
-            "durationISO8601": "PT10M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586070600000,
-            "availableFrom": 1583478600000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Le Journal"
-    },
-    "locators": {
-      "pid": "w172x601yx5z2n1"
-    },
+    "headlines": { "headline": "Le Journal" },
+    "locators": { "pid": "w172x601yx5z2n1", "brandPid": "p03p35rt" },
     "media": {
       "id": "w172x601yx5z2n1",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "Le premier rendez-vous d'information de la soirée.",
         "medium": "Le premier rendez-vous d'information de la soirée."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshbpq04f4kql",
-          "types": ["Original"],
-          "duration": 600,
-          "durationISO8601": "PT10M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586070600000,
-          "availableFrom": 1583478600000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p03p35rt",
-      "title": "Le Journal"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5z2n1"
+    "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5z2n1",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Afrique",
-      "uri": "/afrique"
+      "uri": "/afrique",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x601yx5z0rz"
-            },
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbxn2jgmhs", "brandPid": "p03p35rt" },
             "media": {
-              "id": "w172x601yx5z0rz",
+              "id": "w172xgbxn2jgmhs",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "Le premier rendez-vous d'information de la soirée.",
                 "medium": "Le premier rendez-vous d'information de la soirée."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshbpq04f4hvj",
+                  "versionId": "w1mshm7g4mhydr9",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -150,156 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586068800000,
-                  "availableFrom": 1583476800000
+                  "availableUntil": 1592118600000,
+                  "availableFrom": 1589526600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5z0rz"
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbxn2jgmhs",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x5zn7jwm9p8"
-            },
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbxn2jgkmq", "brandPid": "p03p35rt" },
             "media": {
-              "id": "w172x5zn7jwm9p8",
+              "id": "w172xgbxn2jgkmq",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "Le premier rendez-vous d'information de la soirée.",
                 "medium": "Le premier rendez-vous d'information de la soirée."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshbp98s3ssrt",
-                  "types": ["Original"],
-                  "duration": 900,
-                  "durationISO8601": "PT15M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1586067300000,
-                  "availableFrom": 1583475300000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x5zn7jwm9p8"
-          },
-          {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x5zn7jwm5y4"
-            },
-            "media": {
-              "id": "w172x5zn7jwm5y4",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "06/03/2020 GMT",
-              "synopses": {
-                "short": "Le premier rendez-vous d'information de la soirée.",
-                "medium": "Le premier rendez-vous d'information de la soirée."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshbp98s3sp0p",
-                  "types": ["Original"],
-                  "duration": 900,
-                  "durationISO8601": "PT15M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1586063700000,
-                  "availableFrom": 1583471700000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x5zn7jwm5y4"
-          },
-          {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x601yx5w5qy"
-            },
-            "media": {
-              "id": "w172x601yx5w5qy",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "05/03/2020 GMT",
-              "synopses": {
-                "short": "Le premier rendez-vous d'information de la soirée.",
-                "medium": "Le premier rendez-vous d'information de la soirée."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshbpq04f1nth",
+                  "versionId": "w1mshm7g4mhybw7",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -309,103 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585984200000,
-                  "availableFrom": 1583392200000
+                  "availableUntil": 1592116800000,
+                  "availableFrom": 1589524800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5w5qy"
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbxn2jgkmq",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x601yx5w3vw"
-            },
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbhxq73vk0", "brandPid": "p03p35rt" },
             "media": {
-              "id": "w172x601yx5w3vw",
+              "id": "w172xgbhxq73vk0",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "Le premier rendez-vous d'information de la soirée.",
                 "medium": "Le premier rendez-vous d'information de la soirée."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshbpq04f1lyf",
-                  "types": ["Original"],
-                  "duration": 600,
-                  "durationISO8601": "PT10M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585982400000,
-                  "availableFrom": 1583390400000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5w3vw"
-          },
-          {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x5zn7jwjds5"
-            },
-            "media": {
-              "id": "w172x5zn7jwjds5",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "05/03/2020 GMT",
-              "synopses": {
-                "short": "Le premier rendez-vous d'information de la soirée.",
-                "medium": "Le premier rendez-vous d'information de la soirée."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshbp98s3pwvq",
+                  "versionId": "w1mshm71f86lmsj",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -415,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585980900000,
-                  "availableFrom": 1583388900000
+                  "availableUntil": 1592115300000,
+                  "availableFrom": 1589523300000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x5zn7jwjds5"
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbhxq73vk0",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x5zn7jwj911"
-            },
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbhxq73qsw", "brandPid": "p03p35rt" },
             "media": {
-              "id": "w172x5zn7jwj911",
+              "id": "w172xgbhxq73qsw",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "Le premier rendez-vous d'information de la soirée.",
                 "medium": "Le premier rendez-vous d'information de la soirée."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshbp98s3ps3l",
+                  "versionId": "w1mshm71f86lj1d",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -468,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585977300000,
-                  "availableFrom": 1583385300000
+                  "availableUntil": 1592111700000,
+                  "availableFrom": 1589519700000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x5zn7jwj911"
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbhxq73qsw",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Le Journal"
-            },
-            "locators": {
-              "pid": "w172x601yx5s8tv"
-            },
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbxn2jcqlp", "brandPid": "p03p35rt" },
             "media": {
-              "id": "w172x601yx5s8tv",
+              "id": "w172xgbxn2jcqlp",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "Le premier rendez-vous d'information de la soirée.",
                 "medium": "Le premier rendez-vous d'information de la soirée."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshbpq04dyrxd",
+                  "versionId": "w1mshm7g4mhvhv6",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -521,27 +305,170 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585897800000,
-                  "availableFrom": 1583305800000
+                  "availableUntil": 1592032200000,
+                  "availableFrom": 1589440200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpx6.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03p35rt",
-              "title": "Le Journal"
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbxn2jcqlp",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbxn2jcnqm", "brandPid": "p03p35rt" },
+            "media": {
+              "id": "w172xgbxn2jcnqm",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Le premier rendez-vous d'information de la soirée.",
+                "medium": "Le premier rendez-vous d'information de la soirée."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshm7g4mhvfz4",
+                  "types": ["Original"],
+                  "duration": 600,
+                  "durationISO8601": "PT10M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592030400000,
+                  "availableFrom": 1589438400000
+                }
+              ],
+              "type": "media"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172x601yx5s8tv"
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbxn2jcnqm",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbhxq70ymx", "brandPid": "p03p35rt" },
+            "media": {
+              "id": "w172xgbhxq70ymx",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Le premier rendez-vous d'information de la soirée.",
+                "medium": "Le premier rendez-vous d'information de la soirée."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshm71f86hqwf",
+                  "types": ["Original"],
+                  "duration": 900,
+                  "durationISO8601": "PT15M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592028900000,
+                  "availableFrom": 1589436900000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbhxq70ymx",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Le Journal" },
+            "locators": { "pid": "w172xgbhxq70tws", "brandPid": "p03p35rt" },
+            "media": {
+              "id": "w172xgbhxq70tws",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Le premier rendez-vous d'information de la soirée.",
+                "medium": "Le premier rendez-vous d'information de la soirée."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshm71f86hm49",
+                  "types": ["Original"],
+                  "duration": 900,
+                  "durationISO8601": "PT15M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592025300000,
+                  "availableFrom": 1589433300000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b22y1.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "p03p35rt", "title": "Le Journal" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_afrique_radio/w172xgbhxq70tws",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/amharic/bbc_amharic_radio/w3csz5r9.json
+++ b/data/amharic/bbc_amharic_radio/w3csz5r9.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5r9",
-    "locators": {},
+    "locators": { "pid": "w3csz5r9", "brandPid": "w13xttnt" },
     "type": "WSRADIO",
     "createdBy": "bbc_amharic_radio",
     "language": "am",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
+    "timestamp": 1582565117000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "ቢቢሲ አማርኛ ዜና - BBC News አማርኛ",
       "pageIdentifier": "amharic.bbc_amharic_radio.w3csz5r9.page",
       "producerId": "4",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "AMHARIC"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "ቢቢሲ አማርኛ ዜና"
+    "title": "ቢቢሲ አማርኛ ዜና",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
           "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqtq1d",
-            "types": ["Original"],
-            "duration": 883,
-            "durationISO8601": "PT14M43S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586119470000,
-            "availableFrom": 1583516670000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "ቢቢሲ አማርኛ ዜና"
-    },
-    "locators": {
-      "pid": "w3csz5r9"
-    },
+    "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+    "locators": { "pid": "w3csz5r9", "brandPid": "w13xttnt" },
     "media": {
       "id": "w3csz5r9",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
         "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqtq1d",
-          "types": ["Original"],
-          "duration": 883,
-          "durationISO8601": "PT14M43S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586119470000,
-          "availableFrom": 1583516670000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "w13xttnt",
-      "title": "ቢቢሲ አማርኛ ዜና"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5r9"
+    "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5r9",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Amharic",
-      "uri": "/amharic"
+      "uri": "/amharic",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5tk"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07cd", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5tk",
+              "id": "w3ct07cd",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq3n",
+                  "versionId": "w4hqvt59",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586033070000,
-                  "availableFrom": 1583430270000
+                  "availableUntil": 1592081070000,
+                  "availableFrom": 1589478270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5tk"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07cd",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5wt"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07fn", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5wt",
+              "id": "w3ct07fn",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq5x",
+                  "versionId": "w4hqvt7k",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585946670000,
-                  "availableFrom": 1583343870000
+                  "availableUntil": 1591994670000,
+                  "availableFrom": 1589391870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5wt"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07fn",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5vp"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07dj", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5vp",
+              "id": "w3ct07dj",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq4s",
+                  "versionId": "w4hqvt6f",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585860270000,
-                  "availableFrom": 1583257470000
+                  "availableUntil": 1591908270000,
+                  "availableFrom": 1589305470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5vp"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07dj",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5sf"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07b8", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5sf",
+              "id": "w3ct07b8",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq2j",
+                  "versionId": "w4hqvt45",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585773870000,
-                  "availableFrom": 1583171070000
+                  "availableUntil": 1591821870000,
+                  "availableFrom": 1589219070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5sf"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07b8",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5r8"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct0793", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5r8",
+              "id": "w3ct0793",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq1c",
+                  "versionId": "w4hqvt30",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585514670000,
-                  "availableFrom": 1582911870000
+                  "availableUntil": 1591562670000,
+                  "availableFrom": 1588959870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5r8"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0793",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5tj"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07cc", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5tj",
+              "id": "w3ct07cc",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq3m",
+                  "versionId": "w4hqvt58",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585428270000,
-                  "availableFrom": 1582825470000
+                  "availableUntil": 1591476270000,
+                  "availableFrom": 1588873470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5tj"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07cc",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5ws"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07fm", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5ws",
+              "id": "w3ct07fm",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq5w",
+                  "versionId": "w4hqvt7j",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585341870000,
-                  "availableFrom": 1582739070000
+                  "availableUntil": 1591389870000,
+                  "availableFrom": 1588787070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5ws"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07fm",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ አማርኛ ዜና"
-            },
-            "locators": {
-              "pid": "w3csz5vn"
-            },
+            "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
+            "locators": { "pid": "w3ct07dh", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3csz5vn",
+              "id": "w3ct07dh",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq4r",
+                  "versionId": "w4hqvt6d",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585255470000,
-                  "availableFrom": 1582652670000
+                  "availableUntil": 1591303470000,
+                  "availableFrom": 1588700670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2wb.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8jvj.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "w13xttnt",
-              "title": "ቢቢሲ አማርኛ ዜና"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5vn"
+            "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07dh",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/arabic/bbc_arabic_radio/w3ct01yb.json
+++ b/data/arabic/bbc_arabic_radio/w3ct01yb.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb",
-    "locators": {},
+    "locators": { "pid": "w3ct01yb", "brandPid": "p030vh39" },
     "type": "WSRADIO",
     "createdBy": "bbc_arabic_radio",
     "language": "ar",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1582584617000,
     "lastPublished": 1582584617000,
+    "timestamp": 1582584617000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "نقطة حوار - BBC News Arabic",
       "pageIdentifier": "arabic.bbc_arabic_radio.w3ct01yb.page",
       "producerId": "5",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "ARABIC"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "نقطة حوار"
+    "title": "نقطة حوار",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
           "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvm8h",
-            "types": ["Original"],
-            "duration": 1440,
-            "durationISO8601": "PT24M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586140200000,
-            "availableFrom": 1583533800000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "نقطة حوار"
-    },
-    "locators": {
-      "pid": "w3ct01yb"
-    },
+    "headlines": { "headline": "نقطة حوار" },
+    "locators": { "pid": "w3ct01yb", "brandPid": "p030vh39" },
     "media": {
       "id": "w3ct01yb",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
         "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvm8h",
-          "types": ["Original"],
-          "duration": 1440,
-          "durationISO8601": "PT24M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586140200000,
-          "availableFrom": 1583533800000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p030vh39",
-      "title": "نقطة حوار"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb"
+    "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Arabic",
-      "uri": "/arabic"
+      "uri": "/arabic",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct021q"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct094h", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct021q",
+              "id": "w3ct094h",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmcw",
+                  "versionId": "w4hqvvyd",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586194200000,
-                  "availableFrom": 1583361000000
+                  "availableUntil": 1592134200000,
+                  "availableFrom": 1589412600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct021q"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094h",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct020l"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct093c", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct020l",
+              "id": "w3ct093c",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmbr",
+                  "versionId": "w4hqvvx8",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585913400000,
-                  "availableFrom": 1583188200000
+                  "availableUntil": 1591961400000,
+                  "availableFrom": 1589239800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct020l"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct093c",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct01y9"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct0908", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct01y9",
+              "id": "w3ct0908",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvm8g",
+                  "versionId": "w4hqvvt5",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585740600000,
-                  "availableFrom": 1582929000000
+                  "availableUntil": 1591795800000,
+                  "availableFrom": 1588980600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01y9"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0908",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct021p"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct094g", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct021p",
+              "id": "w3ct094g",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmcv",
+                  "versionId": "w4hqvvyc",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585621800000,
-                  "availableFrom": 1582756200000
+                  "availableUntil": 1591691400000,
+                  "availableFrom": 1588807800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct021p"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094g",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct020k"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct093b", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct020k",
+              "id": "w3ct093b",
               "subType": "episode",
               "format": "Audio",
-              "title": "24/02/2020 GMT",
+              "title": "04/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmbq",
+                  "versionId": "w4hqvvx7",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585308600000,
-                  "availableFrom": 1582583400000
+                  "availableUntil": 1591356600000,
+                  "availableFrom": 1588635000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct020k"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct093b",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct01y8"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct0907", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct01y8",
+              "id": "w3ct0907",
               "subType": "episode",
               "format": "Audio",
-              "title": "21/02/2020 GMT",
+              "title": "01/05/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvm8f",
+                  "versionId": "w4hqvvt4",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585135800000,
-                  "availableFrom": 1582324200000
+                  "availableUntil": 1591191000000,
+                  "availableFrom": 1588375800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01y8"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0907",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct021n"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct094f", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct021n",
+              "id": "w3ct094f",
               "subType": "episode",
               "format": "Audio",
-              "title": "19/02/2020 GMT",
+              "title": "29/04/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmct",
+                  "versionId": "w4hqvvyb",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585017000000,
-                  "availableFrom": 1582151400000
+                  "availableUntil": 1591086600000,
+                  "availableFrom": 1588203000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct021n"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094f",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "نقطة حوار"
-            },
-            "locators": {
-              "pid": "w3ct020j"
-            },
+            "headlines": { "headline": "نقطة حوار" },
+            "locators": { "pid": "w3ct0939", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct020j",
+              "id": "w3ct0939",
               "subType": "episode",
               "format": "Audio",
-              "title": "17/02/2020 GMT",
+              "title": "27/04/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvmbp",
+                  "versionId": "w4hqvvx6",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584703800000,
-                  "availableFrom": 1581978600000
+                  "availableUntil": 1590751800000,
+                  "availableFrom": 1588030200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035djt9.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23t4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vh39",
-              "title": "نقطة حوار"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct020j"
+            "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0939",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/bengali/bbc_bangla_radio/w172x0562jxntqx.json
+++ b/data/bengali/bbc_bangla_radio/w172x0562jxntqx.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxntqx",
-    "locators": {},
+    "locators": { "pid": "w172x0562jxntqx", "brandPid": "p030vjwg" },
     "type": "WSRADIO",
     "createdBy": "bbc_bangla_radio",
     "language": "bn",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
+    "timestamp": 1583569000000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "প্রবাহ - BBC News বাংলা",
       "pageIdentifier": "bengali.bbc_bangla_radio.w172x0562jxntqx.page",
       "producerId": "31",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "BENGALI"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "প্রবাহ"
+    "title": "প্রবাহ",
+    "releaseDateTimeStamp": 1583539200000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
           "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1msh4hq5vv29zd",
-            "types": ["Original"],
-            "duration": 1770,
-            "durationISO8601": "PT29M30S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586181570000,
-            "availableFrom": 1583589570000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "প্রবাহ"
-    },
-    "locators": {
-      "pid": "w172x0562jxntqx"
-    },
+    "headlines": { "headline": "প্রবাহ" },
+    "locators": { "pid": "w172x0562jxntqx", "brandPid": "p030vjwg" },
     "media": {
       "id": "w172x0562jxntqx",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
         "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1msh4hq5vv29zd",
-          "types": ["Original"],
-          "duration": 1770,
-          "durationISO8601": "PT29M30S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586181570000,
-          "availableFrom": 1583589570000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p030vjwg",
-      "title": "প্রবাহ"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxntqx"
+    "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxntqx",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Bengali",
-      "uri": "/bengali"
+      "uri": "/bengali",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x0562jxkxtt"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhxtlr99v", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x0562jxkxtt",
+              "id": "w172xdwhxtlr99v",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hq5vtzf29",
+                  "versionId": "w1mshks1fcl72kc",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586095170000,
-                  "availableFrom": 1583503170000
+                  "availableUntil": 1592056770000,
+                  "availableFrom": 1589464770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxkxtt"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlr99v",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x0562jxh0xq"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhxtlnddr", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x0562jxh0xq",
+              "id": "w172xdwhxtlnddr",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hq5vtwj56",
+                  "versionId": "w1mshks1fcl45n8",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586008770000,
-                  "availableFrom": 1583416770000
+                  "availableUntil": 1591970370000,
+                  "availableFrom": 1589378370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxh0xq"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlnddr",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x0562jxd40m"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhxtlkhhn", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x0562jxd40m",
+              "id": "w172xdwhxtlkhhn",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hq5vtsm83",
+                  "versionId": "w1mshks1fcl18r5",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585922370000,
-                  "availableFrom": 1583330370000
+                  "availableUntil": 1591883970000,
+                  "availableFrom": 1589291970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxd40m"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlkhhn",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x0562jx973j"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhxtlgllk", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x0562jx973j",
+              "id": "w172xdwhxtlgllk",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hq5vtpqc0",
+                  "versionId": "w1mshks1fckycv2",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585835970000,
-                  "availableFrom": 1583243970000
+                  "availableUntil": 1591797570000,
+                  "availableFrom": 1589205570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jx973j"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlgllk",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x0562jx6b6f"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhkk97vf9", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x0562jx6b6f",
+              "id": "w172xdwhkk97vf9",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hq5vtltfx",
+                  "versionId": "w1mshks1238qmnt",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585749570000,
-                  "availableFrom": 1583157570000
+                  "availableUntil": 1591711170000,
+                  "availableFrom": 1589119170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jx6b6f"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk97vf9",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x055q8lzl15"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhkk94yj6", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x055q8lzl15",
+              "id": "w172xdwhkk94yj6",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/03/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hptljd28n",
+                  "versionId": "w1mshks1238mqrq",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585663170000,
-                  "availableFrom": 1583071170000
+                  "availableUntil": 1591624770000,
+                  "availableFrom": 1589032770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x055q8lzl15"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk94yj6",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x055q8lwp42"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhkk921m3", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x055q8lwp42",
+              "id": "w172xdwhkk921m3",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hptlj95ck",
+                  "versionId": "w1mshks1238jtvm",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585576770000,
-                  "availableFrom": 1582984770000
+                  "availableUntil": 1591538370000,
+                  "availableFrom": 1588946370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x055q8lwp42"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk921m3",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "প্রবাহ"
-            },
-            "locators": {
-              "pid": "w172x055q8lss6z"
-            },
+            "headlines": { "headline": "প্রবাহ" },
+            "locators": { "pid": "w172xdwhkk8z4q0", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172x055q8lss6z",
+              "id": "w172xdwhkk8z4q0",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh4hptlj68gg",
+                  "versionId": "w1mshks1238fxyj",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585490370000,
-                  "availableFrom": 1582898370000
+                  "availableUntil": 1591451970000,
+                  "availableFrom": 1588859970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk27.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2kb7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030vjwg",
-              "title": "প্রবাহ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x055q8lss6z"
+            "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk8z4q0",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/burmese/bbc_burmese_radio/w3csz62h.json
+++ b/data/burmese/bbc_burmese_radio/w3csz62h.json
@@ -1,44 +1,48 @@
 {
   "metadata": {
-    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz62h",
-    "locators": {},
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4l",
+    "locators": {
+      "pid": "w3ct0b4l",
+      "brandPid": "p0340rnm"
+    },
     "type": "WSRADIO",
     "createdBy": "bbc_burmese_radio",
     "language": "my",
-    "lastUpdated": 1583601860035,
-    "firstPublished": 1583569000000,
-    "lastPublished": 1583569000000,
+    "lastUpdated": 1589529753485,
+    "firstPublished": 1588872411000,
+    "lastPublished": 1588872411000,
+    "timestamp": 1588872411000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။ - BBC News မြန်မာ",
-      "pageIdentifier": "burmese.bbc_burmese_radio.w3csz62h.page",
+      "pageIdentifier": "burmese.bbc_burmese_radio.w3ct0b4l.page",
       "producerId": "35",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "BURMESE"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
+    "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။",
+    "releaseDateTimeStamp": 1588809600000
   },
   "content": {
     "blocks": [
       {
-        "id": "w3csz62h",
+        "id": "w3ct0b4l",
         "subType": "episode",
         "format": "Audio",
-        "title": "07/03/2020 GMT",
+        "title": "07/05/2020 GMT",
         "synopses": {
           "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
           "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
         "embedding": false,
         "advertising": false,
         "versions": [
           {
-            "versionId": "w4hqtqcl",
+            "versionId": "w4hqvwyh",
             "types": ["Original"],
             "duration": 900,
             "durationISO8601": "PT15M",
@@ -48,11 +52,11 @@
               "nonUk": false,
               "world": true
             },
-            "availableUntil": 1586181570000,
-            "availableFrom": 1583588670000
+            "availableUntil": 1591451970000,
+            "availableFrom": 1588859070000
           }
         ],
-        "imageCopyright": null
+        "type": "media"
       }
     ]
   },
@@ -61,23 +65,24 @@
       "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
     },
     "locators": {
-      "pid": "w3csz62h"
+      "pid": "w3ct0b4l",
+      "brandPid": "p0340rnm"
     },
     "media": {
-      "id": "w3csz62h",
+      "id": "w3ct0b4l",
       "subType": "episode",
       "format": "Audio",
-      "title": "07/03/2020 GMT",
+      "title": "07/05/2020 GMT",
       "synopses": {
         "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
         "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
       "embedding": false,
       "advertising": false,
       "versions": [
         {
-          "versionId": "w4hqtqcl",
+          "versionId": "w4hqvwyh",
           "types": ["Original"],
           "duration": 900,
           "durationISO8601": "PT15M",
@@ -87,33 +92,36 @@
             "nonUk": false,
             "world": true
           },
-          "availableUntil": 1586181570000,
-          "availableFrom": 1583588670000
+          "availableUntil": 1591451970000,
+          "availableFrom": 1588859070000
         }
       ],
-      "imageCopyright": null
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
     "brand": {
       "pid": "p0340rnm",
       "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
     },
-    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz62h"
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4l",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Burmese",
-      "uri": "/burmese"
+      "uri": "/burmese",
+      "type": "simple"
     },
     "groups": [
       {
@@ -124,23 +132,24 @@
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz607"
+              "pid": "w3ct0b4m",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz607",
+              "id": "w3ct0b4m",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq9b",
+                  "versionId": "w4hqvwyj",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -150,50 +159,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586095170000,
-                  "availableFrom": 1583502270000
+                  "availableUntil": 1592056770000,
+                  "availableFrom": 1589463870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz607"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4m",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz64r"
+              "pid": "w3ct0b6w",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz64r",
+              "id": "w3ct0b6w",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqfv",
+                  "versionId": "w4hqvx0s",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -203,50 +215,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586008770000,
-                  "availableFrom": 1583415870000
+                  "availableUntil": 1591970370000,
+                  "availableFrom": 1589377470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz64r"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b6w",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz670"
+              "pid": "w3ct0b5r",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz670",
+              "id": "w3ct0b5r",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqj3",
+                  "versionId": "w4hqvwzn",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -256,50 +271,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585922370000,
-                  "availableFrom": 1583329470000
+                  "availableUntil": 1591883970000,
+                  "availableFrom": 1589291070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz670"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b5r",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz65w"
+              "pid": "w3ct0b17",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz65w",
+              "id": "w3ct0b17",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqgz",
+                  "versionId": "w4hqvwv4",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -309,50 +327,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585835970000,
-                  "availableFrom": 1583243070000
+                  "availableUntil": 1591797570000,
+                  "availableFrom": 1589204670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz65w"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b17",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz61c"
+              "pid": "w3ct0b3g",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz61c",
+              "id": "w3ct0b3g",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqbg",
+                  "versionId": "w4hqvwxc",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -362,50 +383,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585749570000,
-                  "availableFrom": 1583156670000
+                  "availableUntil": 1591711170000,
+                  "availableFrom": 1589118270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz61c"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b3g",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz63l"
+              "pid": "w3ct0b2b",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz63l",
+              "id": "w3ct0b2b",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/03/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqdp",
+                  "versionId": "w4hqvww7",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -415,50 +439,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585663170000,
-                  "availableFrom": 1583070270000
+                  "availableUntil": 1591624770000,
+                  "availableFrom": 1589031870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz63l"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b2b",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz62g"
+              "pid": "w3ct0b02",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz62g",
+              "id": "w3ct0b02",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtqck",
+                  "versionId": "w4hqvwsz",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -468,50 +495,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585576770000,
-                  "availableFrom": 1582983870000
+                  "availableUntil": 1591538370000,
+                  "availableFrom": 1588945470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz62g"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b02",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
             "locators": {
-              "pid": "w3csz606"
+              "pid": "w3ct0b6v",
+              "brandPid": "p0340rnm"
             },
             "media": {
-              "id": "w3csz606",
+              "id": "w3ct0b6v",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
                 "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtq99",
+                  "versionId": "w4hqvx0r",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -521,27 +551,29 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585490370000,
-                  "availableFrom": 1582897470000
+                  "availableUntil": 1591365570000,
+                  "availableFrom": 1588772670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dk5d.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340rnm",
               "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz606"
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b6v",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/gahuza/bbc_gahuza_radio/w172x7rkcj6v0vz.json
+++ b/data/gahuza/bbc_gahuza_radio/w172x7rkcj6v0vz.json
@@ -1,26 +1,30 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6v0vz",
-    "locators": {},
+    "locators": {
+      "pid": "w172x7rkcj6v0vz",
+      "brandPid": "p0340x2n"
+    },
     "type": "WSRADIO",
     "createdBy": "bbc_gahuza_radio",
     "language": "rw",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1582561533000,
     "lastPublished": 1582561533000,
+    "timestamp": 1582561533000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Amakuru ya Gahuzamiryango - BBC News Gahuza",
       "pageIdentifier": "gahuza.bbc_gahuza_radio.w172x7rkcj6v0vz.page",
       "producerId": "40",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "GAHUZA"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Amakuru ya Gahuzamiryango"
+    "title": "Amakuru ya Gahuzamiryango",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,26 +37,11 @@
           "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
           "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshdg6drg0hyj",
-            "types": ["Original"],
-            "duration": 1800,
-            "durationISO8601": "PT30M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586105970000,
-            "availableFrom": 1583513970000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
@@ -61,7 +50,8 @@
       "headline": "Amakuru ya Gahuzamiryango"
     },
     "locators": {
-      "pid": "w172x7rkcj6v0vz"
+      "pid": "w172x7rkcj6v0vz",
+      "brandPid": "p0340x2n"
     },
     "media": {
       "id": "w172x7rkcj6v0vz",
@@ -72,48 +62,36 @@
         "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
         "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshdg6drg0hyj",
-          "types": ["Original"],
-          "duration": 1800,
-          "durationISO8601": "PT30M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586105970000,
-          "availableFrom": 1583513970000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
     "brand": {
       "pid": "p0340x2n",
       "title": "Amakuru ya Gahuzamiryango"
     },
-    "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6v0vz"
+    "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6v0vz",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Gahuza",
-      "uri": "/gahuza"
+      "uri": "/gahuza",
+      "type": "simple"
     },
     "groups": [
       {
@@ -124,23 +102,24 @@
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rkcj6r3yw"
+              "pid": "w172xhgyb8p3gjq",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rkcj6r3yw",
+              "id": "w172xhgyb8p3gjq",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg6drfxm1f",
+                  "versionId": "w1mshncrxj0pfc8",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -150,50 +129,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586019570000,
-                  "availableFrom": 1583427570000
+                  "availableUntil": 1592067570000,
+                  "availableFrom": 1589475570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6r3yw"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgyb8p3gjq",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rkcj6n71s"
+              "pid": "w172xhgyb8p0kmm",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rkcj6n71s",
+              "id": "w172xhgyb8p0kmm",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg6drftq4b",
+                  "versionId": "w1mshncrxj0ljg5",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -203,50 +185,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585933170000,
-                  "availableFrom": 1583341170000
+                  "availableUntil": 1591981170000,
+                  "availableFrom": 1589389170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6n71s"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgyb8p0kmm",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rkcj6kb4p"
+              "pid": "w172xhgyb8nxnqj",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rkcj6kb4p",
+              "id": "w172xhgyb8nxnqj",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg6drfqt77",
+                  "versionId": "w1mshncrxj0hmk2",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -256,50 +241,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585846770000,
-                  "availableFrom": 1583254770000
+                  "availableUntil": 1591894770000,
+                  "availableFrom": 1589302770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6kb4p"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgyb8nxnqj",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rkcj6gf7l"
+              "pid": "w172xhgyb8ntrtf",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rkcj6gf7l",
+              "id": "w172xhgyb8ntrtf",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg6drfmxb4",
+                  "versionId": "w1mshncrxj0dqmz",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -309,50 +297,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585760370000,
-                  "availableFrom": 1583168370000
+                  "availableUntil": 1591808370000,
+                  "availableFrom": 1589216370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6gf7l"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgyb8ntrtf",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rk07x1w84"
+              "pid": "w172xhgxz0cf6tz",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rk07x1w84",
+              "id": "w172xhgxz0cf6tz",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg61h47cbp",
+                  "versionId": "w1mshncrk7q05nj",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -362,50 +353,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585501170000,
-                  "availableFrom": 1582909170000
+                  "availableUntil": 1591549170000,
+                  "availableFrom": 1588957170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rk07x1w84"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgxz0cf6tz",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rk07wyzc1"
+              "pid": "w172xhgxz0cb9xw",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rk07wyzc1",
+              "id": "w172xhgxz0cb9xw",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg61h44gfl",
+                  "versionId": "w1mshncrk7px8rf",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -415,50 +409,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585414770000,
-                  "availableFrom": 1582822770000
+                  "availableUntil": 1591462770000,
+                  "availableFrom": 1588870770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rk07wyzc1"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgxz0cb9xw",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rk07ww2fy"
+              "pid": "w172xhgxz0c7f0s",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rk07ww2fy",
+              "id": "w172xhgxz0c7f0s",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg61h41kjh",
+                  "versionId": "w1mshncrk7ptcvb",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -468,50 +465,53 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585328370000,
-                  "availableFrom": 1582736370000
+                  "availableUntil": 1591376370000,
+                  "availableFrom": 1588784370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rk07ww2fy"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgxz0c7f0s",
+            "type": "ws_radio"
           },
           {
             "headlines": {
               "headline": "Amakuru ya Gahuzamiryango"
             },
             "locators": {
-              "pid": "w172x7rk07ws5jv"
+              "pid": "w172xhgxz0c4j3p",
+              "brandPid": "p0340x2n"
             },
             "media": {
-              "id": "w172x7rk07ws5jv",
+              "id": "w172xhgxz0c4j3p",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
                 "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
                 "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdg61h3ynmd",
+                  "versionId": "w1mshncrk7pqgy7",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -521,27 +521,29 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585241970000,
-                  "availableFrom": 1582649970000
+                  "availableUntil": 1591289970000,
+                  "availableFrom": 1588697970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dkln.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p0340x2n",
               "title": "Amakuru ya Gahuzamiryango"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rk07ws5jv"
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xhgxz0c4j3p",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/hausa/bbc_hausa_radio/w3cszrwm.json
+++ b/data/hausa/bbc_hausa_radio/w3cszrwm.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrwm",
-    "locators": {},
+    "locators": { "pid": "w3cszrwm", "brandPid": "p030s4mx" },
     "type": "WSRADIO",
     "createdBy": "bbc_hausa_radio",
     "language": "ha",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1582486516000,
     "lastPublished": 1582486516000,
+    "timestamp": 1582486516000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Shirin Yamma - BBC News Hausa",
       "pageIdentifier": "hausa.bbc_hausa_radio.w3cszrwm.page",
       "producerId": "51",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "HAUSA"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Shirin Yamma"
+    "title": "Shirin Yamma",
+    "releaseDateTimeStamp": 1583366400000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
           "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvb5b",
-            "types": ["Original"],
-            "duration": 1800,
-            "durationISO8601": "PT30M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586030370000,
-            "availableFrom": 1583438370000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Shirin Yamma"
-    },
-    "locators": {
-      "pid": "w3cszrwm"
-    },
+    "headlines": { "headline": "Shirin Yamma" },
+    "locators": { "pid": "w3cszrwm", "brandPid": "p030s4mx" },
     "media": {
       "id": "w3cszrwm",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
         "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvb5b",
-          "types": ["Original"],
-          "duration": 1800,
-          "durationISO8601": "PT30M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586030370000,
-          "availableFrom": 1583438370000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p030s4mx",
-      "title": "Shirin Yamma"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrwm"
+    "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrwm",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Hausa",
-      "uri": "/hausa"
+      "uri": "/hausa",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszryw"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hvq", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszryw",
+              "id": "w3ct0hvq",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb7l",
+                  "versionId": "w4hqw2pc",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585943970000,
-                  "availableFrom": 1583351970000
+                  "availableUntil": 1592078370000,
+                  "availableFrom": 1589486370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszryw"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hvq",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrxr"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hxz", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrxr",
+              "id": "w3ct0hxz",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb6g",
+                  "versionId": "w4hqw2rm",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585857570000,
-                  "availableFrom": 1583265570000
+                  "availableUntil": 1591991970000,
+                  "availableFrom": 1589399970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrxr"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hxz",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrs7"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hwv", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrs7",
+              "id": "w3ct0hwv",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb1y",
+                  "versionId": "w4hqw2qh",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585771170000,
-                  "availableFrom": 1583179170000
+                  "availableUntil": 1591905570000,
+                  "availableFrom": 1589313570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrs7"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hwv",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrvg"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hr7", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrvg",
+              "id": "w3ct0hr7",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb45",
+                  "versionId": "w4hqw2ks",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585684770000,
-                  "availableFrom": 1583092770000
+                  "availableUntil": 1591819170000,
+                  "availableFrom": 1589227170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrvg"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hr7",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrtb"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0htk", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrtb",
+              "id": "w3ct0htk",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/02/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb31",
+                  "versionId": "w4hqw2n3",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585598370000,
-                  "availableFrom": 1583006370000
+                  "availableUntil": 1591732770000,
+                  "availableFrom": 1589140770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrtb"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0htk",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrwl"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hsb", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrwl",
+              "id": "w3ct0hsb",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb59",
+                  "versionId": "w4hqw2lw",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585425570000,
-                  "availableFrom": 1582833570000
+                  "availableUntil": 1591646370000,
+                  "availableFrom": 1589054370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrwl"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hsb",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszryv"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hvp", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszryv",
+              "id": "w3ct0hvp",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb7k",
+                  "versionId": "w4hqw2pb",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585339170000,
-                  "availableFrom": 1582747170000
+                  "availableUntil": 1591473570000,
+                  "availableFrom": 1588881570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszryv"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hvp",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Shirin Yamma"
-            },
-            "locators": {
-              "pid": "w3cszrxq"
-            },
+            "headlines": { "headline": "Shirin Yamma" },
+            "locators": { "pid": "w3ct0hxy", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3cszrxq",
+              "id": "w3ct0hxy",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvb6f",
+                  "versionId": "w4hqw2rl",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585252770000,
-                  "availableFrom": 1582660770000
+                  "availableUntil": 1591387170000,
+                  "availableFrom": 1588795170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dknl.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b216l.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p030s4mx",
-              "title": "Shirin Yamma"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrxq"
+            "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hxy",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/indonesia/bbc_indonesian_radio/w172x6r5000f38s.json
+++ b/data/indonesia/bbc_indonesian_radio/w172x6r5000f38s.json
@@ -1,570 +1,552 @@
 {
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172x6r5000f38s",
+    "locators": {
+      "pid": "w172x6r5000f38s",
+      "brandPid": "w13xtt0s"
+    },
+    "type": "WSRADIO",
+    "createdBy": "bbc_indonesian_radio",
+    "language": "id",
+    "lastUpdated": 1589529870679,
+    "firstPublished": 1582497310000,
+    "lastPublished": 1582497310000,
+    "timestamp": 1582497310000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "Dunia Pagi Ini - BBC News Indonesia",
+      "pageIdentifier": "indonesian.bbc_indonesian_radio.w172x6r5000f38s.page",
+      "producerId": "54",
+      "contentType": "player-episode",
+      "producer": "INDONESIAN"
+    },
+    "tags": {},
+    "version": "v1.3.0",
+    "blockTypes": ["media"],
+    "title": "Dunia Pagi Ini",
+    "releaseDateTimeStamp": 1583366400000
+  },
   "content": {
     "blocks": [
       {
-        "advertising": false,
-        "embedding": false,
-        "format": "Audio",
         "id": "w172x6r5000f38s",
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
         "subType": "episode",
-        "synopses": {
-          "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-          "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-        },
+        "format": "Audio",
         "title": "05/03/2020 GMT",
-        "type": "media",
-        "versions": []
+        "synopses": {
+          "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+          "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+        "embedding": false,
+        "advertising": false,
+        "versions": [],
+        "type": "media"
       }
     ]
   },
-  "metadata": {
-    "analyticsLabels": {
-      "contentType": "player-episode",
-      "pageIdentifier": "indonesian.bbc_indonesian_radio.w172x6r5000f38s.page",
-      "pageTitle": "Dunia Pagi Ini - BBC News Indonesia",
-      "producer": "INDONESIAN",
-      "producerId": "54"
-    },
-    "blockTypes": [
-      "media"
-    ],
-    "createdBy": "bbc_indonesian_radio",
-    "firstPublished": 1582497310000,
-    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172x6r5000f38s",
-    "language": "id",
-    "lastPublished": 1582497310000,
-    "lastUpdated": 1589373405552,
-    "locators": {
-      "brandPid": "w13xtt0s",
-      "pid": "w172x6r5000f38s"
-    },
-    "options": {},
-    "releaseDateTimeStamp": 1583366400000,
-    "tags": {},
-    "timestamp": 1582497310000,
-    "title": "Dunia Pagi Ini",
-    "type": "WSRADIO",
-    "version": "v1.3.0"
-  },
   "promo": {
+    "headlines": {
+      "headline": "Dunia Pagi Ini"
+    },
+    "locators": {
+      "pid": "w172x6r5000f38s",
+      "brandPid": "w13xtt0s"
+    },
+    "media": {
+      "id": "w172x6r5000f38s",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "05/03/2020 GMT",
+      "synopses": {
+        "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+        "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "embedding": false,
+      "advertising": false,
+      "versions": [],
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
     "brand": {
       "pid": "w13xtt0s",
       "title": "Dunia Pagi Ini"
     },
-    "headlines": {
-      "headline": "Dunia Pagi Ini"
-    },
     "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172x6r5000f38s",
-    "indexImage": {
-      "altText": null,
-      "copyrightHolder": null,
-      "height": 0,
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "id": "",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "subType": "index",
-      "type": "image",
-      "width": 0
-    },
-    "locators": {
-      "brandPid": "w13xtt0s",
-      "pid": "w172x6r5000f38s"
-    },
-    "media": {
-      "advertising": false,
-      "embedding": false,
-      "format": "Audio",
-      "id": "w172x6r5000f38s",
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "subType": "episode",
-      "synopses": {
-        "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-        "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-      },
-      "title": "05/03/2020 GMT",
-      "type": "media",
-      "versions": []
-    },
     "type": "ws_radio"
   },
   "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Indonesian",
+      "uri": "/indonesian",
+      "type": "simple"
+    },
     "groups": [
       {
+        "type": "other-episode",
         "promos": [
           {
+            "headlines": {
+              "headline": "Dunia Pagi Ini"
+            },
+            "locators": {
+              "pid": "w172xh26yzbh17k",
+              "brandPid": "w13xtt0s"
+            },
+            "media": {
+              "id": "w172xh26yzbh17k",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6p2023",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592090100000,
+                  "availableFrom": 1589498100000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
             "brand": {
               "pid": "w13xtt0s",
               "title": "Dunia Pagi Ini"
             },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbh17k",
+            "type": "ws_radio"
+          },
+          {
             "headlines": {
               "headline": "Dunia Pagi Ini"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb97fc",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
             "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26yzb97fc"
+              "pid": "w172xh26yzbgxhf",
+              "brandPid": "w13xtt0s"
             },
             "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh26yzb97fc",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "id": "w172xh26yzbgxhf",
               "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
               "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
               },
-              "title": "12/05/2020 GMT",
-              "type": "media",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
               "versions": [
                 {
-                  "availableFrom": 1589325300000,
+                  "versionId": "w1mshmz1k6p1w9z",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
                   "availableTerritories": {
-                    "nonUk": false,
                     "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592086500000,
+                  "availableFrom": 1589494500000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": {
+              "pid": "w13xtt0s",
+              "title": "Dunia Pagi Ini"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbgxhf",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Dunia Pagi Ini"
+            },
+            "locators": {
+              "pid": "w172xh26yzbd4bg",
+              "brandPid": "w13xtt0s"
+            },
+            "media": {
+              "id": "w172xh26yzbd4bg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "13/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nz350",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592003700000,
+                  "availableFrom": 1589411700000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": {
+              "pid": "w13xtt0s",
+              "title": "Dunia Pagi Ini"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbd4bg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Dunia Pagi Ini"
+            },
+            "locators": {
+              "pid": "w172xh26yzbd0lb",
+              "brandPid": "w13xtt0s"
+            },
+            "media": {
+              "id": "w172xh26yzbd0lb",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "13/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nyzdw",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592000100000,
+                  "availableFrom": 1589408100000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": {
+              "pid": "w13xtt0s",
+              "title": "Dunia Pagi Ini"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbd0lb",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Dunia Pagi Ini"
+            },
+            "locators": {
+              "pid": "w172xh26yzb97fc",
+              "brandPid": "w13xtt0s"
+            },
+            "media": {
+              "id": "w172xh26yzb97fc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "12/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nw67x",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
                     "world": true
                   },
                   "availableUntil": 1591917300000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz1k6nw67x",
-                  "warnings": {}
+                  "availableFrom": 1589325300000
                 }
-              ]
+              ],
+              "type": "media"
             },
-            "type": "ws_radio"
-          },
-          {
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
             "brand": {
               "pid": "w13xtt0s",
               "title": "Dunia Pagi Ini"
             },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb97fc",
+            "type": "ws_radio"
+          },
+          {
             "headlines": {
               "headline": "Dunia Pagi Ini"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb93p7",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
             "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26yzb93p7"
+              "pid": "w172xh26yzb93p7",
+              "brandPid": "w13xtt0s"
             },
             "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
               "id": "w172xh26yzb93p7",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
               "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
+              "format": "Audio",
               "title": "12/05/2020 GMT",
-              "type": "media",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
               "versions": [
                 {
-                  "availableFrom": 1589321700000,
+                  "versionId": "w1mshmz1k6nw2hs",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
                   "availableTerritories": {
-                    "nonUk": false,
                     "uk": false,
+                    "nonUk": false,
                     "world": true
                   },
                   "availableUntil": 1591913700000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz1k6nw2hs",
-                  "warnings": {}
+                  "availableFrom": 1589321700000
                 }
-              ]
+              ],
+              "type": "media"
             },
-            "type": "ws_radio"
-          },
-          {
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
             "brand": {
               "pid": "w13xtt0s",
               "title": "Dunia Pagi Ini"
             },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb93p7",
+            "type": "ws_radio"
+          },
+          {
             "headlines": {
               "headline": "Dunia Pagi Ini"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb6bj8",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
             "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26yzb6bj8"
+              "pid": "w172xh26yzb6bj8",
+              "brandPid": "w13xtt0s"
             },
             "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
               "id": "w172xh26yzb6bj8",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
               "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
+              "format": "Audio",
               "title": "11/05/2020 GMT",
-              "type": "media",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
               "versions": [
                 {
-                  "availableFrom": 1589238900000,
+                  "versionId": "w1mshmz1k6ns9bt",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
                   "availableTerritories": {
-                    "nonUk": false,
                     "uk": false,
+                    "nonUk": false,
                     "world": true
                   },
                   "availableUntil": 1591830900000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz1k6ns9bt",
-                  "warnings": {}
+                  "availableFrom": 1589238900000
                 }
-              ]
+              ],
+              "type": "media"
             },
-            "type": "ws_radio"
-          },
-          {
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
             "brand": {
               "pid": "w13xtt0s",
               "title": "Dunia Pagi Ini"
             },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb6bj8",
+            "type": "ws_radio"
+          },
+          {
             "headlines": {
               "headline": "Dunia Pagi Ini"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb66s4",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
             "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26yzb66s4"
+              "pid": "w172xh26yzb66s4",
+              "brandPid": "w13xtt0s"
             },
             "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
               "id": "w172xh26yzb66s4",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
               "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
+              "format": "Audio",
               "title": "11/05/2020 GMT",
-              "type": "media",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
               "versions": [
                 {
-                  "availableFrom": 1589235300000,
+                  "versionId": "w1mshmz1k6ns5lp",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
                   "availableTerritories": {
-                    "nonUk": false,
                     "uk": false,
+                    "nonUk": false,
                     "world": true
                   },
                   "availableUntil": 1591827300000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz1k6ns5lp",
-                  "warnings": {}
+                  "availableFrom": 1589235300000
                 }
-              ]
+              ],
+              "type": "media"
             },
-            "type": "ws_radio"
-          },
-          {
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
             "brand": {
               "pid": "w13xtt0s",
               "title": "Dunia Pagi Ini"
             },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26lq0zlc0",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26lq0zlc0"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh26lq0zlc0",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "10/05/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1589152500000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1591744500000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz15yckk5k",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26lq0zglw",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26lq0zglw"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh26lq0zglw",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "10/05/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1589148900000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1591740900000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz15yckfff",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26lq0pwmq",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26lq0pwmq"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh26lq0pwmq",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "07/05/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588893300000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1591485300000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz15yc8vg8",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26lq0prwl",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh26lq0prwl"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh26lq0prwl",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "07/05/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588889700000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1591481700000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": [
-                    "Original"
-                  ],
-                  "versionId": "w1mshmz15yc8qq4",
-                  "warnings": {}
-                }
-              ]
-            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb66s4",
             "type": "ws_radio"
           }
-        ],
-        "type": "other-episode"
+        ]
       }
-    ],
-    "site": {
-      "name": "Indonesian",
-      "subType": "site",
-      "type": "simple",
-      "uri": "/indonesian"
-    }
+    ]
   }
 }

--- a/data/indonesia/bbc_indonesian_radio/w172xh267fpn19l.json
+++ b/data/indonesia/bbc_indonesian_radio/w172xh267fpn19l.json
@@ -1,582 +1,507 @@
 {
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpn19l",
+    "locators": { "pid": "w172xh267fpn19l", "brandPid": "w13xtt0s" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_indonesian_radio",
+    "language": "id",
+    "lastUpdated": 1589529753485,
+    "firstPublished": 1587075911000,
+    "lastPublished": 1587075911000,
+    "timestamp": 1587075911000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "Dunia Pagi Ini - BBC News Indonesia",
+      "pageIdentifier": "indonesian.bbc_indonesian_radio.w172xh267fpn19l.page",
+      "producerId": "54",
+      "contentType": "player-episode",
+      "producer": "INDONESIAN"
+    },
+    "tags": {},
+    "version": "v1.3.0",
+    "blockTypes": ["media"],
+    "title": "Dunia Pagi Ini",
+    "releaseDateTimeStamp": 1587945600000
+  },
   "content": {
     "blocks": [
       {
-        "advertising": false,
-        "embedding": false,
-        "format": "Audio",
         "id": "w172xh267fpn19l",
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
         "subType": "episode",
-        "synopses": {
-          "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-          "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-        },
+        "format": "Audio",
         "title": "27/04/2020 GMT",
-        "type": "media",
+        "synopses": {
+          "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+          "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+        "embedding": false,
+        "advertising": false,
         "versions": [
           {
-            "availableFrom": 1588029300000,
+            "versionId": "w1mshmz0tp17044",
+            "types": ["Original"],
+            "duration": 930,
+            "durationISO8601": "PT15M30S",
+            "warnings": {},
             "availableTerritories": {
-              "nonUk": false,
               "uk": false,
+              "nonUk": false,
               "world": true
             },
             "availableUntil": 1590621300000,
-            "duration": 930,
-            "durationISO8601": "PT15M30S",
-            "types": ["Original"],
-            "versionId": "w1mshmz0tp17044",
-            "warnings": {}
+            "availableFrom": 1588029300000
+          }
+        ],
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "Dunia Pagi Ini" },
+    "locators": { "pid": "w172xh267fpn19l", "brandPid": "w13xtt0s" },
+    "media": {
+      "id": "w172xh267fpn19l",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "27/04/2020 GMT",
+      "synopses": {
+        "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+        "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "embedding": false,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "w1mshmz0tp17044",
+          "types": ["Original"],
+          "duration": 930,
+          "durationISO8601": "PT15M30S",
+          "warnings": {},
+          "availableTerritories": {
+            "uk": false,
+            "nonUk": false,
+            "world": true
+          },
+          "availableUntil": 1590621300000,
+          "availableFrom": 1588029300000
+        }
+      ],
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpn19l",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Indonesian",
+      "uri": "/indonesian",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzbh17k", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzbh17k",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6p2023",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592090100000,
+                  "availableFrom": 1589498100000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbh17k",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzbgxhf", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzbgxhf",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6p1w9z",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592086500000,
+                  "availableFrom": 1589494500000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbgxhf",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzbd4bg", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzbd4bg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "13/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nz350",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592003700000,
+                  "availableFrom": 1589411700000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbd4bg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzbd0lb", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzbd0lb",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "13/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nyzdw",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1592000100000,
+                  "availableFrom": 1589408100000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzbd0lb",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzb97fc", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzb97fc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "12/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nw67x",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1591917300000,
+                  "availableFrom": 1589325300000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb97fc",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzb93p7", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzb93p7",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "12/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6nw2hs",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1591913700000,
+                  "availableFrom": 1589321700000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb93p7",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzb6bj8", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzb6bj8",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "11/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6ns9bt",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1591830900000,
+                  "availableFrom": 1589238900000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb6bj8",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Dunia Pagi Ini" },
+            "locators": { "pid": "w172xh26yzb66s4", "brandPid": "w13xtt0s" },
+            "media": {
+              "id": "w172xh26yzb66s4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "11/05/2020 GMT",
+              "synopses": {
+                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
+                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshmz1k6ns5lp",
+                  "types": ["Original"],
+                  "duration": 930,
+                  "durationISO8601": "PT15M30S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1591827300000,
+                  "availableFrom": 1589235300000
+                }
+              ],
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "brand": { "pid": "w13xtt0s", "title": "Dunia Pagi Ini" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh26yzb66s4",
+            "type": "ws_radio"
           }
         ]
       }
     ]
-  },
-  "metadata": {
-    "analyticsLabels": {
-      "contentType": "player-episode",
-      "pageIdentifier": "indonesian.bbc_indonesian_radio.w172xh267fpn19l.page",
-      "pageTitle": "Dunia Pagi Ini - BBC News Indonesia",
-      "producer": "INDONESIAN",
-      "producerId": "54"
-    },
-    "blockTypes": ["media"],
-    "createdBy": "bbc_indonesian_radio",
-    "firstPublished": 1587075911000,
-    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpn19l",
-    "language": "id",
-    "lastPublished": 1587075911000,
-    "lastUpdated": 1588187368652,
-    "locators": {
-      "brandPid": "w13xtt0s",
-      "pid": "w172xh267fpn19l"
-    },
-    "options": {},
-    "releaseDateTimeStamp": 1587945600000,
-    "tags": {},
-    "timestamp": 1587075911000,
-    "title": "Dunia Pagi Ini",
-    "type": "WSRADIO",
-    "version": "v1.2.0"
-  },
-  "promo": {
-    "brand": {
-      "pid": "w13xtt0s",
-      "title": "Dunia Pagi Ini"
-    },
-    "headlines": {
-      "headline": "Dunia Pagi Ini"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpn19l",
-    "indexImage": {
-      "altText": null,
-      "copyrightHolder": null,
-      "height": 0,
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "id": "",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "subType": "index",
-      "type": "image",
-      "width": 0
-    },
-    "locators": {
-      "brandPid": "w13xtt0s",
-      "pid": "w172xh267fpn19l"
-    },
-    "media": {
-      "advertising": false,
-      "embedding": false,
-      "format": "Audio",
-      "id": "w172xh267fpn19l",
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-      "subType": "episode",
-      "synopses": {
-        "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-        "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-      },
-      "title": "27/04/2020 GMT",
-      "type": "media",
-      "versions": [
-        {
-          "availableFrom": 1588029300000,
-          "availableTerritories": {
-            "nonUk": false,
-            "uk": false,
-            "world": true
-          },
-          "availableUntil": 1590621300000,
-          "duration": 930,
-          "durationISO8601": "PT15M30S",
-          "types": ["Original"],
-          "versionId": "w1mshmz0tp17044",
-          "warnings": {}
-        }
-      ]
-    },
-    "type": "ws_radio"
-  },
-  "relatedContent": {
-    "groups": [
-      {
-        "promos": [
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fptv3s",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh267fptv3s"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh267fptv3s",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "29/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588202100000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590794100000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0tp1dsyb",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fptqcn",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh267fptqcn"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh267fptqcn",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "29/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588198500000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590790500000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0tp1dp66",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpqy6p",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh267fpqy6p"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh267fpqy6p",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "28/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588115700000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590707700000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0tp19x17",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpqtgk",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh267fpqtgk"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh267fpqtgk",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "28/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588112100000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590704100000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0tp19s93",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh267fpmxkg",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh267fpmxkg"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh267fpmxkg",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "27/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1588025700000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590617700000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0tp16wd0",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh25w5df94b",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh25w5df94b"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh25w5df94b",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "26/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1587942900000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590534900000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0gdr07yw",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh25w5df5d6",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh25w5df5d6"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh25w5df5d6",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "26/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1587939300000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590531300000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0gdr046r",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          },
-          {
-            "brand": {
-              "pid": "w13xtt0s",
-              "title": "Dunia Pagi Ini"
-            },
-            "headlines": {
-              "headline": "Dunia Pagi Ini"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_indonesian_radio/w172xh25w5d4lf1",
-            "indexImage": {
-              "altText": null,
-              "copyrightHolder": null,
-              "height": 0,
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "id": "",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "index",
-              "type": "image",
-              "width": 0
-            },
-            "locators": {
-              "brandPid": "w13xtt0s",
-              "pid": "w172xh25w5d4lf1"
-            },
-            "media": {
-              "advertising": false,
-              "embedding": false,
-              "format": "Audio",
-              "id": "w172xh25w5d4lf1",
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b4828.png",
-              "subType": "episode",
-              "synopses": {
-                "medium": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya.",
-                "short": "Berita terbaru dari seluruh dunia dan ulasan peristiwa dari Indonesia. Juga berita olahraga terbaru dan berbeda setiap harinya."
-              },
-              "title": "23/04/2020 GMT",
-              "type": "media",
-              "versions": [
-                {
-                  "availableFrom": 1587683700000,
-                  "availableTerritories": {
-                    "nonUk": false,
-                    "uk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1590275700000,
-                  "duration": 930,
-                  "durationISO8601": "PT15M30S",
-                  "types": ["Original"],
-                  "versionId": "w1mshmz0gdqqk7l",
-                  "warnings": {}
-                }
-              ]
-            },
-            "type": "ws_radio"
-          }
-        ],
-        "type": "other-episode"
-      }
-    ],
-    "site": {
-      "name": "Indonesian",
-      "subType": "site",
-      "type": "simple",
-      "uri": "/indonesian"
-    }
   }
 }

--- a/data/korean/bbc_korean_radio/w3ct0kn5.json
+++ b/data/korean/bbc_korean_radio/w3ct0kn5.json
@@ -1,14 +1,11 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn5",
-    "locators": {
-      "pid": "w3ct0kn5",
-      "brandPid": "w13xttll"
-    },
+    "locators": { "pid": "w3ct0kn5", "brandPid": "w13xttll" },
     "type": "WSRADIO",
     "createdBy": "bbc_korean_radio",
     "language": "ko",
-    "lastUpdated": 1588318165729,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1588580293000,
     "lastPublished": 1588580293000,
     "timestamp": 1588580293000,
@@ -21,7 +18,7 @@
       "producer": "KOREAN"
     },
     "tags": {},
-    "version": "v1.2.1",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
     "title": "BBC 코리아 라디오",
     "releaseDateTimeStamp": 1588550400000
@@ -37,37 +34,17 @@
           "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
           "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqw4gw",
-            "types": ["Original"],
-            "duration": 1140,
-            "durationISO8601": "PT19M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1589221140000,
-            "availableFrom": 1588607340000
-          }
-        ],
+        "versions": [],
         "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "BBC 코리아 라디오"
-    },
-    "locators": {
-      "pid": "w3ct0kn5",
-      "brandPid": "w13xttll"
-    },
+    "headlines": { "headline": "BBC 코리아 라디오" },
+    "locators": { "pid": "w3ct0kn5", "brandPid": "w13xttll" },
     "media": {
       "id": "w3ct0kn5",
       "subType": "episode",
@@ -77,42 +54,24 @@
         "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
         "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqw4gw",
-          "types": ["Original"],
-          "duration": 1140,
-          "durationISO8601": "PT19M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1589221140000,
-          "availableFrom": 1588607340000
-        }
-      ],
+      "versions": [],
       "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
       "height": 0,
       "width": 0,
       "altText": null,
       "copyrightHolder": null,
       "type": "image"
     },
-    "brand": {
-      "pid": "w13xttll",
-      "title": "BBC 코리아 라디오"
-    },
+    "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
     "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn5",
     "type": "ws_radio"
   },
@@ -128,28 +87,23 @@
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3ct0km0",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3ct0kpb", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0km0",
+              "id": "w3ct0kpb",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/01 GMT",
+              "title": "2020/05/14 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4fq",
+                  "versionId": "w4hqw4j1",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -159,8 +113,8 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1588961940000,
-                  "availableFrom": 1588348140000
+                  "availableUntil": 1590085140000,
+                  "availableFrom": 1589471340000
                 }
               ],
               "type": "media"
@@ -168,44 +122,36 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0km0",
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kpb",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3ct0kp8",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3ct0krl", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kp8",
+              "id": "w3ct0krl",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/04/30 GMT",
+              "title": "2020/05/13 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4hz",
+                  "versionId": "w4hqw4l9",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -215,8 +161,8 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1588875540000,
-                  "availableFrom": 1588261740000
+                  "availableUntil": 1589998740000,
+                  "availableFrom": 1589384940000
                 }
               ],
               "type": "media"
@@ -224,44 +170,36 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kp8",
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0krl",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3ct0krj",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3ct0kqg", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0krj",
+              "id": "w3ct0kqg",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/04/29 GMT",
+              "title": "2020/05/12 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4l7",
+                  "versionId": "w4hqw4k5",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -271,8 +209,8 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1588789140000,
-                  "availableFrom": 1588175340000
+                  "availableUntil": 1589912340000,
+                  "availableFrom": 1589298540000
                 }
               ],
               "type": "media"
@@ -280,44 +218,36 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0krj",
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kqg",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3ct0kqd",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3ct0kn6", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kqd",
+              "id": "w3ct0kn6",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/04/28 GMT",
+              "title": "2020/05/11 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4k3",
+                  "versionId": "w4hqw4gx",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -327,8 +257,8 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1588702740000,
-                  "availableFrom": 1588088940000
+                  "availableUntil": 1589825940000,
+                  "availableFrom": 1589212140000
                 }
               ],
               "type": "media"
@@ -336,44 +266,36 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kqd",
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn6",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3ct0kn4",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3ct0km1", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kn4",
+              "id": "w3ct0km1",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/04/27 GMT",
+              "title": "2020/05/08 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4gv",
+                  "versionId": "w4hqw4fr",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -383,8 +305,8 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1588616340000,
-                  "availableFrom": 1588002540000
+                  "availableUntil": 1589566740000,
+                  "availableFrom": 1588952940000
                 }
               ],
               "type": "media"
@@ -392,29 +314,21 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn4",
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0km1",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "BBC 코리아 라디오"
-            },
-            "locators": {
-              "pid": "w3csvzmp",
-              "brandPid": "w13xttll"
-            },
+            "headlines": { "headline": "BBC 코리아 라디오" },
+            "locators": { "pid": "w3csvzmp", "brandPid": "w13xttll" },
             "media": {
               "id": "w3csvzmp",
               "subType": "episode",
@@ -424,7 +338,7 @@
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -447,18 +361,15 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05gxl34.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lzc.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "w13xttll",
-              "title": "BBC 코리아 라디오"
-            },
+            "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
             "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3csvzmp",
             "type": "ws_radio"
           }

--- a/data/kyrgyz/bbc_kyrgyz_radio/w3cszwmc.json
+++ b/data/kyrgyz/bbc_kyrgyz_radio/w3cszwmc.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwmc",
-    "locators": {},
+    "locators": { "pid": "w3cszwmc", "brandPid": "p0340xth" },
     "type": "WSRADIO",
     "createdBy": "bbc_kyrgyz_radio",
     "language": "ky",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582550741000,
     "lastPublished": 1582550741000,
+    "timestamp": 1582550741000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Лондон сүйлөйт - BBC News Кыргыз КызMATы",
       "pageIdentifier": "kyrgyz.bbc_kyrgyz_radio.w3cszwmc.page",
       "producerId": "58",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "KYRGYZ"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Лондон сүйлөйт"
+    "title": "Лондон сүйлөйт",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -30,117 +31,79 @@
         "format": "Audio",
         "title": "06/03/2020 GMT",
         "synopses": {
-          "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-          "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+          "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү\n",
+          "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү\n"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvfx2",
-            "types": ["Original"],
-            "duration": 1800,
-            "durationISO8601": "PT30M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586100600000,
-            "availableFrom": 1583501400000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Лондон сүйлөйт"
-    },
-    "locators": {
-      "pid": "w3cszwmc"
-    },
+    "headlines": { "headline": "Лондон сүйлөйт" },
+    "locators": { "pid": "w3cszwmc", "brandPid": "p0340xth" },
     "media": {
       "id": "w3cszwmc",
       "subType": "episode",
       "format": "Audio",
       "title": "06/03/2020 GMT",
       "synopses": {
-        "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-        "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+        "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү\n",
+        "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү\n"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvfx2",
-          "types": ["Original"],
-          "duration": 1800,
-          "durationISO8601": "PT30M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586100600000,
-          "availableFrom": 1583501400000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p0340xth",
-      "title": "Лондон сүйлөйт"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwmc"
+    "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwmc",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Kyrgyz",
-      "uri": "/kyrgyz"
+      "uri": "/kyrgyz",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwpm"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0ky7", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwpm",
+              "id": "w3ct0ky7",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvfzb",
+                  "versionId": "w4hqw4ry",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586014200000,
-                  "availableFrom": 1583415000000
+                  "availableUntil": 1592062200000,
+                  "availableFrom": 1589463000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwpm"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0ky7",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwrw"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0l0h", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwrw",
+              "id": "w3ct0l0h",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvg1l",
+                  "versionId": "w4hqw4v6",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585927800000,
-                  "availableFrom": 1583328600000
+                  "availableUntil": 1591975800000,
+                  "availableFrom": 1589376600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwrw"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0l0h",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwqr"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0kzc", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwqr",
+              "id": "w3ct0kzc",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvg0g",
+                  "versionId": "w4hqw4t2",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585841400000,
-                  "availableFrom": 1583242200000
+                  "availableUntil": 1591889400000,
+                  "availableFrom": 1589290200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwqr"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kzc",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwnh"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0kx3", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwnh",
+              "id": "w3ct0kx3",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvfy6",
+                  "versionId": "w4hqw4qt",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585755000000,
-                  "availableFrom": 1583155800000
+                  "availableUntil": 1591803000000,
+                  "availableFrom": 1589203800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwnh"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kx3",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwmb"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0kvy", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwmb",
+              "id": "w3ct0kvy",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvfx1",
+                  "versionId": "w4hqw4pn",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585495800000,
-                  "availableFrom": 1582896600000
+                  "availableUntil": 1591543800000,
+                  "availableFrom": 1588944600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwmb"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kvy",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwpl"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0ky6", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwpl",
+              "id": "w3ct0ky6",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvfz9",
+                  "versionId": "w4hqw4rx",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585409400000,
-                  "availableFrom": 1582810200000
+                  "availableUntil": 1591457400000,
+                  "availableFrom": 1588858200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwpl"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0ky6",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwrv"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0l0g", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwrv",
+              "id": "w3ct0l0g",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvg1k",
+                  "versionId": "w4hqw4v5",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585323000000,
-                  "availableFrom": 1582723800000
+                  "availableUntil": 1591371000000,
+                  "availableFrom": 1588771800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwrv"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0l0g",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Лондон сүйлөйт"
-            },
-            "locators": {
-              "pid": "w3cszwqq"
-            },
+            "headlines": { "headline": "Лондон сүйлөйт" },
+            "locators": { "pid": "w3ct0kzb", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3cszwqq",
+              "id": "w3ct0kzb",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
-                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү ",
-                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү "
+                "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
+                "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvg0f",
+                  "versionId": "w4hqw4t1",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585236600000,
-                  "availableFrom": 1582637400000
+                  "availableUntil": 1591284600000,
+                  "availableFrom": 1588685400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24cn.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xth",
-              "title": "Лондон сүйлөйт"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwqq"
+            "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kzb",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/nepali/bbc_nepali_radio/w172x83pnptp1s8.json
+++ b/data/nepali/bbc_nepali_radio/w172x83pnptp1s8.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptp1s8",
-    "locators": {},
+    "locators": { "pid": "w172x83pnptp1s8", "brandPid": "p0340xzt" },
     "type": "WSRADIO",
     "createdBy": "bbc_nepali_radio",
     "language": "ne",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582508121000,
     "lastPublished": 1582508121000,
+    "timestamp": 1582508121000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "विहानीपख - BBC News नेपाली",
       "pageIdentifier": "nepali.bbc_nepali_radio.w172x83pnptp1s8.page",
       "producerId": "63",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "NEPALI"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "विहानीपख"
+    "title": "विहानीपख",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -30,117 +31,79 @@
         "format": "Audio",
         "title": "06/03/2020 GMT",
         "synopses": {
-          "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-          "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+          "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+          "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshdtbpy1vjvt",
-            "types": ["Original"],
-            "duration": 900,
-            "durationISO8601": "PT15M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586051070000,
-            "availableFrom": 1583459070000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "विहानीपख"
-    },
-    "locators": {
-      "pid": "w172x83pnptp1s8"
-    },
+    "headlines": { "headline": "विहानीपख" },
+    "locators": { "pid": "w172x83pnptp1s8", "brandPid": "p0340xzt" },
     "media": {
       "id": "w172x83pnptp1s8",
       "subType": "episode",
       "format": "Audio",
       "title": "06/03/2020 GMT",
       "synopses": {
-        "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-        "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+        "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+        "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshdtbpy1vjvt",
-          "types": ["Original"],
-          "duration": 900,
-          "durationISO8601": "PT15M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586051070000,
-          "availableFrom": 1583459070000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p0340xzt",
-      "title": "विहानीपख"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptp1s8"
+    "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptp1s8",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Nepali",
-      "uri": "/nepali"
+      "uri": "/nepali",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83pnptl4w5"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtm2rj2htn", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83pnptl4w5",
+              "id": "w172xhtm2rj2htn",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbpy1rmyq",
+                  "versionId": "w1mshnqfnzvngn6",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585964670000,
-                  "availableFrom": 1583372670000
+                  "availableUntil": 1592099070000,
+                  "availableFrom": 1589507070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptl4w5"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rj2htn",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83pnpth7z2"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtm2rhzlxk", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83pnpth7z2",
+              "id": "w172xhtm2rhzlxk",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbpy1nr1m",
+                  "versionId": "w1mshnqfnzvkkr3",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585878270000,
-                  "availableFrom": 1583286270000
+                  "availableUntil": 1592012670000,
+                  "availableFrom": 1589420670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnpth7z2"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhzlxk",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83pnptdc1z"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtm2rhwq0g", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83pnptdc1z",
+              "id": "w172xhtm2rhwq0g",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbpy1kv4j",
+                  "versionId": "w1mshnqfnzvgnv0",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585791870000,
-                  "availableFrom": 1583199870000
+                  "availableUntil": 1591926270000,
+                  "availableFrom": 1589334270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptdc1z"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhwq0g",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83pnpt9g4w"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtm2rhst3c", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83pnpt9g4w",
+              "id": "w172xhtm2rhst3c",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbpy1gy7f",
+                  "versionId": "w1mshnqfnzvcrxx",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585705470000,
-                  "availableFrom": 1583113470000
+                  "availableUntil": 1591839870000,
+                  "availableFrom": 1589247870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnpt9g4w"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhst3c",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83p9fhwx5f"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtm2rhpx68", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83p9fhwx5f",
+              "id": "w172xhtm2rhpx68",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbbnr2d7z",
+                  "versionId": "w1mshnqfnzv8w0t",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585446270000,
-                  "availableFrom": 1582854270000
+                  "availableUntil": 1591753470000,
+                  "availableFrom": 1589161470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83p9fhwx5f"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhpx68",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83p9fht08b"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtlqh69c6t", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83p9fht08b",
+              "id": "w172xhtlqh69c6t",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbbnqzhbw",
+                  "versionId": "w1mshnqf9qjwb1c",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585359870000,
-                  "availableFrom": 1582767870000
+                  "availableUntil": 1591494270000,
+                  "availableFrom": 1588902270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83p9fht08b"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh69c6t",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83p9fhq3c7"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtlqh66g9q", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83p9fhq3c7",
+              "id": "w172xhtlqh66g9q",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbbnqwlfs",
+                  "versionId": "w1mshnqf9qjsf48",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585273470000,
-                  "availableFrom": 1582681470000
+                  "availableUntil": 1591407870000,
+                  "availableFrom": 1588815870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83p9fhq3c7"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh66g9q",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "विहानीपख"
-            },
-            "locators": {
-              "pid": "w172x83p9fhm6g4"
-            },
+            "headlines": { "headline": "विहानीपख" },
+            "locators": { "pid": "w172xhtlqh63kdm", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172x83p9fhm6g4",
+              "id": "w172xhtlqh63kdm",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
-                "short": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
-                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
+                "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
+                "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshdtbbnqspjp",
+                  "versionId": "w1mshnqf9qjpj75",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585187070000,
-                  "availableFrom": 1582595070000
+                  "availableUntil": 1591321470000,
+                  "availableFrom": 1588729470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4mqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nf6.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340xzt",
-              "title": "विहानीपख"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83p9fhm6g4"
+            "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh63kdm",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/pashto/bbc_pashto_radio/w172x8nvf4bchz5.json
+++ b/data/pashto/bbc_pashto_radio/w172x8nvf4bchz5.json
@@ -20,8 +20,7 @@
     "tags": {},
     "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "وروستي خبرونه",
-    "releaseDateTimeStamp": 1580774400000
+    "title": "وروستي خبرونه"
   },
   "content": {
     "blocks": [

--- a/data/pashto/bbc_pashto_radio/w172x8nvf4bchz5.json
+++ b/data/pashto/bbc_pashto_radio/w172x8nvf4bchz5.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nvf4bchz5",
-    "locators": {},
+    "locators": { "pid": "w172x8nvf4bchz5", "brandPid": "p0340yr4" },
     "type": "WSRADIO",
     "createdBy": "bbc_pashto_radio",
     "language": "ps",
-    "lastUpdated": 1583514316750,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1579858512000,
     "lastPublished": 1579858512000,
+    "timestamp": 1579858512000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "وروستي خبرونه - BBC News پښتو",
       "pageIdentifier": "pashto.bbc_pashto_radio.w172x8nvf4bchz5.page",
       "producerId": "68",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "PASHTO"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "وروستي خبرونه"
+    "title": "وروستي خبرونه",
+    "releaseDateTimeStamp": 1580774400000
   },
   "content": {
     "blocks": [
@@ -33,21 +34,17 @@
           "short": "د نړۍ وروستي خبرونه",
           "medium": "د نړۍ وروستي خبرونه"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
         "embedding": false,
         "advertising": false,
         "versions": [],
-        "imageCopyright": null
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "وروستي خبرونه"
-    },
-    "locators": {
-      "pid": "w172x8nvf4bchz5"
-    },
+    "headlines": { "headline": "وروستي خبرونه" },
+    "locators": { "pid": "w172x8nvf4bchz5", "brandPid": "p0340yr4" },
     "media": {
       "id": "w172x8nvf4bchz5",
       "subType": "episode",
@@ -57,60 +54,56 @@
         "short": "د نړۍ وروستي خبرونه",
         "medium": "د نړۍ وروستي خبرونه"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
       "embedding": false,
       "advertising": false,
       "versions": [],
-      "imageCopyright": null
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p0340yr4",
-      "title": "وروستي خبرونه"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nvf4bchz5"
+    "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nvf4bchz5",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Pashto",
-      "uri": "/pashto"
+      "uri": "/pashto",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6ls5c6"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky2b2f", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6ls5c6",
+              "id": "w172xjcj6ky2b2f",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0g1hd",
+                  "versionId": "w1mshp8n7rxw9r5",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -120,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584100980000,
-                  "availableFrom": 1583496180000
+                  "availableUntil": 1590145380000,
+                  "availableFrom": 1589540580000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6ls5c6"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky2b2f",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6ls1m2"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky26b9", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6ls1m2",
+              "id": "w172xjcj6ky26b9",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0fxr8",
+                  "versionId": "w1mshp8n7rxw601",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -173,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584097380000,
-                  "availableFrom": 1583492580000
+                  "availableUntil": 1590141780000,
+                  "availableFrom": 1589536980000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6ls1m2"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky26b9",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lrxvy"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky22l5", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lrxvy",
+              "id": "w172xjcj6ky22l5",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0ft04",
+                  "versionId": "w1mshp8n7rxw27x",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -226,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584093780000,
-                  "availableFrom": 1583488980000
+                  "availableUntil": 1590138180000,
+                  "availableFrom": 1589533380000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lrxvy"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky22l5",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lrt3t"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky1yv1", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lrt3t",
+              "id": "w172xjcj6ky1yv1",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0fp80",
+                  "versionId": "w1mshp8n7rxvyhs",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -279,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584090180000,
-                  "availableFrom": 1583485380000
+                  "availableUntil": 1590134580000,
+                  "availableFrom": 1589529780000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lrt3t"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky1yv1",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lrpcp"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky1v2x", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lrpcp",
+              "id": "w172xjcj6ky1v2x",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0fkhw",
+                  "versionId": "w1mshp8n7rxvtrn",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -332,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584086580000,
-                  "availableFrom": 1583481780000
+                  "availableUntil": 1590130980000,
+                  "availableFrom": 1589526180000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lrpcp"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky1v2x",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lrkmk"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6ky1qbs", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lrkmk",
+              "id": "w172xjcj6ky1qbs",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0ffrr",
+                  "versionId": "w1mshp8n7rxvq0j",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -385,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584082980000,
-                  "availableFrom": 1583478180000
+                  "availableUntil": 1590127380000,
+                  "availableFrom": 1589522580000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lrkmk"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6ky1qbs",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lrfwf"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6kxzjxg", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lrfwf",
+              "id": "w172xjcj6kxzjxg",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0fb0m",
+                  "versionId": "w1mshp8n7rxsjl6",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -438,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584079380000,
-                  "availableFrom": 1583474580000
+                  "availableUntil": 1590062580000,
+                  "availableFrom": 1589457780000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lrfwf"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6kxzjxg",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "وروستي خبرونه"
-            },
-            "locators": {
-              "pid": "w172x8nww6lp8g3"
-            },
+            "headlines": { "headline": "وروستي خبرونه" },
+            "locators": { "pid": "w172xjcj6kxzf5b", "brandPid": "p0340yr4" },
             "media": {
-              "id": "w172x8nww6lp8g3",
+              "id": "w172xjcj6kxzf5b",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "د نړۍ وروستي خبرونه",
                 "medium": "د نړۍ وروستي خبرونه"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfclcj0c4l9",
+                  "versionId": "w1mshp8n7rxsdv2",
                   "types": ["Original"],
                   "duration": 180,
                   "durationISO8601": "PT3M",
@@ -491,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1584014580000,
-                  "availableFrom": 1583409780000
+                  "availableUntil": 1590058980000,
+                  "availableFrom": 1589454180000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4nl0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340yr4",
-              "title": "وروستي خبرونه"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172x8nww6lp8g3"
+            "brand": { "pid": "p0340yr4", "title": "وروستي خبرونه" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_pashto_radio/w172xjcj6kxzf5b",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/persian/bbc_dari_radio/w3csz7mf.json
+++ b/data/persian/bbc_dari_radio/w3csz7mf.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7mf",
-    "locators": {},
+    "locators": { "pid": "w3csz7mf", "brandPid": "p04xz36l" },
     "type": "WSRADIO",
     "createdBy": "bbc_dari_radio",
     "language": "fa",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1583482631000,
     "lastPublished": 1583482631000,
+    "timestamp": 1583482631000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "چشم انداز بامدادی 1 - BBC News فارسی",
       "pageIdentifier": "persian.bbc_dari_radio.w3csz7mf.page",
       "producerId": "69",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "PERSIAN"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "چشم انداز بامدادی 1"
+    "title": "چشم انداز بامدادی 1",
+    "releaseDateTimeStamp": 1583539200000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
           "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqts03",
-            "types": ["Original"],
-            "duration": 1770,
-            "durationISO8601": "PT29M30S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586152770000,
-            "availableFrom": 1583546370000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "چشم انداز بامدادی 1"
-    },
-    "locators": {
-      "pid": "w3csz7mf"
-    },
+    "headlines": { "headline": "چشم انداز بامدادی 1" },
+    "locators": { "pid": "w3csz7mf", "brandPid": "p04xz36l" },
     "media": {
       "id": "w3csz7mf",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
         "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqts03",
-          "types": ["Original"],
-          "duration": 1770,
-          "durationISO8601": "PT29M30S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586152770000,
-          "availableFrom": 1583546370000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p04xz36l",
-      "title": "چشم انداز بامدادی 1"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7mf"
+    "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7mf",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Persian",
-      "uri": "/persian"
+      "uri": "/persian",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7gl"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0bqc", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7gl",
+              "id": "w3ct0bqc",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtrtm",
+                  "versionId": "w4hqvxj8",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586066370000,
-                  "availableFrom": 1583459970000
+                  "availableUntil": 1592117970000,
+                  "availableFrom": 1589507970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7gl"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bqc",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7tk"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0bvw", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7tk",
+              "id": "w3ct0bvw",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqts5l",
+                  "versionId": "w4hqvxns",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585979970000,
-                  "availableFrom": 1583373570000
+                  "availableUntil": 1592031570000,
+                  "availableFrom": 1589421570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7tk"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bvw",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz802"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0by4", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz802",
+              "id": "w3ct0by4",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtsc2",
+                  "versionId": "w4hqvxr1",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585893570000,
-                  "availableFrom": 1583287170000
+                  "availableUntil": 1591945170000,
+                  "availableFrom": 1589335170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz802"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0by4",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7vp"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0bx0", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7vp",
+              "id": "w3ct0bx0",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqts6q",
+                  "versionId": "w4hqvxpx",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585807170000,
-                  "availableFrom": 1583200770000
+                  "availableUntil": 1591858770000,
+                  "availableFrom": 1589248770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7vp"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bx0",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7hq"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0brh", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7hq",
+              "id": "w3ct0brh",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtrvr",
+                  "versionId": "w4hqvxkd",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585720770000,
-                  "availableFrom": 1583114370000
+                  "availableUntil": 1591772370000,
+                  "availableFrom": 1589162370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7hq"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0brh",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7rr"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0btq", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7rr",
+              "id": "w3ct0btq",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/03/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqts3s",
+                  "versionId": "w4hqvxmm",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585634370000,
-                  "availableFrom": 1583027970000
+                  "availableUntil": 1591685970000,
+                  "availableFrom": 1589075970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7rr"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0btq",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7md"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0bsl", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7md",
+              "id": "w3ct0bsl",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/02/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqts02",
+                  "versionId": "w4hqvxlh",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585547970000,
-                  "availableFrom": 1582941570000
+                  "availableUntil": 1591599570000,
+                  "availableFrom": 1588989570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7md"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bsl",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی 1"
-            },
-            "locators": {
-              "pid": "w3csz7gk"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی 1" },
+            "locators": { "pid": "w3ct0bqb", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3csz7gk",
+              "id": "w3ct0bqb",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqtrtl",
+                  "versionId": "w4hqvxj7",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585461570000,
-                  "availableFrom": 1582855170000
+                  "availableUntil": 1591513170000,
+                  "availableFrom": 1588903170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02y4n1p.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8krp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p04xz36l",
-              "title": "چشم انداز بامدادی 1"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7gk"
+            "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bqb",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/persian/bbc_persian_radio/w172x32355t5635.json
+++ b/data/persian/bbc_persian_radio/w172x32355t5635.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t5635",
-    "locators": {},
+    "locators": { "pid": "w172x32355t5635", "brandPid": "p0340vyx" },
     "type": "WSRADIO",
     "createdBy": "bbc_persian_radio",
     "language": "fa",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582518913000,
     "lastPublished": 1582518913000,
+    "timestamp": 1582518913000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "چشم انداز بامدادی - BBC News فارسی",
       "pageIdentifier": "persian.bbc_persian_radio.w172x32355t5635.page",
       "producerId": "69",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "PERSIAN"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "چشم انداز بامدادی"
+    "title": "چشم انداز بامدادی",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -34,36 +35,17 @@
           "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
           "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1msh7kgr8kyfbf",
-            "types": ["Original"],
-            "duration": 3330,
-            "durationISO8601": "PT55M30S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586064570000,
-            "availableFrom": 1583472570000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "چشم انداز بامدادی"
-    },
-    "locators": {
-      "pid": "w172x32355t5635"
-    },
+    "headlines": { "headline": "چشم انداز بامدادی" },
+    "locators": { "pid": "w172x32355t5635", "brandPid": "p0340vyx" },
     "media": {
       "id": "w172x32355t5635",
       "subType": "episode",
@@ -74,76 +56,57 @@
         "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
         "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1msh7kgr8kyfbf",
-          "types": ["Original"],
-          "duration": 3330,
-          "durationISO8601": "PT55M30S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586064570000,
-          "availableFrom": 1583472570000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p0340vyx",
-      "title": "چشم انداز بامدادی"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t5635"
+    "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t5635",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Persian",
-      "uri": "/persian"
+      "uri": "/persian",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x32355t8308"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2x", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x32355t8308",
+              "id": "w3ct0s2x",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/03/2020 GMT",
+              "title": "15/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7kgr8l1b7j",
+                  "versionId": "w4hqwdpm",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -153,51 +116,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586150970000,
-                  "availableFrom": 1583558970000
+                  "availableUntil": 1592108970000,
+                  "availableFrom": 1589513400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t8308"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2x",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x31pfthxb1h"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2w", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x31pfthxb1h",
+              "id": "w3ct0s2w",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7k20x8pk8r",
+                  "versionId": "w4hqwdpl",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -207,51 +165,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586147400000,
-                  "availableFrom": 1583555400000
+                  "availableUntil": 1592022570000,
+                  "availableFrom": 1589427000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x31pfthxb1h"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2w",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x31pfthtf4d"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2v", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x31pfthtf4d",
+              "id": "w3ct0s2v",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7k20x8lncn",
+                  "versionId": "w4hqwdpk",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -261,51 +214,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586061000000,
-                  "availableFrom": 1583469000000
+                  "availableUntil": 1591936170000,
+                  "availableFrom": 1589340600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x31pfthtf4d"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2v",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x32355t2962"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2t", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x32355t2962",
+              "id": "w3ct0s2t",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7kgr8kvjfb",
+                  "versionId": "w4hqwdpj",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -315,51 +263,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585978170000,
-                  "availableFrom": 1583386170000
+                  "availableUntil": 1591849770000,
+                  "availableFrom": 1589254200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t2962"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2t",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x31pfthqj79"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2s", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x31pfthqj79",
+              "id": "w3ct0s2s",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7k20x8hrgk",
+                  "versionId": "w4hqwdph",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -369,51 +312,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585974600000,
-                  "availableFrom": 1583382600000
+                  "availableUntil": 1591763370000,
+                  "availableFrom": 1589167800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x31pfthqj79"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2s",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x32355szd8z"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2r", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x32355szd8z",
+              "id": "w3ct0s2r",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7kgr8krmj7",
+                  "versionId": "w4hqwdpg",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -423,51 +361,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585891770000,
-                  "availableFrom": 1583299770000
+                  "availableUntil": 1591676970000,
+                  "availableFrom": 1589081400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355szd8z"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2r",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x31pfthmmb6"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2q", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x31pfthmmb6",
+              "id": "w3ct0s2q",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7k20x8dvkg",
+                  "versionId": "w4hqwdpf",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -477,51 +410,46 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585888200000,
-                  "availableFrom": 1583296200000
+                  "availableUntil": 1591590570000,
+                  "availableFrom": 1588995000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x31pfthmmb6"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2q",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "چشم انداز بامدادی"
-            },
-            "locators": {
-              "pid": "w172x32355swhcw"
-            },
+            "headlines": { "headline": "چشم انداز بامدادی" },
+            "locators": { "pid": "w3ct0s2p", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w172x32355swhcw",
+              "id": "w3ct0s2p",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "long": "چشم انداز بامدادی، مجله خبری بخش فارسی رادیو بی‌بی‌سی است. این برنامه شامل تازه‌ترین خبرهای روز ایران و جهان، به همراه گزارش، گفت وگو و تحلیل و تفسیر درباره رویدادهای ایران، منطقه و جهان است."
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1msh7kgr8knqm4",
+                  "versionId": "w4hqwdpd",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -531,27 +459,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585805370000,
-                  "availableFrom": 1583213370000
+                  "availableUntil": 1591504170000,
+                  "availableFrom": 1588908600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlgt.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b21g3.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p0340vyx",
-              "title": "چشم انداز بامدادی"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355swhcw"
+            "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2p",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/sinhala/bbc_sinhala_radio/w172x8zn8th1lwb.json
+++ b/data/sinhala/bbc_sinhala_radio/w172x8zn8th1lwb.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8th1lwb",
-    "locators": {},
+    "locators": { "pid": "w172x8zn8th1lwb", "brandPid": "p0341109" },
     "type": "WSRADIO",
     "createdBy": "bbc_sinhala_radio",
     "language": "si",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582561533000,
     "lastPublished": 1582561533000,
+    "timestamp": 1582561533000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "බීබීසී සිරස ඔස්සේ - BBC News සිංහල",
       "pageIdentifier": "sinhala.bbc_sinhala_radio.w172x8zn8th1lwb.page",
       "producerId": "82",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "SINHALA"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "බීබීසී සිරස ඔස්සේ"
+    "title": "බීබීසී සිරස ඔස්සේ",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
           "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshfpbdvllmrc",
-            "types": ["Original"],
-            "duration": 300,
-            "durationISO8601": "PT5M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586105100000,
-            "availableFrom": 1583513100000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "බීබීසී සිරස ඔස්සේ"
-    },
-    "locators": {
-      "pid": "w172x8zn8th1lwb"
-    },
+    "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+    "locators": { "pid": "w172x8zn8th1lwb", "brandPid": "p0341109" },
     "media": {
       "id": "w172x8zn8th1lwb",
       "subType": "episode",
@@ -72,479 +54,34 @@
         "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
         "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshfpbdvllmrc",
-          "types": ["Original"],
-          "duration": 300,
-          "durationISO8601": "PT5M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586105100000,
-          "availableFrom": 1583513100000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p0341109",
-      "title": "බීබීසී සිරස ඔස්සේ"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8th1lwb"
+    "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8th1lwb",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Sinhala",
-      "uri": "/sinhala"
+      "uri": "/sinhala",
+      "type": "simple"
     },
-    "groups": [
-      {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zn8tgypz7"
-            },
-            "media": {
-              "id": "w172x8zn8tgypz7",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "05/03/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpbdvlhqv8",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1586018700000,
-                  "availableFrom": 1583426700000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8tgypz7"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zn8tgvt24"
-            },
-            "media": {
-              "id": "w172x8zn8tgvt24",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "04/03/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpbdvldty5",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585932300000,
-                  "availableFrom": 1583340300000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8tgvt24"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zn8tgrx51"
-            },
-            "media": {
-              "id": "w172x8zn8tgrx51",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "03/03/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpbdvl9y12",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585845900000,
-                  "availableFrom": 1583253900000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8tgrx51"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zn8tgp07y"
-            },
-            "media": {
-              "id": "w172x8zn8tgp07y",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "02/03/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpbdvl713z",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585759500000,
-                  "availableFrom": 1583167500000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8tgp07y"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zmxk58g8h"
-            },
-            "media": {
-              "id": "w172x8zmxk58g8h",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "28/02/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpb1l8th4j",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585500300000,
-                  "availableFrom": 1582908300000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zmxk58g8h"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zmxk55kcd"
-            },
-            "media": {
-              "id": "w172x8zmxk55kcd",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "27/02/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpb1l8ql7f",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585413900000,
-                  "availableFrom": 1582821900000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zmxk55kcd"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zmxk52ng9"
-            },
-            "media": {
-              "id": "w172x8zmxk52ng9",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "26/02/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpb1l8mpbb",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585327500000,
-                  "availableFrom": 1582735500000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zmxk52ng9"
-          },
-          {
-            "headlines": {
-              "headline": "බීබීසී සිරස ඔස්සේ"
-            },
-            "locators": {
-              "pid": "w172x8zmxk4zrk6"
-            },
-            "media": {
-              "id": "w172x8zmxk4zrk6",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "25/02/2020 GMT",
-              "synopses": {
-                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
-                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfpb1l8jsf7",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585241100000,
-                  "availableFrom": 1582649100000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dlq3.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p0341109",
-              "title": "බීබීසී සිරස ඔස්සේ"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zmxk4zrk6"
-          }
-        ]
-      }
-    ]
+    "groups": [{ "type": "other-episode", "promos": [] }]
   }
 }

--- a/data/somali/bbc_somali_radio/w172x90wfxd2qh4.json
+++ b/data/somali/bbc_somali_radio/w172x90wfxd2qh4.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxd2qh4",
-    "locators": {},
+    "locators": { "pid": "w172x90wfxd2qh4", "brandPid": "p034117l" },
     "type": "WSRADIO",
     "createdBy": "bbc_somali_radio",
     "language": "so",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
+    "timestamp": 1582565117000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Caawa Iyo Caalamka - BBC News Somali",
       "pageIdentifier": "somali.bbc_somali_radio.w172x90wfxd2qh4.page",
       "producerId": "83",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "SOMALI"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Caawa Iyo Caalamka"
+    "title": "Caawa Iyo Caalamka",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
           "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24tk.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshfqkkyhmrc5",
-            "types": ["Original"],
-            "duration": 1800,
-            "durationISO8601": "PT30M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586111370000,
-            "availableFrom": 1583519370000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Caawa Iyo Caalamka"
-    },
-    "locators": {
-      "pid": "w172x90wfxd2qh4"
-    },
+    "headlines": { "headline": "Caawa Iyo Caalamka" },
+    "locators": { "pid": "w172x90wfxd2qh4", "brandPid": "p034117l" },
     "media": {
       "id": "w172x90wfxd2qh4",
       "subType": "episode",
@@ -72,479 +54,34 @@
         "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
         "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24tk.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshfqkkyhmrc5",
-          "types": ["Original"],
-          "duration": 1800,
-          "durationISO8601": "PT30M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586111370000,
-          "availableFrom": 1583519370000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24tk.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24tk.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p034117l",
-      "title": "Caawa Iyo Caalamka"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxd2qh4"
+    "brand": { "pid": "p034117l", "title": "Caawa Iyo Caalamka" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxd2qh4",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Somali",
-      "uri": "/somali"
+      "uri": "/somali",
+      "type": "simple"
     },
-    "groups": [
-      {
-        "type": "other-episode",
-        "promos": [
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90wfxcwxny"
-            },
-            "media": {
-              "id": "w172x90wfxcwxny",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "04/03/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqkkyhfyjz",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585938570000,
-                  "availableFrom": 1583346570000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxcwxny"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90wfxct0rv"
-            },
-            "media": {
-              "id": "w172x90wfxct0rv",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "03/03/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqkkyhc1mw",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585852170000,
-                  "availableFrom": 1583260170000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxct0rv"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x91958p1s2d"
-            },
-            "media": {
-              "id": "w172x91958p1s2d",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "02/03/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqz99slsyf",
-                  "types": ["Original"],
-                  "duration": 1200,
-                  "durationISO8601": "PT20M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585765170000,
-                  "availableFrom": 1583173170000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x91958p1s2d"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90w2n2hcph"
-            },
-            "media": {
-              "id": "w172x90w2n2hcph",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "01/03/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqk6p61dkj",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585679370000,
-                  "availableFrom": 1583087370000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90w2n2hcph"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90w2n29kw9"
-            },
-            "media": {
-              "id": "w172x90w2n29kw9",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "28/02/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqk6p5vlrb",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585506570000,
-                  "availableFrom": 1582914570000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90w2n29kw9"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90w2n23s23"
-            },
-            "media": {
-              "id": "w172x90w2n23s23",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "26/02/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqk6p5nsy4",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585333770000,
-                  "availableFrom": 1582741770000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90w2n23s23"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x90w2n20w50"
-            },
-            "media": {
-              "id": "w172x90w2n20w50",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "25/02/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqk6p5kx11",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585247370000,
-                  "availableFrom": 1582655370000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90w2n20w50"
-          },
-          {
-            "headlines": {
-              "headline": "Caawa Iyo Caalamka"
-            },
-            "locators": {
-              "pid": "w172x918t0c8mgk"
-            },
-            "media": {
-              "id": "w172x918t0c8mgk",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "24/02/2020 GMT",
-              "synopses": {
-                "short": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida.",
-                "medium": "Wararkii ugu dambeeyay ee fiidnimada iyo kuwii ugu muhiimsan dunida iyo Soomaalida."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfqyy1gtnbl",
-                  "types": ["Original"],
-                  "duration": 1200,
-                  "durationISO8601": "PT20M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585160370000,
-                  "availableFrom": 1582568370000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dltz.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p034117l",
-              "title": "Caawa Iyo Caalamka"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x918t0c8mgk"
-          }
-        ]
-      }
-    ]
+    "groups": [{ "type": "other-episode", "promos": [] }]
   }
 }

--- a/data/swahili/bbc_swahili_radio/w172x94ky63591m.json
+++ b/data/swahili/bbc_swahili_radio/w172x94ky63591m.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky63591m",
-    "locators": {},
+    "locators": { "pid": "w172x94ky63591m", "brandPid": "p03411ml" },
     "type": "WSRADIO",
     "createdBy": "bbc_swahili_radio",
     "language": "sw",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582557978000,
     "lastPublished": 1582557978000,
+    "timestamp": 1582557978000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Dira Ya Dunia - BBC News Swahili",
       "pageIdentifier": "swahili.bbc_swahili_radio.w172x94ky63591m.page",
       "producerId": "86",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "SWAHILI"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Dira Ya Dunia"
+    "title": "Dira Ya Dunia",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
           "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshfv8276q9xn",
-            "types": ["Original"],
-            "duration": 3600,
-            "durationISO8601": "PT1H",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586104170000,
-            "availableFrom": 1583512170000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Dira Ya Dunia"
-    },
-    "locators": {
-      "pid": "w172x94ky63591m"
-    },
+    "headlines": { "headline": "Dira Ya Dunia" },
+    "locators": { "pid": "w172x94ky63591m", "brandPid": "p03411ml" },
     "media": {
       "id": "w172x94ky63591m",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
         "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshfv8276q9xn",
-          "types": ["Original"],
-          "duration": 3600,
-          "durationISO8601": "PT1H",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586104170000,
-          "availableFrom": 1583512170000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p03411ml",
-      "title": "Dira Ya Dunia"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky63591m"
+    "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky63591m",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Swahili",
-      "uri": "/swahili"
+      "uri": "/swahili",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94ky632d4j"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtkn3jnxd5", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94ky632d4j",
+              "id": "w172xjtkn3jnxd5",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv8276mf0k",
+                  "versionId": "w1mshpqn77bzj08",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586017770000,
-                  "availableFrom": 1583425770000
+                  "availableUntil": 1592065770000,
+                  "availableFrom": 1589473770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky632d4j"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jnxd5",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94ky62zh7f"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtkn3jl0h2", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94ky62zh7f",
+              "id": "w172xjtkn3jl0h2",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv8276jj3g",
+                  "versionId": "w1mshpqn77bwm35",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585931370000,
-                  "availableFrom": 1583339370000
+                  "availableUntil": 1591979370000,
+                  "availableFrom": 1589387370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky62zh7f"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jl0h2",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94ky62wlbb"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtkn3jh3kz", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94ky62wlbb",
+              "id": "w172xjtkn3jh3kz",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv8276fm6c",
+                  "versionId": "w1mshpqn77bsq62",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585844970000,
-                  "availableFrom": 1583252970000
+                  "availableUntil": 1591892970000,
+                  "availableFrom": 1589300970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky62wlbb"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jh3kz",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94ky62spf7"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtkn3jd6nw", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94ky62spf7",
+              "id": "w172xjtkn3jd6nw",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv8276bq98",
+                  "versionId": "w1mshpqn77bpt8z",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585758570000,
-                  "availableFrom": 1583166570000
+                  "availableUntil": 1591806570000,
+                  "availableFrom": 1589214570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky62spf7"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jd6nw",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94kkxsd4fs"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtk8v6znpf", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94kkxsd4fs",
+              "id": "w172xjtk8v6znpf",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv7pywy59t",
+                  "versionId": "w1mshpqmvz1989j",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585499370000,
-                  "availableFrom": 1582907370000
+                  "availableUntil": 1591547370000,
+                  "availableFrom": 1588955370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94kkxsd4fs"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6znpf",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94kkxs97jp"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtk8v6wrsb", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94kkxs97jp",
+              "id": "w172xjtk8v6wrsb",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv7pywv8dq",
+                  "versionId": "w1mshpqmvz16cdf",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585412970000,
-                  "availableFrom": 1582820970000
+                  "availableUntil": 1591460970000,
+                  "availableFrom": 1588868970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94kkxs97jp"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6wrsb",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94kkxs6bml"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtk8v6svw7", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94kkxs6bml",
+              "id": "w172xjtk8v6svw7",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv7pywrchm",
+                  "versionId": "w1mshpqmvz13ghb",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585326570000,
-                  "availableFrom": 1582734570000
+                  "availableUntil": 1591374570000,
+                  "availableFrom": 1588782570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94kkxs6bml"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6svw7",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Dira Ya Dunia"
-            },
-            "locators": {
-              "pid": "w172x94kkxs3fqh"
-            },
+            "headlines": { "headline": "Dira Ya Dunia" },
+            "locators": { "pid": "w172xjtk8v6pyz4", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172x94kkxs3fqh",
+              "id": "w172xjtk8v6pyz4",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfv7pywnglj",
+                  "versionId": "w1mshpqmvz10kl7",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585240170000,
-                  "availableFrom": 1582648170000
+                  "availableUntil": 1591288170000,
+                  "availableFrom": 1588696170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02xxpq0.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b2knp.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03411ml",
-              "title": "Dira Ya Dunia"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94kkxs3fqh"
+            "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6pyz4",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/tamil/bbc_tamil_radio/w172x966tn9jwmh.json
+++ b/data/tamil/bbc_tamil_radio/w172x966tn9jwmh.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9jwmh",
-    "locators": {},
+    "locators": { "pid": "w172x966tn9jwmh", "brandPid": "p03412jh" },
     "type": "WSRADIO",
     "createdBy": "bbc_tamil_radio",
     "language": "ta",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529870679,
     "firstPublished": 1582557978000,
     "lastPublished": 1582557978000,
+    "timestamp": 1582557978000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "பிபிசி தமிழோசை செய்தியறிக்கை - BBC News தமிழ்",
       "pageIdentifier": "tamil.bbc_tamil_radio.w172x966tn9jwmh.page",
       "producerId": "87",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "TAMIL"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
+    "title": "பிபிசி தமிழோசை செய்தியறிக்கை",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
           "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshfwwypf2xhj",
-            "types": ["Original"],
-            "duration": 300,
-            "durationISO8601": "PT5M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586100600000,
-            "availableFrom": 1583508600000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-    },
-    "locators": {
-      "pid": "w172x966tn9jwmh"
-    },
+    "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+    "locators": { "pid": "w172x966tn9jwmh", "brandPid": "p03412jh" },
     "media": {
       "id": "w172x966tn9jwmh",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
         "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshfwwypf2xhj",
-          "types": ["Original"],
-          "duration": 300,
-          "durationISO8601": "PT5M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586100600000,
-          "availableFrom": 1583508600000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p03412jh",
-      "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9jwmh"
+    "brand": { "pid": "p03412jh", "title": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9jwmh",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Tamil",
-      "uri": "/tamil"
+      "uri": "/tamil",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966tn9fzqd"
-            },
+            "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+            "locators": { "pid": "w172xjw6jkr1hz1", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172x966tn9fzqd",
+              "id": "w172xjw6jkr1hz1",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfwwypf00lf",
+                  "versionId": "w1mshps93pkc3l4",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -150,50 +113,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586014200000,
-                  "availableFrom": 1583422200000
+                  "availableUntil": 1590075000000,
+                  "availableFrom": 1589470200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9fzqd"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkr1hz1",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966tn9c2t9"
-            },
+            "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+            "locators": { "pid": "w172xjw6jkqym1y", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172x966tn9c2t9",
+              "id": "w172xjw6jkqym1y",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfwwypdx3pb",
+                  "versionId": "w1mshps93pk86p1",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -203,50 +164,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585927800000,
-                  "availableFrom": 1583335800000
+                  "availableUntil": 1589988600000,
+                  "availableFrom": 1589383800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9c2t9"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqym1y",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966tn985x6"
-            },
+            "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+            "locators": { "pid": "w172xjw6jkqvq4v", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172x966tn985x6",
+              "id": "w172xjw6jkqvq4v",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfwwypdt6s7",
+                  "versionId": "w1mshps93pk59ry",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -256,50 +215,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585841400000,
-                  "availableFrom": 1583249400000
+                  "availableUntil": 1589902200000,
+                  "availableFrom": 1589297400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn985x6"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqvq4v",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966tn95903"
-            },
+            "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+            "locators": { "pid": "w172xjw6jkqrt7r", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172x966tn95903",
+              "id": "w172xjw6jkqrt7r",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfwwypdq9w4",
+                  "versionId": "w1mshps93pk2dvv",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -309,50 +266,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585755000000,
-                  "availableFrom": 1583163000000
+                  "availableUntil": 1589815800000,
+                  "availableFrom": 1589211000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn95903"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqrt7r",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966gczrr0n"
-            },
+            "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
+            "locators": { "pid": "w172xjw659fc889", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172x966gczrr0n",
+              "id": "w172xjw659fc889",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshfwwlf39rwp",
+                  "versionId": "w1mshps8rf7nvwd",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -362,186 +317,29 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585495800000,
-                  "availableFrom": 1582903800000
+                  "availableUntil": 1589556600000,
+                  "availableFrom": 1588951800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8nx5.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966gczrr0n"
-          },
-          {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966gcznv3k"
-            },
-            "media": {
-              "id": "w172x966gcznv3k",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "27/02/2020 GMT",
-              "synopses": {
-                "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
-                "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfwwlf36vzl",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585409400000,
-                  "availableFrom": 1582817400000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03412jh",
-              "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966gcznv3k"
-          },
-          {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966gczky6g"
-            },
-            "media": {
-              "id": "w172x966gczky6g",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "26/02/2020 GMT",
-              "synopses": {
-                "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
-                "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfwwlf33z2h",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585323000000,
-                  "availableFrom": 1582731000000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03412jh",
-              "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966gczky6g"
-          },
-          {
-            "headlines": {
-              "headline": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "locators": {
-              "pid": "w172x966gczh19c"
-            },
-            "media": {
-              "id": "w172x966gczh19c",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "25/02/2020 GMT",
-              "synopses": {
-                "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
-                "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshfwwlf3125d",
-                  "types": ["Original"],
-                  "duration": 300,
-                  "durationISO8601": "PT5M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1585236600000,
-                  "availableFrom": 1582644600000
-                }
-              ],
-              "imageCopyright": null
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null
-            },
-            "brand": {
-              "pid": "p03412jh",
-              "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966gczh19c"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw659fc889",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/tigrinya/bbc_tigrinya_radio/w3cszzz1.json
+++ b/data/tigrinya/bbc_tigrinya_radio/w3cszzz1.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3cszzz1",
-    "locators": {},
+    "locators": { "pid": "w3cszzz1", "brandPid": "w13xttny" },
     "type": "WSRADIO",
     "createdBy": "bbc_tigrinya_radio",
     "language": "ti",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1582568719000,
     "lastPublished": 1582568719000,
+    "timestamp": 1582568719000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ - BBC News ትግርኛ",
       "pageIdentifier": "tigrinya.bbc_tigrinya_radio.w3cszzz1.page",
       "producerId": "91",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "TIGRINYA"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
+    "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ",
+    "releaseDateTimeStamp": 1583452800000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
           "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvk7v",
-            "types": ["Original"],
-            "duration": 883,
-            "durationISO8601": "PT14M43S",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586121870000,
-            "availableFrom": 1583519070000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-    },
-    "locators": {
-      "pid": "w3cszzz1"
-    },
+    "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+    "locators": { "pid": "w3cszzz1", "brandPid": "w13xttny" },
     "media": {
       "id": "w3cszzz1",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
         "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvk7v",
-          "types": ["Original"],
-          "duration": 883,
-          "durationISO8601": "PT14M43S",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586121870000,
-          "availableFrom": 1583519070000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "w13xttny",
-      "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3cszzz1"
+    "brand": { "pid": "w13xttny", "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3cszzz1",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Tigrinya",
-      "uri": "/tigrinya"
+      "uri": "/tigrinya",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct0019"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p52", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0019",
+              "id": "w3ct0p52",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkb3",
+                  "versionId": "w4hqw80h",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -150,50 +113,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586035470000,
-                  "availableFrom": 1583432670000
+                  "availableUntil": 1592083470000,
+                  "availableFrom": 1589480670000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0019"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p52",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct003k"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p7b", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct003k",
+              "id": "w3ct0p7b",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkdc",
+                  "versionId": "w4hqw82r",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -203,50 +164,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585949070000,
-                  "availableFrom": 1583346270000
+                  "availableUntil": 1591997070000,
+                  "availableFrom": 1589394270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct003k"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p7b",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct002f"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p66", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct002f",
+              "id": "w3ct0p66",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkc7",
+                  "versionId": "w4hqw81m",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -256,50 +215,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585862670000,
-                  "availableFrom": 1583259870000
+                  "availableUntil": 1591910670000,
+                  "availableFrom": 1589307870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct002f"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p66",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct0005"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p3y", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0005",
+              "id": "w3ct0p3y",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvk8z",
+                  "versionId": "w4hqw7zc",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -309,50 +266,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585776270000,
-                  "availableFrom": 1583173470000
+                  "availableUntil": 1591824270000,
+                  "availableFrom": 1589221470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0005"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p3y",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3cszzz0"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p2s", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3cszzz0",
+              "id": "w3ct0p2s",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvk7t",
+                  "versionId": "w4hqw7y6",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -362,50 +317,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585517070000,
-                  "availableFrom": 1582914270000
+                  "availableUntil": 1591565070000,
+                  "availableFrom": 1588962270000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3cszzz0"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p2s",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct0018"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p51", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0018",
+              "id": "w3ct0p51",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkb2",
+                  "versionId": "w4hqw80g",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -415,50 +368,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585430670000,
-                  "availableFrom": 1582827870000
+                  "availableUntil": 1591478670000,
+                  "availableFrom": 1588875870000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0018"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p51",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct003j"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p79", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct003j",
+              "id": "w3ct0p79",
               "subType": "episode",
               "format": "Audio",
-              "title": "26/02/2020 GMT",
+              "title": "06/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkdb",
+                  "versionId": "w4hqw82q",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -468,50 +419,48 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585344270000,
-                  "availableFrom": 1582741470000
+                  "availableUntil": 1591392270000,
+                  "availableFrom": 1588789470000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct003j"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p79",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
-            },
-            "locators": {
-              "pid": "w3ct002d"
-            },
+            "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
+            "locators": { "pid": "w3ct0p65", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct002d",
+              "id": "w3ct0p65",
               "subType": "episode",
               "format": "Audio",
-              "title": "25/02/2020 GMT",
+              "title": "05/05/2020 GMT",
               "synopses": {
                 "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
                 "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvkc6",
+                  "versionId": "w4hqw81l",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -521,27 +470,29 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585257870000,
-                  "availableFrom": 1582655070000
+                  "availableUntil": 1591305870000,
+                  "availableFrom": 1588703070000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws312.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct002d"
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p65",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/urdu/bbc_urdu_radio/w172x9dx052c8sr.json
+++ b/data/urdu/bbc_urdu_radio/w172x9dx052c8sr.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052c8sr",
-    "locators": {},
+    "locators": { "pid": "w172x9dx052c8sr", "brandPid": "p03413l5" },
     "type": "WSRADIO",
     "createdBy": "bbc_urdu_radio",
     "language": "ur",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
+    "timestamp": 1583569000000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "بی بی سی اردو نیوز بلیٹن - BBC News اردو",
       "pageIdentifier": "urdu.bbc_urdu_radio.w172x9dx052c8sr.page",
       "producerId": "95",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "URDU"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "بی بی سی اردو نیوز بلیٹن"
+    "title": "بی بی سی اردو نیوز بلیٹن",
+    "releaseDateTimeStamp": 1583539200000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
           "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshg42dfk3wqk",
-            "types": ["Original"],
-            "duration": 600,
-            "durationISO8601": "PT10M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586175000000,
-            "availableFrom": 1583583000000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "بی بی سی اردو نیوز بلیٹن"
-    },
-    "locators": {
-      "pid": "w172x9dx052c8sr"
-    },
+    "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+    "locators": { "pid": "w172x9dx052c8sr", "brandPid": "p03413l5" },
     "media": {
       "id": "w172x9dx052c8sr",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
         "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshg42dfk3wqk",
-          "types": ["Original"],
-          "duration": 600,
-          "durationISO8601": "PT10M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586175000000,
-          "availableFrom": 1583583000000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p03413l5",
-      "title": "بی بی سی اردو نیوز بلیٹن"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052c8sr"
+    "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052c8sr",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Urdu",
-      "uri": "/urdu"
+      "uri": "/urdu",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx052cj90"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r81vh", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx052cj90",
+              "id": "w172xjzxd3r81vh",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfk446t",
+                  "versionId": "w1mshpwzz7kkngl",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586182200000,
-                  "availableFrom": 1583590200000
+                  "availableUntil": 1592057400000,
+                  "availableFrom": 1589465400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052cj90"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r81vh",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx052cdjw"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r7y3c", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx052cdjw",
+              "id": "w172xjzxd3r7y3c",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfk40gp",
+                  "versionId": "w1mshpwzz7kkjqg",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586178600000,
-                  "availableFrom": 1583586600000
+                  "availableUntil": 1592053800000,
+                  "availableFrom": 1589461800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052cdjw"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r7y3c",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0528mcx"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r7tc7", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0528mcx",
+              "id": "w172xjzxd3r7tc7",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfk179q",
+                  "versionId": "w1mshpwzz7kkdzb",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586095800000,
-                  "availableFrom": 1583503800000
+                  "availableUntil": 1592050200000,
+                  "availableFrom": 1589458200000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0528mcx"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r7tc7",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0528hms"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r54yd", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0528hms",
+              "id": "w172xjzxd3r54yd",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfk13kl",
+                  "versionId": "w1mshpwzz7kgrkh",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586092200000,
-                  "availableFrom": 1583500200000
+                  "availableUntil": 1591971000000,
+                  "availableFrom": 1589379000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0528hms"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r54yd",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0528cwn"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r5168", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0528cwn",
+              "id": "w172xjzxd3r5168",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfk0ztg",
+                  "versionId": "w1mshpwzz7kgmtc",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586088600000,
-                  "availableFrom": 1583496600000
+                  "availableUntil": 1591967400000,
+                  "availableFrom": 1589375400000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0528cwn"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r5168",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0525qgt"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r4xg4", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0525qgt",
+              "id": "w172xjzxd3r4xg4",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfjybdm",
+                  "versionId": "w1mshpwzz7kgj27",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586009400000,
-                  "availableFrom": 1583417400000
+                  "availableUntil": 1591963800000,
+                  "availableFrom": 1589371800000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0525qgt"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r4xg4",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0525lqp"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r2819", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0525lqp",
+              "id": "w172xjzxd3r2819",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfjy6nh",
+                  "versionId": "w1mshpwzz7kcvnd",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586005800000,
-                  "availableFrom": 1583413800000
+                  "availableUntil": 1591884600000,
+                  "availableFrom": 1589292600000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0525lqp"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r2819",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "locators": {
-              "pid": "w172x9dx0525gzk"
-            },
+            "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
+            "locators": { "pid": "w172xjzxd3r2495", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172x9dx0525gzk",
+              "id": "w172xjzxd3r2495",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg42dfjy2xc",
+                  "versionId": "w1mshpwzz7kcqx8",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586002200000,
-                  "availableFrom": 1583410200000
+                  "availableUntil": 1591881000000,
+                  "availableFrom": 1589289000000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p035dm29.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23yf.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03413l5",
-              "title": "بی بی سی اردو نیوز بلیٹن"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx0525gzk"
+            "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r2495",
+            "type": "ws_radio"
           }
         ]
       }

--- a/data/uzbek/bbc_uzbek_radio/w172x9f9qjcq3lm.json
+++ b/data/uzbek/bbc_uzbek_radio/w172x9f9qjcq3lm.json
@@ -1,26 +1,27 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcq3lm",
-    "locators": {},
+    "locators": { "pid": "w172x9f9qjcq3lm", "brandPid": "p03414fb" },
     "type": "WSRADIO",
     "createdBy": "bbc_uzbek_radio",
     "language": "uz",
-    "lastUpdated": 1583601860035,
+    "lastUpdated": 1589529753485,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
+    "timestamp": 1583569000000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Би-би-си Афғонистон учун - BBC News O'zbek",
       "pageIdentifier": "uzbek.bbc_uzbek_radio.w172x9f9qjcq3lm.page",
       "producerId": "96",
-      "contentType": "player-ondemand",
+      "contentType": "player-episode",
       "producer": "UZBEK"
     },
-    "passport": null,
     "tags": {},
-    "version": "v1.1.3",
+    "version": "v1.3.0",
     "blockTypes": ["media"],
-    "title": "Би-би-си Афғонистон учун"
+    "title": "Би-би-си Афғонистон учун",
+    "releaseDateTimeStamp": 1583539200000
   },
   "content": {
     "blocks": [
@@ -33,36 +34,17 @@
           "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
           "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w1mshg4h3svgqjf",
-            "types": ["Original"],
-            "duration": 1800,
-            "durationISO8601": "PT30M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1586181570000,
-            "availableFrom": 1583589570000
-          }
-        ],
-        "imageCopyright": null
+        "versions": [],
+        "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Би-би-си Афғонистон учун"
-    },
-    "locators": {
-      "pid": "w172x9f9qjcq3lm"
-    },
+    "headlines": { "headline": "Би-би-си Афғонистон учун" },
+    "locators": { "pid": "w172x9f9qjcq3lm", "brandPid": "p03414fb" },
     "media": {
       "id": "w172x9f9qjcq3lm",
       "subType": "episode",
@@ -72,75 +54,56 @@
         "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
         "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w1mshg4h3svgqjf",
-          "types": ["Original"],
-          "duration": 1800,
-          "durationISO8601": "PT30M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1586181570000,
-          "availableFrom": 1583589570000
-        }
-      ],
-      "imageCopyright": null
+      "versions": [],
+      "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
       "height": 0,
       "width": 0,
       "altText": null,
-      "copyrightHolder": null
+      "copyrightHolder": null,
+      "type": "image"
     },
-    "brand": {
-      "pid": "p03414fb",
-      "title": "Би-би-си Афғонистон учун"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcq3lm"
+    "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcq3lm",
+    "type": "ws_radio"
   },
   "relatedContent": {
     "site": {
       "subType": "site",
       "name": "Uzbek",
-      "uri": "/uzbek"
+      "uri": "/uzbek",
+      "type": "simple"
     },
     "groups": [
       {
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9qjcm6pj"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk0b3h1ln53", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9qjcm6pj",
+              "id": "w172xk0b3h1ln53",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/03/2020 GMT",
+              "title": "14/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4h3svctmb",
+                  "versionId": "w1mshpxdplvx7s6",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -150,50 +113,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586095170000,
-                  "availableFrom": 1583503170000
+                  "availableUntil": 1592056770000,
+                  "availableFrom": 1589464770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcm6pj"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1ln53",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9qjcj9sf"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk0b3h1hr80", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9qjcj9sf",
+              "id": "w172xk0b3h1hr80",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/03/2020 GMT",
+              "title": "13/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4h3sv8xq7",
+                  "versionId": "w1mshpxdplvtbw3",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -203,50 +161,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1586008770000,
-                  "availableFrom": 1583416770000
+                  "availableUntil": 1591970370000,
+                  "availableFrom": 1589378370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcj9sf"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1hr80",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9qjcfdwb"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk0b3h1dvbx", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9qjcfdwb",
+              "id": "w172xk0b3h1dvbx",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/03/2020 GMT",
+              "title": "12/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4h3sv60t4",
+                  "versionId": "w1mshpxdplvqfz0",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -256,50 +209,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585922370000,
-                  "availableFrom": 1583330370000
+                  "availableUntil": 1591883970000,
+                  "availableFrom": 1589291970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcfdwb"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1dvbx",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9qjcbhz7"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk0b3h19yft", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9qjcbhz7",
+              "id": "w172xk0b3h19yft",
               "subType": "episode",
               "format": "Audio",
-              "title": "03/03/2020 GMT",
+              "title": "11/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4h3sv33x1",
+                  "versionId": "w1mshpxdplvmk1x",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -309,50 +257,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585835970000,
-                  "availableFrom": 1583243970000
+                  "availableUntil": 1591797570000,
+                  "availableFrom": 1589205570000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcbhz7"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h19yft",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9qjc7m24"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk09r6r368k", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9qjc7m24",
+              "id": "w172xk09r6r368k",
               "subType": "episode",
               "format": "Audio",
-              "title": "02/03/2020 GMT",
+              "title": "10/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4h3sv06zy",
+                  "versionId": "w1mshpxdbbkdswn",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -362,50 +305,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585749570000,
-                  "availableFrom": 1583157570000
+                  "availableUntil": 1591711170000,
+                  "availableFrom": 1589119170000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjc7m24"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6r368k",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9c820vww"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk09r6r09cg", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9c820vww",
+              "id": "w172xk09r6r09cg",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/03/2020 GMT",
+              "title": "09/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4grjjsgtp",
+                  "versionId": "w1mshpxdbbk9wzk",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -415,50 +353,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585663170000,
-                  "availableFrom": 1583071170000
+                  "availableUntil": 1591624770000,
+                  "availableFrom": 1589032770000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9c820vww"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6r09cg",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9c81xyzs"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk09r6qxdgc", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9c81xyzs",
+              "id": "w172xk09r6qxdgc",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/02/2020 GMT",
+              "title": "08/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4grjjpkxl",
+                  "versionId": "w1mshpxdbbk702g",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -468,50 +401,45 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585576770000,
-                  "availableFrom": 1582984770000
+                  "availableUntil": 1591538370000,
+                  "availableFrom": 1588946370000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9c81xyzs"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6qxdgc",
+            "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Би-би-си Афғонистон учун"
-            },
-            "locators": {
-              "pid": "w172x9f9c81v22p"
-            },
+            "headlines": { "headline": "Би-би-си Афғонистон учун" },
+            "locators": { "pid": "w172xk09r6qthk8", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172x9f9c81v22p",
+              "id": "w172xk09r6qthk8",
               "subType": "episode",
               "format": "Audio",
-              "title": "28/02/2020 GMT",
+              "title": "07/05/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshg4grjjlp0h",
+                  "versionId": "w1mshpxdbbk435c",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -521,27 +449,26 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1585490370000,
-                  "availableFrom": 1582898370000
+                  "availableUntil": 1591451970000,
+                  "availableFrom": 1588859970000
                 }
               ],
-              "imageCopyright": null
+              "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0755nqh.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8pfx.png",
               "height": 0,
               "width": 0,
               "altText": null,
-              "copyrightHolder": null
+              "copyrightHolder": null,
+              "type": "image"
             },
-            "brand": {
-              "pid": "p03414fb",
-              "title": "Би-би-си Афғонистон учун"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9c81v22p"
+            "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6qthk8",
+            "type": "ws_radio"
           }
         ]
       }

--- a/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/amp.test.js.snap
@@ -6,6 +6,6 @@ exports[`AMP On Demand Radio Episode Expired Episode I can see the brand title 1
 
 exports[`AMP On Demand Radio Episode Expired Episode I can see the episode summary 1`] = `"د نړۍ وروستي خبرونه"`;
 
-exports[`AMP On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۱۵ می ۲۰۲۰"`;
+exports[`AMP On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۴ فبروري ۲۰۲۰"`;
 
-exports[`AMP On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۱۵ می ۲۰۲۰"`;
+exports[`AMP On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۴ فبروري ۲۰۲۰"`;

--- a/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/amp.test.js.snap
@@ -6,6 +6,6 @@ exports[`AMP On Demand Radio Episode Expired Episode I can see the brand title 1
 
 exports[`AMP On Demand Radio Episode Expired Episode I can see the episode summary 1`] = `"د نړۍ وروستي خبرونه"`;
 
-exports[`AMP On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۴ فبروري ۲۰۲۰"`;
+exports[`AMP On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۱۵ می ۲۰۲۰"`;
 
-exports[`AMP On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۴ فبروري ۲۰۲۰"`;
+exports[`AMP On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۱۵ می ۲۰۲۰"`;

--- a/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -6,6 +6,6 @@ exports[`Canonical On Demand Radio Episode Expired Episode I can see the brand t
 
 exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode summary 1`] = `"د نړۍ وروستي خبرونه"`;
 
-exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۱۵ می ۲۰۲۰"`;
+exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۴ فبروري ۲۰۲۰"`;
 
-exports[`Canonical On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۱۵ می ۲۰۲۰"`;
+exports[`Canonical On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۴ فبروري ۲۰۲۰"`;

--- a/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto.expired/__snapshots__/canonical.test.js.snap
@@ -6,6 +6,6 @@ exports[`Canonical On Demand Radio Episode Expired Episode I can see the brand t
 
 exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode summary 1`] = `"د نړۍ وروستي خبرونه"`;
 
-exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۴ فبروري ۲۰۲۰"`;
+exports[`Canonical On Demand Radio Episode Expired Episode I can see the episode title 1`] = `"۱۵ می ۲۰۲۰"`;
 
-exports[`Canonical On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۴ فبروري ۲۰۲۰"`;
+exports[`Canonical On Demand Radio Episode Expired Episode a11y Assistive technology reads the brand and episode title as the headline 1`] = `"وروستي خبرونه, ۱۵ می ۲۰۲۰"`;


### PR DESCRIPTION
Resolves #6526

**Overall change:**
Updating asset from Ares V1 to Ares V2

**Code changes:**

Updated integration snapshots for the expired Pashto asset
Updated the asset from Ares V1 response to V2 response

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
