### PR TITLE
enable bbc-adverts header with display ads docblock pragma

### DIFF
--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -9,12 +9,18 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
   constructor(config, context) {
     super(config, context);
     const { platform } = config.testEnvironmentOptions;
-    const { pathname, service, runScripts = 'true' } = context.docblockPragmas;
+    const {
+      pathname,
+      service,
+      runScripts = 'true',
+      displayAds = 'false',
+    } = context.docblockPragmas;
     const pageType = getPageTypeFromTestPath(context.testPath);
 
     this.pageType = camelCaseToText(pageType);
     this.service = service;
     this.runScripts = runScripts === 'true';
+    this.displayAds = displayAds === 'true';
     this.url = `http://localhost:7080${pathname}${
       platform === 'amp' ? '.amp' : ''
     }`;
@@ -24,7 +30,15 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
     await super.setup();
 
     try {
-      const dom = await fetchDom(this.url, this.runScripts);
+      const dom = await fetchDom({
+        url: this.url,
+        runScripts: this.runScripts,
+        ...(this.displayAds && {
+          headers: {
+            'BBC-Adverts': true,
+          },
+        }),
+      });
 
       Object.defineProperties(this.global, {
         pageType: { value: this.pageType },

--- a/src/integration/integrationTestEnvironment.js
+++ b/src/integration/integrationTestEnvironment.js
@@ -35,7 +35,7 @@ class IntegrationTestEnvironment extends JsdomEnvironment {
         runScripts: this.runScripts,
         ...(this.displayAds && {
           headers: {
-            'BBC-Adverts': true,
+            'BBC-Adverts': 'true',
           },
         }),
       });

--- a/src/integration/utils/fetchDom.js
+++ b/src/integration/utils/fetchDom.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
-
+const fetch = require('isomorphic-fetch');
 const { JSDOM } = require('jsdom');
 const retry = require('retry');
 
-const faultTolerantDomFetch = (url, runScripts) =>
+const faultTolerantDomFetch = ({ url, runScripts, headers }) =>
   new Promise((resolve, reject) => {
     const oneSecond = 1000;
     const operation = retry.operation({
@@ -22,8 +22,10 @@ const faultTolerantDomFetch = (url, runScripts) =>
       }
 
       try {
-        const dom = await JSDOM.fromURL(
-          url,
+        const response = await fetch(url, headers && { headers });
+        const html = await response.text();
+        const dom = new JSDOM(
+          html,
           runScripts ? { runScripts: 'dangerously' } : {},
         );
 

--- a/src/integration/utils/fetchDom.test.js
+++ b/src/integration/utils/fetchDom.test.js
@@ -23,7 +23,7 @@ it('should return DOM from a given url path', async () => {
         `<html><head><title>Some HTML</title></head><body></body></html>`,
       ),
     );
-  const dom = await fetchDom('http://localhost:7080/some/path');
+  const dom = await fetchDom({ url: 'http://localhost:7080/some/path' });
   const pageTitle = dom.window.document.querySelector('title').textContent;
 
   expect(pageTitle).toBe('Some HTML');
@@ -41,7 +41,7 @@ it('should retry to render the DOM if socket hang up error occurs', async () => 
       ),
     );
 
-  const dom = await fetchDom('http://localhost:7080/some/path');
+  const dom = await fetchDom({ url: 'http://localhost:7080/some/path' });
   const pageTitle = dom.window.document.querySelector('title').textContent;
 
   expect(console.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
**Overall change:**
Adds option to display ads in integration tests using `BBC-Adverts=true` header when requesting the page to test.

**Code changes:**

- Add new dockblock pragma `displayAds` that when true, sets `BBC-Adverts=true` when fetching page HTML to create JSDOM with.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
