### PR TITLE
Temporarily whitelist markdown-to-jsx from audit-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "stop": "./scripts/killApp.sh",
     "storybook": "start-storybook -p 9001 -s .storybook/static -c .storybook",
     "test": "npm run test:lint && npm run test:dependencies && npm run test:unit && npm run build -- --hide-modules --colors && run-p --race start amp:validate && run-p --race start test:integration:ci",
-    "test:ci": "npm run start & npm install --no-save cypress@3.4.1 bbc-a11y@latest npm-run-all@latest puppeteer@latest audit-ci@latest && npm run test:integration:ci && run-p cypress:ci test:puppeteer && run-p bbcA11y:ci lighthouse && audit-ci --low --whitelist http-proxy",
+    "test:ci": "npm run start & npm install --no-save cypress@3.4.1 bbc-a11y@latest npm-run-all@latest puppeteer@latest audit-ci@latest && npm run test:integration:ci && run-p cypress:ci test:puppeteer && run-p bbcA11y:ci lighthouse && audit-ci --low --whitelist http-proxy markdown-to-jsx",
     "test:dependencies": "node ./scripts/dependencyCheck",
     "test:e2e": "npm run stop && npm run build && run-p --race start cypress",
     "test:e2e:interactive": "npm run stop && npm run build && run-p --race start cypress:interactive",


### PR DESCRIPTION
(no issue)

**Overall change:**
Temporarily whitelist markdown-to-jsx till a fix is available: https://www.npmjs.com/advisories/1219

```
simorgh@1.0.0 /Users/donohj03/repos/simorgh
├─┬ @storybook/addon-knobs@5.3.18
│ └─┬ @storybook/components@5.3.18
│   └── markdown-to-jsx@6.11.1
└─┬ @storybook/react@5.3.18
  └─┬ @storybook/core@5.3.18
    └─┬ @storybook/ui@5.3.18
      └── markdown-to-jsx@6.11.1  deduped
```

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [NA] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [no] This PR requires manual testing
