### PR TITLE
Fix Cypress Tests - Add vj patterns to acceptable scripts

### DIFF
--- a/cypress/integration/pages/testsForAllCanonicalPages.js
+++ b/cypress/integration/pages/testsForAllCanonicalPages.js
@@ -29,7 +29,7 @@ export const testsThatFollowSmokeTestConfigForAllCanonicalPages = ({
           if ($p.attr('src').includes(envConfig.assetOrigin)) {
             return expect($p.attr('src')).to.match(
               new RegExp(
-                `(\\/static\\/js\\/(?:comscore\\/)?(main|vendor|${config[service].name}|.+Page)-.+?.js)`,
+                `(/include/(vjassets|vjamericas).*|/static/js/(?:comscore/)?(main|vendor|${config[service].name}|.+Page)-.+?.js)`,
                 'g',
               ),
             );


### PR DESCRIPTION
No issue

**Overall change:**
Added patterns to support scripts related to includes in our cypress script check: https://www.test.bbc.com/mundo/23263889 

**Code changes:**
- Update regex to support the following script origins:
  - https://news.files.bbci.co.uk/include/vjassets/js/vendor/require-2.1.20b.min.js
  - https://news.test.files.bbci.co.uk/include/vjamericas/176-eclipse-lookup/assets/embed/js/embed-init.js?v=1.0.33
  - https://news.test.files.bbci.co.uk/include/vjamericas/176-eclipse-lookup/assets/embed/js/shadow-wrapper.js?v=1.0.33

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
