### PR TITLE
Make runScripts optional

### DIFF
--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -9,11 +9,12 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
   constructor(config, context) {
     super(config, context);
     const { platform } = config.testEnvironmentOptions;
-    const { pathname, service } = context.docblockPragmas;
+    const { pathname, service, runScripts = 'true' } = context.docblockPragmas;
     const pageType = getPageTypeFromTestPath(context.testPath);
 
     this.pageType = camelCaseToText(pageType);
     this.service = service;
+    this.runScripts = runScripts === 'true';
     this.url = `http://localhost:7080${pathname}${
       platform === 'amp' ? '.amp' : ''
     }`;
@@ -23,7 +24,7 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
     await super.setup();
 
     try {
-      const dom = await fetchDom(this.url);
+      const dom = await fetchDom(this.url, this.runScripts);
 
       Object.defineProperties(this.global, {
         pageType: { value: this.pageType },

--- a/src/integration/pages/storyPage/gahuza/amp.test.js
+++ b/src/integration/pages/storyPage/gahuza/amp.test.js
@@ -1,6 +1,7 @@
 /**
  * @service gahuza
  * @pathname /gahuza/23313911
+ * @runScripts false
  */
 
 import runAmpIncludeTests from '../ampIncludeTests';

--- a/src/integration/pages/storyPage/gahuza/canonical.test.js
+++ b/src/integration/pages/storyPage/gahuza/canonical.test.js
@@ -1,6 +1,7 @@
 /**
  * @service gahuza
  * @pathname /gahuza/23313911
+ * @runScripts false
  */
 
 import runCanonicalIncludeTests from '../canonicalIncludeTests';

--- a/src/integration/utils/fetchDom.js
+++ b/src/integration/utils/fetchDom.js
@@ -3,7 +3,7 @@
 const { JSDOM } = require('jsdom');
 const retry = require('retry');
 
-const faultTolerantDomFetch = url =>
+const faultTolerantDomFetch = (url, runScripts) =>
   new Promise((resolve, reject) => {
     const oneSecond = 1000;
     const operation = retry.operation({
@@ -22,7 +22,10 @@ const faultTolerantDomFetch = url =>
       }
 
       try {
-        const dom = await JSDOM.fromURL(url, { runScripts: 'dangerously' });
+        const dom = await JSDOM.fromURL(
+          url,
+          runScripts ? { runScripts: 'dangerously' } : {},
+        );
 
         resolve(dom);
       } catch (error) {


### PR DESCRIPTION
**Overall change:**
Some assets have inline scripts that JSDOM can't handle which throws an error. For these types of assets you can add `@runScripts false`

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
