### PR TITLE
Naming changes for TV/Radio Media Player Refactor

### DIFF
--- a/src/app/containers/AVPlayer/index.jsx
+++ b/src/app/containers/AVPlayer/index.jsx
@@ -8,7 +8,7 @@ import pathOr from 'ramda/src/pathOr';
 import { RequestContext } from '#contexts/RequestContext';
 import { ServiceContext } from '#contexts/ServiceContext';
 
-const VideoPlayer = ({
+const AVPlayer = ({
   assetId,
   placeholderSrc,
   title,
@@ -58,7 +58,7 @@ const VideoPlayer = ({
   );
 };
 
-VideoPlayer.propTypes = {
+AVPlayer.propTypes = {
   embedUrl: string,
   assetId: string,
   placeholderSrc: string,
@@ -68,7 +68,7 @@ VideoPlayer.propTypes = {
   className: string,
 };
 
-VideoPlayer.defaultProps = {
+AVPlayer.defaultProps = {
   embedUrl: '',
   assetId: '',
   placeholderSrc: '',
@@ -78,4 +78,4 @@ VideoPlayer.defaultProps = {
   className: '',
 };
 
-export default VideoPlayer;
+export default AVPlayer;

--- a/src/app/containers/AVPlayer/index.test.jsx
+++ b/src/app/containers/AVPlayer/index.test.jsx
@@ -3,7 +3,7 @@ import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { BrowserRouter } from 'react-router-dom';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { RequestContext } from '#contexts/RequestContext';
-import VideoPlayer from '.';
+import AVPlayer from '.';
 
 const origin = 'http://localhost:7080';
 
@@ -28,7 +28,7 @@ const renderComponent = ({
   <RequestContext.Provider value={requestContextValue}>
     <ServiceContextProvider service={service}>
       <BrowserRouter>
-        <VideoPlayer {...videoPlayerProps} />
+        <AVPlayer {...videoPlayerProps} />
       </BrowserRouter>
     </ServiceContextProvider>
   </RequestContext.Provider>

--- a/src/app/containers/AudioPlayer/index.jsx
+++ b/src/app/containers/AudioPlayer/index.jsx
@@ -10,7 +10,7 @@ import { ServiceContext } from '#contexts/ServiceContext';
 
 const AudioPlayer = ({
   assetId,
-  imageUrl,
+  placeholderSrc,
   embedUrl,
   title,
   type,
@@ -33,7 +33,7 @@ const AudioPlayer = ({
     <div className={className}>
       {isAmp ? (
         <AmpMediaPlayer
-          placeholderSrc={imageUrl}
+          placeholderSrc={placeholderSrc}
           src={embedUrl}
           title={iframeTitle}
           skin="audio"
@@ -58,7 +58,7 @@ const AudioPlayer = ({
 
 AudioPlayer.propTypes = {
   assetId: string,
-  imageUrl: string,
+  placeholderSrc: string,
   embedUrl: string,
   type: string,
   title: string,
@@ -68,7 +68,7 @@ AudioPlayer.propTypes = {
 
 AudioPlayer.defaultProps = {
   assetId: '',
-  imageUrl: '',
+  placeholderSrc: '',
   type: '',
   title: '',
   embedUrl: '',

--- a/src/app/pages/LiveRadioPage/index.jsx
+++ b/src/app/pages/LiveRadioPage/index.jsx
@@ -145,7 +145,7 @@ const LiveRadioPage = ({ pageData }) => {
             iframeTitle={iframeTitle}
             title="Live radio"
             type="audio"
-            imageUrl={audioPlaceholderImageSrc}
+            placeholderSrc={audioPlaceholderImageSrc}
           />
         </Grid>
       </StyledGelPageGrid>

--- a/src/app/pages/OnDemandRadioPage/index.jsx
+++ b/src/app/pages/OnDemandRadioPage/index.jsx
@@ -181,7 +181,7 @@ const OnDemandRadioPage = ({ pageData }) => {
               iframeTitle={iframeTitle}
               title="On-demand radio"
               type="audio"
-              imageUrl={audioPlaceholderImageSrc}
+              placeholderSrc={audioPlaceholderImageSrc}
             />
           ) : (
             <StyledMessageContainer>

--- a/src/app/pages/OnDemandTvPage/index.jsx
+++ b/src/app/pages/OnDemandTvPage/index.jsx
@@ -23,7 +23,7 @@ import OnDemandHeadingBlock from '#containers/RadioPageBlocks/Blocks/OnDemandHea
 import ParagraphBlock from '#containers/RadioPageBlocks/Blocks/Paragraph';
 import getPlaceholderImageUrl from '../../routes/utils/getPlaceholderImageUrl';
 import getEmbedUrl from '#lib/utilities/getEmbedUrl';
-import VideoPlayer from '#containers/AVPlayer';
+import AVPlayer from '#containers/AVPlayer';
 
 const StyledGelWrapperGrid = styled.div`
   padding-top: ${GEL_SPACING_TRPL};
@@ -56,7 +56,7 @@ const StyledGelPageGrid = styled(GelPageGrid)`
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 
-const StyledVideoPlayer = styled(VideoPlayer)`
+const StyledVideoPlayer = styled(AVPlayer)`
   margin-top: ${GEL_SPACING_TRPL};
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
     width: calc(100% + ${GEL_SPACING_QUAD});


### PR DESCRIPTION
Part of #6881

**Overall change:**
AudioPlayer props renamed to mirror the naming in the new AVPlayer. This will make switching from AudioPlayer -> AVPlayer simple. VideoPlayer renamed to AVPlayer as it will now support both radio and TV.

**Code changes:**

- Renamed imageUrl to placeholderSrc
- Renamed VideoPlayer to AVPlayer

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
