### PR TITLE
Update most read stale data log

### DIFF
--- a/src/app/containers/MostRead/Canonical/index.jsx
+++ b/src/app/containers/MostRead/Canonical/index.jsx
@@ -108,6 +108,7 @@ const CanonicalMostRead = ({
     service,
     timezone,
     items,
+    isAmp,
   ]);
 
   if (!items) {

--- a/src/app/containers/MostRead/utilities/processMostRead.js
+++ b/src/app/containers/MostRead/utilities/processMostRead.js
@@ -97,6 +97,7 @@ const mostReadItems = ({ data, isAmp, numberOfItems, service }) => {
   logger.warn(MOST_READ_STALE_DATA, {
     message: 'lastRecordTimeStamp is greater than 60min',
     lastRecordTimeStamp: data.lastRecordTimeStamp,
+    generated: data.generated,
     service,
     isAmp,
   });

--- a/src/app/containers/MostRead/utilities/processMostRead.test.js
+++ b/src/app/containers/MostRead/utilities/processMostRead.test.js
@@ -293,6 +293,7 @@ describe('processMostRead', () => {
       expect(nodeLogger.warn).toHaveBeenCalledWith(MOST_READ_STALE_DATA, {
         lastRecordTimeStamp: '2019-11-06T16:28:00Z',
         message: 'lastRecordTimeStamp is greater than 60min',
+        generated: '2019-11-06T17:05:17.981Z',
         service: 'pidgin',
         isAmp: true,
       });


### PR DESCRIPTION
Resolves n/a

**Overall change:**
_Add the generated value from the data response (https://www.bbc.com/pidgin/mostread.json) to the error logs, so that we can check if there is a problem with the data being updated from ares_

**Code changes:**

- _Update server logs for most read stale data_
- _Update unit tests_
- _Add `isAmp` as a dependency of the useEffect (because it was missing before)_
![image](https://user-images.githubusercontent.com/30599794/84169838-016a6e00-aa71-11ea-87cc-cca6d14b8cdc.png)



---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
