### PR TITLE
Remove STY byline e2e

### DIFF
--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -23,25 +23,6 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
         cy.get('main p').should('contain', description);
       });
     });
-
-    it('should render a byline for the page', () => {
-      cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-        const { name, title, persons } = body.promo.byline;
-        const [person] = persons;
-
-        if (name) {
-          cy.get('main ul li').should('contain', name);
-        } else {
-          cy.get('main ul li').should('contain', person.name);
-        }
-
-        if (title) {
-          cy.get('main ul li').should('contain', title);
-        } else {
-          cy.get('main ul li').should('contain', person.function);
-        }
-      });
-    });
   });
 };
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Removed the CPS byline test that fails when a byline is not present (Bylines are not required)

This will soon be replaced with an integration test. 

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
