### PR TITLE
Test E2Es for Russian MAPs with redirect

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4931,10 +4931,10 @@ module.exports = () => ({
           },
           test: {
             paths: [
-              '/russian/av/media-52355574',
+              '/russian/av/media-23320267', // CPS video with redirect
               '/russian/news/2016/05/160510_tc2_testmap3', // TC2 video
             ],
-            enabled: false,
+            enabled: true,
           },
           local: {
             paths: [],


### PR DESCRIPTION
**Overall change:**

Added a cps url with /av/ whihc should be redirected to the same url without /av/
Also has a tc2 url
Enabled: true



- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Passes on test
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)

