### PR TITLE
Removing memo for live radio

### DIFF
--- a/src/app/routes/liveRadio/index.js
+++ b/src/app/routes/liveRadio/index.js
@@ -1,13 +1,11 @@
-import { memo } from 'react';
 import { LiveRadioPage } from '#pages';
-import pageIsSame from '../utils/pageIsSame';
 import { liveRadioPath } from '../utils/regex';
 import getInitialData from './getInitialData';
 
 export default {
   path: liveRadioPath,
   exact: true,
-  component: memo(LiveRadioPage, pageIsSame),
+  component: LiveRadioPage,
   getInitialData,
   pageType: 'media',
 };


### PR DESCRIPTION
Part of #7531

**Overall change:**
Removing memo for Live Radio as it is not required. Required by MAPs to prevent a re-render of the video when using the Skip to Content link.

**Code changes:**

- Removed memo for Live Radio

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
