### PR TITLE
Bump @bbc/psammead-assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,9 +1795,9 @@
       "integrity": "sha512-Jjkk9ieEa0WXK4Wvw82YVvMhP4yi0pBOftwNhQGOVLx1Av8KSHFHacFxHEiVcVxoXCPpdeWaLYrKm0fcyoxlKA=="
     },
     "@bbc/psammead-assets": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.14.0.tgz",
-      "integrity": "sha512-mkjtc2BIVmtUXy9dTpmKqrzBmlgbPJmIfxDEK4L47LqrXQxrVgf7XFmug3SnQ5okKy7//5/C509V/eLsoTC8VA=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-2.14.1.tgz",
+      "integrity": "sha512-/QoNnowCBQh1mLB05nT8dxdf2Ud2U7GYbbBB/tescO68oIPlj/cLMJOXQc9sUQPxVgQQCQeA0Ls/o8dIOpry3Q=="
     },
     "@bbc/psammead-brand": {
       "version": "5.1.24",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@bbc/gel-foundations": "4.1.0",
     "@bbc/moment-timezone-include": "^1.1.4",
     "@bbc/psammead-amp-geo": "^1.1.2",
-    "@bbc/psammead-assets": "^2.14.0",
+    "@bbc/psammead-assets": "^2.14.1",
     "@bbc/psammead-brand": "^5.1.24",
     "@bbc/psammead-bulleted-list": "1.0.11",
     "@bbc/psammead-bulletin": "^3.2.6",


### PR DESCRIPTION
**Overall change:**
In this [PR](https://github.com/bbc/simorgh/pull/7180/) we introduced a version of the `@bbc/psammead-embed-error` package which uses `"@bbc/psammead-assets": "^2.14.1"` as a dependency, but Simorgh is still using the `^2.14.0` version of `psammead-assets` resulting in a duplication of packages.

![npm-duplication](https://user-images.githubusercontent.com/46446236/88147070-9fb32d00-cbf4-11ea-9e7f-7e0d16e0ff9a.png)


**Code changes:**
- Bump `@bbc/psammead-assets` to `2.14.1`

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added labels to this PR for the relevant pod(s) affected by these changes
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
