### PR TITLE
Investigate csp urls for ads

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -70,6 +70,17 @@ const directives = {
       'https://www.bbc.co.uk', // STY include indepthtoolkit
       'https://news.files.bbci.co.uk', // STY include
       'https://news.test.files.bbci.co.uk', // STY include
+      // dotcom required urls
+      'https://securepubads.g.doubleclick.net',
+      'https://pagead2.googlesyndication.com',
+      'https://survey.effectivemeasure.net',
+      'https://www.bbc.co.uk',
+      'https://static.test.files.bbci.co.uk',
+      'https://experience.tinypass.com',
+      'https://detect-survey.effectivemeasure.net',
+      'https://collector.effectivemeasure.net/',
+      'https://csi.gstatic.com',
+      // end dotcom required urls
       "'self'",
     ],
   },
@@ -127,6 +138,12 @@ const directives = {
       'https://www.bbc.co.uk', // STY include
       'http://www.bbc.co.uk', // for localhost STY include
       'https://bbc-maps.carto.com', // STY include maps
+      // dotcom required urls
+      'https://tpc.googlesyndication.com',
+      'https://bcp.crwdcntrl.net',
+      'https://edigitalsurvey.com',
+      'https://*.safeframe.googlesyndication.com/',
+      // end dotcom required urls
       "'self'",
     ],
   },
@@ -212,6 +229,16 @@ const directives = {
       'https://news.bbcimg.co.uk', // STY include
       'https://static.bbc.co.uk', // STY include
       'http://static.bbc.co.uk', // localhost STY include
+      // dotcom required urls
+      'data:',
+      'https://pagead2.googlesyndication.com',
+      'https://tpc.googlesyndication.com',
+      'https://securepubads.g.doubleclick.net',
+      'https://www.google.com',
+      'https://secure-us.imrworldwide.com',
+      'https://collector.effectivemeasure.net',
+      'https://sb.scorecardresearch.com',
+      // end dotcom required urls
       "data: 'self'", // needed at the end to maintain proper order
     ],
   },
@@ -270,8 +297,26 @@ const directives = {
       'https://passport-control.int.tools.bbc.co.uk/bookmarkletScript.js', // Passport bookmarklet - int
       'https://passport-control.test.tools.bbc.co.uk/bookmarkletScript.js', // Passport bookmarklet - test
       'https://passport-control.tools.bbc.co.uk/bookmarkletScript.js', // Passport bookmarklet - live
+      // dotcom required urls
+      'https://tpc.googlesyndication.com',
+      'https://privacy.crwdcntrl.net',
+      'https://gn-web-assets.api.bbc.com',
+      'https://securepubads.g.doubleclick.net',
+      'https://bcp.crwdcntrl.net',
+      'https://ad.crwdcntrl.net',
+      'https://sb.scorecardresearch.com',
+      'https://me-ssl.effectivemeasure.net',
+      'https://bbc.gscontxt.net',
+      'https://adservice.google.co.uk',
+      'https://adservice.google.com',
+      'https://t.effectivemeasure.net',
+      'https://tags.crwdcntrl.net',
+      'https://collector.effectivemeasure.net',
+      'https://cdn.ampproject.org',
+      // end dotcom required urls
       "'self'",
       "'unsafe-inline'",
+      "'unsafe-eval'",
     ],
   },
   styleSrc: {
@@ -313,6 +358,13 @@ const directives = {
       'https://static.bbci.co.uk', // STY includes
     ],
   },
+  defaultSrc: {
+    canonicalNonLive: [
+      'https://*.safeframe.googlesyndication.com',
+      'https://tpc.googlesyndication.com',
+      "'self'",
+    ],
+  },
 };
 
 export const generateChildSrc = ({ isAmp }) => (isAmp ? ['blob:'] : ["'self'"]);
@@ -324,7 +376,10 @@ export const generateConnectSrc = ({ isAmp, isLive }) => {
   return directives.connectSrc.canonicalLive;
 };
 
-export const generateDefaultSrc = () => ["'self'"];
+export const generateDefaultSrc = ({ isAmp, isLive }) => {
+  if (!isLive && !isAmp) return directives.defaultSrc.canonicalNonLive;
+  return ["'self'"];
+};
 
 export const generateFontSrc = ({ isAmp }) =>
   isAmp ? directives.fontSrc.amp : directives.fontSrc.canonical;
