### PR TITLE
Enable PGL E2E assets on all envs

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -123,7 +123,7 @@ module.exports = () => ({
           },
           local: {
             paths: ['/afaanoromoo/oduu-41217768'],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: false,

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -114,15 +114,27 @@ module.exports = () => ({
       photoGalleryPage: {
         environments: {
           live: {
-            paths: ['/afaanoromoo/oduu-50716382'],
-            enabled: false,
+            paths: [
+              '/pidgin/tori-49221071',
+              '/mundo/deportes-36935058', // PGL LTR
+              '/persian/magazine-49281981', // PGL RTL
+            ],
+            enabled: true,
           },
           test: {
-            paths: ['/afaanoromoo/oduu-23141286'],
-            enabled: false,
+            paths: [
+              '/pidgin/media-23133346',
+              '/mundo/23100337', // PGL LRT
+              '/persian/world-23080171', // PGL RTL
+            ],
+            enabled: true,
           },
           local: {
-            paths: ['/afaanoromoo/oduu-41217768'],
+            paths: [
+              '/pidgin/tori-49221071',
+              '/mundo/deportes-36935058', // PGL LTR
+              '/persian/magazine-49281981', // PGL RTL
+            ],
             enabled: true,
           },
         },

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -114,28 +114,16 @@ module.exports = () => ({
       photoGalleryPage: {
         environments: {
           live: {
-            paths: [
-              '/pidgin/tori-49221071',
-              '/mundo/deportes-36935058', // PGL LTR
-              '/persian/magazine-49281981', // PGL RTL
-            ],
-            enabled: true,
+            paths: ['/afaanoromoo/oduu-50716382'],
+            enabled: false,
           },
           test: {
-            paths: [
-              '/pidgin/media-23133346',
-              '/mundo/23100337', // PGL LRT
-              '/persian/world-23080171', // PGL RTL
-            ],
-            enabled: true,
+            paths: ['/afaanoromoo/oduu-23141286'],
+            enabled: false,
           },
           local: {
-            paths: [
-              '/pidgin/tori-49221071',
-              '/mundo/deportes-36935058', // PGL LTR
-              '/persian/magazine-49281981', // PGL RTL
-            ],
-            enabled: true,
+            paths: ['/afaanoromoo/oduu-41217768'],
+            enabled: false,
           },
         },
         smoke: false,
@@ -2837,11 +2825,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/mundo/deportes-36935058'],
-            enabled: false,
+            enabled: true,
           },
           test: {
             paths: ['/mundo/noticias-23147451'],
-            enabled: false,
+            enabled: true,
           },
           local: {
             paths: ['/mundo/deportes-36935058'],
@@ -3459,11 +3447,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/persian/magazine-49281981'],
-            enabled: false,
+            enabled: true,
           },
           test: {
             paths: ['/persian/23104784'],
-            enabled: false,
+            enabled: true,
           },
           local: {
             paths: ['/persian/magazine-49281981'],
@@ -3588,11 +3576,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/pidgin/50913502'],
-            enabled: false,
+            enabled: true,
           },
           test: {
             paths: ['/pidgin/sport-23252855'],
-            enabled: false,
+            enabled: true,
           },
           local: {
             paths: ['/pidgin/sport-23252855'],


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Enables e2e's for PGL assets on `local` `test` and `live`.

**Code changes:**

- Enables PGL assets in Cypress config

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
