### PR TITLE
Add pageType to radio schedules logging

### DIFF
--- a/src/app/routes/home/getInitialData/index.js
+++ b/src/app/routes/home/getInitialData/index.js
@@ -42,7 +42,12 @@ export default async ({ path, service, variant, pageType }) => {
     const pageDataPromise = fetchPageData({ path, pageType });
 
     const { json, status } = pageHasRadioSchedule
-      ? await withRadioSchedule({ pageDataPromise, service, path })
+      ? await withRadioSchedule({
+          pageDataPromise,
+          service,
+          path,
+          pageType: 'Home',
+        })
       : await pageDataPromise;
 
     return {

--- a/src/app/routes/idx/getInitialData/index.js
+++ b/src/app/routes/idx/getInitialData/index.js
@@ -47,6 +47,7 @@ export default async ({ path, service, variant, pageType }) => {
           service,
           path,
           radioService: 'dari',
+          pageType: 'IDX',
         })
       : await pageDataPromise;
 

--- a/src/app/routes/liveRadio/getInitialData/index.js
+++ b/src/app/routes/liveRadio/getInitialData/index.js
@@ -41,6 +41,7 @@ export default async ({ path: pathname, pageType, service }) => {
           service,
           path: pathname,
           radioService: getRadioService({ service, pathname }),
+          pageType: 'LiveRadio',
         })
       : await pageDataPromise;
 

--- a/src/app/routes/onDemandRadio/getInitialData/index.js
+++ b/src/app/routes/onDemandRadio/getInitialData/index.js
@@ -34,6 +34,7 @@ export default async ({ path: pathname, pageType, service }) => {
           service,
           path: pathname,
           radioService: getRadioService({ service, pathname }),
+          pageType: 'OnDemandRadio',
         })
       : await pageDataPromise;
 

--- a/src/app/routes/utils/withRadioSchedule/index.js
+++ b/src/app/routes/utils/withRadioSchedule/index.js
@@ -36,6 +36,7 @@ const withRadioSchedule = async ({
   service,
   path,
   radioService,
+  pageType,
 }) => {
   const { SIMORGH_APP_ENV, SIMORGH_BASE_URL } = process.env;
 
@@ -47,7 +48,10 @@ const withRadioSchedule = async ({
     baseUrl: SIMORGH_BASE_URL,
   });
 
-  logger.info(RADIO_SCHEDULE_REQUEST_RECEIVED, { url: radioScheduleUrl });
+  logger.info(RADIO_SCHEDULE_REQUEST_RECEIVED, {
+    url: radioScheduleUrl,
+    pageType,
+  });
   const radioSchedulePromise = fetchData(radioScheduleUrl);
 
   const [{ json: pageData, ...rest }, radioScheduleJson] = await Promise.all([


### PR DESCRIPTION
Resolves #7377

**Overall change:**
We currently cannot differentiate between a Home, IDX, Live Radio or OD Radio schedule call in our logs. Passing in pageType for logging.

**Code changes:**

- Pass in pageType for radio schedule logging (Home, IDX, Live Radio, OD Radio)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
