### PR TITLE
exit in tests script with error code if tests fail

### DIFF
--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -51,14 +51,19 @@ const startApp = () => {
 };
 
 const runTests = () =>
-  new Promise(resolve => {
+  new Promise((resolve, reject) => {
     const child = spawn(
       'jest',
       [filesToTest, '--runInBand', '--colors', ...getJestArgs()],
       { stdio: 'inherit' },
     );
-
-    child.on('exit', resolve);
+    child.on('exit', code => {
+      if (code === 1) {
+        reject(code);
+      } else {
+        resolve();
+      }
+    });
   });
 
 if (isCI) {
@@ -90,5 +95,9 @@ if (isCI) {
         }),
     )
     .then(runTests)
-    .then(stopApp);
+    .then(stopApp)
+    .catch(async () => {
+      await stopApp();
+      process.exit(1);
+    });
 }

--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -59,7 +59,7 @@ const runTests = () =>
     );
     child.on('exit', code => {
       if (code === 1) {
-        reject(code);
+        reject();
       } else {
         resolve();
       }


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/7120

**Overall change:**
Fails CI if integration tests fail.

**Code changes:**

- Checks exit code of tests run process and rejects promise if equals to 1 which is handled in the promise chain catch where the global process object's exit method is called with 1 to indicate a failure that will fail CI.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
