### PR TITLE
Update Apple Touch Icon integration test snapshots

### DIFF
--- a/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
@@ -293,22 +293,22 @@ Object {
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
@@ -212,22 +212,22 @@ Object {
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/news/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -300,22 +300,22 @@ Object {
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -219,22 +219,22 @@ Object {
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
@@ -202,22 +202,22 @@ Object {
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
@@ -121,22 +121,22 @@ Object {
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Articles SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/scotland/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/frontPage/arabic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/arabic/__snapshots__/amp.test.js.snap
@@ -461,85 +461,85 @@ Object {
 
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
+}
+`;
+
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 8`] = `
+Object {
   "sizes": "192x192",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 8`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
   "sizes": "384x384",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 9`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 10`] = `
 Object {
   "sizes": "512x512",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 10`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 11`] = `
 Object {
   "sizes": null,
   "url": "http://localhost:7080/arabic/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 11`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 12`] = `
 Object {
   "sizes": "72x72",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-72x72.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 12`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 13`] = `
 Object {
   "sizes": "96x96",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-96x96.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 13`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 14`] = `
 Object {
   "sizes": "128x128",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-128x128.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 14`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 15`] = `
 Object {
   "sizes": "144x144",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-144x144.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 15`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 16`] = `
 Object {
   "sizes": "152x152",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-152x152.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 16`] = `
-Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
-}
-`;
-
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 17`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 18`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 

--- a/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
@@ -336,85 +336,85 @@ Object {
 
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
+}
+`;
+
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 8`] = `
+Object {
   "sizes": "192x192",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 8`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
   "sizes": "384x384",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 9`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 10`] = `
 Object {
   "sizes": "512x512",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 10`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 11`] = `
 Object {
   "sizes": null,
   "url": "http://localhost:7080/arabic/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 11`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 12`] = `
 Object {
   "sizes": "72x72",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-72x72.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 12`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 13`] = `
 Object {
   "sizes": "96x96",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-96x96.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 13`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 14`] = `
 Object {
   "sizes": "128x128",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-128x128.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 14`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 15`] = `
 Object {
   "sizes": "144x144",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-144x144.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 15`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 16`] = `
 Object {
   "sizes": "152x152",
   "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-152x152.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 16`] = `
-Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
-}
-`;
-
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 17`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 18`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/amp.test.js.snap
@@ -433,85 +433,85 @@ Object {
 
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
+}
+`;
+
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 8`] = `
+Object {
   "sizes": "192x192",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 8`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
   "sizes": "384x384",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 9`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 10`] = `
 Object {
   "sizes": "512x512",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 10`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 11`] = `
 Object {
   "sizes": null,
   "url": "http://localhost:7080/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 11`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 12`] = `
 Object {
   "sizes": "72x72",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-72x72.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 12`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 13`] = `
 Object {
   "sizes": "96x96",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-96x96.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 13`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 14`] = `
 Object {
   "sizes": "128x128",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-128x128.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 14`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 15`] = `
 Object {
   "sizes": "144x144",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-144x144.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 15`] = `
+exports[`AMP Front Page SEO Apple Touch Icon should match attributes 16`] = `
 Object {
   "sizes": "152x152",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-152x152.png",
 }
 `;
 
-exports[`AMP Front Page SEO Apple Touch Icon should match attributes 16`] = `
-Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
-}
-`;
-
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 17`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Front Page SEO Apple Touch Icon should match attributes 18`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -308,85 +308,85 @@ Object {
 
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
+}
+`;
+
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 8`] = `
+Object {
   "sizes": "192x192",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 8`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
   "sizes": "384x384",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 9`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 10`] = `
 Object {
   "sizes": "512x512",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 10`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 11`] = `
 Object {
   "sizes": null,
   "url": "http://localhost:7080/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 11`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 12`] = `
 Object {
   "sizes": "72x72",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-72x72.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 12`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 13`] = `
 Object {
   "sizes": "96x96",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-96x96.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 13`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 14`] = `
 Object {
   "sizes": "128x128",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-128x128.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 14`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 15`] = `
 Object {
   "sizes": "144x144",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-144x144.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 15`] = `
+exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 16`] = `
 Object {
   "sizes": "152x152",
   "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-152x152.png",
 }
 `;
 
-exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 16`] = `
-Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
-}
-`;
-
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 17`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Front Page SEO Apple Touch Icon should match attributes 18`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
@@ -342,22 +342,22 @@ Object {
 
 exports[`AMP persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
@@ -217,22 +217,22 @@ Object {
 
 exports[`Canonical persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical persian/afghanistan IDX page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
@@ -304,22 +304,22 @@ Object {
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
@@ -179,22 +179,22 @@ Object {
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/ukrainian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/liveRadio/amharic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/amharic/__snapshots__/amp.test.js.snap
@@ -276,22 +276,22 @@ Object {
 
 exports[`AMP Amharic Live Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Amharic Live Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Amharic Live Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/liveRadio/amharic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/amharic/__snapshots__/canonical.test.js.snap
@@ -151,22 +151,22 @@ Object {
 
 exports[`Canonical Amharic Live Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Amharic Live Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Amharic Live Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/amharic/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/liveRadio/korean/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/amp.test.js.snap
@@ -276,22 +276,22 @@ Object {
 
 exports[`AMP Korean Live Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Korean Live Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Korean Live Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -151,22 +151,22 @@ Object {
 
 exports[`Canonical Korean Live Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Korean Live Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Korean Live Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/korean/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
@@ -320,22 +320,22 @@ Object {
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -195,22 +195,22 @@ Object {
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/arabic/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -348,22 +348,22 @@ Object {
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -223,22 +223,22 @@ Object {
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/persian/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
@@ -318,22 +318,22 @@ Object {
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -193,22 +193,22 @@ Object {
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pidgin/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -348,22 +348,22 @@ Object {
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -223,22 +223,22 @@ Object {
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
@@ -327,22 +327,22 @@ Object {
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Most Read Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
@@ -202,22 +202,22 @@ Object {
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Most Read Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/vietnamese/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/indonesia/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/indonesia/__snapshots__/amp.test.js.snap
@@ -296,22 +296,22 @@ Object {
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/indonesia/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/indonesia/__snapshots__/canonical.test.js.snap
@@ -171,22 +171,22 @@ Object {
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/indonesia/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/amp.test.js.snap
@@ -317,22 +317,22 @@ Object {
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/canonical.test.js.snap
@@ -192,22 +192,22 @@ Object {
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/amp.test.js.snap
@@ -317,22 +317,22 @@ Object {
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -192,22 +192,22 @@ Object {
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical On Demand Radio Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
@@ -315,22 +315,22 @@ Object {
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
@@ -190,22 +190,22 @@ Object {
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/pashto/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
@@ -301,22 +301,22 @@ Object {
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP On Demand T V Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
@@ -176,22 +176,22 @@ Object {
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical On Demand T V Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/somali/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -313,22 +313,22 @@ Object {
 
 exports[`AMP Photo Gallery Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Photo Gallery Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Photo Gallery Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -201,22 +201,22 @@ Object {
 
 exports[`Canonical Photo Gallery Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Photo Gallery Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Photo Gallery Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
@@ -300,22 +300,22 @@ Object {
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -175,22 +175,22 @@ Object {
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/kyrgyz/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -328,22 +328,22 @@ Object {
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`AMP Story Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -203,22 +203,22 @@ Object {
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 7`] = `
 Object {
-  "sizes": "192x192",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
+  "sizes": "180x180",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-180x180.png",
 }
 `;
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 8`] = `
 Object {
-  "sizes": "384x384",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
+  "sizes": "192x192",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-192x192.png",
 }
 `;
 
 exports[`Canonical Story Page SEO Apple Touch Icon should match attributes 9`] = `
 Object {
-  "sizes": "512x512",
-  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-512x512.png",
+  "sizes": "384x384",
+  "url": "https://news.files.bbci.co.uk/include/articles/public/mundo/images/icons/icon-384x384.png",
 }
 `;
 


### PR DESCRIPTION
Resolves no issue

**Overall change:**
Integration test snapshots don't appear to have been updated when icons were changed. Unsure how this made it into latest, but PRs seem to be failing now.

**Code changes:**

- Updated snapshots in integration tests.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
