### PR TITLE
Make index alsos which are promo assets work

### DIFF
--- a/data/persian/frontpage/index.json
+++ b/data/persian/frontpage/index.json
@@ -42,58 +42,95 @@
   },
   "content": {
     "groups": [
-      {
-        "type": "top-story",
-        "title": "Top story",
-        "maxRelatedLinks": 6,
+            {
         "items": [
           {
-            "headlines": {
-              "headline": "وزارت خارجه ایران: انگلیسی‌ها هرچه زودتر نفتکش حامل نفت ایران را رها کنند"
-            },
-            "locators": {
-              "assetUri": "/persian/iran-48960890",
-              "cpsUrn": "urn:bbc:content:assetUri:persian/iran-48960890"
-            },
-            "summary": "سخنگوی وزارت خارجه ایران با اعلام اینکه در ارتباط با توقیف ابرنفتکس حامل نفت ایران، سفیر بریتانیا در تهران بار دیگر به این وزارتخانه احضار شده است. وی دولت بریتانیا را به اقدام غیرقانونی در توقیف این نفتکش متهم کرده و همچنین گفته است که مقصد نفتکش سوریه نبوده است.",
-            "timestamp": 1562918428000,
-            "passport": {
-              "category": {
-                "categoryId": "http://www.bbc.co.uk/ontologies/applicationlogic-news/News",
-                "categoryName": "News"
-              },
-              "campaigns": [
-                {
-                  "campaignId": "5a988e4739461b000e9dabfc",
-                  "campaignName": "WS - Update me"
-                }
-              ]
-            },
             "cpsType": "STY",
+            "headlines": {
+              "headline": "تست تست"
+            },
+            "id": "urn:bbc:ares::asset:persian/iran-23297514",
             "indexImage": {
-              "id": "107846673",
-              "subType": "index",
-              "href": "http://c.files.bbci.co.uk/9320/production/_107846673_uk1.jpg",
-              "path": "/cpsprodpb/9320/production/_107846673_uk1.jpg",
+              "altText": "لبلب",
+              "caption": "لبلب",
+              "copyrightHolder": "fdf",
               "height": 549,
-              "width": 976,
-              "altText": "گریس ۱",
-              "caption": "نفتکش گریس-۱ حامل نفت خام ایران به درخواست دولت جبل‌الطارق توسط تفنگداران دریایی بریتانیا توقیف شد",
-              "copyrightHolder": "Getty Images"
+              "href": "http://b.files.bbci.co.uk/499B/test/_63734881_world-map-corona_nc.png",
+              "id": "63734881",
+              "path": "/cpsdevpb/499B/test/_63734881_world-map-corona_nc.png",
+              "subType": "index",
+              "type": "image",
+              "width": 976
+            },
+            "language": "fa",
+            "locators": {
+              "assetId": "23297514",
+              "assetUri": "/persian/iran-23297514",
+              "cpsUrn": "urn:bbc:content:assetUri:persian/iran-23297514",
+              "curie": "http://www.bbc.co.uk/asset/f51e7e4c-33e6-9749-8718-fe31de961d62"
             },
             "options": {
-              "isBreakingNews": false,
+              "isBreakingNews": true,
               "isFactCheck": false
             },
+            "overtypedSummary": "نارندرا مودی، نخست‌وزیر هند با محکوم کردن حمله انتحاری به سربازان این کشور در کشمیر، به پاکستان در باره ایجاد بی‌ثباتی در کشورش هشدار داده است.",
             "prominence": "standard",
-            "id": "urn:bbc:ares::asset:persian/iran-48960890",
+            "relatedItems": [
+              {
+                "cpsType": "STY",
+                "headlines": {
+                  "headline": "یک سیاره 'شبیه زمین' در نزدیکی منظومه شمسی کشف 2"
+                },
+                "id": "urn:bbc:ares::asset:persian/science-23069368",
+                "language": "fa",
+                "locators": {
+                  "assetUri": "/persian/science-23069368",
+                  "cpsUrn": "urn:bbc:content:assetUri:/persian/science-23069368"
+                },
+                "summary": "ستاره‌شناسان می‌گویند سیاره‌ای را در نزدیکی منظومه شمسی شناسایی کردند که تقریبا هم اندازه کره زمین است و به دور ستاره پروکسیما قنطورس می‌چرخد.",
+                "timestamp": 1472108857000,
+                "type": "cps"
+              },
+              {
+                "cpsType": "STY",
+                "headlines": {
+                  "headline": "یک سیاره 'شبیه زمین' در نزدیکی منظومه شمسی کشف 4"
+                },
+                "id": "urn:bbc:ares::asset:persian/afghanistan-23069386",
+                "language": "fa",
+                "locators": {
+                  "assetUri": "/persian/afghanistan-23069386",
+                  "cpsUrn": "urn:bbc:content:assetUri:/persian/afghanistan-23069386"
+                },
+                "summary": "ستاره‌شناسان می‌گویند سیاره‌ای را در نزدیکی منظومه شمسی شناسایی کردند که تقریبا هم اندازه کره زمین است و به دور ستاره پروکسیما قنطورس می‌چرخد.",
+                "timestamp": 1472114141000,
+                "type": "cps"
+              },
+              {
+                "name": "Promo link in Index Alsos",
+                "type": "link",
+                "uri": "https://www.bbc.com/persian/live/53482744?ns_mchannel=social&ns_source=twitter&ns_campaign=bbc_live&ns_linkname=5f16cd1ee58936065f587b11%26%DA%A9%D9%85%DA%A9%20%D8%BA%D9%88%D8%A7%D8%B5%D8%A7%D9%86%20%D8%A8%D9%87%20%D9%86%D8%AC%D8%A7%D8%AA%20%DB%8C%DA%A9%20%D8%B4%D8%A7%D9%87%E2%80%8C%D9%86%D9%87%D9%86%DA%AF%262020-07-21T11%3A10%3A23.221Z&ns_fee=0&pinned_post_locator=urn:asset:9734d6bb-98e8-4bcf-8fa9-09f165dd1b1d&pinned_post_asset_id=5f16cd1ee58936065f587b11&pinned_post_type=share"
+              }
+            ],
+            "section": {
+              "name": "صفحه ایران",
+              "subType": "IDX",
+              "type": "simple",
+              "uri": "/persian/iran"
+            },
+            "summary": "تست تست",
+            "timestamp": 1588685965000,
             "type": "cps"
           }
         ],
+        "maxRelatedLinks": 4,
+        "semanticGroupName": "Top story",
         "strapline": {
-          "name": "Top story - Persian"
+          "name": "خبر اول",
+          "summary": "خبر اول"
         },
-        "semanticGroupName": "Top story"
+        "title": "Top story",
+        "type": "top-story"
       },
       {
         "type": "live-event-now",

--- a/src/app/containers/StoryPromo/IndexAlsos/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/IndexAlsos/__snapshots__/index.test.jsx.snap
@@ -197,6 +197,21 @@ exports[`Index Alsos Snapshots should render multiple correctly 1`] = `
         </span>
       </a>
     </li>
+    <li
+      class="c3"
+      role="listitem"
+    >
+      <a
+        class="c4"
+        href="https://www.bbc.com/persian"
+      >
+        <span
+          class="c8"
+        >
+          Promo link in Index Alsos
+        </span>
+      </a>
+    </li>
   </ul>
 </div>
 `;

--- a/src/app/containers/StoryPromo/IndexAlsos/index.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.jsx
@@ -59,6 +59,26 @@ buildIndexAlsosMediaIndicator.defaultProps = {
   dir: 'ltr',
 };
 
+const extractLinkPromoData = item => {
+  const indexAlsoItem = {};
+  indexAlsoItem.id = pathOr(null, ['uri'], item);
+  indexAlsoItem.indexAlsoHeadline = pathOr(null, ['name'], item);
+  indexAlsoItem.url = pathOr(null, ['uri'], item);
+
+  return indexAlsoItem;
+};
+
+const extractAssetPromoData = item => {
+  const indexAlsoItem = {};
+  indexAlsoItem.id = pathOr(null, ['id'], item);
+  const assetHeadline = pathOr(null, ['headlines', 'headline'], item);
+  const overtypedHeadline = pathOr(null, ['headlines', 'overtyped'], item);
+  indexAlsoItem.indexAlsoHeadline = overtypedHeadline || assetHeadline;
+  indexAlsoItem.url = pathOr(null, ['locators', 'assetUri'], item);
+
+  return indexAlsoItem;
+};
+
 /*
  * When there are more than one Index Alsos, they should be wrapped in a list item `IndexAlsosLi` within an unordered list `IndexAlsosUl`.
  * On the other hand, when there is exactly one Index Also, it should use the `IndexAlso` component and it should not be contained within a list.
@@ -77,23 +97,13 @@ const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
         {alsoItems.slice(0, MAX_NUM_INDEX_ALSOS).map(item => {
           const { cpsType, mediaType } = item;
 
-          const aresId = pathOr(null, ['id'], item);
-          const promoId = pathOr(null, ['uri'], item);
-          const id = aresId || promoId;
-
-          const headline = pathOr(null, ['headlines', 'headline'], item);
-          const overtypedHeadline = pathOr(
-            null,
-            ['headlines', 'overtyped'],
-            item,
-          );
-          const promoHeadline = pathOr(null, ['name'], item);
-          const indexAlsoHeadline =
-            overtypedHeadline || headline || promoHeadline;
-
-          const assetUrl = pathOr(null, ['locators', 'assetUri'], item);
-          const promoUrl = pathOr(null, ['uri'], item);
-          const url = assetUrl || promoUrl;
+          let indexAlsoData;
+          if (item.type === 'link') {
+            indexAlsoData = extractLinkPromoData(item);
+          } else {
+            indexAlsoData = extractAssetPromoData(item);
+          }
+          const { id, indexAlsoHeadline, url } = indexAlsoData;
 
           const indexAlsoMediaIndicator = buildIndexAlsosMediaIndicator({
             cpsType,

--- a/src/app/containers/StoryPromo/IndexAlsos/index.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.jsx
@@ -75,7 +75,11 @@ const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
     <IndexAlsos offScreenText={relatedContent} data-e2e="index-alsos">
       <IndexAlsosWrapper>
         {alsoItems.slice(0, MAX_NUM_INDEX_ALSOS).map(item => {
-          const { id, cpsType, mediaType } = item;
+          const { cpsType, mediaType } = item;
+
+          const aresId = pathOr(null, ['id'], item);
+          const promoId = pathOr(null, ['uri'], item);
+          const id = aresId || promoId;
 
           const headline = pathOr(null, ['headlines', 'headline'], item);
           const overtypedHeadline = pathOr(
@@ -123,16 +127,18 @@ const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
 const alsoItemsPropTypes = shape({
   headlines: shape({
     headline: string.isRequired,
-  }).isRequired,
+  }),
   locators: shape({
     assetUri: string.isRequired,
     cpsUrn: string,
-  }).isRequired,
+  }),
   summary: string,
   timestamp: number,
-  cpsType: string.isRequired,
-  id: string.isRequired,
+  cpsType: string,
+  id: string,
   type: string,
+  name: string,
+  url: string,
 });
 
 IndexAlsosContainer.propTypes = {

--- a/src/app/containers/StoryPromo/IndexAlsos/index.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, Fragment } from 'react';
-import { arrayOf, shape, oneOf, number, string } from 'prop-types';
+import { arrayOf, shape, oneOf, number, string, oneOfType } from 'prop-types';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
 import pathOr from 'ramda/src/pathOr';
 import MediaIndicator from '@bbc/psammead-media-indicator';
@@ -134,25 +134,31 @@ const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
   );
 };
 
-const alsoItemsPropTypes = shape({
+const assetPromoAlsoItemsPropTypes = shape({
   headlines: shape({
     headline: string.isRequired,
-  }),
+  }).isRequired,
   locators: shape({
     assetUri: string.isRequired,
     cpsUrn: string,
-  }),
+  }).isRequired,
   summary: string,
   timestamp: number,
-  cpsType: string,
-  id: string,
+  cpsType: string.isRequired,
+  id: string.isRequired,
   type: string,
-  name: string,
-  url: string,
+});
+
+const linkPromoAlsoItemsPropTypes = shape({
+  name: string.isRequired,
+  url: string.isRequired,
+  id: string.isRequired,
 });
 
 IndexAlsosContainer.propTypes = {
-  alsoItems: arrayOf(alsoItemsPropTypes).isRequired,
+  alsoItems: arrayOf(
+    oneOfType(assetPromoAlsoItemsPropTypes, linkPromoAlsoItemsPropTypes),
+  ).isRequired,
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   dir: oneOf(['ltr', 'rtl']),

--- a/src/app/containers/StoryPromo/IndexAlsos/index.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.jsx
@@ -83,9 +83,14 @@ const IndexAlsosContainer = ({ alsoItems, script, service, dir }) => {
             ['headlines', 'overtyped'],
             item,
           );
-          const indexAlsoHeadline = overtypedHeadline || headline;
+          const promoHeadline = pathOr(null, ['name'], item);
+          const indexAlsoHeadline =
+            overtypedHeadline || headline || promoHeadline;
 
-          const url = pathOr(null, ['locators', 'assetUri'], item);
+          const assetUrl = pathOr(null, ['locators', 'assetUri'], item);
+          const promoUrl = pathOr(null, ['uri'], item);
+          const url = assetUrl || promoUrl;
+
           const indexAlsoMediaIndicator = buildIndexAlsosMediaIndicator({
             cpsType,
             mediaType,

--- a/src/app/containers/StoryPromo/IndexAlsos/index.test.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.test.jsx
@@ -45,74 +45,81 @@ describe('Index Alsos', () => {
   });
 
   describe('Assertions', () => {
-    it('should render a regular headline', () => {
-      const { container } = render(
-        <IndexAlsosContainer
-          alsoItems={relatedItems}
-          script={latin}
-          service="news"
-        />,
-      );
+    describe('It links to a CPS asset', () => {
+      it('should render a regular headline', () => {
+        const { container } = render(
+          <IndexAlsosContainer
+            alsoItems={relatedItems}
+            script={latin}
+            service="news"
+          />,
+        );
 
-      const firstListItem = container.querySelector('li');
-      const headline = firstListItem.getElementsByTagName('span')[2].innerHTML;
-      expect(headline).toEqual('APC ba ta isa ta kore ni ba – Buba Galadima');
+        const firstListItem = container.querySelector('li');
+        const headline = firstListItem.getElementsByTagName('span')[2]
+          .innerHTML;
+        expect(headline).toEqual('APC ba ta isa ta kore ni ba – Buba Galadima');
+      });
+
+      it('should render an overtyped headline', () => {
+        const { container } = render(
+          <IndexAlsosContainer
+            alsoItems={relatedItems}
+            script={latin}
+            service="news"
+          />,
+        );
+
+        const secondListItem = container.querySelectorAll('li')[1];
+        const headline = secondListItem.getElementsByTagName('span')[0]
+          .innerHTML;
+        expect(headline).toEqual('Overtyped headline');
+      });
+
+      it('should render a CPS url', () => {
+        const { container } = render(
+          <IndexAlsosContainer
+            alsoItems={relatedItems}
+            script={latin}
+            service="news"
+          />,
+        );
+
+        const firstListItem = container.querySelector('li');
+        const url = firstListItem.getElementsByTagName('a')[0].pathname;
+        expect(url).toEqual('/hausa/labarai-48916590');
+      });
     });
 
-    it('should render an overtyped headline', () => {
-      const { container } = render(
-        <IndexAlsosContainer
-          alsoItems={relatedItems}
-          script={latin}
-          service="news"
-        />,
-      );
+    describe('It links to a url', () => {
+      it('should render a promo headline', () => {
+        const { container } = render(
+          <IndexAlsosContainer
+            alsoItems={relatedItems}
+            script={latin}
+            service="news"
+          />,
+        );
 
-      const secondListItem = container.querySelectorAll('li')[1];
-      const headline = secondListItem.getElementsByTagName('span')[0].innerHTML;
-      expect(headline).toEqual('Overtyped headline');
-    });
+        const thirdListItem = container.querySelectorAll('li')[2];
+        const headline = thirdListItem.getElementsByTagName('span')[0]
+          .innerHTML;
+        expect(headline).toEqual('Promo link in Index Alsos');
+      });
 
-    it('should render a promo headline', () => {
-      const { container } = render(
-        <IndexAlsosContainer
-          alsoItems={relatedItems}
-          script={latin}
-          service="news"
-        />,
-      );
+      it('should render a promo hyperlink', () => {
+        const { container } = render(
+          <IndexAlsosContainer
+            alsoItems={relatedItems}
+            script={latin}
+            service="news"
+          />,
+        );
 
-      const thirdListItem = container.querySelectorAll('li')[2];
-      const headline = thirdListItem.getElementsByTagName('span')[0].innerHTML;
-      expect(headline).toEqual('Promo link in Index Alsos');
-    });
-
-    it('should render a CPS url', () => {
-      const { container } = render(
-        <IndexAlsosContainer
-          alsoItems={relatedItems}
-          script={latin}
-          service="news"
-        />,
-      );
-
-      const firstListItem = container.querySelector('li');
-      const url = firstListItem.getElementsByTagName('a')[0].pathname;
-      expect(url).toEqual('/hausa/labarai-48916590');
-    });
-
-    it('should render a promo hyperlink', () => {
-      const { container } = render(
-        <IndexAlsosContainer
-          alsoItems={relatedItems}
-          script={latin}
-          service="news"
-        />,
-      );
-
-      const thirdListItem = container.querySelectorAll('li')[2];
-      const url = thirdListItem.getElementsByTagName('a')[0].href;
-      expect(url).toEqual('https://www.bbc.com/persian');
+        const thirdListItem = container.querySelectorAll('li')[2];
+        const url = thirdListItem.getElementsByTagName('a')[0].href;
+        expect(url).toEqual('https://www.bbc.com/persian');
+      });
     });
   });
 });

--- a/src/app/containers/StoryPromo/IndexAlsos/index.test.jsx
+++ b/src/app/containers/StoryPromo/IndexAlsos/index.test.jsx
@@ -72,5 +72,47 @@ describe('Index Alsos', () => {
       const headline = secondListItem.getElementsByTagName('span')[0].innerHTML;
       expect(headline).toEqual('Overtyped headline');
     });
+
+    it('should render a promo headline', () => {
+      const { container } = render(
+        <IndexAlsosContainer
+          alsoItems={relatedItems}
+          script={latin}
+          service="news"
+        />,
+      );
+
+      const thirdListItem = container.querySelectorAll('li')[2];
+      const headline = thirdListItem.getElementsByTagName('span')[0].innerHTML;
+      expect(headline).toEqual('Promo link in Index Alsos');
+    });
+
+    it('should render a CPS url', () => {
+      const { container } = render(
+        <IndexAlsosContainer
+          alsoItems={relatedItems}
+          script={latin}
+          service="news"
+        />,
+      );
+
+      const firstListItem = container.querySelector('li');
+      const url = firstListItem.getElementsByTagName('a')[0].pathname;
+      expect(url).toEqual('/hausa/labarai-48916590');
+    });
+
+    it('should render a promo hyperlink', () => {
+      const { container } = render(
+        <IndexAlsosContainer
+          alsoItems={relatedItems}
+          script={latin}
+          service="news"
+        />,
+      );
+
+      const thirdListItem = container.querySelectorAll('li')[2];
+      const url = thirdListItem.getElementsByTagName('a')[0].href;
+      expect(url).toEqual('https://www.bbc.com/persian');
+    });
   });
 });

--- a/src/app/containers/StoryPromo/IndexAlsos/relatedItems.js
+++ b/src/app/containers/StoryPromo/IndexAlsos/relatedItems.js
@@ -31,6 +31,11 @@ const relatedItems = [
     id: 'urn:bbc:ares::asset:hausa/labarai-42837051',
     type: 'cps',
   },
+  {
+    name: 'Promo link in Index Alsos',
+    type: 'link',
+    uri: 'https://www.bbc.com/persian',
+  },
 ];
 
 export default relatedItems;

--- a/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -6627,6 +6627,21 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
             </span>
           </a>
         </li>
+        <li
+          class="c13"
+          role="listitem"
+        >
+          <a
+            class="c14"
+            href="https://www.bbc.com/persian"
+          >
+            <span
+              class="c18"
+            >
+              Promo link in Index Alsos
+            </span>
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/app/containers/StoryPromo/index.test.jsx
+++ b/src/app/containers/StoryPromo/index.test.jsx
@@ -331,13 +331,13 @@ describe('StoryPromo Container', () => {
     });
 
     describe('With Index Alsos', () => {
-      it('should render a list with two related items', () => {
+      it('should render a list with three related items', () => {
         const { container } = render(
           <WrappedStoryPromo item={indexAlsosItem} promoType="top" />,
         );
 
         expect(container.getElementsByTagName('ul')).toHaveLength(1);
-        expect(container.getElementsByTagName('li')).toHaveLength(2);
+        expect(container.getElementsByTagName('li')).toHaveLength(3);
       });
 
       it('should render a related item not contained within a list', () => {


### PR DESCRIPTION
Resolves #7298  

**Overall change:**
Fixes an issue where Promo assets would render incorrectly as Index Alsos (in Front Page Top Story)

**Code changes:**

- Updates fixture data for the Persian front page to include a promo asset as an index also
- Updates the IndexAlsos container to use the promo asset data which is totally different to a normal promo
- Adds new tests for promo asset as index also
- Updates existing tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
