### PR TITLE
Adding default skin prop to AVPlayer

### DIFF
--- a/src/app/containers/AVPlayer/index.jsx
+++ b/src/app/containers/AVPlayer/index.jsx
@@ -15,6 +15,7 @@ const AVPlayer = ({
   embedUrl,
   iframeTitle,
   type,
+  skin,
   className,
 }) => {
   const { translations, service } = useContext(ServiceContext);
@@ -40,6 +41,7 @@ const AVPlayer = ({
           placeholderSrc={placeholderSrc}
           src={embedUrl}
           title={iframeTitle}
+          skin={skin}
           noJsMessage={noJsMessage}
           service={service}
         />
@@ -48,6 +50,7 @@ const AVPlayer = ({
           showPlaceholder={false}
           src={embedUrl}
           title={iframeTitle}
+          skin={skin}
           service={service}
           mediaInfo={mediaInfo}
           noJsMessage={noJsMessage}
@@ -66,6 +69,7 @@ AVPlayer.propTypes = {
   title: string,
   iframeTitle: string,
   className: string,
+  skin: string,
 };
 
 AVPlayer.defaultProps = {
@@ -76,6 +80,7 @@ AVPlayer.defaultProps = {
   title: '',
   iframeTitle: '',
   className: '',
+  skin: 'classic',
 };
 
 export default AVPlayer;


### PR DESCRIPTION
Part of #6881

**Overall change:**
Added classic as default value for skin prop. OD Radio and LiveRadio will pass through 'audio' when moved over to AVPlayer

**Code changes:**

- Added `classic` as default value for skin prop

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
