### PR TITLE
Disabled live radio e2es for 18 services

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -225,11 +225,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/afrique/bbc_afrique_radio/liveradio'],
@@ -395,11 +395,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/amharic/bbc_amharic_radio/liveradio'],
@@ -560,11 +560,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/arabic/bbc_arabic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/arabic/bbc_arabic_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/arabic/bbc_arabic_radio/liveradio'],
@@ -865,11 +865,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/bengali/bbc_bangla_radio/liveradio'],
@@ -1035,11 +1035,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/burmese/bbc_burmese_radio/liveradio'],
@@ -1254,11 +1254,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/gahuza/bbc_gahuza_radio/liveradio'],
@@ -1557,11 +1557,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/hausa/bbc_hausa_radio/liveradio'],
@@ -2026,11 +2026,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/indonesia/bbc_indonesian_radio/liveradio'],
@@ -2494,11 +2494,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/kyrgyz/bbc_kyrgyz_radio/liveradio'],
@@ -2984,11 +2984,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/nepali/bbc_nepali_radio/liveradio'],
@@ -3203,11 +3203,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/pashto/bbc_pashto_radio/liveradio'],
@@ -4392,11 +4392,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
@@ -4560,11 +4560,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/somali/bbc_somali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/somali/bbc_somali_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/somali/bbc_somali_radio/liveradio'],
@@ -4746,11 +4746,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/swahili/bbc_swahili_radio/liveradio'],
@@ -4916,11 +4916,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/tamil/bbc_tamil_radio/liveradio'],
@@ -5352,11 +5352,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/tigrinya/bbc_tigrinya_radio/liveradio'],
@@ -6066,11 +6066,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/urdu/bbc_urdu_radio/liveradio'],
@@ -6236,11 +6236,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/uzbek/bbc_uzbek_radio/liveradio'],

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1726,11 +1726,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/hindi/bbc_hindi_radio/liveradio'],


### PR DESCRIPTION

**Overall change:**

As part of reducing the run time of the Cypress tests, I am disabling some of the services that run on live radio pages.

Keeping 

afaanoromoo (keeping due to the two different url issue)
Hindi (having a redirect related to hindi radio soon, not sure if keeping it in is needed but can remove later)
Korean (LTR)
Persian (bbc_persian_radio and bbc_dari_radio) (RTL)


Removed

Afrique
Amharic
Arabic
Bengali
Burmese
Gahuza
Hausa
Indonesia
Kyrgyz
Nepali
Pashto
Sinhala
Somali
Swahili
Tamil
Tigrinya
Urdu
Uzbek

**Code changes:**

Changed enabled to false.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Running these services on my machine took 73.36 seconds on test and 72.25 seconds on live when just running the live radio page type.
