### PR TITLE
POC - Change consent preferences on AMP after initial choice

### DIFF
--- a/src/app/containers/ConsentBanner/Banner/index.amp.jsx
+++ b/src/app/containers/ConsentBanner/Banner/index.amp.jsx
@@ -12,9 +12,9 @@ const Accept = (message, onClick, dataAttribute) => (
 );
 
 const Reject = (message, href, onClick, dataAttribute) => (
-  <a href={href} on={onClick} {...dataAttribute}>
+  <div href={href} on={onClick} {...dataAttribute}>
     {message}
-  </a>
+  </div>
 );
 
 const AmpConsentBannerContainer = ({

--- a/src/app/containers/ConsentBanner/index.amp.jsx
+++ b/src/app/containers/ConsentBanner/index.amp.jsx
@@ -69,14 +69,9 @@ const Amp = () => (
         />
       </div>
       <div id="post-consent-ui">
-        <Banner
-          type="privacy"
-          acceptAction={`tap:consent-element.dismiss`}
-          rejectAction={`${console.log('aksjdhasdladj')}`}
-          promptId={postPromptId}
-        >
-          Aaslkdjalskdjalskjd
-        </Banner>
+        <button on={`tap:${parentId}.prompt`} type="button">
+          Consent Preferences
+        </button>
       </div>
     </amp-consent>
   </AmpConsentWrapper>

--- a/src/app/containers/ConsentBanner/index.amp.jsx
+++ b/src/app/containers/ConsentBanner/index.amp.jsx
@@ -5,6 +5,7 @@ import Banner from './Banner/index.amp';
 
 const parentId = 'consent';
 const promptId = 'consent-prompt';
+const postPromptId = 'post-consent-ui';
 const privacyId = 'privacy';
 const cookieId = 'cookie';
 
@@ -15,6 +16,7 @@ const ampConsentData = {
       promptUI: promptId,
     },
   },
+  postPromptUI: postPromptId,
   policy: {
     default: {
       waitFor: {
@@ -65,6 +67,16 @@ const Amp = () => (
           promptId={cookieId}
           hidden
         />
+      </div>
+      <div id="post-consent-ui">
+        <Banner
+          type="privacy"
+          acceptAction={`tap:consent-element.dismiss`}
+          rejectAction={`${console.log('aksjdhasdladj')}`}
+          promptId={postPromptId}
+        >
+          Aaslkdjalskdjalskjd
+        </Banner>
       </div>
     </amp-consent>
   </AmpConsentWrapper>

--- a/src/app/lib/config/toggles/index.js
+++ b/src/app/lib/config/toggles/index.js
@@ -1,7 +1,7 @@
 const toggles = {
   local: {
     ads: {
-      enabled: false,
+      enabled: true,
     },
     chartbeatAnalytics: {
       enabled: true,


### PR DESCRIPTION
Possible solution for #7086

**Overall change:**
Adds a simple button which allows users to change their consent preferences after accepting or rejecting personalisation  with a prompt which brings back the consent banner.

**Additional Context**
#7086 explains how our AMP consent works differently from our canonical solution:

> Our AMP pages do not have access to the same cookies as above. This is primarily because the pages are most often served from the Google AMP cache, and so served on a non-BBC domain - standard browser security patterns will not grant a webpage on a third-party domain access to bbc.com cookies.
When the Cookie Banner is accepted on AMP, AMP itself (the code provided for the platform by Google) records in Local Storage (a form of browser data storage similar to, but distinct from, cookies) that the user has consented.

Clarifying this, regardless of whether the user accepts or declines the personalisation, AMP stores a hash in local storage (`amp-store`) to register this information. The difference is that the hash registering that personalised ads have been rejected has `npa=1` in the ad request. This information can be used to verify that this proposed solution correctly changes the AMP consent accordingly and can be tested by looking at the `ads?` request in dev tools.

The purpose of this POC is to show that the consent can be revoked/re-consented by utilising [`postPromptUI`](https://amp.dev/documentation/components/amp-consent/#post-prompt) which brings up a prompt after a user chooses to accept or reject personalisation consent. Re-selecting a choice will overwrite the `amp-store` hash in local storage. 

**Things not addressed in this POC**
- This POC shows the desired functionality and this implementation is done in this way just to show this. However, how we want to do this in production is a question to be answered before continuing. At the moment we have a button which shows up in the footer to bring up the consent banner again. As we cannot link back to the consent preferences in the same way as the canonical pages do, is there any better way to do this? Anywhere else we could add it (eg. a persisting button that shows regardless of where the user has scrolled)? 

- From #7086 

> If the user is outside of the EEA (+ UK), they can be opted in by default, but still need a way of revoking their permission, this is specifically for californian legislation.

The consent banner for AMP currently does not show for users outside of the EEA and this POC does not add the functionality to auto-opt in for personalised ads for these users.

- AMP Consent has a master issue [here](https://github.com/ampproject/amphtml/issues/15651) which shows a list of enhancements to be made to the package. In particular, [this issue](https://github.com/ampproject/amphtml/issues/15394) regarding showing the user their current choice in personalisation options may be something to look into in the future. 



**Code changes:**
- Added `postPromptUI` to `ampConsentData` in Consent Banner.
- Changed Reject `href` to `div` to test the `amp-store` hash change. This is because the reject link in the Consent Banner usually goes to the BBC Cookies/Preferences management page where canonical consent preferences are set. This is semantically incorrect as @thekp pointed out but will be changed if/when we make a production version of this solution.
- Toggled Ads on locally to test the differences in the `amp-store` hash for personalised/non-personalised ads

**Other Notes**
- The reason why the button has just an `on` attribute is because the event that usually follows is written this way is because of the way AMP handles [actions and events](https://amp.dev/documentation/guides-and-tutorials/learn/amp-actions-and-events/) which does not follow the usual [Javascript Events convention](https://www.w3schools.com/jsref/dom_obj_event.asp)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
