### PR TITLE
Update integration tests for Related Content

### DIFF
--- a/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
@@ -446,7 +446,7 @@ exports[`CpsRelatedContent should render Story Feature components when given app
 <section
     aria-labelledby="features-analysis-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="features-analysis-heading"
     role="region"
   >
     <div
@@ -1037,7 +1037,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 <section
     aria-labelledby="features-analysis-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="features-analysis-heading"
     role="region"
   >
     <div

--- a/src/app/containers/CpsOnwardJourney/index.jsx
+++ b/src/app/containers/CpsOnwardJourney/index.jsx
@@ -168,7 +168,7 @@ const CpsOnwardJourney = ({
   const CpsOnwardJourneyWrapper = ({ children }) =>
     parentColumns ? (
       <Wrapper
-        data-e2e="related-content"
+        data-e2e={labelId}
         parentColumns={parentColumns}
         columnType={columnType}
         {...a11yAttributes}
@@ -176,7 +176,7 @@ const CpsOnwardJourney = ({
         {children}
       </Wrapper>
     ) : (
-      <LegacyGridWrapper data-e2e="related-content" {...a11yAttributes}>
+      <LegacyGridWrapper data-e2e={labelId} {...a11yAttributes}>
         <LegacyGridItemConstrainedLarge>
           {children}
         </LegacyGridItemConstrainedLarge>

--- a/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
@@ -436,7 +436,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
       <section
         aria-labelledby="recommendations-heading"
         class="c2"
-        data-e2e="related-content"
+        data-e2e="recommendations-heading"
         role="region"
       >
         <div
@@ -1091,7 +1091,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
       <section
         aria-labelledby="recommendations-heading"
         class="c2"
-        data-e2e="related-content"
+        data-e2e="recommendations-heading"
         role="region"
       >
         <div
@@ -1926,7 +1926,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
       <section
         aria-labelledby="recommendations-heading"
         class="c2"
-        data-e2e="related-content"
+        data-e2e="recommendations-heading"
         role="region"
       >
         <div

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -525,7 +525,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 <section
     aria-labelledby="related-content-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="related-content-heading"
     role="region"
   >
     <div
@@ -1199,7 +1199,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 <section
     aria-labelledby="related-content-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="related-content-heading"
     role="region"
   >
     <div

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -405,7 +405,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 <section
     aria-labelledby="top-stories-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="top-stories-heading"
     role="region"
   >
     <div
@@ -878,7 +878,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 <section
     aria-labelledby="top-stories-heading"
     class="c0"
-    data-e2e="related-content"
+    data-e2e="top-stories-heading"
     role="region"
   >
     <div

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -2657,7 +2657,7 @@ exports[`Media Asset Page should render component 1`] = `
             <section
               aria-labelledby="related-content-heading"
               class="c28"
-              data-e2e="related-content"
+              data-e2e="related-content-heading"
               role="region"
             >
               <div

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -4366,7 +4366,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                 <section
                   aria-labelledby="related-content-heading"
                   class="c15"
-                  data-e2e="related-content"
+                  data-e2e="related-content-heading"
                   role="region"
                 >
                   <div
@@ -8279,7 +8279,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                 <section
                   aria-labelledby="related-content-heading"
                   class="c34"
-                  data-e2e="related-content"
+                  data-e2e="related-content-heading"
                   role="region"
                 >
                   <div

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2050,7 +2050,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                 <section
                   aria-labelledby="related-content-heading"
                   class="c36"
-                  data-e2e="related-content"
+                  data-e2e="related-content-heading"
                   role="region"
                 >
                   <div
@@ -2099,7 +2099,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   <section
                     aria-labelledby="top-stories-heading"
                     class="c36"
-                    data-e2e="related-content"
+                    data-e2e="top-stories-heading"
                     role="region"
                   >
                     <div
@@ -2271,7 +2271,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   <section
                     aria-labelledby="features-analysis-heading"
                     class="c36"
-                    data-e2e="related-content"
+                    data-e2e="features-analysis-heading"
                     role="region"
                   >
                     <div
@@ -5223,7 +5223,7 @@ exports[`Story Page should render correctly when the secondary column data is no
                     <section
                       aria-labelledby="related-content-heading"
                       class="c38"
-                      data-e2e="related-content"
+                      data-e2e="related-content-heading"
                       role="region"
                     >
                       <div
@@ -8032,7 +8032,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                     <section
                       aria-labelledby="related-content-heading"
                       class="c38"
-                      data-e2e="related-content"
+                      data-e2e="related-content-heading"
                       role="region"
                     >
                       <div
@@ -8081,7 +8081,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       <section
                         aria-labelledby="top-stories-heading"
                         class="c38"
-                        data-e2e="related-content"
+                        data-e2e="top-stories-heading"
                         role="region"
                       >
                         <div
@@ -8213,7 +8213,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       <section
                         aria-labelledby="features-analysis-heading"
                         class="c38"
-                        data-e2e="related-content"
+                        data-e2e="features-analysis-heading"
                         role="region"
                       >
                         <div

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -143,26 +143,6 @@ Object {
 }
 `;
 
-exports[`Canonical Media Asset Page I can see related content: "المايوه الشرعي" يثير جدلا في الساحل الشمالي في مصر 1`] = `"/arabic/tv-and-radio-53492142"`;
-
-exports[`Canonical Media Asset Page I can see related content: آيا صوفيا: كيف أصبح المبنى التاريخي في قلب هذه المعركة السياسية؟ 1`] = `"/arabic/media-53262408"`;
-
-exports[`Canonical Media Asset Page I can see related content: أردوغان يرتل القرآن في أول صلاة جمعة في آيا صوفيا 1`] = `"/arabic/tv-and-radio-53532358"`;
-
-exports[`Canonical Media Asset Page I can see related content: التحرش الإلكتروني شبح جديد يهدد نساء في مصر 1`] = `"/arabic/media-53525480"`;
-
-exports[`Canonical Media Asset Page I can see related content: عرض سعودي للفنان المصري عبد الرحمن ابو زهرة بعد شكواه من تجاهل المخرجين له 1`] = `"/arabic/tv-and-radio-53519417"`;
-
-exports[`Canonical Media Asset Page I can see related content: قصة أخطر صورة سيلفي التقطت في متنزه بالمكسيك 1`] = `"/arabic/media-53528843"`;
-
-exports[`Canonical Media Asset Page I can see related content: كيف أصبح رئيس تركيا رجب طيب أردوغان أحد أبرز القادة؟ 1`] = `"/arabic/media-53529792"`;
-
-exports[`Canonical Media Asset Page I can see related content: لحظة اعتراض طائرة حربية أمريكية لطائرة ركاب إيرانية متجهة إلى لبنان 1`] = `"/arabic/media-53527555"`;
-
-exports[`Canonical Media Asset Page I can see related content: مباشر: تلفزيون بي بي سي عربي 1`] = `"/arabic/media-49522519"`;
-
-exports[`Canonical Media Asset Page I can see related content: هل حذف غوغل فلسطين من خرائطه بالفعل؟ 1`] = `"/arabic/media-53532058"`;
-
 exports[`Canonical Media Asset Page I can see the headline 1`] = `"شركة شارب للإلكترونيات تحث موظفيها على شراء منتجاتها"`;
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `

--- a/src/integration/pages/mediaAssetPage/crossPlatformTests.js
+++ b/src/integration/pages/mediaAssetPage/crossPlatformTests.js
@@ -65,7 +65,7 @@ export default () => {
 
         it('should match text and url', () => {
           expect({
-            text: relatedContentLink.textContent,
+            text: relatedContentText,
             url: relatedContentUrl,
           }).toMatchSnapshot();
         });

--- a/src/integration/pages/mediaAssetPage/crossPlatformTests.js
+++ b/src/integration/pages/mediaAssetPage/crossPlatformTests.js
@@ -45,17 +45,31 @@ export default () => {
     });
   }
 
-  const relatedContentLinks = document.querySelectorAll(
-    '[data-e2e="related-content"] a',
-  );
+  describe(`Related Content`, () => {
+    const relatedContentLinks = document.querySelectorAll(
+      '[data-e2e="related-content-heading"] a',
+    );
 
-  if (relatedContentLinks) {
-    relatedContentLinks.forEach(relatedContentLink => {
-      it(`I can see related content: ${relatedContentLink.textContent}`, () => {
-        expect(relatedContentLink).toBeInTheDocument();
-        expect(relatedContentLink.textContent).toBeTruthy();
-        expect(relatedContentLink.getAttribute('href')).toMatchSnapshot();
+    if (relatedContentLinks) {
+      relatedContentLinks.forEach(relatedContentLink => {
+        const relatedContentText = relatedContentLink.textContent;
+        const relatedContentUrl = relatedContentLink.getAttribute('href');
+
+        it('should be in the document', () => {
+          expect(relatedContentLink).toBeInTheDocument();
+        });
+
+        it('should contain text', () => {
+          expect(relatedContentText).toBeTruthy();
+        });
+
+        it('should match text and url', () => {
+          expect({
+            text: relatedContentLink.textContent,
+            url: relatedContentUrl,
+          }).toMatchSnapshot();
+        });
       });
-    });
-  }
+    }
+  });
 };

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -171,26 +171,6 @@ Object {
 }
 `;
 
-exports[`Canonical Media Asset Page I can see related content: ابهام در مورد منشاء 'انفجار' در تاسیسات هسته‌ای نطنز 1`] = `"/persian/iran-53313694"`;
-
-exports[`Canonical Media Asset Page I can see related content: اعتصاب غذای شماری از زندانیان ایرانی در ارمنستان 1`] = `"/persian/iran-53315112"`;
-
-exports[`Canonical Media Asset Page I can see related content: تاثیر کرونا بر گاوبازی در اسپانیا 1`] = `"/persian/world-53324472"`;
-
-exports[`Canonical Media Asset Page I can see related content: تلویزیون فارسی بی‌بی‌سی: پخش زنده اینترنتی 1`] = `"/persian/media-49522521"`;
-
-exports[`Canonical Media Asset Page I can see related content: جنجال بر سر واریز۲۳۱ میلیون تومانی به حساب نمایندگان مجلس ایران 1`] = `"/persian/iran-53313696"`;
-
-exports[`Canonical Media Asset Page I can see related content: رشد بورس تهران حبابی است؟ 1`] = `"/persian/business-53313698"`;
-
-exports[`Canonical Media Asset Page I can see related content: هشدار عباس عراقچی؛ 'خسارات راهبردی' ایران به چه معناست؟ 1`] = `"/persian/tv-and-radio-53317117"`;
-
-exports[`Canonical Media Asset Page I can see related content: پرستاری که با نواختن ویولن به بیماران آرامش می‌دهد 1`] = `"/persian/world-53324474"`;
-
-exports[`Canonical Media Asset Page I can see related content: کشمکش بر سر ممنوعیت واردات موبایل‌های بالای ۳۰۰ یورو 1`] = `"/persian/business-53315108"`;
-
-exports[`Canonical Media Asset Page I can see related content: کودتای ۲۸ مرداد به روایت اردشیر زاهدی 1`] = `"/persian/iran/2013/08/130819_l42_vid_coup_eye3"`;
-
 exports[`Canonical Media Asset Page I can see the headline 1`] = `"Trump long headline"`;
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
@@ -266,14 +266,6 @@ exports[`AMP Media Asset Page I can see a bulleted list item 1`] = `"<Media Asse
 
 exports[`AMP Media Asset Page I can see a bulleted list item with link: <Media Asset Page> 1`] = `"http://www.bbc.com/afrique/23248423"`;
 
-exports[`AMP Media Asset Page I can see related content: Audio, BBC News Pidgin One Minute News, 0,15 1`] = `"/pidgin/media-23147054"`;
-
-exports[`AMP Media Asset Page I can see related content: Image gallery, Kenya Elections Pictures: 8 August 2017 1`] = `"/pidgin/23146654"`;
-
-exports[`AMP Media Asset Page I can see related content: Lagos 'Gay' men Appear for Court, say Dem no dey Guilty 1`] = `"/pidgin/tori-23143754"`;
-
-exports[`AMP Media Asset Page I can see related content: Police Arrest 3 ontop Anambra Church Attack 1`] = `"/pidgin/tori-23145776"`;
-
 exports[`AMP Media Asset Page I can see the headline 1`] = `"Simorgh: Media Pod Build First CPS Media Asset Page in Simorgh & < >"`;
 
 exports[`AMP Media Asset Page I can see the timestamp 1`] = `"13 September 2019"`;
@@ -281,6 +273,34 @@ exports[`AMP Media Asset Page I can see the timestamp 1`] = `"13 September 2019"
 exports[`AMP Media Asset Page Media Player a11y assistive technology can read the media player title 1`] = `"Media player"`;
 
 exports[`AMP Media Asset Page Media Player iframe with valid URL should be rendered 1`] = `"https://polling.test.bbc.co.uk/ws/av-embeds/cps/pidgin/23248703/p01kx42v/pcm/amp"`;
+
+exports[`AMP Media Asset Page Related Content should match text and url 1`] = `
+Object {
+  "text": "Police Arrest 3 ontop Anambra Church Attack",
+  "url": "/pidgin/tori-23145776",
+}
+`;
+
+exports[`AMP Media Asset Page Related Content should match text and url 2`] = `
+Object {
+  "text": "Lagos 'Gay' men Appear for Court, say Dem no dey Guilty",
+  "url": "/pidgin/tori-23143754",
+}
+`;
+
+exports[`AMP Media Asset Page Related Content should match text and url 3`] = `
+Object {
+  "text": "Image gallery, Kenya Elections Pictures: 8 August 2017",
+  "url": "/pidgin/23146654",
+}
+`;
+
+exports[`AMP Media Asset Page Related Content should match text and url 4`] = `
+Object {
+  "text": "Audio, BBC News Pidgin One Minute News, 0,15",
+  "url": "/pidgin/media-23147054",
+}
+`;
 
 exports[`AMP Media Asset Page SEO Apple Touch Icon should match attributes 1`] = `
 Object {

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -133,24 +133,6 @@ exports[`Canonical Media Asset Page I can see a bulleted list item 1`] = `"<Medi
 
 exports[`Canonical Media Asset Page I can see a bulleted list item with link: <Media Asset Page> 1`] = `"http://www.bbc.com/afrique/23248423"`;
 
-exports[`Canonical Media Asset Page I can see related content: 'I no know say I different for society until pipo begin look me one kain' 1`] = `"/pidgin/media-53580248"`;
-
-exports[`Canonical Media Asset Page I can see related content: Audio, BBC News Pidgin One Minute News, 0,15 1`] = `"/pidgin/media-23147054"`;
-
-exports[`Canonical Media Asset Page I can see related content: Bundu Ama: Di community wey get only 'one' toilet 1`] = `"/pidgin/media-53591139"`;
-
-exports[`Canonical Media Asset Page I can see related content: Image gallery, Kenya Elections Pictures: 8 August 2017 1`] = `"/pidgin/23146654"`;
-
-exports[`Canonical Media Asset Page I can see related content: James Brown: Meet popular Nigeria cross dresser 1`] = `"/pidgin/media-53468506"`;
-
-exports[`Canonical Media Asset Page I can see related content: Lagos 'Gay' men Appear for Court, say Dem no dey Guilty 1`] = `"/pidgin/tori-23143754"`;
-
-exports[`Canonical Media Asset Page I can see related content: Naira Marley: Jude Chukwuka AKA Fada Maler say "I be Marlian for life" 1`] = `"/pidgin/tori-53509788"`;
-
-exports[`Canonical Media Asset Page I can see related content: Police Arrest 3 ontop Anambra Church Attack 1`] = `"/pidgin/tori-23145776"`;
-
-exports[`Canonical Media Asset Page I can see related content: Savage Trap Queen: I dey make 80k - 100k per blue film 1`] = `"/pidgin/tori-45225863"`;
-
 exports[`Canonical Media Asset Page I can see the headline 1`] = `"Simorgh: Media Pod Build First CPS Media Asset Page in Simorgh & < >"`;
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `
@@ -168,6 +150,34 @@ exports[`Canonical Media Asset Page I can see the timestamp 1`] = `"13 September
 exports[`Canonical Media Asset Page Media Player a11y assistive technology can read the media player title 1`] = `"Media player"`;
 
 exports[`Canonical Media Asset Page Media Player iframe with valid URL should be rendered 1`] = `"https://test.bbc.com/ws/av-embeds/cps/pidgin/23248703/p01kx42v/pcm"`;
+
+exports[`Canonical Media Asset Page Related Content should match text and url 1`] = `
+Object {
+  "text": "Police Arrest 3 ontop Anambra Church Attack",
+  "url": "/pidgin/tori-23145776",
+}
+`;
+
+exports[`Canonical Media Asset Page Related Content should match text and url 2`] = `
+Object {
+  "text": "Lagos 'Gay' men Appear for Court, say Dem no dey Guilty",
+  "url": "/pidgin/tori-23143754",
+}
+`;
+
+exports[`Canonical Media Asset Page Related Content should match text and url 3`] = `
+Object {
+  "text": "Image gallery, Kenya Elections Pictures: 8 August 2017",
+  "url": "/pidgin/23146654",
+}
+`;
+
+exports[`Canonical Media Asset Page Related Content should match text and url 4`] = `
+Object {
+  "text": "Audio, BBC News Pidgin One Minute News, 0,15",
+  "url": "/pidgin/media-23147054",
+}
+`;
 
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 1`] = `
 Object {


### PR DESCRIPTION
Resolves: #6909 

**Overall change:**
All onward journeys - related content, most watched, recommendations etc, were configured with the same attribute for testing (`data-e2e="related-content"`)

However, in order to be able to test each onward journey individually (via integration / E2E tests), the attribute value should be unique.

**Code changes:**
- Use `labelId` (which is a required field for the `CpsOnwardJourney` component), and use this as the value of the `data-e2e` attribute
- Update snapshots
- Update the related content integration test on MAPs - use correct `data-e2e` attribute value, and make the tests more consistent with other tests which check for multiple items on a page e.g. navigation links https://github.com/bbc/simorgh/blob/latest/src/integration/common/header.js#L21

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
