### PR TITLE
Bump psammead-timestamp-container version to 4.0.0 & radio-schedule to 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,18 @@
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
         "@bbc/psammead-timestamp-container": "^3.0.3"
+      },
+      "dependencies": {
+        "@bbc/psammead-timestamp-container": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
+          "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
+          "requires": {
+            "@bbc/gel-foundations": "^4.0.1",
+            "@bbc/psammead-timestamp": "^2.2.28",
+            "moment-timezone": "^0.5.26"
+          }
+        }
       }
     },
     "@bbc/psammead-rich-text-transforms": {
@@ -1648,9 +1660,9 @@
       }
     },
     "@bbc/psammead-timestamp-container": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
-      "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-4.0.0.tgz",
+      "integrity": "sha512-jgme3OH4urOv4kB4HC4kfJr2K7g481XN2og7Zi5YlKrPeKwHVdu38cwTGPoVB2OJjE1O8JztYgG6/iewzYKSLw==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-timestamp": "^2.2.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1532,16 +1532,16 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.4.tgz",
-      "integrity": "sha512-qEdR3w4EYOupg2vxspnDCUYQ1/Mwa6uTq3Ex0JSWcWHcxAjp+XpnzZ+c042AauNgvZV5smVWJxOq7WAqdZsE2Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-3.0.5.tgz",
+      "integrity": "sha512-QDrAfje80W5GHPOLEHZoG4b9gKh+GRso/4qIkuIBJsXhDaDCytV+4v0LLCTcHrcvKFS21z/qHqLP2EXkzq/3pA==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-assets": "^2.14.0",
         "@bbc/psammead-detokeniser": "^1.0.0",
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
-        "@bbc/psammead-timestamp-container": "^3.0.3"
+        "@bbc/psammead-timestamp-container": "^4.0.0"
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,18 +1542,6 @@
         "@bbc/psammead-live-label": "^1.0.0",
         "@bbc/psammead-styles": "^4.4.0",
         "@bbc/psammead-timestamp-container": "^3.0.3"
-      },
-      "dependencies": {
-        "@bbc/psammead-timestamp-container": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@bbc/psammead-timestamp-container/-/psammead-timestamp-container-3.0.3.tgz",
-          "integrity": "sha512-+oal9v6Lcbb7u8osqSp/udNwKe99v2WvXT2DRwOkKjNjZBGg4bvFeqgidaZB3L8okN7OweiO/nyXMMJ2Zq1jxQ==",
-          "requires": {
-            "@bbc/gel-foundations": "^4.0.1",
-            "@bbc/psammead-timestamp": "^2.2.28",
-            "moment-timezone": "^0.5.26"
-          }
-        }
       }
     },
     "@bbc/psammead-rich-text-transforms": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@bbc/psammead-story-promo": "^6.0.3",
     "@bbc/psammead-story-promo-list": "^4.0.8",
     "@bbc/psammead-styles": "^4.4.0",
-    "@bbc/psammead-timestamp-container": "^3.0.3",
+    "@bbc/psammead-timestamp-container": "^4.0.0",
     "@bbc/psammead-useful-links": "^1.0.18",
     "@bbc/psammead-visually-hidden-text": "^1.3.0",
     "@loadable/component": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bbc/psammead-most-read": "^4.1.2",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",
-    "@bbc/psammead-radio-schedule": "^3.0.4",
+    "@bbc/psammead-radio-schedule": "^3.0.5",
     "@bbc/psammead-rich-text-transforms": "^2.0.1",
     "@bbc/psammead-script-link": "^1.0.15",
     "@bbc/psammead-section-label": "^5.0.6",


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/3474

**Overall change:**
Implementing the work within this Psammead Pr into Simorgh: https://github.com/bbc/psammead/pull/3472

**Code changes**
Increased version of `psammead-timestamp-container` within package.json from 3.0.3 to 4.0.0. This was a major change, captured here: https://github.com/bbc/psammead/pull/3472

Bumped version of `psammead-radio-schedule` to 3.0.5, this minor version change updates the package to make use of `psammead-timestamp-container` 4.0.0

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
