### PR TITLE
prevent summary rendering in secondary column at medium gel widths

### DIFF
--- a/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
@@ -81,11 +81,6 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                   STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 eaCWBB"
-              >
-                This is a test asset used in Simorgh, please do not edit it without asking.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="2020-02-03"
@@ -135,11 +130,6 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                   Robert Mugabe: Zimbabwe eferela nwa amadi a aka
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 eaCWBB"
-              >
-                Gọọmentị nakwa ndị Zimbabwe pụtara n'igwe iji kwanyere aka chịburu ha bụ Robert Mugabe ugwu ikpeazụ ya na Harare.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="2020-02-03"

--- a/src/app/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/containers/CpsFeaturesAnalysis/index.jsx
@@ -25,7 +25,12 @@ const FeaturesAnalysis = ({ content, parentColumns }) => {
     <StoryPromoUl>
       {items.map(item => (
         <StoryPromoLi key={item.id || item.uri}>
-          <StoryPromo item={item} dir={dir} displayImage />
+          <StoryPromo
+            item={item}
+            dir={dir}
+            displayImage
+            displaySummary={false}
+          />
         </StoryPromoLi>
       ))}
     </StoryPromoUl>

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -94,11 +94,6 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   </span>
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 eaCWBB"
-              >
-                James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="1970-01-18"
@@ -149,11 +144,6 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   How light companies dey use estimated billing show Nigerians pepper
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 eaCWBB"
-              >
-                Lawmakers for Nigeria wan make am crime for light companies to use guesswork give customer estimated bill.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="1970-01-18"
@@ -204,11 +194,6 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   Nigeria: Wetin 5,222 megawatts electric fit do?
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 eaCWBB"
-              >
-                Di Transmission Company of Nigeria and di vice-president office carry tori come outside say electric power wey di country produce don increase pass before as e reach 5,222 megawatts dis December.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="1970-01-18"

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -60,7 +60,7 @@ const CpsRelatedContent = ({ content, parentColumns }) => {
           key={item.id || item.uri}
           dir={dir}
         >
-          <StoryPromo item={item} dir={dir} />
+          <StoryPromo item={item} dir={dir} displaySummary={false} />
         </Grid>
       ))}
     </Grid>

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -62,11 +62,6 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                   China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 hTsuvP"
-              >
-                Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="2020-02-03"
@@ -97,11 +92,6 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                   Nigeria don get five new cases of Coronavirus - See how e happun
                 </a>
               </h3>
-              <p
-                class="Summary-sc-1dvfmi3-4 hTsuvP"
-              >
-                Nigeria Health say di patients from UK and America travel come di kontri.
-              </p>
               <time
                 class="StyledTimestamp-um718p-0 kVWTyt"
                 datetime="2020-02-03"
@@ -174,11 +164,6 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
                 China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
               </a>
             </h3>
-            <p
-              class="Summary-sc-1dvfmi3-4 hTsuvP"
-            >
-              Un día después de que en Estados Unidos anunciaran que pasan a probar en humanos una posible vacuna para el nuevo coronavirus, diversas instituciones chinas revelaron este martes sus planes para iniciar a partir de abril ensayos clínicos de varias posibles vacunas contra el covid-19.
-            </p>
             <time
               class="StyledTimestamp-um718p-0 kVWTyt"
               datetime="2020-02-03"

