### PR TITLE
Remove Canonical Ads

### DIFF
--- a/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
@@ -1,22 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Ad Container Snapshots should correctly render a Canonical ad 1`] = `
-<html>
-  <head>
-    <script
-      src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
-    />
-  </head>
-  <body>
-    <div>
-      <div
-        class="dotcom-ad"
-        id="dotcom-leaderboard"
-      />
-    </div>
-  </body>
-</html>
-`;
+exports[`Ad Container Snapshots should correctly render a Canonical ad 1`] = `<div />`;
 
 exports[`Ad Container Snapshots should correctly render an AMP ad 1`] = `
 .c0 {

--- a/src/app/containers/Ad/index.jsx
+++ b/src/app/containers/Ad/index.jsx
@@ -4,7 +4,6 @@ import useToggle from '#hooks/useToggle';
 import { RequestContext } from '../../contexts/RequestContext';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import Amp from './Amp';
-import Canonical from './Canonical';
 
 const AdContainer = () => {
   const { isAmp } = useContext(RequestContext);
@@ -16,8 +15,10 @@ const AdContainer = () => {
     return null;
   }
 
-  const Ad = isAmp ? Amp : Canonical;
-  return <Ad />;
+  if (isAmp) {
+    return <Amp />;
+  }
+  return null;
 };
 
 export default AdContainer;


### PR DESCRIPTION
Resolves Build Pipeline issues

**Overall change:**
Removing Canonical Ads for now as an error has started blocking the pipeline.

**Code changes:**

- Remove the code that loads a canonical ad
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
