### PR TITLE
Updated Pashto fixture data OD-episode image

### DIFF
--- a/data/pashto/bbc_pashto_radio/w3ct0lz1.json
+++ b/data/pashto/bbc_pashto_radio/w3ct0lz1.json
@@ -37,7 +37,7 @@
           "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
           "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
         "embedding": false,
         "advertising": false,
         "versions": [
@@ -77,7 +77,7 @@
         "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
         "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
       "embedding": false,
       "advertising": false,
       "versions": [
@@ -101,8 +101,8 @@
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
       "height": 0,
       "width": 0,
       "altText": null,
@@ -144,7 +144,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -168,8 +168,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -200,7 +200,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -224,8 +224,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -256,7 +256,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -280,8 +280,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -312,7 +312,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -336,8 +336,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -368,7 +368,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -392,8 +392,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -424,7 +424,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -448,8 +448,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -480,7 +480,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -504,8 +504,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,
@@ -536,7 +536,7 @@
                 "short": "د بي بي سي ورلډ سروس څخه پروګرام کول",
                 "medium": "د بي بي سي ورلډ سروس څخه پروګرام کول"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "embedding": false,
               "advertising": false,
               "versions": [
@@ -560,8 +560,8 @@
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
               "height": 0,
               "width": 0,
               "altText": null,

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -208,7 +208,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"AudioObject","name":"ماښامنۍ خپرونه","description":"د بي بي سي ورلډ سروس څخه پروګرام کول","duration":"PT29M30S","thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg","uploadDate":"2020-05-01T00:00:00.000Z","embedURL":"https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps/amp?morph_env=live"}
+      {"@context":"http://schema.org","@type":"AudioObject","name":"ماښامنۍ خپرونه","description":"د بي بي سي ورلډ سروس څخه پروګرام کول","duration":"PT29M30S","thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png","uploadDate":"2020-05-01T00:00:00.000Z","embedURL":"https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps/amp?morph_env=live"}
     </script>
   </head>
   <body>
@@ -674,8 +674,8 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
                   attribution=""
                   height="224"
                   layout="responsive"
-                  src="https://ichef.bbci.co.uk/images/ic/112x112/p063j1dv.jpg"
-                  srcset="https://ichef.bbci.co.uk/images/ic/112x112/p063j1dv.jpg 112w,https://ichef.bbci.co.uk/images/ic/224x224/p063j1dv.jpg 224w"
+                  src="https://ichef.bbci.co.uk/images/ic/112x112/p08b23c8.png"
+                  srcset="https://ichef.bbci.co.uk/images/ic/112x112/p08b23c8.png 112w,https://ichef.bbci.co.uk/images/ic/224x224/p08b23c8.png 224w"
                   width="224"
                 />
               </div>
@@ -1328,7 +1328,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"AudioObject","name":"ماښامنۍ خپرونه","description":"د بي بي سي ورلډ سروس څخه پروګرام کول","duration":"PT29M30S","thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg","uploadDate":"2020-05-01T00:00:00.000Z","embedURL":"https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps?morph_env=live"}
+      {"@context":"http://schema.org","@type":"AudioObject","name":"ماښامنۍ خپرونه","description":"د بي بي سي ورلډ سروس څخه پروګرام کول","duration":"PT29M30S","thumbnailUrl":"https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png","uploadDate":"2020-05-01T00:00:00.000Z","embedURL":"https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps?morph_env=live"}
     </script>
   </head>
   <body>
@@ -1397,8 +1397,8 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
                   alt="BBC News پښتو"
                   class="c13"
                   sizes="(min-width: 1007px) 112px, 100vw"
-                  src="https://ichef.bbci.co.uk/images/ic/112x112/p063j1dv.jpg"
-                  srcset="https://ichef.bbci.co.uk/images/ic/112x112/p063j1dv.jpg 112w,https://ichef.bbci.co.uk/images/ic/224x224/p063j1dv.jpg 224w"
+                  src="https://ichef.bbci.co.uk/images/ic/112x112/p08b23c8.png"
+                  srcset="https://ichef.bbci.co.uk/images/ic/112x112/p08b23c8.png 112w,https://ichef.bbci.co.uk/images/ic/224x224/p08b23c8.png 224w"
                 />
               </div>
             </div>

--- a/src/app/pages/OnDemandRadioPage/fixtureData/pashto.json
+++ b/src/app/pages/OnDemandRadioPage/fixtureData/pashto.json
@@ -12,10 +12,10 @@
   "releaseDateTimeStamp": 1588291200000,
   "pageTitle": "ماښامنۍ خپرونه - BBC News پښتو",
   "pageIdentifier": "pashto.bbc_pashto_radio.w3ct0lz1.page",
-  "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg",
+  "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png",
   "promoBrandTitle": "ماښامنۍ خپرونه",
   "durationISO8601": "PT29M30S",
-  "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg",
+  "thumbnailImageUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png",
   "metadata": {
     "type": "On Demand Radio"
   }

--- a/src/app/routes/onDemandRadio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.test.js
@@ -23,12 +23,12 @@ describe('Get initial data for on demand radio', () => {
     expect(pageData.language).toEqual('ps');
     expect(pageData.metadata.type).toEqual('On Demand Radio');
     expect(pageData.imageUrl).toEqual(
-      'ichef.bbci.co.uk/images/ic/$recipe/p063j1dv.jpg',
+      'ichef.bbci.co.uk/images/ic/$recipe/p08b23c8.png',
     );
     expect(pageData.promoBrandTitle).toEqual('ماښامنۍ خپرونه');
     expect(pageData.durationISO8601).toEqual('PT29M30S');
     expect(pageData.thumbnailImageUrl).toEqual(
-      'https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
+      'https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png',
     );
   });
 

--- a/src/integration/pages/onDemandRadioEpisode/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto/__snapshots__/amp.test.js.snap
@@ -141,7 +141,7 @@ Object {
   "duration": "PT29M30S",
   "embedURL": "https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps/amp?morph_env=live",
   "name": "ماښامنۍ خپرونه",
-  "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg",
+  "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png",
   "uploadDate": "2020-05-01T00:00:00.000Z",
 }
 `;

--- a/src/integration/pages/onDemandRadioEpisode/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioEpisode/pashto/__snapshots__/canonical.test.js.snap
@@ -40,7 +40,7 @@ Object {
   "duration": "PT29M30S",
   "embedURL": "https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_radio/w3ct0lz1/ps?morph_env=live",
   "name": "ماښامنۍ خپرونه",
-  "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg",
+  "thumbnailUrl": "https://ichef.bbci.co.uk/images/ic/1024x576/p08b23c8.png",
   "uploadDate": "2020-05-01T00:00:00.000Z",
 }
 `;


### PR DESCRIPTION
Pashto fixtures for on-demand radio were previously using the older on-demand radio episode image `ichef.bbci.co.uk/.../.../p063j1dv.jpg`

This updates them to use the new image
`ichef.bbci.co.uk/.../.../p08b23c8.png`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)