### PR TITLE
handle test error and exit with code 1 to fail CI

### DIFF
--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -67,7 +67,9 @@ const runTests = () =>
   });
 
 if (isCI) {
-  runTests();
+  runTests().catch(() => {
+    process.exit(1);
+  });
 } else {
   const spinner = ora().start();
 


### PR DESCRIPTION
**Overall change:**
Fails CI if integration tests fail.

It does this by catching int test errors and exiting with code 1 to fail CI.

Proof of failure can be seen here https://ci.news.tools.bbc.co.uk/blue/organizations/jenkins/simorgh/detail/int-tests-fail-ci-TEST/1/pipeline/51

**Code changes:**

- add catch block to CI `runTests` promise and calls `process.exit(1);`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
