### PR TITLE
Removing schedules for Gahuza's Live Radio page

### DIFF
--- a/src/app/lib/config/services/gahuza.js
+++ b/src/app/lib/config/services/gahuza.js
@@ -191,7 +191,6 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
-      onLiveRadioPage: true,
       onFrontPage: false,
       header: 'Ibiganiro bishya',
       durationLabel: 'Umwanya bimara %duration%',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
We are no longer showing a schedule for Gahuza as it appears so infrequently (for the time being).

**Code changes:**

- Removed live radio schedule from the Gahuza service config

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
