### PR TITLE
Add AMP iFrame script to VJ Amp Include

### DIFF
--- a/src/app/containers/Include/amp/VjAmp.jsx
+++ b/src/app/containers/Include/amp/VjAmp.jsx
@@ -1,7 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Helmet } from 'react-helmet';
 import { shape, string } from 'prop-types';
 import { GridItemConstrainedMedium } from '#lib/styledGrid';
+
+const AmpHead = () => (
+  <Helmet>
+    <script
+      async
+      custom-element="amp-iframe"
+      src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"
+    />
+  </Helmet>
+);
 
 const IncludeGrid = styled(GridItemConstrainedMedium)`
   display: grid;
@@ -9,17 +20,20 @@ const IncludeGrid = styled(GridItemConstrainedMedium)`
 
 const VjAmp = ({ ampMetadata: { imageWidth, imageHeight, image, src } }) => {
   return (
-    <IncludeGrid>
-      <amp-iframe
-        width={imageWidth}
-        height={imageHeight}
-        layout="responsive"
-        sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-forms"
-        src={src}
-      >
-        <amp-img layout="fill" src={image} placeholder />
-      </amp-iframe>
-    </IncludeGrid>
+    <>
+      <AmpHead />
+      <IncludeGrid>
+        <amp-iframe
+          width={imageWidth}
+          height={imageHeight}
+          layout="responsive"
+          sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-forms"
+          src={src}
+        >
+          <amp-img layout="fill" src={image} placeholder />
+        </amp-iframe>
+      </IncludeGrid>
+    </>
   );
 };
 

--- a/src/app/containers/Include/amp/VjAmp.test.jsx
+++ b/src/app/containers/Include/amp/VjAmp.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import VjAmp from './VjAmp';
 
 const vjProps = {
@@ -16,5 +16,23 @@ describe('VJ include container on Amp', () => {
     expect(container.querySelector('amp-iframe')).toBeInTheDocument();
     expect(container.querySelector('amp-img')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
+  });
+
+  it(`should add amp-iframe extension script to page head`, async () => {
+    render(<VjAmp ampMetadata={vjProps} />);
+
+    await waitFor(() => {
+      const scripts = Array.from(document.querySelectorAll('head script'));
+
+      expect(scripts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            src: `https://cdn.ampproject.org/v0/amp-iframe-0.1.js`,
+          }),
+        ]),
+      );
+
+      expect(scripts).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
No issue

**Overall change:**
Adds a missing script required for amp-iframes to load, allowing VJ includes to load on AMP Story pages _without a media player_. Story pages without a media player were unaffected as the script in included with the media player.

**Code changes:**
- Add amp-iframe extension script to `VjAmp` component using helmet, the script will be de-duped where a media player is present.
- Add test to check the script is added to the page head when the `VjAmp` component is used.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**
Example of an affected page: http://localhost:7080/gahuza/23299713.amp
Example of a page with a media player that should still work: http://localhost:7080/mundo/23263889.amp ("Test Includes: Visual Journalism with iFrame" appears to not have an amp version when it should have "Test Includes: Visual Journalism with interactive content" does have an amp version and loads as expected)

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
