### PR TITLE
Patch lodash in cypress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8186,9 +8186,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.9.0.tgz",
-      "integrity": "sha512-qGxT5E0j21FPryzhb0OBjCdhoR/n1jXtumpFFSBPYWsaZZhNaBvc3XlBUDEZKkkXPsqUFYiyhWdHN/zo0t5FcA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.10.0.tgz",
+      "integrity": "sha512-eFv1WPp4zFrAgZ6mwherBGVsTpHvay/hEF5F7U7yfAkTxsUQn/ZG/LdX67fIi3bKDTQXYzFv/CvywlQSeug8Bg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -8289,6 +8289,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "dev": true
         },
         "moment": {
@@ -9922,7 +9928,7 @@
     },
     "eslint-config-prettier": {
       "version": "6.11.0",
-      "resolved": "https://npm.morph.int.tools.bbc.co.uk/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
       "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
@@ -16034,9 +16040,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "chrome-launcher": "^0.13.3",
     "compression-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^6.0.2",
-    "cypress": "4.9.0",
+    "cypress": "^4.10.0",
     "cypress-multi-reporters": "^1.4.0",
     "depcheck": "^0.9.2",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Bumps cypress to 4.10 and manually patches lodash within cypress to 4.17.19
- Bumps lodash to 4.17.19 in the package-lock

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
