### PR TITLE
Bump @bbc/psammead-social-embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1588,9 +1588,9 @@
       }
     },
     "@bbc/psammead-social-embed": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-social-embed/-/psammead-social-embed-1.1.1.tgz",
-      "integrity": "sha512-E5uJBlM0yj9M6Q5tshTuKlLGiT8r4KRwpxT5tYfLMAQ4rear1P+eo4JCGs1bF1wnlMjfjowZx0JB1HjW6Z29GA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-social-embed/-/psammead-social-embed-1.1.2.tgz",
+      "integrity": "sha512-JMvBfRa607+G+07b76VOM8AkVfDvfK4gpifs4TqVVtEu9JOW0IGlrb1yMkb7hGtGRw+zjdWqPcdhXfDrfIiz+Q==",
       "requires": {
         "@bbc/gel-foundations": "^4.0.1",
         "@bbc/psammead-styles": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@bbc/psammead-script-link": "^1.0.15",
     "@bbc/psammead-section-label": "^5.0.6",
     "@bbc/psammead-sitewide-links": "^4.0.12",
-    "@bbc/psammead-social-embed": "^1.1.1",
+    "@bbc/psammead-social-embed": "^1.1.2",
     "@bbc/psammead-story-promo": "^6.0.3",
     "@bbc/psammead-story-promo-list": "^4.0.8",
     "@bbc/psammead-styles": "^4.4.0",

--- a/src/app/containers/SocialEmbed/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/SocialEmbed/__snapshots__/index.test.jsx.snap
@@ -1,16 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SocialEmbedContainer AMP should render correctly 1`] = `
-<html>
-  <head>
-    <script
-      async="true"
-      custom-element="amp-twitter"
-      src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"
-    />
-  </head>
-  <body>
-    .c2 {
+.c2 {
   position: relative;
 }
 
@@ -120,7 +111,16 @@ exports[`SocialEmbedContainer AMP should render correctly 1`] = `
   }
 }
 
-<div>
+<html>
+  <head>
+    <script
+      async="true"
+      custom-element="amp-twitter"
+      src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"
+    />
+  </head>
+  <body>
+    <div>
       <div
         class="c0"
       >
@@ -157,7 +157,7 @@ exports[`SocialEmbedContainer AMP should render correctly 1`] = `
 </html>
 `;
 
-exports[`SocialEmbedContainer Canonical should render correctly 1`] = `
+exports[`SocialEmbedContainer Canonical should render and unmount correctly 1`] = `
 .c2 {
   position: relative;
 }
@@ -284,65 +284,53 @@ exports[`SocialEmbedContainer Canonical should render correctly 1`] = `
   }
 }
 
-<html>
-  <head>
-    <script
-      async="true"
-      src="https://platform.twitter.com/widgets.js"
-    />
-  </head>
-  <body>
-    <div>
-      <div
-        class="c0"
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <a
+        class="c3"
+        href="#skip-twitter-content-2"
       >
-        <div
-          class="c1"
+        Skip Twitter content, 2
+      </a>
+      <div
+        class="c4"
+      >
+        <blockquote
+          class="twitter-tweet"
         >
-          <div
-            class="c2"
+          <p
+            dir="ltr"
+            lang="en"
           >
-            <a
-              class="c3"
-              href="#skip-twitter-content-2"
-            >
-              Skip Twitter content, 2
-            </a>
-            <div
-              class="c4"
-            >
-              <blockquote
-                class="twitter-tweet"
-              >
-                <p
-                  dir="ltr"
-                  lang="en"
-                >
-                  Australia: Due to the recommendations of local, state, federal and international government authorities, including the Center for Disease Control, to reduce potential health risks in response to the current global health crisis, we are no longer traveling to Aus for the show.
-                </p>
-                — Miley Ray Cyrus (@MileyCyrus) 
-                <a
-                  href="https://twitter.com/MileyCyrus/status/1237210910835392512?ref_src=twsrc%5Etfw"
-                >
-                  March 10, 2020
-                </a>
-              </blockquote>
-              
+            Australia: Due to the recommendations of local, state, federal and international government authorities, including the Center for Disease Control, to reduce potential health risks in response to the current global health crisis, we are no longer traveling to Aus for the show.
+          </p>
+          — Miley Ray Cyrus (@MileyCyrus) 
+          <a
+            href="https://twitter.com/MileyCyrus/status/1237210910835392512?ref_src=twsrc%5Etfw"
+          >
+            March 10, 2020
+          </a>
+        </blockquote>
+        
 
-            </div>
-            <p
-              class="c5"
-              id="skip-twitter-content-2"
-              tabindex="-1"
-            >
-              End of Twitter content, 2
-            </p>
-          </div>
-        </div>
       </div>
+      <p
+        class="c5"
+        id="skip-twitter-content-2"
+        tabindex="-1"
+      >
+        End of Twitter content, 2
+      </p>
     </div>
-  </body>
-</html>
+  </div>
+</div>
 `;
 
 exports[`SocialEmbedContainer Canonical should render correctly without an embed block 1`] = `

--- a/src/app/containers/SocialEmbed/index.test.jsx
+++ b/src/app/containers/SocialEmbed/index.test.jsx
@@ -7,13 +7,26 @@ import { twitterBlock, twitterBlockNoEmbed } from './fixtures';
 
 describe('SocialEmbedContainer', () => {
   describe('Canonical', () => {
-    shouldMatchSnapshot(
-      'should render correctly',
-      withContexts(SocialEmbedContainer, {
-        isAmp: false,
-        isEnabled: true,
-      })({ blocks: [twitterBlock] }),
-    );
+    it('should render and unmount correctly', () => {
+      const { container, unmount } = render(
+        withContexts(SocialEmbedContainer, {
+          isAmp: false,
+          isEnabled: true,
+        })({ blocks: [twitterBlock] }),
+      );
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        document.querySelector(
+          'head script[src="https://platform.twitter.com/widgets.js"]',
+        ),
+      ).toBeTruthy();
+      unmount();
+      expect(
+        document.querySelector(
+          'head script[src="https://platform.twitter.com/widgets.js"]',
+        ),
+      ).toBeFalsy();
+    });
 
     it('should not render when disabled', () => {
       const { container } = render(


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/6448.

**Overall change:**
This bump introduces fixes for:
- Sporadic hydration warnings caused by Tweets and Instagram embeds.
- The possibility of duplicate provider scripts being added to the `<head />`.

**Code changes:**

- Bump @bbc/psammead-social-embed to latest
- Update test.
- Update snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- ~~[ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- ~~[ ] This PR requires manual testing~~
