### PR TITLE
remove cypress tests covered by integration

### DIFF
--- a/cypress/integration/pages/testsForAllCanonicalPages.js
+++ b/cypress/integration/pages/testsForAllCanonicalPages.js
@@ -1,5 +1,4 @@
 import envConfig from '../../support/config/envs';
-import config from '../../support/config/services';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
@@ -24,42 +23,6 @@ export const testsThatFollowSmokeTestConfigForAllCanonicalPages = ({
           });
         });
       }
-      it('should only have expected bundle script tags', () => {
-        cy.get('script[src]').each($p => {
-          if ($p.attr('src').includes(envConfig.assetOrigin)) {
-            return expect($p.attr('src')).to.match(
-              new RegExp(
-                `(/include/(vjassets|vjamericas).*|/static/js/(?:comscore/)?(main|vendor|${config[service].name}|.+Page)-.+?.js)`,
-                'g',
-              ),
-            );
-          }
-          return null;
-        });
-      });
-
-      it('should have 1 bundle for its service', () => {
-        let matches = 0;
-
-        cy.get('script[src]')
-          .each($p => {
-            const match = $p
-              .attr('src')
-              .match(
-                new RegExp(
-                  `(\\/static\\/js\\/${config[service].name}-\\w+\\.\\w+\\.js)`,
-                  'g',
-                ),
-              );
-
-            if (match) {
-              matches += 1;
-            }
-          })
-          .then(() => {
-            expect(matches).to.equal(1);
-          });
-      });
       if (['photoGalleryPage', 'storyPage'].includes(pageType)) {
         describe('CPS PGL and STY Tests', () => {
           it('should render at least one image', () => {


### PR DESCRIPTION
No Issue

**Overall change:**
Following https://github.com/bbc/simorgh/pull/7631#issuecomment-680817979, I have removed two tests that are duplicated in our integration test suite: https://github.com/bbc/simorgh/blob/5135193e1d827d7dbb521e19eabbeedb3aa799e2/src/integration/common/core.canonical.js#L4

The regex in the bundle scripts test is different between cypress and the integration test because I introduced a test for includes (https://github.com/bbc/simorgh/pull/7616) and that loaded some assets specific to VJ includes, this test does not exist in the integration test suite.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
