### PR TITLE
Removing logMediaPlayerStatus toggle as it is no longer used

### DIFF
--- a/src/app/lib/config/toggles/README.md
+++ b/src/app/lib/config/toggles/README.md
@@ -9,7 +9,6 @@
 | `enableFetchingToggles` | Enable fetching toggle values from remote Toggles Config API for specified services |
 | `include`               | Display Include on Story (STY) Pages |  |
 | `liveRadioSchedule`     | Display Radio Schedule on Live Radio Pages | |
-| `logMediaPlayerStatus`  | Log the HTTP status code returned by the Media Player iFrame URL | |
 | `mostRead`              | Display Most Read | |
 | `mostWatched`           | Display Most Watched | |
 | `navOnArticles`         | Display Navigation on Article Pages | |

--- a/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
+++ b/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
@@ -22,9 +22,6 @@ Object {
   "include": Object {
     "enabled": true,
   },
-  "logMediaPlayerStatus": Object {
-    "enabled": false,
-  },
   "mostRead": Object {
     "enabled": true,
   },
@@ -80,9 +77,6 @@ Object {
   "include": Object {
     "enabled": true,
   },
-  "logMediaPlayerStatus": Object {
-    "enabled": false,
-  },
   "mostRead": Object {
     "enabled": true,
   },
@@ -134,9 +128,6 @@ Object {
   },
   "include": Object {
     "enabled": true,
-  },
-  "logMediaPlayerStatus": Object {
-    "enabled": false,
   },
   "mostRead": Object {
     "enabled": true,

--- a/src/app/lib/config/toggles/const.js
+++ b/src/app/lib/config/toggles/const.js
@@ -6,7 +6,6 @@ export default {
   ENABLE_FETCHING_TOGGLES: 'enableFetchingToggles',
   INCLUDE: 'include',
   LIVE_RADIO_SCHEDULE: 'liveRadioSchedule',
-  LOG_MEDIA_PLAYER_STATUS: 'logMediaPlayerStatus',
   MEDIA_PLAYER: 'mediaPlayer',
   MOST_READ: 'mostRead',
   NAVIGATION_ON_ARTICLES: 'navOnArticles',

--- a/src/app/lib/config/toggles/liveConfig.js
+++ b/src/app/lib/config/toggles/liveConfig.js
@@ -23,9 +23,6 @@ export default {
   onDemandRadioSchedule: {
     enabled: true,
   },
-  logMediaPlayerStatus: {
-    enabled: false,
-  },
   mostRead: {
     enabled: true,
   },

--- a/src/app/lib/config/toggles/localConfig.js
+++ b/src/app/lib/config/toggles/localConfig.js
@@ -26,9 +26,6 @@ export default {
   onDemandRadioSchedule: {
     enabled: true,
   },
-  logMediaPlayerStatus: {
-    enabled: false,
-  },
   mostRead: {
     enabled: true,
   },

--- a/src/app/lib/config/toggles/testConfig.js
+++ b/src/app/lib/config/toggles/testConfig.js
@@ -23,9 +23,6 @@ export default {
   onDemandRadioSchedule: {
     enabled: true,
   },
-  logMediaPlayerStatus: {
-    enabled: false,
-  },
   mostRead: {
     enabled: true,
   },


### PR DESCRIPTION
Resolves #1178

**Overall change:**
https://github.com/bbc/simorgh-infrastructure/issues/1178 removed the use of the logMediaPlayerStatus toggle. This PR removes it from the configs

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
