### PR TITLE
Remove left/right padding from CpsAssetMediaPlayer below 600px

### DIFF
--- a/src/app/containers/CpsAssetMediaPlayer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsAssetMediaPlayer/__snapshots__/index.test.jsx.snap
@@ -60,27 +60,21 @@ exports[`MediaPlayer render amp legacy media player 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c0 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c0 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -189,27 +183,21 @@ exports[`MediaPlayer render canonical legacy media player 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c0 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c0 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -301,27 +289,21 @@ exports[`MediaPlayer render the amp player 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c0 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c0 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -421,27 +403,21 @@ exports[`MediaPlayer render the canonical player without a placeholder 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c0 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c0 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c0 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c0 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c0 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }

--- a/src/app/containers/CpsAssetMediaPlayer/index.jsx
+++ b/src/app/containers/CpsAssetMediaPlayer/index.jsx
@@ -4,6 +4,7 @@ import { string, bool } from 'prop-types';
 import styled from 'styled-components';
 import {
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import {
@@ -13,22 +14,26 @@ import {
 } from '@bbc/gel-foundations/spacings';
 
 import MediaPlayerContainer from '../MediaPlayer';
-import { GridItemConstrainedLarge } from '#lib/styledGrid';
+import { GridItemConstrainedLargeNoMargin } from '#lib/styledGrid';
 import {
   mediaPlayerPropTypes,
   emptyBlockArrayDefaultProps,
 } from '#models/propTypes';
 import filterForBlockType from '#lib/utilities/blockHandlers';
 
-const Wrapper = styled(GridItemConstrainedLarge)`
+const Wrapper = styled(GridItemConstrainedLargeNoMargin)`
   margin-top: ${GEL_SPACING};
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     margin-top: ${GEL_SPACING_DBL};
   }
 
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    padding: 0 ${GEL_SPACING_DBL};
+  }
+
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
-    padding-top: ${GEL_SPACING};
+    padding: ${GEL_SPACING} 0 0;
     margin-top: ${GEL_SPACING_QUAD};
   }
 

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -440,27 +440,21 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
   }
 }
 
-@media (max-width:25rem) {
-  .c2 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c2 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c2 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c2 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c2 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -1915,27 +1909,21 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c2 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c2 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c2 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c2 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c2 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -1133,27 +1133,21 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
-@media (max-width:25rem) {
-  .c27 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c27 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c27 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c27 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c27 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -3544,27 +3538,21 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 }
 
-@media (max-width:25rem) {
-  .c29 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c29 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c29 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c29 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c29 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }
@@ -5321,27 +5309,21 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-@media (max-width:25rem) {
-  .c29 {
-    padding: 0 0.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:62.9375rem) {
-  .c29 {
-    padding: 0 1rem;
-  }
-}
-
 @media (min-width:25rem) {
   .c29 {
     margin-top: 1rem;
   }
 }
 
+@media (min-width:37.5rem) {
+  .c29 {
+    padding: 0 1rem;
+  }
+}
+
 @media (min-width:63rem) {
   .c29 {
-    padding-top: 0.5rem;
+    padding: 0.5rem 0 0;
     margin-top: 2rem;
   }
 }


### PR DESCRIPTION
Resolves #6863

**Overall change:**
Remove the white space either side of the player on devices smaller than 600px wide

**Code changes:**

- Replace grid container Wrapper `GridItemConstrainedLarge` (which comes with padding) with `GridItemConstrainedLargeNoMargin`
- Add left/right padding of 1rem/16px above 600px.
- Adjust styling above 1008px to reflect previous state (0.5rem top-padding, no side padding)

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
