### PR TITLE
Fix issue with toggling ads "On"

### DIFF
--- a/src/app/containers/Ad/Canonical/CanonicalAdBootstrapJs.jsx
+++ b/src/app/containers/Ad/Canonical/CanonicalAdBootstrapJs.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 
 const CanonicalAdBootstrapJs = () => (
-  <>
-    <Helmet
-      script={[
-        {
-          type: 'text/javascript',
-          // Once the Ad script has loaded, ads pushed to `cmd` are rendered
-          innerHTML: `
+  <Helmet
+    script={[
+      {
+        type: 'text/javascript',
+        // Once the Ad script has loaded, ads pushed to `cmd` are rendered
+        innerHTML: `
             document.cookie = 'ads-debug=true';
             window.dotcom = window.dotcom || { cmd: [] };
             window.dotcomConfig = {
@@ -16,13 +15,9 @@ const CanonicalAdBootstrapJs = () => (
               playerAds: false,
             };
           `,
-        },
-      ]}
-    />
-    <Helmet>
-      <script src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js" />
-    </Helmet>
-  </>
+      },
+    ]}
+  />
 );
 
 export default CanonicalAdBootstrapJs;

--- a/src/app/containers/Ad/Canonical/__snapshots__/CanonicalAdBootstrapJs.test.jsx.snap
+++ b/src/app/containers/Ad/Canonical/__snapshots__/CanonicalAdBootstrapJs.test.jsx.snap
@@ -15,9 +15,6 @@ exports[`CanonicalAds Ads Snapshots should push dotcom bootstrap and configurati
             };
           
     </script>
-    <script
-      src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
-    />
   </head>
   <body>
     <div />

--- a/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
@@ -1,8 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CanonicalAds Ads Snapshots should correctly render an Canonical leaderboard ad with dotcom-bootstrap script 1`] = `
-<div
-  class="dotcom-ad"
-  id="dotcom-leaderboard"
-/>
+<html>
+  <head>
+    <script
+      src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
+    />
+  </head>
+  <body>
+    <div>
+      <div
+        class="dotcom-ad"
+        id="dotcom-leaderboard"
+      />
+    </div>
+  </body>
+</html>
 `;

--- a/src/app/containers/Ad/Canonical/index.jsx
+++ b/src/app/containers/Ad/Canonical/index.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import AdSlot from './AdSlot';
 
-const CanonicalAd = () => <AdSlot uniqueId="leaderboard" />;
-
+const CanonicalAd = () => (
+  <>
+    {/* Loading dotcom-bootstrap.js here instead of CanonicalAdBootstrapJs to avoid it loading on live */}
+    {/* This can be moved once we allow the script to load on live */}
+    <Helmet>
+      <script src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js" />
+    </Helmet>
+    <AdSlot uniqueId="leaderboard" />
+  </>
+);
 export default CanonicalAd;

--- a/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
@@ -4,18 +4,6 @@ exports[`Ad Container Snapshots should correctly render a Canonical ad 1`] = `
 <html>
   <head>
     <script
-      type="text/javascript"
-    >
-      
-            document.cookie = 'ads-debug=true';
-            window.dotcom = window.dotcom || { cmd: [] };
-            window.dotcomConfig = {
-              pageAds: true,
-              playerAds: false,
-            };
-          
-    </script>
-    <script
       src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
     />
   </head>

--- a/src/app/containers/Ad/index.jsx
+++ b/src/app/containers/Ad/index.jsx
@@ -5,7 +5,6 @@ import { RequestContext } from '../../contexts/RequestContext';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import AmpAd from './Amp';
 import CanonicalAd from './Canonical';
-import CanonicalAdBootstrap from './Canonical/CanonicalAdBootstrapJs';
 
 const AdContainer = () => {
   const { isAmp } = useContext(RequestContext);
@@ -21,12 +20,7 @@ const AdContainer = () => {
     return <AmpAd />;
   }
 
-  return (
-    <>
-      <CanonicalAdBootstrap />
-      <CanonicalAd />
-    </>
-  );
+  return <CanonicalAd />;
 };
 
 export default AdContainer;

--- a/src/app/pages/FrontPage/index.jsx
+++ b/src/app/pages/FrontPage/index.jsx
@@ -8,6 +8,7 @@ import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import { frontPageDataPropTypes } from '#models/propTypes/frontPage';
 import { ServiceContext } from '#contexts/ServiceContext';
+import { RequestContext } from '#contexts/RequestContext';
 import LinkedData from '#containers/LinkedData';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
@@ -19,6 +20,7 @@ import MetadataContainer from '#containers/Metadata';
 import MostReadContainer from '#containers/MostRead';
 import MostReadSection from '#containers/MostRead/section';
 import MostReadSectionLabel from '#containers/MostRead/label';
+import CanonicalAdBootstrapJs from '#containers/Ad/Canonical/CanonicalAdBootstrapJs';
 
 const FrontPageMostReadSection = styled(MostReadSection)`
   /* To centre page layout for Group 4+ */
@@ -50,6 +52,7 @@ MostReadWrapper.propTypes = {
 
 const FrontPage = ({ pageData, mostReadEndpointOverride }) => {
   const {
+    ads,
     product,
     serviceLocalizedName,
     translations,
@@ -57,6 +60,7 @@ const FrontPage = ({ pageData, mostReadEndpointOverride }) => {
     radioSchedule,
   } = useContext(ServiceContext);
 
+  const hasAds = path(['hasAds'], ads);
   const home = path(['home'], translations);
   const groups = path(['content', 'groups'], pageData);
   const lang = path(['metadata', 'language'], pageData);
@@ -65,6 +69,7 @@ const FrontPage = ({ pageData, mostReadEndpointOverride }) => {
   const radioScheduleData = path(['radioScheduleData'], pageData);
   const radioScheduleOnPage = path(['onFrontPage'], radioSchedule);
   const radioSchedulePosition = path(['frontPagePosition'], radioSchedule);
+  const { isAmp } = useContext(RequestContext);
 
   // eslint-disable-next-line jsx-a11y/aria-role
   const offScreenText = (
@@ -79,6 +84,8 @@ const FrontPage = ({ pageData, mostReadEndpointOverride }) => {
 
   return (
     <>
+      {/* dotcom and dotcomConfig need to be setup before the main dotcom javascript file is loaded */}
+      {hasAds && !isAmp && <CanonicalAdBootstrapJs />}
       <ATIAnalytics data={pageData} />
       <ChartbeatAnalytics data={pageData} />
       <MetadataContainer

--- a/src/app/pages/FrontPage/index.test.jsx
+++ b/src/app/pages/FrontPage/index.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { render, act } from '@testing-library/react';
@@ -17,11 +18,15 @@ const requestContextData = {
 };
 
 // eslint-disable-next-line react/prop-types
-const FrontPageWithContext = ({ isAmp = false, ...props }) => (
+const FrontPageWithContext = ({
+  isAmp = false,
+  service = 'pidgin',
+  ...props
+}) => (
   <BrowserRouter>
-    <ToggleContextProvider service="pidgin" origin="https://www.test.bbc.com">
+    <ToggleContextProvider service={service} origin="https://www.test.bbc.com">
       <RequestContextProvider isAmp={isAmp} {...requestContextData}>
-        <ServiceContextProvider service="pidgin">
+        <ServiceContextProvider service={service}>
           <FrontPage {...props} />
         </ServiceContextProvider>
       </RequestContextProvider>
@@ -51,6 +56,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   window.dotcom = undefined;
+  window.dotcomConfig = undefined;
 });
 
 jest.mock('uuid', () => {
@@ -181,6 +187,33 @@ describe('Front Page', () => {
       sections.forEach(section => {
         expect(section.getAttribute('role')).toEqual('region');
       });
+    });
+
+    it('should create window.dotcomConfig when on Canonical and hasAds is true', async () => {
+      await act(async () => {
+        render(<FrontPageWithContext pageData={pageData} />);
+      });
+
+      expect(window.dotcomConfig).toEqual({
+        pageAds: true,
+        playerAds: false,
+      });
+    });
+
+    it('should create window.dotcomConfig when on Canonical and hasAds is false', async () => {
+      await act(async () => {
+        render(<FrontPageWithContext service="japanese" pageData={pageData} />);
+      });
+
+      expect(window.dotcomConfig).toBeFalsy();
+    });
+
+    it('should not create window.dotcomConfig when on Amp and hasAds is true', async () => {
+      await act(async () => {
+        render(<FrontPageWithContext pageData={pageData} isAmp />);
+      });
+
+      expect(window.dotcomConfig).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
A recreation of https://github.com/bbc/simorgh/pull/6814 since something went weird with the git HEAD.

**Overall change:**
Resolves an issue with the ads bootstrapping. The setup needs to be performed before they are toggled on or it can cause an issue preventing them from loading

**Code changes:**
Moved window.dotcom settings into FrontPage/index.jsx

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
