### PR TITLE
Use latest version of Puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "storybook": "start-storybook -p 9001 -s .storybook/static -c .storybook",
     "test": "npm run build && npm run test:local",
     "test:local": "npm run test:lint && npm run test:dependencies && npm run test:unit && run-p --race start amp:validate && run-p --race start test:integration:ci",
-    "test:ci": "npm run start & npm install --no-save cypress@3.4.1 bbc-a11y@latest npm-run-all@latest puppeteer@4.0.1 audit-ci@latest && npm run test:integration:ci && run-p cypress:ci test:puppeteer && run-p bbcA11y:ci lighthouse && audit-ci --config audit-ci.json",
+    "test:ci": "npm run start & npm install --no-save cypress@3.4.1 bbc-a11y@latest npm-run-all@latest puppeteer@latest audit-ci@latest && npm run test:integration:ci && run-p cypress:ci test:puppeteer && run-p bbcA11y:ci lighthouse && audit-ci --config audit-ci.json",
     "test:dependencies": "node ./scripts/dependencyCheck",
     "test:e2e": "npm run stop && npm run build && run-p --race start cypress",
     "test:e2e:interactive": "npm run stop && npm run build && run-p --race start cypress:interactive",


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/7149

**Overall change:**
_We hardcoded the version of puppeteer because there was bug with version 5 release where it excessively logged which caused our travis jobs to crash because it exceeded the max number logs possible._

There is a new version of puppeteer now: https://github.com/puppeteer/puppeteer/releases/tag/v5.1.0 and when running locally, I do not see excessive logs like before: 
![image](https://user-images.githubusercontent.com/30599794/87579610-179dc680-c6ce-11ea-9d60-b0cf1f1f4adf.png)
 

**Code changes:**

- _Install latest version of puppeteer on CI_

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added labels to this PR for the relevant pod(s) affected by these changes
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
