### PR TITLE
Remove cypress footer tests covered by integration

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -353,33 +353,6 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
       }
     });
 
-    describe('Footer Tests', () => {
-      describe('footer tests', () => {
-        it('should have a visible footer', () => {
-          cy.get('footer')
-            .should('have.length', 1)
-            .should('have.attr', 'role', 'contentinfo')
-            .find('a')
-            .should('have.attr', 'href', `/${config[service].name}`)
-            .find('svg')
-            .should('be.visible');
-        });
-      });
-
-      it('should render the BBC branding', () => {
-        cy.get('footer a')
-          .eq(0)
-          .should(
-            'contain',
-            appConfig[config[service].name][variant].serviceLocalizedName !==
-              undefined
-              ? `${appConfig[config[service].name][variant].product}, ${
-                  appConfig[config[service].name][variant].serviceLocalizedName
-                }`
-              : appConfig[config[service].name][variant].product,
-          );
-      });
-    });
     if (
       ['mediaAssetPage', 'photoGalleryPage', 'storyPage'].includes(pageType)
     ) {


### PR DESCRIPTION
Resolves #6650

**Overall change:**
Removed footer Cypress test as this is already covered by integration tests. Confirmed it was covering the same area.

**Code changes:**

- Removal of cypress test

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
