### PR TITLE
Add babel-plugin-proposal-optional-chaining to replace path/pathOr

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,5 @@
 var plugins = [
+  '@babel/plugin-proposal-optional-chaining',
   '@babel/plugin-proposal-object-rest-spread', // allows ...spread notation
   '@babel/plugin-syntax-dynamic-import', // allows `await import()` syntax
   '@babel/plugin-transform-runtime',

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,13 +936,21 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
-      "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
+      "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-proposal-private-methods": {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   "devDependencies": {
     "@babel/core": "^7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
+    "@babel/plugin-proposal-optional-chaining": "^7.10.4",
     "@babel/plugin-proposal-throw-expressions": "^7.10.1",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.10.4",

--- a/src/app/containers/AVPlayer/index.jsx
+++ b/src/app/containers/AVPlayer/index.jsx
@@ -4,7 +4,6 @@ import {
   CanonicalMediaPlayer,
   AmpMediaPlayer,
 } from '@bbc/psammead-media-player';
-import pathOr from 'ramda/src/pathOr';
 import { RequestContext } from '#contexts/RequestContext';
 import { ServiceContext } from '#contexts/ServiceContext';
 
@@ -26,11 +25,10 @@ const AVPlayer = ({
     title,
     type,
   };
-  const noJsMessage = pathOr(
-    `This ${mediaInfo.type} cannot play in your browser. Please enable JavaScript or try a different browser.`,
-    ['media', 'noJs'],
-    translations,
-  );
+
+  const noJsMessage =
+    translations?.media?.noJs ||
+    `This ${mediaInfo.type} cannot play in your browser. Please enable JavaScript or try a different browser.`;
 
   if (!isValidPlatform || !assetId) return null;
 

--- a/src/app/containers/Ad/Amp/index.jsx
+++ b/src/app/containers/Ad/Amp/index.jsx
@@ -10,7 +10,6 @@ import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 
 import { GEL_SPACING_DBL, GEL_SPACING } from '@bbc/gel-foundations/spacings';
 import { C_LUNAR_LIGHT, C_RHINO } from '@bbc/psammead-styles/colours';
-import pathOr from 'ramda/src/pathOr';
 import { getMinion } from '@bbc/gel-foundations/typography';
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -77,7 +76,7 @@ export const AMP_ACCESS_FETCH = service => {
 
 const AmpAd = ({ slotType }) => {
   const { ads, dir, script, service } = useContext(ServiceContext);
-  const label = pathOr('Advertisement', ['advertisementLabel'], ads);
+  const label = ads?.advertisementLabel || 'Advertisement';
 
   return (
     <div amp-access="toggles.ads.enabled" amp-access-hide="true">

--- a/src/app/containers/Ad/index.jsx
+++ b/src/app/containers/Ad/index.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { oneOf } from 'prop-types';
-import pathOr from 'ramda/src/pathOr';
 import useToggle from '#hooks/useToggle';
 import { RequestContext } from '#contexts/RequestContext';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -10,7 +9,7 @@ import CanonicalAd from './Canonical';
 const AdContainer = ({ slotType }) => {
   const { isAmp } = useContext(RequestContext);
   const { ads } = useContext(ServiceContext);
-  const hasAds = pathOr(false, ['hasAds'], ads);
+  const hasAds = ads?.hasAds || false;
   const { enabled: adsEnabled } = useToggle('ads');
 
   if (!hasAds || !adsEnabled) {

--- a/src/app/containers/Bulletin/index.jsx
+++ b/src/app/containers/Bulletin/index.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import pathOr from 'ramda/src/pathOr';
 import { shape, bool, oneOfType } from 'prop-types';
 import Bulletin from '@bbc/psammead-bulletin';
 import ImageWithPlaceholder from '../ImageWithPlaceholder';
@@ -58,30 +57,30 @@ BulletinImage.defaultProps = {
 const BulletinContainer = ({ item, lazyLoadImage }) => {
   const { script, service, dir, translations } = useContext(ServiceContext);
 
-  const headline = pathOr(null, ['name'], item);
-  const ctaLink = pathOr(null, ['uri'], item);
+  const headline = item?.name || null;
+  const ctaLink = item?.uri || null;
 
   if (!headline || !ctaLink) {
     return null;
   }
 
-  const summary = pathOr(null, ['summary'], item);
+  const summary = item?.summary || null;
 
-  const imageValues = pathOr(null, ['indexImage'], item);
+  const imageValues = item?.indexImage || null;
   const Image = imageValues && (
     <BulletinImage lazyLoad={lazyLoadImage} imageValues={imageValues} />
   );
 
-  const contentType = pathOr(null, ['contentType'], item);
+  const contentType = item?.contentType || null;
   const mediaType = contentType === 'TVBulletin' ? 'video' : 'audio';
 
-  const watchText = pathOr('Watch', ['media', 'watch'], translations);
-  const listenText = pathOr('Listen', ['media', 'listen'], translations);
-  const liveText = pathOr('LIVE', ['media', 'liveLabel'], translations);
+  const watchText = translations?.media?.watch || 'Watch';
+  const listenText = translations?.media?.listen || 'Listen';
+  const liveText = translations?.media?.liveLabel || 'LIVE';
   const ctaText = contentType === 'TVBulletin' ? watchText : listenText;
   const ctaTextIsEnglish = ctaText === 'Watch' || ctaText === 'Listen';
 
-  const isLive = pathOr(null, ['isLive'], item);
+  const isLive = item?.isLive || null;
 
   // This offscreen text should come from a fully translated string.
   // https://github.com/bbc/simorgh/issues/5626

--- a/src/app/containers/Caption/index.jsx
+++ b/src/app/containers/Caption/index.jsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { any, arrayOf, shape, string } from 'prop-types';
 import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
 import Caption from '@bbc/psammead-caption';
-import pathOr from 'ramda/src/pathOr';
 import { ServiceContext } from '#contexts/ServiceContext';
 import Blocks from '../Blocks';
 import Fragment from '../Fragment';
@@ -34,9 +33,10 @@ const chooseOffscreenText = (
   }
 };
 const renderParagraph = block => {
-  const paragraphBlock = pathOr(null, ['model', 'blocks'], block);
+  const paragraphBlock = block?.model?.blocks || null;
+  const key = paragraphBlock?.[0]?.id || null;
   return (
-    <p key={pathOr(null, ['0', 'id'], paragraphBlock)}>
+    <p key={key}>
       <Blocks blocks={paragraphBlock} componentsToRender={componentsToRender} />
     </p>
   );
@@ -65,12 +65,7 @@ const CaptionContainer = ({ block, type }) => {
     defaultCaptionOffscreenText,
   );
 
-  const paragraphBlocks = pathOr(
-    null,
-    ['model', 'blocks', 0, 'model', 'blocks'],
-    block,
-  );
-
+  const paragraphBlocks = block?.model?.blocks?.[0]?.model?.blocks || null;
   return renderCaption(paragraphBlocks, offscreenText, script, service);
 };
 


### PR DESCRIPTION
Resolves #6258

_**Currently just a draft pending further discussion**_

**Overall change:**

- Adds babel-plugin-proposal-optional-chaining to simorgh and replaces a few existing pathOr uses

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
