### PR TITLE
Live Russian MAP E2Es (a URL to redirect and a TC2)

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4926,8 +4926,11 @@ module.exports = () => ({
       mediaAssetPage: {
         environments: {
           live: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/russian/av/media-45527896', // CPS video with redirect
+              '/russian/multimedia/2012/04/120411_v_titanic_last_survivor', // TC2 video
+            ],
+            enabled: true,
           },
           test: {
             paths: [


### PR DESCRIPTION
**Overall change:**

Added a cps asset url with /av/ which should redirect to the same url without the redirect and not fail to visit the site.
Added also a tc2 url.
Enabled.


- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Will test after release
