### PR TITLE
Stop running tests on merge to latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,7 @@ def buildStaticAssets(env, tag) {
 
   sh "npm run build:$env"
   sh 'rm -rf staticAssets && mkdir staticAssets'
+  sh "find build -type f -name '*.png' -delete" // Temo remove all .png assets to speed up upload of static assets (These assets are already avaiable on the CDN)
   sh "cp -R build/. staticAssets"
   sh "cd staticAssets && xargs -a ../excludeFromPublicBuild.txt rm -f {}"
   zip archive: true, dir: 'staticAssets', glob: '', zipFile: "static${tag}.zip"
@@ -155,7 +156,12 @@ pipeline {
         buildApplication()
       }
     }
+
+    // Dont run on latest
     stage ('Test') {
+      when {
+        expression { env.BRANCH_NAME != 'latest' }
+      }
       failFast true
       parallel {
         stage ('Test Development') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,10 +157,11 @@ pipeline {
       }
     }
 
-    // Only run chromatic tests on latest
     stage ('Test') {
       failFast true
       parallel {
+
+        // Do not run on latest, as these tests ran in the PR checks
         stage ('Test Development') {
           when {
             expression { env.BRANCH_NAME != 'latest' }
@@ -181,6 +182,7 @@ pipeline {
           }
         }
 
+        // Do not run on latest, as these tests ran in the PR checks
         stage ('Test Production') {
           when {
             expression { env.BRANCH_NAME != 'latest' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,12 @@ pipeline {
         installDependencies()
       }
     }
+
+    // Do not run on latest
     stage ('Build for Test') {
+      when {
+        expression { env.BRANCH_NAME != 'latest' }
+      }
       agent {
         docker {
           image "${nodeImage}"


### PR DESCRIPTION
Resolves N/A

This PR stops the CI pipeline from running the tests on a merge to latest, as these tests have already run as part of the PR checks. A PR cannot be merged in with failing CI checks.

**Overall change:**
- Do not run the testing stage on a merge to latest
- Remove .png assets before uploading via the static assets uploader

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added labels to this PR for the relevant pod(s) affected by these changes
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
