### PR TITLE
toggle radio schedule off for these service on OD radio pages

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.js
+++ b/src/app/lib/config/services/afaanoromoo.js
@@ -196,7 +196,7 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       onLiveRadioPage: true,
-      onOnDemandRadioPage: true,
+      onOnDemandRadioPage: false,
       onFrontPage: false,
       header: 'Dhaggeeffadhaa',
       durationLabel: 'Turtii %duration%',

--- a/src/app/lib/config/services/amharic.js
+++ b/src/app/lib/config/services/amharic.js
@@ -190,7 +190,7 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       onLiveRadioPage: true,
-      onOnDemandRadioPage: true,
+      onOnDemandRadioPage: false,
       onFrontPage: false,
       header: 'ያድምጡ',
       durationLabel: 'ርዝመት %duration%',

--- a/src/app/lib/config/services/bengali.js
+++ b/src/app/lib/config/services/bengali.js
@@ -203,7 +203,7 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       onLiveRadioPage: true,
-      onOnDemandRadioPage: true,
+      onOnDemandRadioPage: false,
       onFrontPage: false,
       header: 'রেডিও অনুষ্ঠান',
       durationLabel: 'স্থিতিকাল %duration%',

--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -207,7 +207,7 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       onLiveRadioPage: true,
-      onOnDemandRadioPage: true,
+      onOnDemandRadioPage: false,
       onFrontPage: false,
       header: 'နောက်ဆုံးလွှင့် အစီအစဉ်များ',
       durationLabel: 'ကြာမြင့်ချိန် %duration%',

--- a/src/app/lib/config/services/nepali.js
+++ b/src/app/lib/config/services/nepali.js
@@ -197,6 +197,7 @@ export const service = {
     },
     radioSchedule: {
       hasRadioSchedule: true,
+      onOnDemandRadioPage: false,
       onLiveRadioPage: true,
       onFrontPage: false,
       header: 'पछिल्लो कार्यक्रम सुन्नुहोस्',

--- a/src/app/lib/config/services/tigrinya.js
+++ b/src/app/lib/config/services/tigrinya.js
@@ -190,7 +190,7 @@ export const service = {
     radioSchedule: {
       hasRadioSchedule: true,
       onLiveRadioPage: true,
-      onOnDemandRadioPage: true,
+      onOnDemandRadioPage: false,
       onFrontPage: false,
       header: 'ስምዑ',
       durationLabel: 'ዕምሪ ፈነወ %duration%',


### PR DESCRIPTION
**Overall change:**
Disable schedule component on OD radio pages for these services: Afaan/Amharic/Bengali/Burmese/Tigrinya/Nepali

**Code changes:**

- set `onOnDemandRadioPage` to `false` in service configs

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
