### PR TITLE
Disabled Afaanoromoo live radio tests

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -60,17 +60,17 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/afaanoromoo/bbc_afaanoromoo_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: [
               '/afaanoromoo/bbc_afaanoromoo_radio/liveradio?renderer_env=live',
             ],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/afaanoromoo/bbc_afaanoromoo_radio/liveradio'],
-            enabled: true,
+            enabled: false,
           },
         },
         smoke: false,


### PR DESCRIPTION
Disabled afaanoromoo live radio tests until schedule is enabled on them, as live tests are failing due to the test expecting a schedule when there isn't one. This is because it is looking at a different toggle than the one we are using for phased release.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**
Will run again when merged
