### PR TITLE
On Demand TV - Moving styling and page type values out of videoPlayer

### DIFF
--- a/src/app/pages/OnDemandTvPage/VideoPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/VideoPlayer/__snapshots__/index.test.jsx.snap
@@ -18,28 +18,32 @@ exports[`VideoPlayer should render correctly for amp 1`] = `
   <body>
     <div>
       <div
-        class="c0"
+        class=""
       >
-        <amp-iframe
-          allowfullscreen="allowfullscreen"
-          frameborder="0"
-          layout="fill"
-          sandbox="allow-scripts allow-same-origin"
-          scrolling="no"
-          src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
-          title="video player"
+        <div
+          class="c0"
         >
-          <amp-img
-            alt=""
-            attribution=""
-            height="16"
+          <amp-iframe
+            allowfullscreen="allowfullscreen"
+            frameborder="0"
             layout="fill"
-            placeholder="true"
-            src="https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg"
-            width="9"
-          />
-          <noscript />
-        </amp-iframe>
+            sandbox="allow-scripts allow-same-origin"
+            scrolling="no"
+            src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
+            title="video player"
+          >
+            <amp-img
+              alt=""
+              attribution=""
+              height="16"
+              layout="fill"
+              placeholder="true"
+              src="https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg"
+              width="9"
+            />
+            <noscript />
+          </amp-iframe>
+        </div>
       </div>
     </div>
   </body>
@@ -64,16 +68,20 @@ exports[`VideoPlayer should render correctly for canonical 1`] = `
 }
 
 <div
-  class="c0"
+  class=""
 >
-  <iframe
-    allow="autoplay; fullscreen"
-    allowfullscreen=""
-    class="c1"
-    scrolling="no"
-    src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
-    title="video player"
-  />
-  <noscript />
+  <div
+    class="c0"
+  >
+    <iframe
+      allow="autoplay; fullscreen"
+      allowfullscreen=""
+      class="c1"
+      scrolling="no"
+      src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
+      title="video player"
+    />
+    <noscript />
+  </div>
 </div>
 `;

--- a/src/app/pages/OnDemandTvPage/VideoPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/VideoPlayer/__snapshots__/index.test.jsx.snap
@@ -1,21 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VideoPlayer should render correctly for amp 1`] = `
-.c1 {
+.c0 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
-}
-
-.c0 {
-  margin-top: 1.5rem;
-}
-
-@media (max-width:37.4375rem) {
-  .c0 {
-    width: calc(100% + 2rem);
-    margin: 0 -1rem;
-  }
 }
 
 <html>
@@ -31,30 +20,26 @@ exports[`VideoPlayer should render correctly for amp 1`] = `
       <div
         class="c0"
       >
-        <div
-          class="c1"
+        <amp-iframe
+          allowfullscreen="allowfullscreen"
+          frameborder="0"
+          layout="fill"
+          sandbox="allow-scripts allow-same-origin"
+          scrolling="no"
+          src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
+          title="video player"
         >
-          <amp-iframe
-            allowfullscreen="allowfullscreen"
-            frameborder="0"
+          <amp-img
+            alt=""
+            attribution=""
+            height="16"
             layout="fill"
-            sandbox="allow-scripts allow-same-origin"
-            scrolling="no"
-            src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_brand_tv/id/ps/amp?morph_env=live"
-            title="ویډیو پلیئر"
-          >
-            <amp-img
-              alt=""
-              attribution=""
-              height="16"
-              layout="fill"
-              placeholder="true"
-              src="https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg"
-              width="9"
-            />
-            <noscript />
-          </amp-iframe>
-        </div>
+            placeholder="true"
+            src="https://ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg"
+            width="9"
+          />
+          <noscript />
+        </amp-iframe>
       </div>
     </div>
   </body>
@@ -62,17 +47,13 @@ exports[`VideoPlayer should render correctly for amp 1`] = `
 `;
 
 exports[`VideoPlayer should render correctly for canonical 1`] = `
-.c1 {
+.c0 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.c0 {
-  margin-top: 1.5rem;
-}
-
-.c2 {
+.c1 {
   border: 0;
   left: 0;
   overflow: hidden;
@@ -82,28 +63,17 @@ exports[`VideoPlayer should render correctly for canonical 1`] = `
   height: 100%;
 }
 
