### PR TITLE
enables ATI marketing campaign on live

### DIFF
--- a/src/app/containers/ATIAnalytics/atiUrl/index.js
+++ b/src/app/containers/ATIAnalytics/atiUrl/index.js
@@ -55,8 +55,6 @@ export const buildATIPageTrackPath = ({
   const x6Value =
     platform === 'amp' ? referrer : referrer && encodeURIComponent(referrer);
 
-  const shouldIncludeMarketingString = process.env.SIMORGH_APP_ENV !== 'live';
-
   const pageViewBeaconValues = [
     {
       key: 's',
@@ -192,9 +190,7 @@ export const buildATIPageTrackPath = ({
     {
       key: 'xto',
       description: 'marketing campaign',
-      value: shouldIncludeMarketingString
-        ? getATIMarketingString(decodedHref, campaignType)
-        : null,
+      value: getATIMarketingString(decodedHref, campaignType),
       wrap: false,
     },
     {


### PR DESCRIPTION
Resolves #7598

**Overall change:**
_Enables ATI marketing campaign on live._

**Code changes:**
- removes conditional that disables marketing string value on live.
---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
