### PR TITLE
Pass path as path, not pathname

### DIFF
--- a/src/app/routes/liveRadio/getInitialData/index.js
+++ b/src/app/routes/liveRadio/getInitialData/index.js
@@ -71,7 +71,7 @@ export default async ({ path: pathname, pageType, service }) => {
       ? await withRadioSchedule({
           pageDataPromise,
           service,
-          pathname,
+          path: pathname,
           radioService: getRadioService(service),
         })
       : await pageDataPromise;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**

Naming mistake led to the renderer override not being applied for Live Radio schedules on test. Fixing that mistake.

**Code changes:**

- Passing path as the expected prop

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
