### PR TITLE
Delete ads integration tests

### DIFF
--- a/src/integration/pages/frontPage/canonicalTests.js
+++ b/src/integration/pages/frontPage/canonicalTests.js
@@ -24,21 +24,3 @@ export default () => {
     }
   });
 };
-
-describe('Ads', () => {
-  const hasAds = service === 'arabic';
-  const leaderboardEl = document.getElementById('dotcom-leaderboard');
-  const mpuEl = document.getElementById('dotcom-mpu');
-
-  if (hasAds) {
-    it('ad should be in the document', () => {
-      expect(leaderboardEl).toBeInTheDocument();
-      expect(mpuEl).toBeInTheDocument();
-    });
-  } else {
-    it('ad should not be in the document', () => {
-      expect(leaderboardEl).not.toBeInTheDocument();
-      expect(mpuEl).not.toBeInTheDocument();
-    });
-  }
-});

--- a/src/integration/pages/storyPage/canonicalTests.js
+++ b/src/integration/pages/storyPage/canonicalTests.js
@@ -38,44 +38,4 @@ export default () => {
       });
     }
   });
-
-  describe('Ads', () => {
-    const hasAds = service === 'mundo';
-    const leaderboardEl = document.getElementById('dotcom-leaderboard');
-    const mpuEl = document.getElementById('dotcom-mpu');
-
-    if (hasAds) {
-      it('should have ads in the document', () => {
-        expect(leaderboardEl).toBeInTheDocument();
-        expect(mpuEl).toBeInTheDocument();
-      });
-    } else {
-      it('should not have ads in the document', () => {
-        expect(leaderboardEl).not.toBeInTheDocument();
-        expect(mpuEl).not.toBeInTheDocument();
-      });
-    }
-
-    it('should configure GNL dotcom library where service has ads and adCampaignKeyword is in metadata', () => {
-      const scripts = [...document.querySelectorAll('head script')].filter(
-        ({ textContent }) =>
-          hasAds &&
-          textContent.toString().includes('dotcomConfig') &&
-          textContent.toString().includes('adcampaign:'),
-      );
-
-      expect(scripts).toMatchSnapshot();
-    });
-
-    it('should configure GNL dotcom library where service has ads and adCampaignKeyword is not in metadata', () => {
-      const scripts = [...document.querySelectorAll('head script')].filter(
-        ({ textContent }) =>
-          hasAds &&
-          textContent.toString().includes('dotcomConfig') &&
-          !textContent.toString().includes('adcampaign:'),
-      );
-
-      expect(scripts).toMatchSnapshot();
-    });
-  });
 };

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -2,10 +2,6 @@
 
 exports[`Canonical Story Page A11y I can see the skip to content link 1`] = `"Сайтка өтүү"`;
 
-exports[`Canonical Story Page Ads should configure GNL dotcom library where service has ads and adCampaignKeyword is in metadata 1`] = `Array []`;
-
-exports[`Canonical Story Page Ads should configure GNL dotcom library where service has ads and adCampaignKeyword is not in metadata 1`] = `Array []`;
-
 exports[`Canonical Story Page Analytics ATI 1`] = `"<img height=\\"1px\\" width=\\"1px\\" alt=\\"\\" style=\\"position:absolute\\" src=\\"https://logws1363.ati-host.net?s=598343&amp;s2=58&amp;p=story::kyrgyz.story.23292889.page&amp;x1=[urn:bbc:cps:bb9390aa-4b35-e448-b295-cbd7369fe457]&amp;x2=[responsive]&amp;x3=[news-kyrgyz]&amp;x4=[ky]&amp;x7=[article]&amp;x8=[simorgh-nojs]&amp;x9=[Test+STY+for+social+embeds+-+BBC+News+Кыргыз+Кызматы]&amp;x11=[2020-04-24T14:51:17.000Z]&amp;x12=[2020-04-24T14:51:17.000Z]\\"/>"`;
 
 exports[`Canonical Story Page Footer I can click on the BBC branding and it would take me to the homepage 1`] = `"/kyrgyz"`;

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -2,26 +2,6 @@
 
 exports[`Canonical Story Page A11y I can see the skip to content link 1`] = `"Ir al contenido"`;
 
-exports[`Canonical Story Page Ads should configure GNL dotcom library where service has ads and adCampaignKeyword is in metadata 1`] = `
-Array [
-  <script
-    data-react-helmet="true"
-    type="text/javascript"
-  >
-    
-    window.dotcom = window.dotcom || { cmd: [] };
-    window.dotcomConfig = {
-      pageAds: true,
-      playerAds: false,
-      adcampaign: 'test'
-    };
-    
-  </script>,
-]
-`;
-
-exports[`Canonical Story Page Ads should configure GNL dotcom library where service has ads and adCampaignKeyword is not in metadata 1`] = `Array []`;
-
 exports[`Canonical Story Page Analytics ATI 1`] = `"<img height=\\"1px\\" width=\\"1px\\" alt=\\"\\" style=\\"position:absolute\\" src=\\"https://logws1363.ati-host.net?s=598343&amp;s2=62&amp;p=world::mundo.world.story.51266689.page&amp;x1=[urn:bbc:cps:faf2993a-dcc0-0746-81a6-a6aca4cd59b1]&amp;x2=[responsive]&amp;x3=[news-mundo]&amp;x4=[es]&amp;x7=[article]&amp;x8=[simorgh-nojs]&amp;x9=[Brexit:+qué+cambiará+para+visitar,+trabajar+y+estudiar+en+Reino+Unido+tras+la+salida+del+país+de+la+Unión+Europea+-+BBC+News+Mundo]&amp;x11=[2020-01-30T06:35:49.000Z]&amp;x12=[2020-01-31T23:08:08.000Z]&amp;x14=[0b0bfd5a-81b8-43fa-91fc-57f1fcd24487~2e91364c-5c77-4660-b76e-d76202785e64~6a73afa3-ea6b-45c1-80bb-49060b99f864~9a18805c-fb88-40ba-9763-bcc121d5d55c~ca170ae3-99c1-48db-9b67-2866f85e7342~f94293fd-ff83-400e-8bc0-89ec01930fce]&amp;x16=[WS%20-%20Give%20me%20perspective]&amp;x17=[Explainer]\\"/>"`;
 
 exports[`Canonical Story Page Footer I can click on the BBC branding and it would take me to the homepage 1`] = `"/mundo"`;


### PR DESCRIPTION
Resolves #7758 

**Overall change:**
A couple of integration tests for ads are failing because the toggles in the test environment have been disabled. These tests should not be dependent on an external configuration, so we have decided to remove them.

**Code changes:**
- Delete Ads tests from integration tests (Front Pages & STY pages)

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
