### PR TITLE
Updating OD Radio Styling

### DIFF
--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/__snapshots__/index.test.jsx.snap
@@ -62,7 +62,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
 
 @media screen {
   .c0 {
-    padding: 2rem 0 1.5rem;
+    padding: 2rem 0 1rem;
   }
 }
 

--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandHeading/index.jsx
@@ -6,7 +6,7 @@ import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import {
   GEL_SPACING_QUAD,
   GEL_SPACING,
-  GEL_SPACING_TRPL,
+  GEL_SPACING_DBL,
   GEL_SPACING_SEPT,
 } from '@bbc/gel-foundations/spacings';
 import { MEDIA_QUERY_TYPOGRAPHY } from '@bbc/gel-foundations/breakpoints';
@@ -17,7 +17,7 @@ import { ServiceContext } from '#contexts/ServiceContext';
 
 const StyledHeadline = styled(Headline)`
   @media screen {
-    padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_TRPL};
+    padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_DBL};
   }
 `;
 

--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandImage/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandImage/__snapshots__/index.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
 }
 
 .c0 {
-  padding: 2rem 0;
+  padding: 2rem 0 1.5rem;
   padding-right: 1rem;
 }
 

--- a/src/app/containers/RadioPageBlocks/Blocks/OnDemandImage/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/OnDemandImage/index.jsx
@@ -5,6 +5,7 @@ import Image, { AmpImg } from '@bbc/psammead-image';
 import {
   GEL_SPACING_QUAD,
   GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
 } from '@bbc/gel-foundations/spacings';
 import { GEL_GROUP_1_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
 import { RequestContext } from '#contexts/RequestContext';
@@ -13,7 +14,7 @@ import { ServiceContext } from '#contexts/ServiceContext';
 const paddingDir = ({ dir }) => `padding-${dir === 'rtl' ? 'left' : 'right'}`;
 
 const ImageContainer = styled.div`
-  padding: ${GEL_SPACING_QUAD} 0;
+  padding: ${GEL_SPACING_QUAD} 0 ${GEL_SPACING_TRPL};
   ${paddingDir}: ${GEL_SPACING_DBL};
   @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     display: none;

--- a/src/app/containers/RadioPageBlocks/Blocks/Paragraph/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioPageBlocks/Blocks/Paragraph/__snapshots__/index.test.jsx.snap
@@ -26,6 +26,12 @@ exports[`MediaPageBlocks Paragraph should render correctly 1`] = `
   }
 }
 
+@media (max-width:62.9375rem) {
+  .c0 {
+    padding-bottom: 0.5rem;
+  }
+}
+
 <p
   class="c0"
   id="idAttr"

--- a/src/app/containers/RadioPageBlocks/Blocks/Paragraph/index.jsx
+++ b/src/app/containers/RadioPageBlocks/Blocks/Paragraph/index.jsx
@@ -1,7 +1,16 @@
 import React, { useContext } from 'react';
+import styled from 'styled-components';
 import { string } from 'prop-types';
+import { GEL_SPACING } from '@bbc/gel-foundations/spacings';
+import { GEL_GROUP_3_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
 import ParagraphComponent from '@bbc/psammead-paragraph';
 import { ServiceContext } from '#contexts/ServiceContext';
+
+const StyledParagraphComponent = styled(ParagraphComponent)`
+  @media (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
+    padding-bottom: ${GEL_SPACING};
+  }
+`;
 
 const ParagraphContainer = ({ idAttr, text }) => {
   const { script, service } = useContext(ServiceContext);
@@ -9,9 +18,9 @@ const ParagraphContainer = ({ idAttr, text }) => {
   if (!text) return null;
 
   return (
-    <ParagraphComponent script={script} service={service} id={idAttr}>
+    <StyledParagraphComponent script={script} service={service} id={idAttr}>
       {text}
-    </ParagraphComponent>
+    </StyledParagraphComponent>
   );
 };
 

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -275,7 +275,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 }
 
 .c12 {
-  padding: 2rem 0;
+  padding: 2rem 0 1.5rem;
   padding-left: 1rem;
 }
 
@@ -513,7 +513,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 
 @media screen {
   .c6 {
-    padding: 2rem 0 1.5rem;
+    padding: 2rem 0 1rem;
   }
 }
 
@@ -549,6 +549,12 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   .c10 {
     font-size: 1.375rem;
     line-height: 2rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c10 {
+    padding-bottom: 0.5rem;
   }
 }
 
@@ -789,7 +795,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 }
 
 .c12 {
-  padding: 2rem 0;
+  padding: 2rem 0 1.5rem;
   padding-left: 1rem;
 }
 
@@ -1037,7 +1043,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 
 @media screen {
   .c6 {
-    padding: 2rem 0 1.5rem;
+    padding: 2rem 0 1rem;
   }
 }
 
@@ -1073,6 +1079,12 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   .c10 {
     font-size: 1.375rem;
     line-height: 2rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c10 {
+    padding-bottom: 0.5rem;
   }
 }
 
@@ -1491,7 +1503,7 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 }
 
 .c12 {
-  padding: 2rem 0;
+  padding: 2rem 0 1.5rem;
   padding-right: 1rem;
 }
 
@@ -1729,7 +1741,7 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
 
 @media screen {
   .c6 {
-    padding: 2rem 0 1.5rem;
+    padding: 2rem 0 1rem;
   }
 }
 
@@ -1765,6 +1777,12 @@ exports[`OnDemand Radio Page  should not show the audio player if it is not avai
   .c10 {
     font-size: 1rem;
     line-height: 1.75rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c10 {
+    padding-bottom: 0.5rem;
   }
 }
 
@@ -1981,7 +1999,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 }
 
 .c12 {
-  padding: 2rem 0;
+  padding: 2rem 0 1.5rem;
   padding-right: 1rem;
 }
 
@@ -2219,7 +2237,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 
 @media screen {
   .c6 {
-    padding: 2rem 0 1.5rem;
+    padding: 2rem 0 1rem;
   }
 }
 
@@ -2255,6 +2273,12 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   .c10 {
     font-size: 1rem;
     line-height: 1.75rem;
+  }
+}
+
+@media (max-width:62.9375rem) {
+  .c10 {
+    padding-bottom: 0.5rem;
   }
 }
 

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
       </div>
       <strong
         aria-hidden="true"
-        class="Headline-sc-1kh1qhu-0 StyledHeadline-gehp0k-0 gEGsBa"
+        class="Headline-sc-1kh1qhu-0 StyledHeadline-gehp0k-0 gBkukD"
       >
         <span
           class="BrandTitle-gehp0k-1 fjmQIa"
@@ -61,7 +61,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
         </span>
       </strong>
       <p
-        class="Paragraph-k859h4-0 fxxgUd"
+        class="Paragraph-k859h4-0 StyledParagraphComponent-v70vjd-0 cvyKtV"
       >
         د بي بي سي پښتو ټلویزیوني خپرونه چې هره ورځ د افغانستان په شپږ بجو په ژوندۍ بڼه خپرېږي. دلته یې لیدلی شئ.
       </p>


### PR DESCRIPTION
Resolves #6790

**Overall change:**

Updating the display of the OD Radio pages as per Ed's designs.

**Code changes:**

- Reduced padding at the bottom of the summary to 8px for screen size below 1008px
- Set padding to 16px between H1 + date and date + paragraph across all breakpoints
- Reduced padding at the bottom of the image from 32px to 24px

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
