### PR TITLE
Add Top Stories translation for Ukrainian

### DIFF
--- a/src/app/lib/config/services/ukrainian.js
+++ b/src/app/lib/config/services/ukrainian.js
@@ -181,7 +181,7 @@ export const service = {
           endTextVisuallyHidden: 'Кінець %provider_name% допису',
         },
       },
-      topStoriesTitle: 'Top Stories',
+      topStoriesTitle: 'Головне',
       featuresAnalysisTitle: 'Докладно',
     },
     brandSVG,


### PR DESCRIPTION
Resolves #7053

**Overall change:**
Add the missing translation for Top Stories for the Ukrainian service.

**Code changes:**
- Add `Головне` to the `topStoriesTitle` field within the Ukrainian config. 

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added labels to this PR for the relevant pod(s) affected by these changes
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
