### PR TITLE
Update Psammead Media Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,9 +1525,9 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.10.tgz",
-      "integrity": "sha512-Qz/omqcCpgyF+25UlbV5uoYs/DlFFxDNiSqvDrt5o24YLPORzk4zLdoke5dJhAOdiItQAAGLeB+SrACjIRHEQA==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-2.7.11.tgz",
+      "integrity": "sha512-AZF7U7O4tC1kbqjWDJHcL8F0tsfZMp3Ch+kHcexdUXHQi5CwWVDxSC2jx/Q9hzldahMupkODJQtFb/SuVlpMpQ==",
       "requires": {
         "@bbc/psammead-assets": "^2.14.0",
         "@bbc/psammead-image": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@bbc/psammead-live-label": "^1.0.0",
     "@bbc/psammead-locales": "^4.1.8",
     "@bbc/psammead-media-indicator": "^4.0.7",
-    "@bbc/psammead-media-player": "^2.7.10",
+    "@bbc/psammead-media-player": "^2.7.11",
     "@bbc/psammead-most-read": "^4.1.3",
     "@bbc/psammead-navigation": "^6.0.11",
     "@bbc/psammead-paragraph": "^2.2.28",

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -238,7 +238,6 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
 .c6 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 
@@ -487,7 +486,6 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 .c6 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -227,7 +227,6 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 .c14 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 
@@ -747,7 +746,6 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 .c15 {
   height: 165px;
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
Part of #6881

**Overall change:**
Updating the Psammead media player version to stop the time indicator from being partially chopped off.

**Code changes:**

- Updated version
- Updated the snapshots to reflect the Psammead code change
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
