### PR TITLE
Adding LiveRadio tests for AVPlayer

### DIFF
--- a/src/app/containers/AVPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/AVPlayer/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AVPlayer for Radio should match snapshot for AMP AVPlayer 1`] = `
+exports[`AVPlayer for Live Radio should match snapshot for canonical AVPlayer 1`] = `
+.c0 {
+  padding-top: 56.25%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c1 {
+  border: 0;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+<div
+  class=""
+>
+  <div
+    class="c0"
+  >
+    <iframe
+      allow="autoplay; fullscreen"
+      allowfullscreen=""
+      class="c1"
+      scrolling="no"
+      src="https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_korean_radio/liveradio/ko"
+      title="오디오 플레이어"
+    />
+    <noscript />
+  </div>
+</div>
+`;
+
+exports[`AVPlayer for On Demand Radio should match snapshot for AMP AVPlayer 1`] = `
 .c0 {
   padding-top: 56.25%;
   position: relative;
@@ -50,7 +86,7 @@ exports[`AVPlayer for Radio should match snapshot for AMP AVPlayer 1`] = `
 </html>
 `;
 
-exports[`AVPlayer for TV should match snapshot for canonical AVPlayer 1`] = `
+exports[`AVPlayer for On Demand TV should match snapshot for canonical AVPlayer 1`] = `
 .c0 {
   padding-top: 56.25%;
   position: relative;

--- a/src/app/containers/AVPlayer/index.test.jsx
+++ b/src/app/containers/AVPlayer/index.test.jsx
@@ -40,14 +40,14 @@ const GenerateFixtureData = ({
   </RequestContextProvider>
 );
 
-const AVPlayerCanonicalTV = (
+const AVPlayerCanonicalODTV = (
   <GenerateFixtureData
     platform="canonical"
     embedUrl="https://polling.test.bbc.co.uk/ws/av-embeds/media/pashto/bbc_pashto_tv/w172xcldhhrdqgb/ps?morph_env=live"
   />
 );
 
-const AVPlayerAMPRadio = (
+const AVPlayerAMPODRadio = (
   <GenerateFixtureData
     platform="amp"
     embedUrl="https://polling.test.bbc.co.uk/ws/av-embeds/media/afaanoromoo/bbc_afaanoromoo_radio/w3ct0l8r/om/amp"
@@ -58,26 +58,37 @@ const AVPlayerAMPRadio = (
   />
 );
 
-describe('AVPlayer for TV', () => {
+const AVPlayerLiveRadio = (
+  <GenerateFixtureData
+    platform="canonical"
+    embedUrl="https://polling.test.bbc.co.uk/ws/av-embeds/media/bbc_korean_radio/liveradio/ko"
+    title="Live radio"
+    type="audio"
+    iframeTitle="오디오 플레이어"
+    skin="audio"
+  />
+);
+
+describe('AVPlayer for On Demand TV', () => {
   shouldMatchSnapshot(
     'should match snapshot for canonical AVPlayer',
-    AVPlayerCanonicalTV,
+    AVPlayerCanonicalODTV,
   );
 
   it('should render the iframe on canonical', () => {
-    render(AVPlayerCanonicalTV);
+    render(AVPlayerCanonicalODTV);
 
     expect(document.querySelector('iframe')).toBeInTheDocument();
   });
 
   it('should contain the noscript tag for no-JS scenarios on canonical', () => {
-    render(AVPlayerCanonicalTV);
+    render(AVPlayerCanonicalODTV);
 
     expect(document.querySelector('noscript')).toBeInTheDocument();
   });
 
   it('should contain the iframe title on canonical', () => {
-    const { container } = render(AVPlayerCanonicalTV);
+    const { container } = render(AVPlayerCanonicalODTV);
 
     const AVPlayerIframeTitle = container
       .querySelector('iframe')
@@ -87,31 +98,60 @@ describe('AVPlayer for TV', () => {
   });
 });
 
-describe('AVPlayer for Radio', () => {
+describe('AVPlayer for On Demand Radio', () => {
   shouldMatchSnapshot(
     'should match snapshot for AMP AVPlayer',
-    AVPlayerAMPRadio,
+    AVPlayerAMPODRadio,
   );
 
   it('should render the iframe on AMP', () => {
-    render(AVPlayerAMPRadio);
+    render(AVPlayerAMPODRadio);
 
     expect(document.querySelector('amp-iframe')).toBeInTheDocument();
   });
 
   it('should contain the noscript tag for no-JS scenarios on AMP', () => {
-    render(AVPlayerAMPRadio);
+    render(AVPlayerAMPODRadio);
 
     expect(document.querySelector('noscript')).toBeInTheDocument();
   });
 
   it('should contain the iframe title on AMP', () => {
-    const { container } = render(AVPlayerAMPRadio);
+    const { container } = render(AVPlayerAMPODRadio);
 
     const AVPlayerIframeTitle = container
       .querySelector('amp-iframe')
       .getAttribute('title');
 
     expect(AVPlayerIframeTitle).toEqual('Audio player');
+  });
+});
+
+describe('AVPlayer for Live Radio', () => {
+  shouldMatchSnapshot(
+    'should match snapshot for canonical AVPlayer',
+    AVPlayerLiveRadio,
+  );
+
+  it('should render the iframe on canonical', () => {
+    render(AVPlayerLiveRadio);
+
+    expect(document.querySelector('iframe')).toBeInTheDocument();
+  });
+
+  it('should contain the noscript tag for no-JS scenarios on canonical', () => {
+    render(AVPlayerLiveRadio);
+
+    expect(document.querySelector('noscript')).toBeInTheDocument();
+  });
+
+  it('should contain the iframe title on canonical', () => {
+    const { container } = render(AVPlayerLiveRadio);
+
+    const AVPlayerIframeTitle = container
+      .querySelector('iframe')
+      .getAttribute('title');
+
+    expect(AVPlayerIframeTitle).toEqual('오디오 플레이어');
   });
 });


### PR DESCRIPTION
Resolves #6881

**Overall change:**
Switching LiveRadio over to use the new AVPlayer. Tests first followed by switch.

**Code changes:**

- Added LiveRadio tests to the new AVPlayer component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
