### PR TITLE
Integration tests for Most Watched component on media asset page

### DIFF
--- a/src/app/containers/MostWatched/index.jsx
+++ b/src/app/containers/MostWatched/index.jsx
@@ -20,7 +20,6 @@ const MostWatched = ({ data, hasHeader }) => {
   return (
     <CpsOnwardJourney
       labelId="most-watched-heading"
-      data-e2e="most-watched"
       title={hasHeader ? header : ''}
       isMapContent
       content={data}

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -161,6 +161,76 @@ exports[`Canonical Media Asset Page Media Player a11y assistive technology can r
 
 exports[`Canonical Media Asset Page Media Player iframe with valid URL should be rendered 1`] = `"https://test.bbc.com/ws/av-embeds/legacy/arabic/worldnews/2015/11/151120_t_arabic_av/17694217/ar"`;
 
+exports[`Canonical Media Asset Page Most Watched should match text and url 1`] = `
+Object {
+  "text": "كيف أصبح رئيس تركيا رجب طيب أردوغان أحد أبرز القادة؟",
+  "url": "/arabic/media-53529792",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 2`] = `
+Object {
+  "text": "قصة أخطر صورة سيلفي التقطت في متنزه بالمكسيك",
+  "url": "/arabic/media-53528843",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 3`] = `
+Object {
+  "text": "مباشر: تلفزيون بي بي سي عربي",
+  "url": "/arabic/media-49522519",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 4`] = `
+Object {
+  "text": "لحظة اعتراض طائرة حربية أمريكية لطائرة ركاب إيرانية متجهة إلى لبنان",
+  "url": "/arabic/media-53527555",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 5`] = `
+Object {
+  "text": "هل حذف غوغل فلسطين من خرائطه بالفعل؟",
+  "url": "/arabic/media-53532058",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 6`] = `
+Object {
+  "text": "عرض سعودي للفنان المصري عبد الرحمن ابو زهرة بعد شكواه من تجاهل المخرجين له",
+  "url": "/arabic/tv-and-radio-53519417",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 7`] = `
+Object {
+  "text": "أردوغان يرتل القرآن في أول صلاة جمعة في آيا صوفيا",
+  "url": "/arabic/tv-and-radio-53532358",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 8`] = `
+Object {
+  "text": "التحرش الإلكتروني شبح جديد يهدد نساء في مصر",
+  "url": "/arabic/media-53525480",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 9`] = `
+Object {
+  "text": "آيا صوفيا: كيف أصبح المبنى التاريخي في قلب هذه المعركة السياسية؟",
+  "url": "/arabic/media-53262408",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 10`] = `
+Object {
+  "text": "\\"المايوه الشرعي\\" يثير جدلا في الساحل الشمالي في مصر",
+  "url": "/arabic/tv-and-radio-53492142",
+}
+`;
+
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 1`] = `
 Object {
   "sizes": null,

--- a/src/integration/pages/mediaAssetPage/crossPlatformTests.js
+++ b/src/integration/pages/mediaAssetPage/crossPlatformTests.js
@@ -93,7 +93,7 @@ export default () => {
 
         it('should match text and url', () => {
           expect({
-            text: mostWatchedLink.textContent,
+            text: mostWatchedText,
             url: mostWatchedUrl,
           }).toMatchSnapshot();
         });

--- a/src/integration/pages/mediaAssetPage/crossPlatformTests.js
+++ b/src/integration/pages/mediaAssetPage/crossPlatformTests.js
@@ -72,4 +72,32 @@ export default () => {
       });
     }
   });
+
+  describe(`Most Watched`, () => {
+    const mostWatchedLinks = document.querySelectorAll(
+      '[data-e2e="most-watched-heading"] a',
+    );
+
+    if (mostWatchedLinks) {
+      mostWatchedLinks.forEach(mostWatchedLink => {
+        const mostWatchedText = mostWatchedLink.textContent;
+        const mostWatchedUrl = mostWatchedLink.getAttribute('href');
+
+        it('should be in the document', () => {
+          expect(mostWatchedLink).toBeInTheDocument();
+        });
+
+        it('should contain text', () => {
+          expect(mostWatchedText).toBeTruthy();
+        });
+
+        it('should match text and url', () => {
+          expect({
+            text: mostWatchedLink.textContent,
+            url: mostWatchedUrl,
+          }).toMatchSnapshot();
+        });
+      });
+    }
+  });
 };

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -189,6 +189,76 @@ exports[`Canonical Media Asset Page Media Player a11y assistive technology can r
 
 exports[`Canonical Media Asset Page Media Player iframe with valid URL should be rendered 1`] = `"https://test.bbc.com/ws/av-embeds/cps/persian/iran-23231114/p01lmkjk/fa"`;
 
+exports[`Canonical Media Asset Page Most Watched should match text and url 1`] = `
+Object {
+  "text": "تلویزیون فارسی بی‌بی‌سی: پخش زنده اینترنتی",
+  "url": "/persian/media-49522521",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 2`] = `
+Object {
+  "text": "پرستاری که با نواختن ویولن به بیماران آرامش می‌دهد",
+  "url": "/persian/world-53324474",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 3`] = `
+Object {
+  "text": "جنجال بر سر واریز۲۳۱ میلیون تومانی به حساب نمایندگان مجلس ایران",
+  "url": "/persian/iran-53313696",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 4`] = `
+Object {
+  "text": "هشدار عباس عراقچی؛ 'خسارات راهبردی' ایران به چه معناست؟",
+  "url": "/persian/tv-and-radio-53317117",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 5`] = `
+Object {
+  "text": "تاثیر کرونا بر گاوبازی در اسپانیا",
+  "url": "/persian/world-53324472",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 6`] = `
+Object {
+  "text": "ابهام در مورد منشاء 'انفجار' در تاسیسات هسته‌ای نطنز",
+  "url": "/persian/iran-53313694",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 7`] = `
+Object {
+  "text": "اعتصاب غذای شماری از زندانیان ایرانی در ارمنستان",
+  "url": "/persian/iran-53315112",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 8`] = `
+Object {
+  "text": "رشد بورس تهران حبابی است؟",
+  "url": "/persian/business-53313698",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 9`] = `
+Object {
+  "text": "کشمکش بر سر ممنوعیت واردات موبایل‌های بالای ۳۰۰ یورو",
+  "url": "/persian/business-53315108",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 10`] = `
+Object {
+  "text": "کودتای ۲۸ مرداد به روایت اردشیر زاهدی",
+  "url": "/persian/iran/2013/08/130819_l42_vid_coup_eye3",
+}
+`;
+
 exports[`Canonical Media Asset Page SEO Apple Touch Icon should match attributes 1`] = `
 Object {
   "sizes": null,

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -151,6 +151,76 @@ exports[`Canonical Media Asset Page Media Player a11y assistive technology can r
 
 exports[`Canonical Media Asset Page Media Player iframe with valid URL should be rendered 1`] = `"https://test.bbc.com/ws/av-embeds/cps/pidgin/23248703/p01kx42v/pcm"`;
 
+exports[`Canonical Media Asset Page Most Watched should match text and url 1`] = `
+Object {
+  "text": "'I no know say I different for society until pipo begin look me one kain'",
+  "url": "/pidgin/media-53580248",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 2`] = `
+Object {
+  "text": "Bundu Ama: Di community wey get only 'one' toilet",
+  "url": "/pidgin/media-53591139",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 3`] = `
+Object {
+  "text": "Naira Marley: Jude Chukwuka AKA Fada Maler say \\"I be Marlian for life\\"",
+  "url": "/pidgin/tori-53509788",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 4`] = `
+Object {
+  "text": "James Brown: Meet popular Nigeria cross dresser",
+  "url": "/pidgin/media-53468506",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 5`] = `
+Object {
+  "text": "Savage Trap Queen: I dey make 80k - 100k per blue film",
+  "url": "/pidgin/tori-45225863",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 6`] = `
+Object {
+  "text": "80-year-old man wey bin dey use sand to clean im teeth don get im own toothbrush",
+  "url": "/pidgin/tori-53359602",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 7`] = `
+Object {
+  "text": "Chichi Igbo: 'Di kain Internet bully I dey face daily, if my skin no tight I for don kpai'",
+  "url": "/pidgin/tori-53146818",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 8`] = `
+Object {
+  "text": "Regina Daniels share her thoughts on motherhood and her and Ned Nwoko baby",
+  "url": "/pidgin/tori-53377321",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 9`] = `
+Object {
+  "text": "Omohtee: 'Fat wey don turn to doti dey comot from my bumbum surgery wey I do' - Victim of 'failed bum surgery'",
+  "url": "/pidgin/tori-53331401",
+}
+`;
+
+exports[`Canonical Media Asset Page Most Watched should match text and url 10`] = `
+Object {
+  "text": "BBC Pidgin Minute",
+  "url": "/pidgin/media-53261804",
+}
+`;
+
 exports[`Canonical Media Asset Page Related Content should match text and url 1`] = `
 Object {
   "text": "Police Arrest 3 ontop Anambra Church Attack",


### PR DESCRIPTION
Resolves #7708

**Overall change:**
Adds integration tests for the most watched component on MAPs

**Code changes:**
- Adding most watched test
- Updating snapshots

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