-@media (max-width:37.4375rem) {
-  .c0 {
-    width: calc(100% + 2rem);
-    margin: 0 -1rem;
-  }
-}
-
 <div
   class="c0"
 >
-  <div
+  <iframe
+    allow="autoplay; fullscreen"
+    allowfullscreen=""
     class="c1"
-  >
-    <iframe
-      allow="autoplay; fullscreen"
-      allowfullscreen=""
-      class="c2"
-      scrolling="no"
-      src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_brand_tv/id/ps?morph_env=live"
-      title="ویډیو پلیئر"
-    />
-    <noscript />
-  </div>
+    scrolling="no"
+    src="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live"
+    title="video player"
+  />
+  <noscript />
 </div>
 `;

--- a/src/app/pages/OnDemandTvPage/VideoPlayer/index.jsx
+++ b/src/app/pages/OnDemandTvPage/VideoPlayer/index.jsx
@@ -16,6 +16,7 @@ const VideoPlayer = ({
   embedUrl,
   iframeTitle,
   type,
+  className,
 }) => {
   const { translations, service } = useContext(ServiceContext);
   const { isAmp, platform } = useContext(RequestContext);
@@ -35,7 +36,7 @@ const VideoPlayer = ({
   if (!isValidPlatform || !assetId) return null;
 
   return (
-    <>
+    <div className={className}>
       {isAmp ? (
         <AmpMediaPlayer
           placeholderSrc={placeholderSrc}
@@ -55,7 +56,7 @@ const VideoPlayer = ({
           noJsClassName="no-js"
         />
       )}
-    </>
+    </div>
   );
 };
 
@@ -66,6 +67,7 @@ VideoPlayer.propTypes = {
   type: string,
   title: string,
   iframeTitle: string,
+  className: string,
 };
 
 VideoPlayer.defaultProps = {
@@ -75,6 +77,7 @@ VideoPlayer.defaultProps = {
   type: '',
   title: '',
   iframeTitle: '',
+  className: '',
 };
 
 export default VideoPlayer;

--- a/src/app/pages/OnDemandTvPage/VideoPlayer/index.jsx
+++ b/src/app/pages/OnDemandTvPage/VideoPlayer/index.jsx
@@ -1,98 +1,41 @@
 import React, { useContext } from 'react';
-import { useLocation } from 'react-router-dom';
-import styled from 'styled-components';
-import {
-  GEL_SPACING_DBL,
-  GEL_SPACING_TRPL,
-  GEL_SPACING_QUAD,
-} from '@bbc/gel-foundations/spacings';
-import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
-import { string, bool } from 'prop-types';
-
+import { string } from 'prop-types';
 import {
   CanonicalMediaPlayer,
   AmpMediaPlayer,
-  MediaMessage,
 } from '@bbc/psammead-media-player';
 import pathOr from 'ramda/src/pathOr';
 import { RequestContext } from '#contexts/RequestContext';
 import { ServiceContext } from '#contexts/ServiceContext';
-import getEmbedUrl from '#lib/utilities/getEmbedUrl';
 import getPlaceholderImageUrl from '../../../routes/utils/getPlaceholderImageUrl';
-
-const StyledWrapper = styled.div`
-  margin-top: ${GEL_SPACING_TRPL};
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    width: calc(100% + ${GEL_SPACING_QUAD});
-    margin: 0 -${GEL_SPACING_DBL};
-  }
-`;
-
-const landscapeRatio = '56.25%'; // (9/16)*100 = 16:9
-const StyledMessageContainer = styled.div`
-  padding-top: ${landscapeRatio};
-  position: relative;
-  overflow: hidden;
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    width: calc(100% + ${GEL_SPACING_QUAD});
-    margin: 0 -${GEL_SPACING_DBL};
-  }
-`;
 
 const VideoPlayer = ({
   assetId,
-  masterBrand,
   imageUrl,
-  episodeIsAvailable,
+  title,
+  embedUrl,
+  iframeTitle,
+  type,
 }) => {
-  const { lang, translations, service } = useContext(ServiceContext);
+  const { translations, service } = useContext(ServiceContext);
   const { isAmp, platform } = useContext(RequestContext);
-  const location = useLocation();
+
   const isValidPlatform = ['amp', 'canonical'].includes(platform);
   const mediaInfo = {
-    title: 'On-demand TV',
-    type: 'video',
+    title,
+    type,
   };
   const noJsMessage = pathOr(
     `This ${mediaInfo.type} cannot play in your browser. Please enable JavaScript or try a different browser.`,
     ['media', 'noJs'],
     translations,
   );
-
-  if (!episodeIsAvailable) {
-    const expiredContentMessage = pathOr(
-      'This content is no longer available',
-      ['media', 'contentExpired'],
-      translations,
-    );
-
-    return (
-      <StyledMessageContainer>
-        <MediaMessage service={service} message={expiredContentMessage} />
-      </StyledMessageContainer>
-    );
-  }
   const placeholderSrc = getPlaceholderImageUrl(imageUrl);
 
-  if (!isValidPlatform || !masterBrand || !assetId) return null;
-
-  const mediaId = `${service}/${masterBrand}/${assetId}/${lang}`;
-
-  const embedUrl = getEmbedUrl({
-    mediaId,
-    type: 'media',
-    isAmp,
-    queryString: location.search,
-  });
-
-  const iframeTitle = pathOr(
-    'Video player',
-    ['mediaAssetPage', 'videoPlayer'],
-    translations,
-  );
+  if (!isValidPlatform || !assetId) return null;
 
   return (
-    <StyledWrapper>
+    <>
       {isAmp ? (
         <AmpMediaPlayer
           placeholderSrc={placeholderSrc}
@@ -112,22 +55,26 @@ const VideoPlayer = ({
           noJsClassName="no-js"
         />
       )}
-    </StyledWrapper>
+    </>
   );
 };
 
 VideoPlayer.propTypes = {
-  masterBrand: string,
+  embedUrl: string,
   assetId: string,
   imageUrl: string,
-  episodeIsAvailable: bool,
+  type: string,
+  title: string,
+  iframeTitle: string,
 };
 
 VideoPlayer.defaultProps = {
-  masterBrand: '',
+  embedUrl: '',
   assetId: '',
   imageUrl: '',
-  episodeIsAvailable: true,
+  type: '',
+  title: '',
+  iframeTitle: '',
 };
 
 export default VideoPlayer;

--- a/src/app/pages/OnDemandTvPage/VideoPlayer/index.test.jsx
+++ b/src/app/pages/OnDemandTvPage/VideoPlayer/index.test.jsx
@@ -11,6 +11,11 @@ const defaultTvPlayerProps = {
   assetId: 'id',
   imageUrl: 'ichef.bbci.co.uk/images/ic/1024x576/p063j1dv.jpg',
   masterBrand: 'bbc_brand_tv',
+  title: 'On Demand TV',
+  embedUrl:
+    'https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps/amp?morph_env=live',
+  iframeTitle: 'video player',
+  type: 'video',
 };
 
 const defaultRequestContextValue = { platform: 'foobar', origin };

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
   </div>
   <noscript />
   <main
-    class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1brqmij-1 cyJdzv"
+    class="GridComponent-nf79gm-0 iakllL GelPageGrid-ylca1m-0 StyledGelPageGrid-sc-1brqmij-2 dmHANZ"
     dir="rtl"
     role="main"
   >
@@ -28,7 +28,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
         class="StyledGelWrapperGrid-sc-1brqmij-0 eydjDr"
       >
         <div
-          class="StyledMessageContainer-tc95in-1 glnohn"
+          class="StyledMessageContainer-sc-1brqmij-1 lbxLAU"
         >
           <div
             class="StyledWrapper-sc-1pnftlt-0 jywlaE"

--- a/src/app/pages/OnDemandTvPage/index.jsx
+++ b/src/app/pages/OnDemandTvPage/index.jsx
@@ -55,7 +55,7 @@ const StyledGelPageGrid = styled(GelPageGrid)`
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 
-const StyledWrapper = styled.div`
+const StyledVideoPlayer = styled(VideoPlayer)`
   margin-top: ${GEL_SPACING_TRPL};
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     width: calc(100% + ${GEL_SPACING_QUAD});
@@ -167,16 +167,14 @@ const OnDemandTvPage = ({ pageData }) => {
             enableGelGutters
           >
             {episodeIsAvailable ? (
-              <StyledWrapper>
-                <VideoPlayer
-                  embedUrl={embedUrl}
-                  assetId={episodeId}
-                  imageUrl={imageUrl}
-                  type={type}
-                  title={title}
-                  iframeTitle={iframeTitle}
-                />
-              </StyledWrapper>
+              <StyledVideoPlayer
+                embedUrl={embedUrl}
+                assetId={episodeId}
+                imageUrl={imageUrl}
+                type={type}
+                title={title}
+                iframeTitle={iframeTitle}
+              />
             ) : (
               <StyledMessageContainer>
                 <MediaMessage

--- a/src/app/pages/OnDemandTvPage/index.jsx
+++ b/src/app/pages/OnDemandTvPage/index.jsx
@@ -3,9 +3,13 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { shape, string, number, bool } from 'prop-types';
 import {
+  GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
+import pathOr from 'ramda/src/pathOr';
+import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
+import { MediaMessage } from '@bbc/psammead-media-player';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { formatUnixTimestamp } from '@bbc/psammead-timestamp-container/utilities';
 import ChartbeatAnalytics from '../../containers/ChartbeatAnalytics';
@@ -24,6 +28,18 @@ const StyledGelWrapperGrid = styled.div`
   padding-top: ${GEL_SPACING_TRPL};
 `;
 
+const landscapeRatio = '56.25%'; // (9/16)*100 = 16:9
+const StyledMessageContainer = styled.div`
+  margin-top: ${GEL_SPACING_TRPL};
+  padding-top: ${landscapeRatio};
+  position: relative;
+  overflow: hidden;
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    width: calc(100% + ${GEL_SPACING_QUAD});
+    margin: 0 -${GEL_SPACING_DBL};
+  }
+`;
+
 const getGroups = (zero, one, two, three, four, five) => ({
   group0: zero,
   group1: one,
@@ -37,6 +53,14 @@ const StyledGelPageGrid = styled(GelPageGrid)`
   padding-bottom: ${GEL_SPACING_QUAD};
   width: 100%;
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
+`;
+
+const StyledWrapper = styled.div`
+  margin-top: ${GEL_SPACING_TRPL};
+  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
+    width: calc(100% + ${GEL_SPACING_QUAD});
+    margin: 0 -${GEL_SPACING_DBL};
+  }
 `;
 
 const OnDemandTvPage = ({ pageData }) => {
@@ -55,7 +79,9 @@ const OnDemandTvPage = ({ pageData }) => {
     durationISO8601,
   } = pageData;
 
-  const { lang, timezone, locale, dir, service } = useContext(ServiceContext);
+  const { lang, timezone, locale, dir, service, translations } = useContext(
+    ServiceContext,
+  );
   const { isAmp } = useContext(RequestContext);
   const location = useLocation();
 
@@ -75,6 +101,20 @@ const OnDemandTvPage = ({ pageData }) => {
     isAmp,
     queryString: location.search,
   });
+
+  const expiredContentMessage = pathOr(
+    'This content is no longer available',
+    ['media', 'contentExpired'],
+    translations,
+  );
+  const iframeTitle = pathOr(
+    'Video player',
+    ['mediaAssetPage', 'videoPlayer'],
+    translations,
+  );
+
+  const type = 'video';
+  const title = 'On-demand TV';
 
   return (
     <>
@@ -126,12 +166,25 @@ const OnDemandTvPage = ({ pageData }) => {
             columns={getGroups(6, 6, 6, 6, 6, 6)}
             enableGelGutters
           >
-            <VideoPlayer
-              masterBrand={masterBrand}
-              assetId={episodeId}
-              imageUrl={imageUrl}
-              episodeIsAvailable={episodeIsAvailable}
-            />
+            {episodeIsAvailable ? (
+              <StyledWrapper>
+                <VideoPlayer
+                  embedUrl={embedUrl}
+                  assetId={episodeId}
+                  imageUrl={imageUrl}
+                  type={type}
+                  title={title}
+                  iframeTitle={iframeTitle}
+                />
+              </StyledWrapper>
+            ) : (
+              <StyledMessageContainer>
+                <MediaMessage
+                  service={service}
+                  message={expiredContentMessage}
+                />
+              </StyledMessageContainer>
+            )}
           </StyledGelWrapperGrid>
           <OnDemandHeadingBlock
             brandTitle={brandTitle}


### PR DESCRIPTION
Resolves #6878

**Overall change:**

Moving On Demand TV-specific logic out of VideoPlayer component and into the ODTV page component.

**Code changes:**

- Moved video player styling into ondemandTvPage component
- Moved content unavailable MediaMessage component into ondemandTvPage component
- Moved TV-specific values (iframe title, media type) into ondemandTvPage component and pass down as props to VideoPlayer.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
