### PR TITLE
Putting Hausa and Korean Radio Schedules live

### DIFF
--- a/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
+++ b/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
@@ -26,7 +26,7 @@ Object {
     "enabled": true,
   },
   "liveRadioSchedule": Object {
-    "enabled": false,
+    "enabled": true,
     "value": "(hausa|korean)",
   },
   "logMediaPlayerStatus": Object {

--- a/src/app/lib/config/toggles/liveConfig.js
+++ b/src/app/lib/config/toggles/liveConfig.js
@@ -24,7 +24,7 @@ export default {
     enabled: true,
   },
   liveRadioSchedule: {
-    enabled: false,
+    enabled: true,
     value: '(hausa|korean)',
   },
   logMediaPlayerStatus: {


### PR DESCRIPTION
Resolves #7333 

**Overall change:**
Setting Korean and Hausa Radio Schedules loose on the world

**Code changes:**

- Set korean and hausa schedules live

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
