### PR TITLE
Remove padding when screen is smaller than 1008px

### DIFF
--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -287,10 +287,6 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   flex-grow: 1;
 }
 
-.c4 {
-  padding-top: 1.5rem;
-}
-
 @supports (display:grid) {
   .c0 {
     display: grid;
@@ -603,6 +599,12 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   }
 }
 
+@media (min-width:63rem) {
+  .c4 {
+    padding-top: 1.5rem;
+  }
+}
+
 <div>
       <amp-analytics>
         <script
@@ -797,10 +799,6 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-}
-
-.c4 {
-  padding-top: 1.5rem;
 }
 
 .c16 {
@@ -1122,6 +1120,12 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   .c4 {
     margin: 0 auto;
     max-width: 80rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c4 {
+    padding-top: 1.5rem;
   }
 }
 
@@ -1499,10 +1503,6 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
   flex-grow: 1;
 }
 
-.c4 {
-  padding-top: 1.5rem;
-}
-
 @supports (display:grid) {
   .c0 {
     display: grid;
@@ -1802,6 +1802,12 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
   }
 }
 
+@media (min-width:63rem) {
+  .c4 {
+    padding-top: 1.5rem;
+  }
+}
+
 <div>
   <noscript />
   <div>
@@ -1985,10 +1991,6 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-}
-
-.c4 {
-  padding-top: 1.5rem;
 }
 
 @supports (display:grid) {
@@ -2311,6 +2313,12 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   .c4 {
     margin: 0 auto;
     max-width: 80rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c4 {
+    padding-top: 1.5rem;
   }
 }
 

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { shape, string, number } from 'prop-types';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
+import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import MetadataContainer from '../../containers/Metadata';
 import ATIAnalytics from '../../containers/ATIAnalytics';
 import ChartbeatAnalytics from '../../containers/ChartbeatAnalytics';
@@ -41,7 +42,9 @@ const StyledGelPageGrid = styled(GelPageGrid)`
 `;
 
 const StyledGelWrapperGrid = styled(GelPageGrid)`
-  padding-top: ${GEL_SPACING_TRPL};
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    padding-top: ${GEL_SPACING_TRPL};
+  }
 `;
 
 /* eslint-disable react/prop-types */


### PR DESCRIPTION
Resolves #6785

**Overall change:**
Removed additional padding above episode info for smaller screens 

**Code changes:**

Padding is now enclosed in a media query

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
