### PR TITLE
Revert "Revert "add sameSite and secure attribute to cookies""

### DIFF
--- a/src/app/containers/ConsentBanner/CanonicalLogic/index.js
+++ b/src/app/containers/ConsentBanner/CanonicalLogic/index.js
@@ -14,8 +14,12 @@ const PRIVACY_COOKIE_PREVIOUS_VALUES = ['0', '1'];
 
 const onClient = typeof window !== 'undefined';
 
+// We opted for the sameSite=None attribute below to maintain consistency with Orbit/cross-TLD browsing
+// Setting sameSite=None allows the cookie to be accessed and updated on `.co.uk` and `.com`
+const SAME_SITE_VALUE = 'None';
+
 const setPolicyCookie = (value, logger) => {
-  setCookie(POLICY_COOKIE, value);
+  setCookie({ name: POLICY_COOKIE, value, sameSite: SAME_SITE_VALUE });
   setCookieOven(POLICY_COOKIE, value, logger);
 };
 
@@ -30,11 +34,19 @@ const showCookieBanner = () =>
 const policyCookieSet = () => !!Cookie.get(POLICY_COOKIE);
 
 const setSeenPrivacyBanner = () =>
-  setCookie(PRIVACY_COOKIE, PRIVACY_COOKIE_CURRENT);
+  setCookie({
+    name: PRIVACY_COOKIE,
+    value: PRIVACY_COOKIE_CURRENT,
+    sameSite: SAME_SITE_VALUE,
+  });
 const setDefaultPolicy = logger => setPolicyCookie(POLICY_DENIED, logger);
 const setApprovedPolicy = logger => setPolicyCookie(POLICY_APPROVED, logger);
 const setDismissedCookieBanner = () =>
-  setCookie(EXPLICIT_COOKIE, COOKIE_BANNER_APPROVED);
+  setCookie({
+    name: EXPLICIT_COOKIE,
+    value: COOKIE_BANNER_APPROVED,
+    sameSite: SAME_SITE_VALUE,
+  });
 
 const consentBannerUtilities = ({
   setShowPrivacyBanner,

--- a/src/app/contexts/UserContext/cookies/index.js
+++ b/src/app/contexts/UserContext/cookies/index.js
@@ -25,5 +25,14 @@ export const setPreferredVariantCookie = (service, variant) => {
 
   const variantCookieName = `ckps_${getVariantCookieName(service)}`;
   const COOKIE_EXPIRY = 7;
-  setCookie(variantCookieName, variant, COOKIE_EXPIRY);
+
+  // Setting variant cookie to have sameSite=Lax because the purpose of this
+  // cookie is to only be used in a first-party context and make sure the page
+  // is rendered correctly on initial load when arrived from external source.
+  setCookie({
+    name: variantCookieName,
+    value: variant,
+    expires: COOKIE_EXPIRY,
+    sameSite: 'Lax',
+  });
 };

--- a/src/app/contexts/UserContext/cookies/index.test.js
+++ b/src/app/contexts/UserContext/cookies/index.test.js
@@ -86,6 +86,7 @@ describe('UserContext cookies', () => {
       expect(Cookie.set).toHaveBeenCalledWith('ckps_foo', 'bar', {
         domain: '.bbc.com',
         expires: 7,
+        sameSite: 'Lax',
       });
     });
 
@@ -109,6 +110,7 @@ describe('UserContext cookies', () => {
       expect(Cookie.set).toHaveBeenCalledWith('ckps_serbian', 'lat', {
         domain: '.bbc.com',
         expires: 7,
+        sameSite: 'Lax',
       });
     });
 
@@ -118,6 +120,7 @@ describe('UserContext cookies', () => {
       expect(Cookie.set).toHaveBeenCalledWith('ckps_chinese', 'simp', {
         domain: '.bbc.com',
         expires: 7,
+        sameSite: 'Lax',
       });
     });
 
@@ -127,6 +130,7 @@ describe('UserContext cookies', () => {
       expect(Cookie.set).toHaveBeenCalledWith('ckps_chinese', 'simp', {
         domain: '.bbc.com',
         expires: 7,
+        sameSite: 'Lax',
       });
     });
   });

