### PR TITLE
Amend Sinhala live e2e STY asset

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4520,7 +4520,7 @@ module.exports = () => ({
       storyPage: {
         environments: {
           live: {
-            paths: ['/sinhala/sri-lanka-52851837'],
+            paths: ['/sinhala/world-51723376'],
             enabled: true,
           },
           test: {


### PR DESCRIPTION
Resolves No Issue

**Overall change:**
Due to a failing test on the live build, the Sinhala live e2e STY asset url needs to be updated. The current asset is failing because it doesn't have an "Introduction" role. I have also ran the test locally with the live tests, and it is now passing.

**Code changes:**

- Changed Sinhala STY live asset URL.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
