### PR TITLE
Clear up ws_cleanup Jenkins workspace directories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -151,7 +150,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -162,7 +160,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -189,7 +186,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -204,7 +200,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -233,7 +228,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {
@@ -248,7 +242,6 @@ pipeline {
           agent {
             docker {
               image "${nodeImage}"
-              args '-u root -v /etc/pki:/certs'
             }
           }
           steps {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh-infrastructure/issues/1095

**Overall change:**
_Stop builds on Jenkins creating files as the root user in order that the Workspace Cleanup plugin can successfully clear workspaces_

**Code changes:**
- Remove unneeded `args` parameter to `docker` command

**Additional context**
The Workspace Cleanup plugin is designed to clear Jenkins workspaces. However during our build process we launch various Docker containers under the `root` user. Any files these containers create will also be owned by root. See for example the `build` directory created below:

```
drwxr-xr-x 3 root    root          37 Jun 22 12:52 build
-rwxr-xr-x 1 jenkins jenkins 12773683 Jun 22 12:52 cc-test-reporter
drwxr-xr-x 3 jenkins jenkins       87 Jun 22 12:59 coverage
drwxr-xr-x 2 jenkins jenkins       21 Jun 22 12:52 log
...
```
The effect of this seems to be that the plugin is unable to clean up these workspaces and so renames them to `_ws-cleanup_$ID`. This contributes to Jenkins disk space filling up.

This fix was suggested by the discussion on [JENKINS-24440](https://issues.jenkins-ci.org/browse/JENKINS-24440) about `cleanWs`/`deleteDir` not being able to remove directories containing files owned by root (e.g. created in a Docker container).

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [NA] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [NA] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [no] This PR requires manual testing
