### PR TITLE
Remove lodash from forced resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -190,11 +190,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -205,12 +208,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -265,7 +271,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -297,12 +306,14 @@
       "requires": {
         "@babel/types": "^7.10.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -325,12 +336,14 @@
           "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
             }
           }
         }
@@ -359,12 +372,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -393,12 +409,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -437,12 +456,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -502,7 +524,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.5",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -575,12 +597,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -626,7 +651,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -746,11 +774,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -761,12 +792,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -877,12 +911,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -917,7 +954,7 @@
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.11.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1056,11 +1093,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1071,12 +1111,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1131,7 +1174,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -1171,11 +1217,14 @@
       "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -1289,11 +1338,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1304,12 +1356,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1452,12 +1507,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1535,12 +1593,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -1668,11 +1729,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1683,12 +1747,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1867,11 +1934,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -1882,12 +1952,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2387,11 +2460,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2402,12 +2478,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2755,12 +2834,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -2949,11 +3031,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -2964,12 +3049,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3240,12 +3328,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3581,11 +3672,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3596,12 +3690,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -3710,12 +3807,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         }
@@ -3923,12 +4023,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -4371,11 +4474,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -4386,12 +4492,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -4555,7 +4664,7 @@
         "@babel/types": "^7.10.1",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -4567,7 +4676,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "ms": {
           "version": "2.1.2",
@@ -4582,12 +4693,14 @@
       "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -6204,11 +6317,13 @@
       "resolved": "https://registry.npmjs.org/@loadable/server/-/server-5.12.0.tgz",
       "integrity": "sha512-Sb4hPz3vPf2z8GMPlW2kSiDwy3Lv38LhVFEW/Uy3BJqHxNlollJDD3rXQ6zmCZY5S/x/m1tPox8UyIBhcr8SZg==",
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -6338,7 +6453,7 @@
         "escape-html": "^1.0.3",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
         "react-color": "^2.17.0",
@@ -6347,7 +6462,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6383,7 +6501,7 @@
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "prop-types": "^15.6.2",
         "react": "^16.8.3",
@@ -6395,7 +6513,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6438,7 +6559,7 @@
         "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
         "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "stable": "^0.1.8",
@@ -6447,7 +6568,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6472,7 +6596,7 @@
         "@types/react-textarea-autosize": "^4.3.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -6490,7 +6614,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6695,11 +6822,14 @@
       "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6748,7 +6878,7 @@
         "babel-plugin-react-docgen": "^4.0.0",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mini-css-extract-plugin": "^0.7.0",
         "prop-types": "^15.7.2",
         "react-dev-utils": "^9.0.0",
@@ -6759,7 +6889,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6774,14 +6907,17 @@
         "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -6827,7 +6963,7 @@
         "fast-deep-equal": "^2.0.1",
         "fuse.js": "^3.4.6",
         "global": "^4.3.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -6848,7 +6984,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -7135,7 +7274,7 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -7167,7 +7306,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -8540,11 +8682,14 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.14"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -9072,11 +9217,14 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -9159,13 +9307,16 @@
       "integrity": "sha512-vzpnBlfGv8XOhJM2zbPyyqw2OLEbelgZZsaaRRTpVwNKuYuc+pUg4+dy7i9gCRms0uOQn4osX571HRcCJMJCmA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "react-docgen": "^5.0.0",
         "recast": "^0.14.7"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -9183,11 +9334,13 @@
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -9351,11 +9504,14 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -10242,7 +10398,7 @@
         "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.15.0",
         "parse5": "^3.0.1"
       },
       "dependencies": {
@@ -10257,7 +10413,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -11740,7 +11899,7 @@
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "log-symbols": "^3.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
@@ -11817,7 +11976,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -11855,7 +12017,7 @@
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -11868,7 +12030,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -12205,7 +12370,7 @@
         "ignore": "^5.1.8",
         "js-yaml": "^3.14.0",
         "json5": "^2.1.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "multimatch": "^4.0.0",
         "please-upgrade-node": "^3.2.0",
@@ -12314,11 +12479,14 @@
             "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.20"
+            "lodash": "^4.17.19"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -12329,12 +12497,15 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -12413,7 +12584,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -13288,12 +13462,15 @@
       "integrity": "sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "react-is": "^16.12.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -13502,7 +13679,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -13568,7 +13745,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -13911,12 +14091,15 @@
       "integrity": "sha512-isM/fsUxS4wN1+nLsWoV5T4gLgBQnsql3nMTr8u+cEls1bL8rRQO5CP5GtxJxaOfbcKqnz401styw+H/P+e78Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "vscode-json-languageservice": "^3.7.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -16227,14 +16410,17 @@
         "@types/webpack": "^4.41.8",
         "html-minifier-terser": "^5.0.1",
         "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
         "util.promisify": "1.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -16295,12 +16481,15 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -16635,7 +16824,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
@@ -16667,7 +16856,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.0",
@@ -23105,7 +23297,7 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
       },
@@ -23152,7 +23344,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "log-symbols": {
           "version": "2.2.0",
@@ -23765,7 +23960,7 @@
       "dev": true,
       "requires": {
         "@icons/material": "^0.2.4",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.11",
         "material-colors": "^1.2.1",
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
@@ -23773,7 +23968,10 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -23938,7 +24136,7 @@
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.20",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
             "rxjs": "^6.4.0",
@@ -23948,7 +24146,10 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.20"
+              "version": "4.17.20",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "dev": true
             }
           }
         },
@@ -24341,7 +24542,7 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -24396,11 +24597,14 @@
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.0.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -24611,7 +24815,7 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "^1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
@@ -24934,11 +25138,14 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -27919,7 +28126,7 @@
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^7.0.1",
@@ -28064,7 +28271,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "log-symbols": {
           "version": "4.0.0",
@@ -28538,7 +28748,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -28580,7 +28790,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "slice-ansi": {
           "version": "2.1.0",
@@ -28694,12 +28907,15 @@
         "is-regex": "^1.0.4",
         "is-symbol": "^1.0.3",
         "isobject": "^4.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -29871,7 +30087,7 @@
       "requires": {
         "axios": "^0.19.2",
         "joi": "^17.1.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.19",
         "minimist": "^1.2.5",
         "rxjs": "^6.5.5"
       },
@@ -29886,7 +30102,10 @@
           }
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },
@@ -30314,7 +30533,7 @@
         "express": "^4.16.3",
         "filesize": "^3.6.1",
         "gzip-size": "^5.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
         "opener": "^1.5.1",
         "ws": "^6.0.0"
@@ -30374,7 +30593,10 @@
           "dev": true
         },
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -31157,11 +31379,14 @@
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "description": "Simorgh",
   "main": "./src/client.js",
-  "resolutions": {
-    "lodash": "^4.17.20"
-  },
+  "resolutions": {},
   "scripts": {
     "preinstall": "npx npm-force-resolutions",
     "amp:validate": "wait-on -t 20000 http://localhost:7080/status && node ./scripts/ampHtmlValidator/cli.js",


### PR DESCRIPTION
No Issue

**Overall change:**
No longer force lodash resolution as dependencies have now updated to be compatible with the latest version of lodash.

This fixes an issue with our force resolutions implementation where `npm ci` gave different results to `npm install`. We should consider whether remove the force resolution approach altogether or whether we need to tighten up our processes/scripts for when we need to force resolutions in future.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
