### PR TITLE
Padding issue for media message

### DIFF
--- a/src/app/containers/MediaPlayer/index.jsx
+++ b/src/app/containers/MediaPlayer/index.jsx
@@ -5,12 +5,17 @@ import moment from 'moment-timezone';
 import pathOr from 'ramda/src/pathOr';
 import path from 'ramda/src/path';
 import Figure from '@bbc/psammead-figure';
+import {
+  GEL_SPACING_DBL,
+  GEL_SPACING_TRPL,
+} from '@bbc/gel-foundations/spacings';
 import styled from 'styled-components';
 import {
   CanonicalMediaPlayer,
   AmpMediaPlayer,
   MediaMessage,
 } from '@bbc/psammead-media-player';
+import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import Caption from '../Caption';
 import Metadata from './Metadata';
 import getEmbedUrl from '#lib/utilities/getEmbedUrl';
@@ -116,8 +121,12 @@ const MediaPlayerContainer = ({
   const landscapeRatio = '56.25%'; // (9/16)*100 = 16:9
   const StyledMessageContainer = styled.div`
     padding-top: ${landscapeRatio};
+    margin-bottom: ${GEL_SPACING_DBL};
     position: relative;
     overflow: hidden;
+    @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+      padding-bottom: ${GEL_SPACING_TRPL};
+    }
   `;
 
   const noJsMessage = `This ${mediaInfo.type} cannot play in your browser. Please enable JavaScript or try a different browser.`;


### PR DESCRIPTION
Resolves NaN

**Overall change:**

Not enough space between the Media Message and the title (compare https://www.bbc.com/persian/afghanistan/2013/04/130429_l42_vid_afgh_corruption with https://www.bbc.com/persian/business-53800790)

**Code changes:**

- Adding space between Media Message component and Title

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
