### PR TITLE
OD radio styling of BrandTitle to match a11y guidelines

### DIFF
--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/__snapshots__/index.test.jsx.snap
@@ -26,7 +26,8 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
 }
 
 .c1 {
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: 0.5rem;
 }
 

--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/index.jsx
@@ -22,7 +22,8 @@ const StyledHeadline = styled(Headline)`
 `;
 
 const BrandTitle = styled.span`
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: ${GEL_SPACING};
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
     padding-bottom: 0;

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -237,7 +237,8 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 }
 
 .c7 {
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: 0.5rem;
 }
 
@@ -742,7 +743,8 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 }
 
 .c7 {
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: 0.5rem;
 }
 
@@ -1453,7 +1455,8 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 }
 
 .c7 {
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: 0.5rem;
 }
 
@@ -1901,7 +1904,8 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 }
 
 .c7 {
-  display: block;
+  display: inline-block;
+  width: 100%;
   padding-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
Resolves #6579

**Overall change:**
Changed styling of `BrandTitle` from:

```
display:block
```

to:

```
display: inline-block;
width: 100%
```

So that it does not interrupt the NVDA screen-reader reading over the `H1`. Issue explains in more detail.

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
