### PR TITLE
Use correct "BBC" in ukrainian config

### DIFF
--- a/src/app/lib/config/services/ukrainian.js
+++ b/src/app/lib/config/services/ukrainian.js
@@ -66,10 +66,10 @@ const baseServiceConfig = {
         solutions: [
           'Перевірте ще раз адресу посилання',
           'Натисніть на кнопку "оновити" в браузері',
-          'Шукати сторінку в пошуковому вікні ВВС',
+          'Шукати сторінку в пошуковому вікні BBC',
         ],
         callToActionFirst: 'Спробуйте зайти на головну сторінку ',
-        callToActionLinkText: 'ВВС News Україна',
+        callToActionLinkText: 'BBC News Україна',
         callToActionLast: '',
         callToActionLinkUrl: 'https://www.bbc.com/ukrainian',
       },
@@ -149,7 +149,7 @@ const baseServiceConfig = {
       bbc_ukrainian_tv: {
         title: 'Випуск новин',
         subtitle:
-          'ВВС News Україна розповідає про головні події дня на Громадському і на сайті bbc.ua',
+          'BBC News Україна розповідає про головні події дня на Громадському і на сайті bbc.ua',
       },
       listen: 'Прослухати',
       watch: 'Дивитися',
@@ -168,7 +168,7 @@ const baseServiceConfig = {
         text: 'Контент недоступний',
         linkText: 'Дивіться більше у %provider_name%',
         linkTextSuffixVisuallyHidden: ', зовнішнє посилання',
-        warningText: 'ВВС не несе відповідальності за контент інших сайтів.',
+        warningText: 'BBC не несе відповідальності за контент інших сайтів.',
       },
       skipLink: {
         text: 'Пропустити %provider_name% допис',
@@ -226,7 +226,7 @@ const baseServiceConfig = {
         lang: 'en-GB',
       },
     ],
-    copyrightText: 'BBC. ВВС не несе відповідальності за контент інших сайтів.',
+    copyrightText: 'BBC. BBC не несе відповідальності за контент інших сайтів.',
   },
   fonts: [],
   timezone: 'GMT',
@@ -256,7 +256,7 @@ const baseServiceConfig = {
       url: '/ukrainian/magazine',
     },
     {
-      title: 'Книга року ВВС',
+      title: 'Книга року BBC',
       url: '/ukrainian/features-50320117',
     },
     {


### PR DESCRIPTION
Resolves #7112

**Overall change:**
Screen readers on Ukrainian service (frontpage and IDX) were pronouncing "BBC" in different ways: sometimes as English letters "b b c" and sometimes as Ukrainian letters "v v s". This was because in the config files BBC sometimes was written in Ukrainian letters v v s (ввс) which were identical to the eye. This PR replaces all Ukrainian "ввс" with English "BBC".
Tested this with VoiceOver and BBC is now pronounced correctly everywhere. Hence, we don't actually need to add any lang attributes.

**Code changes:**
- Update "BBC" in Ukrainian config file.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
