### PR TITLE
Fixing Persian duration translation

### DIFF
--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -217,7 +217,7 @@ export const service = {
       onIdxPage: true,
       idxPagePosition: 'Features',
       header: 'برنامه‌های رادیو',
-      durationLabel: 'مدت %duration%',
+      durationLabel: '%duration% المدة الزمنية',
     },
     recommendations: {
       hasStoryRecommendations: false,

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -2446,7 +2446,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     <span
                       class="c25"
                     >
-                       مدت ۰۳،۰۰ 
+                       ۰۳،۰۰ المدة الزمنية 
                     </span>
                     <span
                       aria-hidden="true"
@@ -2573,7 +2573,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     <span
                       class="c25"
                     >
-                       مدت ۲۹،۳۰ 
+                       ۲۹،۳۰ المدة الزمنية 
                     </span>
                     <span
                       aria-hidden="true"
@@ -2700,7 +2700,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     <span
                       class="c25"
                     >
-                       مدت ۲۹،۳۰ 
+                       ۲۹،۳۰ المدة الزمنية 
                     </span>
                     <span
                       aria-hidden="true"
@@ -2828,7 +2828,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     <span
                       class="c25"
                     >
-                       مدت ۲۶،۳۰ 
+                       ۲۶،۳۰ المدة الزمنية 
                     </span>
                     <span
                       aria-hidden="true"


### PR DESCRIPTION
Resolves #7374

**Overall change:**
Wrong translation for Persian radio schedule duration

**Code changes:**

- Updated translation

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