--- a/src/app/lib/utilities/setCookie/index.jsx
+++ b/src/app/lib/utilities/setCookie/index.jsx
@@ -1,6 +1,7 @@
 import Cookie from 'js-cookie';
 
 const COOKIE_EXPIRY = 365;
+const SAMESITE_DEFAULT = 'Lax';
 
 export const getCookieDomain = domain => {
   const domainParts = domain.split('.');
@@ -13,10 +14,29 @@ export const getCookieDomain = domain => {
   return domain;
 };
 
-const setCookie = (name, value, expires = COOKIE_EXPIRY) =>
-  Cookie.set(name, value, {
+const setCookie = ({
+  name,
+  value,
+  expires = COOKIE_EXPIRY,
+  sameSite = SAMESITE_DEFAULT,
+}) => {
+  const isHttps = window.location.protocol === 'https:';
+
+  // Modern browsers default sameSite value to Lax
+  // Setting sameSite='None' allows cookies will be sent in all contexts, i.e sending cross-origin is allowed.
+  // Setting sameSite='Strict' allows cookies to only set in first-party context
+  const sameSiteValues = {
+    Lax: 'Lax',
+    Strict: 'Strict',
+    None: isHttps ? 'None' : undefined, // SameSite=None can only be added to cookie when the page is https
+  };
+
+  return Cookie.set(name, value, {
     expires,
     domain: getCookieDomain(document.domain),
+    sameSite: sameSiteValues[sameSite],
+    ...(isHttps && { secure: true }),
   });
+};
 
 export default setCookie;

--- a/src/app/lib/utilities/setCookie/index.test.jsx
+++ b/src/app/lib/utilities/setCookie/index.test.jsx
@@ -1,4 +1,5 @@
 import Cookie from 'js-cookie';
+import { setWindowValue, resetWindowValue } from '@bbc/psammead-test-helpers';
 import setCookie, { getCookieDomain } from '.';
 
 const cookieSpy = jest.spyOn(Cookie, 'set');
@@ -10,17 +11,19 @@ describe('setCookie Assertion Tests', () => {
 
   describe('Setting cookie with domain and duration', () => {
     it('should return cookie with domain and expiration of 1 year', () => {
-      setCookie('test', '111');
+      setCookie({ name: 'test', value: '111' });
       expect(cookieSpy).toHaveBeenCalledWith('test', '111', {
         domain: '.bbc.com',
         expires: 365,
+        sameSite: 'Lax',
       });
     });
     it('should return cookie with domain and expiration of 1 week', () => {
-      setCookie('test', '111', 7);
+      setCookie({ name: 'test', value: '111', expires: 7 });
       expect(cookieSpy).toHaveBeenCalledWith('test', '111', {
         domain: '.bbc.com',
         expires: 7,
+        sameSite: 'Lax',
       });
     });
   });
@@ -39,6 +42,29 @@ describe('setCookie Assertion Tests', () => {
     });
     it('should return exactly the same domain given if the domain is anything else', () => {
       expect(getCookieDomain('localhost')).toBe('localhost');
+    });
+  });
+
+  describe('Setting cookie with sameSite and secure attribute when https', () => {
+    const windowLocation = window.location;
+
+    afterEach(() => {
+      resetWindowValue('location', windowLocation);
+    });
+
+    it('should return cookie with domain, expiration of 1 year, sameSite=None and secure=true', () => {
+      setWindowValue('location', {
+        protocol: 'https:',
+      });
+
+      setCookie({ name: 'test', value: '111', sameSite: 'None' });
+
+      expect(cookieSpy).toHaveBeenCalledWith('test', '111', {
+        domain: '.bbc.com',
+        expires: 365,
+        sameSite: 'None',
+        secure: true,
+      });
     });
   });
 });


### PR DESCRIPTION
Reverts bbc/simorgh#7065

This PR adds the sameSite='None' and secure=true to our https pages for our privacy,policy,explicit cookie. It has been reverted because it failed the E2E's on TEST environment.