### PR TITLE
Fix IDT2 Amp Validation

### DIFF
--- a/scripts/ampHtmlValidator/index.js
+++ b/scripts/ampHtmlValidator/index.js
@@ -14,6 +14,7 @@ const pageTypes = [
   'mostReadPage',
   'onDemandRadio',
   'mediaAssetPage',
+  'storyPage',
 ];
 
 const getPageString = async url => {

--- a/scripts/ampHtmlValidator/index.test.js
+++ b/scripts/ampHtmlValidator/index.test.js
@@ -115,6 +115,6 @@ describe('amp validator tests', () => {
     </html>`,
     }));
     await runValidator(true);
-    expect(log).toBeCalledTimes(29);
+    expect(log).toBeCalledTimes(32);
   });
 });

--- a/src/app/containers/Include/amp/Idt2Amp.jsx
+++ b/src/app/containers/Include/amp/Idt2Amp.jsx
@@ -11,7 +11,7 @@ const IncludeGrid = styled(GridItemConstrainedMedium)`
 const Idt2Amp = ({ imageBlock }) =>
   imageBlock ? (
     <IncludeGrid>
-      <AmpImg fallback={false} {...imageBlock} />
+      <AmpImg {...imageBlock} />
     </IncludeGrid>
   ) : null;
 

--- a/src/app/containers/Include/amp/__snapshots__/Idt2Amp.test.jsx.snap
+++ b/src/app/containers/Include/amp/__snapshots__/Idt2Amp.test.jsx.snap
@@ -52,7 +52,6 @@ exports[`AmpIncludeContainer should render for a valid IDT2 include 1`] = `
     <amp-img
       alt="image alt text"
       attribution=""
-      fallback="false"
       height="1864"
       layout="responsive"
       src="https://foobar.com/includes/image/816"


### PR DESCRIPTION
No Issue

**Overall change:**
Removes attribute that fails amp validation that is used for IDT2 includes on AMP

**Code changes:**
- Remove fallback attribute from `amp-img`, it looks like this should only be present when specifying a fallback image: https://amp.dev/documentation/components/amp-img/#example:-specifying-a-fallback-image 
- Update our amp validation to validate story pages

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