@@ -362,7 +417,7 @@ export const generateWorkerSrc = ({ isAmp }) =>
 
 const helmetCsp = ({ isAmp, isLive }) => ({
   directives: {
-    'default-src': generateDefaultSrc(),
+    'default-src': generateDefaultSrc({ isAmp, isLive }),
     'child-src': generateChildSrc({ isAmp }),
     'connect-src': generateConnectSrc({ isAmp, isLive }),
     'font-src': generateFontSrc({ isAmp }),

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -261,9 +261,22 @@ describe('cspHeader', () => {
         'https://www.bbc.co.uk',
         'https://news.files.bbci.co.uk',
         'https://news.test.files.bbci.co.uk',
+        'https://securepubads.g.doubleclick.net',
+        'https://pagead2.googlesyndication.com',
+        'https://survey.effectivemeasure.net',
+        'https://www.bbc.co.uk',
+        'https://static.test.files.bbci.co.uk',
+        'https://experience.tinypass.com',
+        'https://detect-survey.effectivemeasure.net',
+        'https://collector.effectivemeasure.net/',
+        'https://csi.gstatic.com',
         "'self'",
       ],
-      defaultSrcExpectation: ["'self'"],
+      defaultSrcExpectation: [
+        'https://*.safeframe.googlesyndication.com',
+        'https://tpc.googlesyndication.com',
+        "'self'",
+      ],
       fontSrcExpectation: [
         'https://gel.files.bbci.co.uk',
         'https://ws-downloads.files.bbci.co.uk',
@@ -286,6 +299,10 @@ describe('cspHeader', () => {
         'https://www.bbc.co.uk',
         'http://www.bbc.co.uk',
         'https://bbc-maps.carto.com',
+        'https://tpc.googlesyndication.com',
+        'https://bcp.crwdcntrl.net',
+        'https://edigitalsurvey.com',
+        'https://*.safeframe.googlesyndication.com/',
         "'self'",
       ],
       imgSrcExpectation: [
@@ -312,6 +329,14 @@ describe('cspHeader', () => {
         'https://news.bbcimg.co.uk',
         'https://static.bbc.co.uk',
         'http://static.bbc.co.uk',
+        'data:',
+        'https://pagead2.googlesyndication.com',
+        'https://tpc.googlesyndication.com',
+        'https://securepubads.g.doubleclick.net',
+        'https://www.google.com',
+        'https://secure-us.imrworldwide.com',
+        'https://collector.effectivemeasure.net',
+        'https://sb.scorecardresearch.com',
         "data: 'self'",
       ],
       scriptSrcExpectation: [
@@ -333,8 +358,24 @@ describe('cspHeader', () => {
         'https://passport-control.int.tools.bbc.co.uk/bookmarkletScript.js',
         'https://passport-control.test.tools.bbc.co.uk/bookmarkletScript.js',
         'https://passport-control.tools.bbc.co.uk/bookmarkletScript.js',
+        'https://tpc.googlesyndication.com',
+        'https://privacy.crwdcntrl.net',
+        'https://gn-web-assets.api.bbc.com',
+        'https://securepubads.g.doubleclick.net',
+        'https://bcp.crwdcntrl.net',
+        'https://ad.crwdcntrl.net',
+        'https://sb.scorecardresearch.com',
+        'https://me-ssl.effectivemeasure.net',
+        'https://bbc.gscontxt.net',
+        'https://adservice.google.co.uk',
+        'https://adservice.google.com',
+        'https://t.effectivemeasure.net',
+        'https://tags.crwdcntrl.net',
+        'https://collector.effectivemeasure.net',
+        'https://cdn.ampproject.org',
         "'self'",
         "'unsafe-inline'",
+        "'unsafe-eval'",
       ],
       styleSrcExpectation: [
         'https://news.files.bbci.co.uk',
@@ -378,7 +419,9 @@ describe('cspHeader', () => {
         });
 
         it(`Then it has this defaultSrc`, () => {
-          expect(generateDefaultSrc()).toEqual(defaultSrcExpectation);
+          expect(generateDefaultSrc({ isAmp, isLive })).toEqual(
+            defaultSrcExpectation,
+          );
         });
 
         it(`Then it has this fontSrc`, () => {


### PR DESCRIPTION
Reverts bbc/simorgh#6933

**Overall change:**
_Adding CSP urls to enable Ads on TEST_

**Code changes:**

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
