### PR TITLE
integration test improvements for schedules

### DIFF
--- a/src/integration/common/radioSchedule.js
+++ b/src/integration/common/radioSchedule.js
@@ -1,14 +1,18 @@
-export default ({ shouldBeInTheDocument }) => {
+const servicesWithRadioSchedule = ['indonesia'];
+const servicesWithoutRadioSchedule = ['gahuza'];
+
+export default ({ isAmp }) => {
   describe('Radio Schedule', () => {
     const scheduleWrapperEl = document.querySelector(
       '[data-e2e="radio-schedule"]',
     );
 
-    if (shouldBeInTheDocument) {
+    if (!isAmp && servicesWithRadioSchedule.includes(service)) {
       it('should be in the document', () => {
         expect(scheduleWrapperEl).toBeInTheDocument();
       });
-    } else {
+    }
+    if (isAmp || servicesWithoutRadioSchedule.includes(service)) {
       it('should not be in the document', () => {
         expect(scheduleWrapperEl).not.toBeInTheDocument();
       });

--- a/src/integration/pages/liveRadio/ampTests.js
+++ b/src/integration/pages/liveRadio/ampTests.js
@@ -1,10 +1,15 @@
 import runCrossPlatformTests from './crossPlatformTests';
-import { runCoreAmpTests, runAmpAnalyticsTests } from '../../common';
+import {
+  runCoreAmpTests,
+  runAmpAnalyticsTests,
+  runRadioScheduleTests,
+} from '../../common';
 
 export default () => {
   runCrossPlatformTests();
   runCoreAmpTests();
   runAmpAnalyticsTests();
+  runRadioScheduleTests({ isAmp: true });
 
   it('Media player image placeholder', () => {
     const audioPlaceholderImage = document.querySelector(

--- a/src/integration/pages/liveRadio/canonicalTests.js
+++ b/src/integration/pages/liveRadio/canonicalTests.js
@@ -5,18 +5,9 @@ import {
   runRadioScheduleTests,
 } from '../../common';
 
-const servicesWithRadioSchedule = ['indonesia'];
-const servicesWithoutRadioSchedule = ['gahuza'];
-
 export default () => {
   runCrossPlatformTests();
   runCoreCanonicalTests();
   runCanonicalAnalyticsTests();
-
-  if (servicesWithRadioSchedule.includes(service)) {
-    runRadioScheduleTests({ shouldBeInTheDocument: true });
-  }
-  if (servicesWithoutRadioSchedule.includes(service)) {
-    runRadioScheduleTests({ shouldBeInTheDocument: false });
-  }
+  runRadioScheduleTests({ isAmp: false });
 };

--- a/src/integration/pages/onDemandRadioPage/ampTests.js
+++ b/src/integration/pages/onDemandRadioPage/ampTests.js
@@ -1,6 +1,11 @@
-import { runCoreAmpTests, runAmpAnalyticsTests } from '../../common';
+import {
+  runCoreAmpTests,
+  runAmpAnalyticsTests,
+  runRadioScheduleTests,
+} from '../../common';
 
 export default () => {
   runCoreAmpTests();
   runAmpAnalyticsTests();
+  runRadioScheduleTests({ isAmp: true });
 };

--- a/src/integration/pages/onDemandRadioPage/canonicalTests.js
+++ b/src/integration/pages/onDemandRadioPage/canonicalTests.js
@@ -4,17 +4,8 @@ import {
   runRadioScheduleTests,
 } from '../../common';
 
-const servicesWithRadioSchedule = ['indonesia'];
-const servicesWithoutRadioSchedule = ['gahuza'];
-
 export default () => {
   runCoreCanonicalTests();
   runCanonicalAnalyticsTests();
-
-  if (servicesWithRadioSchedule.includes(service)) {
-    runRadioScheduleTests({ shouldBeInTheDocument: true });
-  }
-  if (servicesWithoutRadioSchedule.includes(service)) {
-    runRadioScheduleTests({ shouldBeInTheDocument: false });
-  }
+  runRadioScheduleTests({ isAmp: false });
 };


### PR DESCRIPTION
**Overall change:**
Tests that radio schedule does not render on AMP platform

**Code changes:**

- pass `isAmp` argument into `runRadioScheduleTests` and test that the radio schedule can not be found in AMP pages for live radio and OD radio

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
