### PR TITLE
Enable STY Ads on Live

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -190,7 +190,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -208,7 +208,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -306,7 +306,7 @@
       "requires": {
         "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -336,7 +336,7 @@
           "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -372,7 +372,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -409,7 +409,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -456,7 +456,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -524,7 +524,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.5",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -597,7 +597,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -774,7 +774,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -792,7 +792,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -911,7 +911,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -954,7 +954,7 @@
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.11.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1093,7 +1093,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -1111,7 +1111,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1217,7 +1217,7 @@
       "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
@@ -1338,7 +1338,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -1356,7 +1356,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1507,7 +1507,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1593,7 +1593,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1729,7 +1729,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -1747,7 +1747,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1934,7 +1934,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -1952,7 +1952,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -2460,7 +2460,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -2478,7 +2478,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -2834,7 +2834,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3031,7 +3031,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -3049,7 +3049,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3328,7 +3328,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3672,7 +3672,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -3690,7 +3690,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3807,7 +3807,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4023,7 +4023,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4474,7 +4474,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -4492,7 +4492,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4664,7 +4664,7 @@
         "@babel/types": "^7.10.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -4693,7 +4693,7 @@
       "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -6317,7 +6317,7 @@
       "resolved": "https://registry.npmjs.org/@loadable/server/-/server-5.12.0.tgz",
       "integrity": "sha512-Sb4hPz3vPf2z8GMPlW2kSiDwy3Lv38LhVFEW/Uy3BJqHxNlollJDD3rXQ6zmCZY5S/x/m1tPox8UyIBhcr8SZg==",
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
@@ -6453,7 +6453,7 @@
         "escape-html": "^1.0.3",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
         "react-color": "^2.17.0",
@@ -6501,7 +6501,7 @@
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.6.2",
         "react": "^16.8.3",
@@ -6559,7 +6559,7 @@
         "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
         "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "stable": "^0.1.8",
@@ -6596,7 +6596,7 @@
         "@types/react-textarea-autosize": "^4.3.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -6822,7 +6822,7 @@
       "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
@@ -6878,7 +6878,7 @@
         "babel-plugin-react-docgen": "^4.0.0",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mini-css-extract-plugin": "^0.7.0",
         "prop-types": "^15.7.2",
         "react-dev-utils": "^9.0.0",
@@ -6907,7 +6907,7 @@
         "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "util-deprecate": "^1.0.2"
@@ -6963,7 +6963,7 @@
         "fast-deep-equal": "^2.0.1",
         "fuse.js": "^3.4.6",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -7274,7 +7274,7 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -8526,7 +8526,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.14"
       },
       "dependencies": {
         "lodash": {
@@ -9061,7 +9061,7 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -9151,7 +9151,7 @@
       "integrity": "sha512-vzpnBlfGv8XOhJM2zbPyyqw2OLEbelgZZsaaRRTpVwNKuYuc+pUg4+dy7i9gCRms0uOQn4osX571HRcCJMJCmA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "react-docgen": "^5.0.0",
         "recast": "^0.14.7"
       },
@@ -9178,7 +9178,7 @@
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -9348,7 +9348,7 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -10242,7 +10242,7 @@
         "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.15.0",
         "parse5": "^3.0.1"
       },
       "dependencies": {
@@ -11743,7 +11743,7 @@
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "log-symbols": "^3.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
@@ -11861,7 +11861,7 @@
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -12214,7 +12214,7 @@
         "ignore": "^5.1.8",
         "js-yaml": "^3.14.0",
         "json5": "^2.1.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "multimatch": "^4.0.0",
         "please-upgrade-node": "^3.2.0",
@@ -12323,7 +12323,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
@@ -12341,7 +12341,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -13306,7 +13306,7 @@
       "integrity": "sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "react-is": "^16.12.0"
       },
       "dependencies": {
@@ -13523,7 +13523,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -13935,7 +13935,7 @@
       "integrity": "sha512-isM/fsUxS4wN1+nLsWoV5T4gLgBQnsql3nMTr8u+cEls1bL8rRQO5CP5GtxJxaOfbcKqnz401styw+H/P+e78Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "vscode-json-languageservice": "^3.7.0"
       },
       "dependencies": {
@@ -16254,7 +16254,7 @@
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
         "util.promisify": "1.0.0"
@@ -16325,7 +16325,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
@@ -16668,7 +16668,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
@@ -23141,7 +23141,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       },
@@ -23357,15 +23357,6 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
-    },
-    "prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
     },
     "private": {
       "version": "0.1.8",
@@ -23813,7 +23804,7 @@
       "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "material-colors": "^1.2.1",
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
@@ -23989,7 +23980,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -24395,7 +24386,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -24450,7 +24441,7 @@
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -24668,7 +24659,7 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "^1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
@@ -24991,7 +24982,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
@@ -27979,7 +27970,7 @@
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^7.0.1",
@@ -28601,7 +28592,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -28760,7 +28751,7 @@
         "is-regex": "^1.0.4",
         "is-symbol": "^1.0.3",
         "isobject": "^4.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3"
       },
       "dependencies": {
@@ -29940,7 +29931,7 @@
       "requires": {
         "axios": "^0.19.2",
         "joi": "^17.1.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimist": "^1.2.5",
         "rxjs": "^6.5.5"
       },
@@ -30386,7 +30377,7 @@
         "express": "^4.16.3",
         "filesize": "^3.6.1",
         "gzip-size": "^5.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
         "opener": "^1.5.1",
         "ws": "^6.0.0"
@@ -31232,7 +31223,7 @@
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -190,7 +190,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -208,7 +208,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -306,7 +306,7 @@
       "requires": {
         "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.20",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -336,7 +336,7 @@
           "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -372,7 +372,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -409,7 +409,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -456,7 +456,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -524,7 +524,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.5",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -597,7 +597,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -774,7 +774,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -792,7 +792,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -911,7 +911,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -954,7 +954,7 @@
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.11.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1093,7 +1093,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -1111,7 +1111,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1217,7 +1217,7 @@
       "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -1338,7 +1338,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -1356,7 +1356,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1507,7 +1507,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1593,7 +1593,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1729,7 +1729,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -1747,7 +1747,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -1934,7 +1934,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -1952,7 +1952,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -2460,7 +2460,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -2478,7 +2478,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -2834,7 +2834,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3031,7 +3031,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -3049,7 +3049,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3328,7 +3328,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3672,7 +3672,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -3690,7 +3690,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -3807,7 +3807,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4023,7 +4023,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4474,7 +4474,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -4492,7 +4492,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -4664,7 +4664,7 @@
         "@babel/types": "^7.10.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "debug": {
@@ -4693,7 +4693,7 @@
       "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.20",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -6317,7 +6317,7 @@
       "resolved": "https://registry.npmjs.org/@loadable/server/-/server-5.12.0.tgz",
       "integrity": "sha512-Sb4hPz3vPf2z8GMPlW2kSiDwy3Lv38LhVFEW/Uy3BJqHxNlollJDD3rXQ6zmCZY5S/x/m1tPox8UyIBhcr8SZg==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -6453,7 +6453,7 @@
         "escape-html": "^1.0.3",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
         "react-color": "^2.17.0",
@@ -6501,7 +6501,7 @@
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.6.2",
         "react": "^16.8.3",
@@ -6559,7 +6559,7 @@
         "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
         "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "stable": "^0.1.8",
@@ -6596,7 +6596,7 @@
         "@types/react-textarea-autosize": "^4.3.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -6822,7 +6822,7 @@
       "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -6878,7 +6878,7 @@
         "babel-plugin-react-docgen": "^4.0.0",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "mini-css-extract-plugin": "^0.7.0",
         "prop-types": "^15.7.2",
         "react-dev-utils": "^9.0.0",
@@ -6907,7 +6907,7 @@
         "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "util-deprecate": "^1.0.2"
@@ -6963,7 +6963,7 @@
         "fast-deep-equal": "^2.0.1",
         "fuse.js": "^3.4.6",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -7274,7 +7274,7 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -8526,7 +8526,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -9061,7 +9061,7 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -9151,7 +9151,7 @@
       "integrity": "sha512-vzpnBlfGv8XOhJM2zbPyyqw2OLEbelgZZsaaRRTpVwNKuYuc+pUg4+dy7i9gCRms0uOQn4osX571HRcCJMJCmA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "react-docgen": "^5.0.0",
         "recast": "^0.14.7"
       },
@@ -9178,7 +9178,7 @@
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -9348,7 +9348,7 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -10242,7 +10242,7 @@
         "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
+        "lodash": "^4.17.20",
         "parse5": "^3.0.1"
       },
       "dependencies": {
@@ -11743,7 +11743,7 @@
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "log-symbols": "^3.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
@@ -11861,7 +11861,7 @@
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "debug": {
@@ -12214,7 +12214,7 @@
         "ignore": "^5.1.8",
         "js-yaml": "^3.14.0",
         "json5": "^2.1.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "multimatch": "^4.0.0",
         "please-upgrade-node": "^3.2.0",
@@ -12323,7 +12323,7 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.20"
           },
           "dependencies": {
             "lodash": {
@@ -12341,7 +12341,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.20",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
@@ -13306,7 +13306,7 @@
       "integrity": "sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "react-is": "^16.12.0"
       },
       "dependencies": {
@@ -13523,7 +13523,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -13935,7 +13935,7 @@
       "integrity": "sha512-isM/fsUxS4wN1+nLsWoV5T4gLgBQnsql3nMTr8u+cEls1bL8rRQO5CP5GtxJxaOfbcKqnz401styw+H/P+e78Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "vscode-json-languageservice": "^3.7.0"
       },
       "dependencies": {
@@ -16254,7 +16254,7 @@
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
         "util.promisify": "1.0.0"
@@ -16325,7 +16325,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.20",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
@@ -16668,7 +16668,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
@@ -23141,7 +23141,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.20",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       },
@@ -23357,6 +23357,15 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -23804,7 +23813,7 @@
       "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.20",
         "material-colors": "^1.2.1",
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
@@ -23980,7 +23989,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.12",
+            "lodash": "^4.17.20",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -24386,7 +24395,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "^1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -24441,7 +24450,7 @@
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.1"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -24659,7 +24668,7 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "^1.21.0"
       },
       "dependencies": {
         "prismjs": {
@@ -24982,7 +24991,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {
@@ -27970,7 +27979,7 @@
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^7.0.1",
@@ -28592,7 +28601,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.20",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -28751,7 +28760,7 @@
         "is-regex": "^1.0.4",
         "is-symbol": "^1.0.3",
         "isobject": "^4.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "memoizerific": "^1.11.3"
       },
       "dependencies": {
@@ -29931,7 +29940,7 @@
       "requires": {
         "axios": "^0.19.2",
         "joi": "^17.1.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimist": "^1.2.5",
         "rxjs": "^6.5.5"
       },
@@ -30377,7 +30386,7 @@
         "express": "^4.16.3",
         "filesize": "^3.6.1",
         "gzip-size": "^5.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "mkdirp": "^0.5.1",
         "opener": "^1.5.1",
         "ws": "^6.0.0"
@@ -31223,7 +31232,7 @@
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.20"
       },
       "dependencies": {
         "lodash": {

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -154,7 +154,6 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
     path(['metadata', 'options', 'allowAdvertising'], pageData),
     adsEnabled,
     showAdsBasedOnLocation,
-    process.env.SIMORGH_APP_ENV !== 'live',
   ].every(Boolean);
 
   const componentsToRender = {

--- a/src/app/pages/StoryPage/index.test.jsx
+++ b/src/app/pages/StoryPage/index.test.jsx
@@ -274,15 +274,14 @@ describe('Story Page', () => {
   });
 
   it.each`
-    environment | showAdsBasedOnLocation | showAdsBasedOnLocationExpectation
-    ${'live'}   | ${true}                | ${'permitted to be shown'}
-    ${'test'}   | ${true}                | ${'permitted to be shown'}
-    ${'live'}   | ${false}               | ${'not permitted to be shown'}
-    ${'test'}   | ${false}               | ${'not permitted to be shown'}
+    showAdsBasedOnLocation | showAdsBasedOnLocationExpectation
+    ${true}                | ${'permitted to be shown'}
+    ${true}                | ${'permitted to be shown'}
+    ${false}               | ${'not permitted to be shown'}
+    ${false}               | ${'not permitted to be shown'}
   `(
-    'should not render ads when the ads toggle is disabled, current environment is $environment and is in a location where ads are $showAdsBasedOnLocationExpectation',
-    async ({ environment, showAdsBasedOnLocation }) => {
-      process.env.SIMORGH_APP_ENV = environment;
+    'should not render ads when the ads toggle is disabled and is in a location where ads are $showAdsBasedOnLocationExpectation',
+    async ({ showAdsBasedOnLocation }) => {
       const toggles = {
         ads: {
           enabled: false,
@@ -321,105 +320,82 @@ describe('Story Page', () => {
     },
   );
 
-  it.each`
-    environment
-    ${'live'}
-    ${'test'}
-  `(
-    'should not render ads when the ads are not permitted for asset, current environment is $environment, ads are enabled and location permits ads',
-    async ({ environment }) => {
-      process.env.SIMORGH_APP_ENV = environment;
-      const toggles = {
-        ads: {
-          enabled: true,
-        },
-      };
-      const pidginPageDataDisallowAdvertising = deepClone(pidginPageData);
-      pidginPageDataDisallowAdvertising.metadata.options.allowAdvertising = false;
+  it('should not render ads when the ads are not permitted for asset, ads are enabled and location permits ads', async () => {
+    const toggles = {
+      ads: {
+        enabled: true,
+      },
+    };
+    const pidginPageDataDisallowAdvertising = deepClone(pidginPageData);
+    pidginPageDataDisallowAdvertising.metadata.options.allowAdvertising = false;
 
-      fetchMock.mock(
-        'http://localhost/some-cps-sty-path.json',
-        pidginPageDataDisallowAdvertising,
-      );
-      fetchMock.mock(
-        'http://localhost/pidgin/mostread.json',
-        pidginMostReadData,
-      );
-      fetchMock.mock(
-        'http://localhost/pidgin/sty-secondary-column.json',
-        pidginSecondaryColumnData,
-      );
+    fetchMock.mock(
+      'http://localhost/some-cps-sty-path.json',
+      pidginPageDataDisallowAdvertising,
+    );
+    fetchMock.mock('http://localhost/pidgin/mostread.json', pidginMostReadData);
+    fetchMock.mock(
+      'http://localhost/pidgin/sty-secondary-column.json',
+      pidginSecondaryColumnData,
+    );
 
-      const { pageData } = await getInitialData({
-        path: '/some-cps-sty-path',
-        service: 'pidgin',
-        pageType,
-      });
+    const { pageData } = await getInitialData({
+      path: '/some-cps-sty-path',
+      service: 'pidgin',
+      pageType,
+    });
 
-      const { queryByTestId } = render(
-        <Page
-          pageData={pageData}
-          service="pidgin"
-          toggles={toggles}
-          showAdsBasedOnLocation
-        />,
-      );
+    const { queryByTestId } = render(
+      <Page
+        pageData={pageData}
+        service="pidgin"
+        toggles={toggles}
+        showAdsBasedOnLocation
+      />,
+    );
 
-      const storyPageAds = queryByTestId('sty-ads');
-      expect(storyPageAds).not.toBeInTheDocument();
-      const adBootstrap = queryByTestId('adBootstrap');
-      expect(adBootstrap).not.toBeInTheDocument();
-    },
-  );
+    const storyPageAds = queryByTestId('sty-ads');
+    expect(storyPageAds).not.toBeInTheDocument();
+    const adBootstrap = queryByTestId('adBootstrap');
+    expect(adBootstrap).not.toBeInTheDocument();
+  });
 
-  it.each`
-    environment
-    ${'live'}
-    ${'test'}
-  `(
-    'should not render ads when the ads toggle is enabled, current environment is $environment and is in a location where ads are not permitted to be shown',
-    async ({ environment }) => {
-      process.env.SIMORGH_APP_ENV = environment;
-      const toggles = {
-        ads: {
-          enabled: true,
-        },
-      };
+  it('should not render ads when the ads toggle is enabled and is in a location where ads are not permitted to be shown', async () => {
+    const toggles = {
+      ads: {
+        enabled: true,
+      },
+    };
 
-      fetchMock.mock('http://localhost/some-cps-sty-path.json', pidginPageData);
-      fetchMock.mock(
-        'http://localhost/pidgin/mostread.json',
-        pidginMostReadData,
-      );
-      fetchMock.mock(
-        'http://localhost/pidgin/sty-secondary-column.json',
-        pidginSecondaryColumnData,
-      );
+    fetchMock.mock('http://localhost/some-cps-sty-path.json', pidginPageData);
+    fetchMock.mock('http://localhost/pidgin/mostread.json', pidginMostReadData);
+    fetchMock.mock(
+      'http://localhost/pidgin/sty-secondary-column.json',
+      pidginSecondaryColumnData,
+    );
 
-      const { pageData } = await getInitialData({
-        path: '/some-cps-sty-path',
-        service: 'pidgin',
-        pageType,
-      });
+    const { pageData } = await getInitialData({
+      path: '/some-cps-sty-path',
+      service: 'pidgin',
+      pageType,
+    });
 
-      const { queryByTestId } = render(
-        <Page
-          pageData={pageData}
-          service="pidgin"
-          toggles={toggles}
-          showAdsBasedOnLocation={false}
-        />,
-      );
+    const { queryByTestId } = render(
+      <Page
+        pageData={pageData}
+        service="pidgin"
+        toggles={toggles}
+        showAdsBasedOnLocation={false}
+      />,
+    );
 
-      const storyPageAds = queryByTestId('sty-ads');
-      expect(storyPageAds).not.toBeInTheDocument();
-      const adBootstrap = queryByTestId('adBootstrap');
-      expect(adBootstrap).not.toBeInTheDocument();
-    },
-  );
+    const storyPageAds = queryByTestId('sty-ads');
+    expect(storyPageAds).not.toBeInTheDocument();
+    const adBootstrap = queryByTestId('adBootstrap');
+    expect(adBootstrap).not.toBeInTheDocument();
+  });
 
-  it('should render ads when the ads toggle is enabled and current environment is not live', async () => {
-    process.env.SIMORGH_APP_ENV = 'test';
+  it('should render ads when the ads toggle is enabled', async () => {
     const toggles = {
       ads: {
         enabled: true,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Remove the environment check, enabling STY page Ads on live

**Code changes:**

- Removes the env variable check for STY Ads

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