--- a/src/app/containers/CpsTopStories/index.jsx
+++ b/src/app/containers/CpsTopStories/index.jsx
@@ -14,7 +14,12 @@ const TopStories = ({ content, parentColumns }) => {
   const title = pathOr('Top Stories', ['topStoriesTitle'], translations);
 
   const singleTransform = promo => (
-    <StoryPromo item={promo} dir={dir} displayImage={false} />
+    <StoryPromo
+      item={promo}
+      dir={dir}
+      displayImage={false}
+      displaySummary={false}
+    />
   );
 
   const listTransform = items => (

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -1038,11 +1038,6 @@ exports[`Media Asset Page should render component 1`] = `
                             Police Arrest 3 ontop Anambra Church Attack
                           </a>
                         </h3>
-                        <p
-                          class="Summary-sc-1dvfmi3-4 eaCWBB"
-                        >
-                          Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
-                        </p>
                         <time
                           class="StyledTimestamp-um718p-0 kVWTyt"
                           datetime="2017-08-08"
@@ -1093,11 +1088,6 @@ exports[`Media Asset Page should render component 1`] = `
                             Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                           </a>
                         </h3>
-                        <p
-                          class="Summary-sc-1dvfmi3-4 eaCWBB"
-                        >
-                          The men wey dem arrest almost one week ago don say dem no dey guilty, as court order dem to go for sexual rehabilitation.
-                        </p>
                         <time
                           class="StyledTimestamp-um718p-0 kVWTyt"
                           datetime="2017-08-08"
@@ -1183,11 +1173,6 @@ exports[`Media Asset Page should render component 1`] = `
                             </span>
                           </a>
                         </h3>
-                        <p
-                          class="Summary-sc-1dvfmi3-4 eaCWBB"
-                        >
-                          This na some of the picture wey our eye see as Kenya people go vote for election today
-                        </p>
                         <time
                           class="StyledTimestamp-um718p-0 kVWTyt"
                           datetime="2017-08-08"
@@ -1286,11 +1271,6 @@ exports[`Media Asset Page should render component 1`] = `
                             </span>
                           </a>
                         </h3>
-                        <p
-                          class="Summary-sc-1dvfmi3-4 eaCWBB"
-                        >
-                          All di local and world tori wey you suppose know in 60 seconds!
-                        </p>
                         <time
                           class="StyledTimestamp-um718p-0 kVWTyt"
                           datetime="2017-08-17"

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -2895,7 +2895,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
     </script>
   </head>
   <body>
-    .c40 {
+    .c39 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -2988,7 +2988,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   font-style: normal;
 }
 
-.c37 {
+.c36 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -3029,7 +3029,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   padding-bottom: 1rem;
 }
 
-.c36 {
+.c35 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -3164,17 +3164,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   line-height: 1.25rem;
 }
 
-.c35 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
 .c34 {
   position: static;
   color: #222222;
@@ -3205,7 +3194,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   color: #6E6E73;
 }
 
-.c38 {
+.c37 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3216,7 +3205,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   display: block;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3512,14 +3501,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c36 {
+  .c35 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c36 {
+  .c35 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -3752,42 +3741,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c35 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c35 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c35 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c35 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c38 {
+  .c37 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c38 {
+  .c37 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -4465,13 +4426,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c35"
-                            >
-                              Bole festival showcase di different types of bole dem.
-                            </p>
                             <time
-                              class="c36"
+                              class="c35"
                               datetime="2018-08-09"
                             >
                               9th August 2018
@@ -4495,22 +4451,22 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                               class="c30"
                             >
                               <div
-                                class="c37"
+                                class="c36"
                               />
                               <div
                                 class="c31"
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c38"
+                                  class="c37"
                                   dir="ltr"
                                 >
                                   <div
-                                    class="c39"
+                                    class="c38"
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      class="c40"
+                                      class="c39"
                                       focusable="false"
                                       height="13px"
                                       viewBox="0 0 32 26"
@@ -4556,13 +4512,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c35"
-                            >
-                              Jollof Festival happun for Lagos Nigeria on Sunday and na time for pipo wey show to sample West Africa fine food dem.
-                            </p>
                             <time
-                              class="c36"
+                              class="c35"
                               datetime="2018-08-19"
                             >
                               19th August 2018
@@ -6249,7 +6200,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   padding-bottom: 1rem;
 }
 
-.c56 {
+.c55 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -6382,17 +6333,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-}
-
-.c55 {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
 }
 
 .c54 {
@@ -6860,14 +6800,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c56 {
+  .c55 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c56 {
+  .c55 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -7096,34 +7036,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   .c53 {
     font-size: 1rem;
     line-height: 1.25rem;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c55 {
-    font-size: 0.9375rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c55 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c55 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c55 {
-    display: none;
-    visibility: hidden;
   }
 }
 
@@ -8393,13 +8305,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 ADR və Qazaxdan Qarsadək müsəlman dəhlizi ideyası
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              Bu il Azərbaycan Demokratik Respublikasının elan edilməsinin 100 illik yubileyidir. BBC Azərbaycanca bu ərəfədə Azərbaycan xalqının epik və mühüm günlərini həftəlik esselərlə təqdim edir.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-05-17"
                             >
                               17 May 2018
@@ -8448,13 +8355,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 ADR-100: Türk Əsgəri üçün Cəbrayıl çörəyi
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              ADR-100 layihəmizdə növbəti yazı: 1918-ci il martın 3-də Bolşeviklər Almaniya, Bolqarıstan, Avstriya-Macarıstan və Osmanlı nümayəndələri ilə Brest-Litovsk Sülh Sazişi imzalayır. İmzalanma Bakının azadlığı ilə nəticələnən bir sıra hadisələrə səbəb olur.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-03-27"
                             >
                               27 Mart 2018
@@ -8503,13 +8405,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 Borçalı: Tortdan hərəyə bir tikə - təkbaşına isə onu yemək olmaz
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              #ADR100 layihəmizdə: 1918-1920-ci illərdə Gürcüstanla Azərbaycan arasında əməkdaşlıq yeni respublikalar üçün olduqca mühüm idi. Eyni zamanda Bakı ilə Tbilisi arasında gərginlik yaradan məsələlər mövcud idi. Belə məsələlərdən biri də ərazi mübahisələri idi.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-05-10"
                             >
                               10 May 2018
@@ -8558,13 +8455,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 Cümhuriyyət hökuməti Azərbaycanı necə idarə edirdi? İlk 6 ayın hadisələri
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              1918-ci il mayın 28-də Azərbaycanın istiqlaliyyəti elan olunanda bu hadisədən bir gün əvvəl dağılmış Zaqafqaziya Seyminin 44 nəfər müsəlman nümayəndəsi Tiflisdə toplanır və özlərini Azərbaycanın Milli Şurası elan edirlər.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-04-10"
                             >
                               10 Aprel 2018
@@ -8613,13 +8505,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 1918-1991: Bir müstəqilliyin iki bəyanı
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              25 il əvvəl bu gün Azərbaycan çökməkdə olan Sovet İttifaqından özünün müstəqillyini bəyan edib. Bu, Azərbaycan Respublikasının ikinci doğuluşu idi.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2016-10-18"
                             >
                               18 Oktyabr 2016
@@ -8679,13 +8566,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              Çərşənbə axşamı şəhər sakinləri BBC Azərbaycancanın "Müstəqillik sizə nə verib?" sualını cavablandırıb.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2016-10-18"
                             >
                               18 Oktyabr 2016
@@ -8734,13 +8616,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 1918-ci ilə baxış: Mayın 28-nə aparan o yaz günlərində həyat necə idi?
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              Bu il Azərbaycan Demokratik Respublikasının elan edilməsinin 100 illik yubileyidir. BBC Azərbaycanca bu ərəfədə Azərbaycan xalqının epik və mühüm günlərini həftəlik esselərlə təqdim edəcək.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-03-22"
                             >
                               22 Mart 2018
@@ -8789,13 +8666,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 #ADR100 Zaqatala: Azərbaycanın qalib gəldiyi mübahisə
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              Bir çox azərbaycanlı və gürcüstanlı siyasətçiləri anlayırdılar ki, onların içində olduğu həssas dövrdən salamat çıxmaq üçün iqtisadi, siyasi və hərbi müttəfiqlik vacibdir. Eyni zamanda hər iki respublika arasında bir sıra mübahisələr də mövcud idi.
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-05-04"
                             >
                               4 May 2018
@@ -8844,13 +8716,8 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                                 Cümhuriyyət hökumətinin İranla əlaqələri necə idi?
                               </a>
                             </h3>
-                            <p
-                              class="c55"
-                            >
-                              İranın Xəzər sahilinə çıxan bölgələrində Azərbaycan Respublikasını böyük ticari imkanlar gözləyirdi. İran ixracatının 60-70 faizinin istehsalı ənənəvi olaraq məhz həmin regionun payına düşüb. Azərbaycan və xüsusilə Bakı-Batumi dəhlizi isə Avropa bazarına aparan təbii çıxış idi. Bəs milli hökümət iqtisadi imkanları gəlirli xarici ticarətə çevirə bildimi?
-                            </p>
                             <time
-                              class="c56"
+                              class="c55"
                               datetime="2018-04-29"
                             >
                               29 Aprel 2018

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Story Page should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
-  .c55 {
+  .c54 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -154,7 +154,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
 }
 
-.c51 {
+.c50 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -258,7 +258,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding: 0;
 }
 
-.c52 {
+.c51 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -267,7 +267,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   margin-right: 0.5rem;
 }
 
-.c56 {
+.c55 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -295,7 +295,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   margin: 0;
 }
 
-.c59 {
+.c58 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -306,11 +306,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   position: relative;
 }
 
-.c57 {
+.c56 {
   position: relative;
 }
 
-.c58 > * {
+.c57 > * {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
@@ -327,7 +327,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   display: inline;
 }
 
-.c60 {
+.c59 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -336,18 +336,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-}
-
-.c50 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
 }
 
 .c49 {
@@ -380,7 +368,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   color: #6E6E73;
 }
 
-.c61 {
+.c60 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -391,7 +379,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   display: block;
 }
 
-.c53 {
+.c52 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -404,7 +392,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding-right: 0.5rem;
 }
 
-.c54 {
+.c53 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -416,7 +404,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   height: 100%;
 }
 
-.c62 {
+.c61 {
   padding: 0 0.25rem;
 }
 
@@ -510,7 +498,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding-bottom: 2rem;
 }
 
-.c63 {
+.c62 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
@@ -757,14 +745,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c51 {
+  .c50 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c51 {
+  .c50 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -1003,14 +991,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width:63rem) {
-  .c56 {
+  .c55 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c56 {
+  .c55 {
     width: initial;
     grid-column: 1 / span 2;
   }
@@ -1041,13 +1029,13 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width:37.5rem) {
-  .c59 {
+  .c58 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c59 {
+  .c58 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -1055,7 +1043,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c59 {
+  .c58 {
     display: block;
     width: initial;
     padding: initial;
@@ -1072,14 +1060,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width:25rem) {
-  .c58 {
+  .c57 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c58 > * {
+  .c57 > * {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
@@ -1100,70 +1088,42 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c60 {
+  .c59 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c60 {
+  .c59 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c50 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c50 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c50 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c50 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c61 {
+  .c60 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c61 {
+  .c60 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c53 {
+  .c52 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c53 {
+  .c52 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -1876,13 +1836,8 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 DSS: Wepụ aka enwe n'ofe na Benue
                               </a>
                             </h3>
-                            <p
-                              class="c50"
-                            >
-                              DSS achọpụtala n'aka ndị ISIS dị na mkpamkpa nke na-akpa na Naijirịa ugbua nke gosiri na ọbughị nanị ndị Fulani na-achụ ehị na-kpa arụa
-                            </p>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2019-09-25"
                             >
                               25th September 2019
@@ -1912,7 +1867,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                   role="text"
                                 >
                                   <span
-                                    class="c52"
+                                    class="c51"
                                     dir="ltr"
                                   >
                                     AS E DE HAPPEN 
@@ -1921,11 +1876,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c50"
-                            >
-                              New Test m̀ịṅị̀ịọ́ụ̄ please ignore, test summary
-                            </p>
                           </div>
                         </div>
                       </li>
@@ -1942,15 +1892,15 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           >
                             <div
                               aria-hidden="true"
-                              class="c53"
+                              class="c52"
                               dir="ltr"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="c55"
+                                  class="c54"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 13 12"
@@ -1986,13 +1936,8 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c50"
-                            >
-                              Akụkọ ihe na-eme n'ụwa niile
-                            </p>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-22"
                             >
                               22nd January 2018
@@ -2050,11 +1995,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2064,16 +2009,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2083,7 +2028,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-22"
                             >
                               22nd January 2018
@@ -2099,11 +2044,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2113,16 +2058,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2132,7 +2077,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-21"
                             >
                               21st January 2018
@@ -2148,11 +2093,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2162,16 +2107,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2181,7 +2126,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-21"
                             >
                               21st January 2018
@@ -2197,11 +2142,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2211,16 +2156,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2230,7 +2175,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-20"
                             >
                               20th January 2018
@@ -2246,11 +2191,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2260,16 +2205,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2279,7 +2224,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-20"
                             >
                               20th January 2018
@@ -2295,11 +2240,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2309,16 +2254,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2328,7 +2273,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-20"
                             >
                               20th January 2018
@@ -2344,11 +2289,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2358,19 +2303,19 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c61"
+                                  class="c60"
                                   dir="ltr"
                                 >
                                   <div
-                                    class="c54"
+                                    class="c53"
                                   >
                                     <svg
                                       aria-hidden="true"
-                                      class="c55"
+                                      class="c54"
                                       focusable="false"
                                       height="12px"
                                       viewBox="0 0 13 12"
@@ -2384,7 +2329,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                       />
                                     </svg>
                                     <time
-                                      class="c62"
+                                      class="c61"
                                       datetime="PT49S"
                                     >
                                       0:49
@@ -2395,11 +2340,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2425,7 +2370,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2018-01-07"
                             >
                               7th January 2018
@@ -2441,11 +2386,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2455,16 +2400,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2474,7 +2419,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2017-12-20"
                             >
                               20th December 2017
@@ -2490,11 +2435,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                           class="c46"
                         >
                           <div
-                            class="c56"
+                            class="c55"
                             dir="ltr"
                           >
                             <div
-                              class="c57"
+                              class="c56"
                             >
                               <div
                                 class="c16"
@@ -2504,16 +2449,16 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 />
                               </div>
                               <div
-                                class="c58"
+                                class="c57"
                               />
                             </div>
                           </div>
                           <div
-                            class="c59"
+                            class="c58"
                             dir="ltr"
                           >
                             <h3
-                              class="c60"
+                              class="c59"
                             >
                               <a
                                 class="c49"
@@ -2523,7 +2468,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="c51"
+                              class="c50"
                               datetime="2017-12-21"
                             >
                               21st December 2017
@@ -2535,7 +2480,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   </section>
                 </div>
                 <div
-                  class="c63"
+                  class="c62"
                 />
               </div>
             </div>
@@ -4225,7 +4170,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 `;
 
 exports[`Story Page snapshots should match snapshot for STY 1`] = `
-.c61 {
+.c60 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4234,7 +4179,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 0.75rem;
 }
 
-.c63 {
+.c62 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4243,7 +4188,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 0.75rem;
 }
 
-.c64 {
+.c63 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4410,7 +4355,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding-bottom: 1rem;
 }
 
-.c53 {
+.c52 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -4514,7 +4459,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding: 0;
 }
 
-.c54 {
+.c53 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -4542,7 +4487,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   margin: 0;
 }
 
-.c57 {
+.c56 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -4553,11 +4498,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   position: relative;
 }
 
-.c55 {
+.c54 {
   position: relative;
 }
 
-.c56 > * {
+.c55 > * {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
@@ -4574,7 +4519,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   display: inline;
 }
 
-.c58 {
+.c57 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -4583,18 +4528,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-}
-
-.c52 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
 }
 
 .c51 {
@@ -4627,7 +4560,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   color: #6E6E73;
 }
 
-.c59 {
+.c58 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -4638,7 +4571,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   display: block;
 }
 
-.c60 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4650,7 +4583,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 100%;
 }
 
-.c62 {
+.c61 {
   padding: 0 0.25rem;
 }
 
@@ -4748,7 +4681,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding-bottom: 2rem;
 }
 
-.c65 {
+.c64 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
@@ -5009,14 +4942,14 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c53 {
+  .c52 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c53 {
+  .c52 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -5255,14 +5188,14 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:63rem) {
-  .c54 {
+  .c53 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c54 {
+  .c53 {
     width: initial;
     grid-column: 1 / span 2;
   }
@@ -5293,13 +5226,13 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c57 {
+  .c56 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c57 {
+  .c56 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -5307,7 +5240,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c57 {
+  .c56 {
     display: block;
     width: initial;
     padding: initial;
@@ -5324,14 +5257,14 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:25rem) {
-  .c56 {
+  .c55 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c56 > * {
+  .c55 > * {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
@@ -5352,56 +5285,28 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c58 {
+  .c57 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c58 {
+  .c57 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c52 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c52 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c52 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c52 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c59 {
+  .c58 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c59 {
+  .c58 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -6346,13 +6251,8 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     ATMs across the country
                                   </a>
                                 </h3>
-                                <p
-                                  class="c52"
-                                >
-                                  Here we have an article about a particular topic
-                                </p>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2019-09-10"
                                 >
                                   10th September 2019
@@ -6381,13 +6281,8 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Jacob Zuma: Staying!!!
                                   </a>
                                 </h3>
-                                <p
-                                  class="c52"
-                                >
-                                  Lawmakers for South Africa Parliament don vote make President Jacob Zuma continue dey run things for government.
-                                </p>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-08"
                                 >
                                   8th August 2017
@@ -6416,13 +6311,8 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Feature promo
                                   </a>
                                 </h3>
-                                <p
-                                  class="c52"
-                                >
-                                  Feature promo summary
-                                </p>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2019-12-06"
                                 >
                                   6th December 2019
@@ -6480,11 +6370,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6494,16 +6384,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6513,7 +6403,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-09"
                                 >
                                   9th August 2017
@@ -6529,11 +6419,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6543,19 +6433,19 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c59"
+                                      class="c58"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c60"
+                                        class="c59"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c61"
+                                          class="c60"
                                           focusable="false"
                                           height="12px"
                                           viewBox="0 0 32 32"
@@ -6566,7 +6456,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                           />
                                         </svg>
                                         <time
-                                          class="c62"
+                                          class="c61"
                                           datetime="PT1M7S"
                                         >
                                           1:07
@@ -6577,11 +6467,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6608,7 +6498,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2020-02-17"
                                 >
                                   17th February 2020
@@ -6624,11 +6514,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6638,19 +6528,19 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c59"
+                                      class="c58"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c60"
+                                        class="c59"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c63"
+                                          class="c62"
                                           focusable="false"
                                           height="12px"
                                           viewBox="0 0 13 12"
@@ -6669,11 +6559,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6695,7 +6585,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2020-02-17"
                                 >
                                   17th February 2020
@@ -6711,11 +6601,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6725,16 +6615,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6744,7 +6634,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-12-05"
                                 >
                                   5th December 2017
@@ -6760,11 +6650,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6774,16 +6664,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6793,7 +6683,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-08"
                                 >
                                   8th August 2017
@@ -6809,11 +6699,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6823,16 +6713,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6842,7 +6732,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-09"
                                 >
                                   9th August 2017
@@ -6858,11 +6748,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6872,16 +6762,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6891,7 +6781,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2020-02-17"
                                 >
                                   17th February 2020
@@ -6907,11 +6797,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6921,16 +6811,16 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   />
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -6940,7 +6830,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-08"
                                 >
                                   8th August 2017
@@ -6956,11 +6846,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="c48"
                             >
                               <div
-                                class="c54"
+                                class="c53"
                                 dir="ltr"
                               >
                                 <div
-                                  class="c55"
+                                  class="c54"
                                 >
                                   <div
                                     class="c18"
@@ -6970,19 +6860,19 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     />
                                   </div>
                                   <div
-                                    class="c56"
+                                    class="c55"
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c59"
+                                      class="c58"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c60"
+                                        class="c59"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c64"
+                                          class="c63"
                                           focusable="false"
                                           height="13px"
                                           viewBox="0 0 32 26"
@@ -7003,11 +6893,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                 </div>
                               </div>
                               <div
-                                class="c57"
+                                class="c56"
                                 dir="ltr"
                               >
                                 <h3
-                                  class="c58"
+                                  class="c57"
                                 >
                                   <a
                                     class="c51"
@@ -7029,7 +6919,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   </a>
                                 </h3>
                                 <time
-                                  class="c53"
+                                  class="c52"
                                   datetime="2017-08-08"
                                 >
                                   8th August 2017
@@ -7041,7 +6931,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </section>
                     </div>
                     <div
-                      class="c65"
+                      class="c64"
                     />
                   </div>
                 </div>

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -350,17 +350,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding-top: 0.5rem;
 }
 
-.c61 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
 .c49 {
   position: static;
   color: #222222;
@@ -391,7 +380,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   color: #6E6E73;
 }
 
-.c62 {
+.c61 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -427,7 +416,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   height: 100%;
 }
 
-.c63 {
+.c62 {
   padding: 0 0.25rem;
 }
 
@@ -521,7 +510,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   padding-bottom: 2rem;
 }
 
-.c64 {
+.c63 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
@@ -1154,41 +1143,13 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c61 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c61 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c61 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c61 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c62 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c62 {
+  .c61 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -2121,11 +2082,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 Lee ihe Barcelona mere Real Betis
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Barcelona emerigo Real Betis na asọmpị La Liga
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-22"
@@ -2175,11 +2131,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 Aubameyang nwere ike ifu ndị Arsenal ọnụ ego karịrị nderi pounds iri ise
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Agbu a ndị otu bọọlụ Arsenal na Dortmund ebidola mkparịta ụka maka azụma ahịa Aubameyang dịka ọ ga-abụ onye kacha oke ọnụ ahịa ndị Arsenal ga-azụ.
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-21"
@@ -2229,11 +2180,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 "Alexis Sanchez ga-abanye Manchester united ma ọ buru na....." Wenger
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Onye nchikwa Arsenal ,Arsene wenger ekwuola na Alexis Sanchez ga-abanye Manchester United ma ọ buru na Henrikh Mkhitaryan bata otu Arsenal
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-21"
@@ -2283,11 +2229,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 Dịka osi ga n'ime asọmpi Premier League
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Asọmpi Premier league ndị ụbọchị taa akwakọrọla ọnụ, a na wetara gi osi ga. ebe otu egwuregwu ndị ama ama nwetachara mmeri n'asọmpi ha.
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-20"
@@ -2337,11 +2278,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 Djokovic enwela mmeri Agbanyeghị ihe mmerụ ahụ
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Onye ama ama n'egwuregwu teenisi bụ Novak Djokovic agafela na agba nke anọ n'ihe egwuregwu teenisi nke Australian Open.
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-20"
@@ -2391,11 +2327,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 CHAN: Naịjirịa na Guinea nọ na ịrụ Group C
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Naịjirịa meriri Libya 1-0. Guinia meriri Equatorial Guinea 1-0 eji bụkọtara ndị isi na group C na CHAN
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-20"
@@ -2431,7 +2362,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               >
                                 <div
                                   aria-hidden="true"
-                                  class="c62"
+                                  class="c61"
                                   dir="ltr"
                                 >
                                   <div
@@ -2453,7 +2384,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                       />
                                     </svg>
                                     <time
-                                      class="c63"
+                                      class="c62"
                                       datetime="PT49S"
                                     >
                                       0:49
@@ -2493,11 +2424,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 </span>
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Azịza ọnụ onye DSP Omoni, Uweoji nke Rivers Steeti
-                            </p>
                             <time
                               class="c51"
                               datetime="2018-01-07"
@@ -2547,11 +2473,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 O nwere ihe o mere ma Dino Melaye nọrọ n'egwu m?
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              'Kach' Nwa minista Ibe Kachikwu tinyere Sinetọ Dino Melaye n'ime ihe onyonyo egwu ọ gụrụ mana ọnaghị atọ ndi Naijurịa ọchị
-                            </p>
                             <time
                               class="c51"
                               datetime="2017-12-20"
@@ -2601,11 +2522,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                 Ọkụ Festac: Ajọ ọnwụnwa nke keresimesi
                               </a>
                             </h3>
-                            <p
-                              class="c61"
-                            >
-                              Ọkụ a tapiala nkwa ahịa karịrị nari nde Naira na Legọs
-                            </p>
                             <time
                               class="c51"
                               datetime="2017-12-21"
@@ -2619,7 +2535,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   </section>
                 </div>
                 <div
-                  class="c64"
+                  class="c63"
                 />
               </div>
             </div>
@@ -4309,7 +4225,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 `;
 
 exports[`Story Page snapshots should match snapshot for STY 1`] = `
-.c62 {
+.c61 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4318,7 +4234,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 0.75rem;
 }
 
-.c64 {
+.c63 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4327,7 +4243,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 0.75rem;
 }
 
-.c65 {
+.c64 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -4681,17 +4597,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding-top: 0.5rem;
 }
 
-.c59 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
 .c51 {
   position: static;
   color: #222222;
@@ -4722,7 +4627,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   color: #6E6E73;
 }
 
-.c60 {
+.c59 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -4733,7 +4638,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   display: block;
 }
 
-.c61 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4745,7 +4650,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   height: 100%;
 }
 
-.c63 {
+.c62 {
   padding: 0 0.25rem;
 }
 
@@ -4843,7 +4748,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   padding-bottom: 2rem;
 }
 
-.c66 {
+.c65 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
@@ -5490,41 +5395,13 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c59 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c59 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width:37.4375rem) {
-  .c59 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:63rem) {
-  .c59 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width:20rem) and (max-width:37.4375rem) {
-  .c60 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c60 {
+  .c59 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
@@ -6635,11 +6512,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     How Lagos Dey Fight Lassa Fever
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  100 workers for LUTH dey under observation after two people die from Lassa Fever.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-08-09"
@@ -6675,15 +6547,15 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c60"
+                                      class="c59"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c61"
+                                        class="c60"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c62"
+                                          class="c61"
                                           focusable="false"
                                           height="12px"
                                           viewBox="0 0 32 32"
@@ -6694,7 +6566,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                           />
                                         </svg>
                                         <time
-                                          class="c63"
+                                          class="c62"
                                           datetime="PT1M7S"
                                         >
                                           1:07
@@ -6735,11 +6607,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     </span>
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Justin Trudeau has been re-elected prime minister of Canada with a reduced share of the vote.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2020-02-17"
@@ -6775,15 +6642,15 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c60"
+                                      class="c59"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c61"
+                                        class="c60"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c64"
+                                          class="c63"
                                           focusable="false"
                                           height="12px"
                                           viewBox="0 0 13 12"
@@ -6827,11 +6694,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     </span>
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Kojey Radical and guests discuss how to write about something you’ve not experienced.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2020-02-17"
@@ -6881,11 +6743,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Libya: omo ile Ghana márùndínláàdóje pada sile
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Omo Orileede Ghana to le ni márùndínláàdóje ti pada sile lati Libya ti won ti lo se atipo, leyin ti fonran fihan wipe won n ta won bi eru.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-12-05"
@@ -6935,11 +6792,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Like Scaramucci, Like Others
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  President Trump sack Anthony Scaramucci after ten days for office, but wetin happen to Scaramucci don happen to other people before.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-08-08"
@@ -6989,11 +6841,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Anambra Attack: 'My Friend Uchenna na Nice Girl'- Gabros
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Chukwuka Gabros tell BBC about Im friend wey die for the church attack for Ozubulu, Anambra State.
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-08-09"
@@ -7043,11 +6890,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2020-02-17"
@@ -7097,11 +6939,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     Anambra Church: Police Arrest 3
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  Governor Willie Obiano of Anambra State bin don promise say government go handle the matter sharp, sharp
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-08-08"
@@ -7137,15 +6974,15 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                   >
                                     <div
                                       aria-hidden="true"
-                                      class="c60"
+                                      class="c59"
                                       dir="ltr"
                                     >
                                       <div
-                                        class="c61"
+                                        class="c60"
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="c65"
+                                          class="c64"
                                           focusable="false"
                                           height="13px"
                                           viewBox="0 0 32 26"
@@ -7191,11 +7028,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                                     </span>
                                   </a>
                                 </h3>
-                                <p
-                                  class="c59"
-                                >
-                                  This na some of the picture wey our eye see as Kenya people go vote for election today
-                                </p>
                                 <time
                                   class="c53"
                                   datetime="2017-08-08"
@@ -7209,7 +7041,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </section>
                     </div>
                     <div
-                      class="c66"
+                      class="c65"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Resolves #6746 

**Overall change:**
_prevent summary rendering in secondary column at medium gel widths._

**Code changes:**

- set `displaySummary` to false for story page secondary column sections._

**To test**
- run this asset http://localhost:7080/mundo/23263889 locally
- reduce the screen width to GEL group 3 breakpoint (`600px - 1007px`)
- note that the summary isn't shown as compared to an story page on test
---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [X] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [X] This PR requires manual testing
