### PR TITLE
Temporarily allowlist node-fetch vulnerability pending fix

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,6 @@
 {
   "low": true,
   "allowlist": [
+    1556
   ]
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,6 +1,5 @@
 {
   "low": true,
   "allowlist": [
-    1523
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21855,9 +21855,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-forge": {

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "minimist": "^1.2.5",
     "mocha": "^8.1.3",
     "mocha-junit-reporter": "^2.0.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "ora": "^4.1.1",
     "prettier": "^2.1.1",


### PR DESCRIPTION
**Overall change:**
Allow-lists https://www.npmjs.com/advisories/1556 (low-severity) pending an upstream fix being merged.
Resolves https://github.com/bbc/simorgh/network/alert/package-lock.json/node-fetch/open
Supercedes #7728

3 out of the 4 below are dev dependencies, the vulnerability is low severity & we don't use `node-fetch` to gate the size of the files (usage in `isomorphic-fetch`)

```json
  "advisories": {
    "1556": {
      "findings": [
        {
          "version": "1.7.3",
          "paths": [
            "isomorphic-fetch>node-fetch"
          ]
        },
        {
          "version": "2.6.0",
          "paths": [
            "@storybook/react>@storybook/core>node-fetch"
          ]
        },
        {
          "version": "2.6.0",
          "paths": [
            "jest-fetch-mock>cross-fetch>node-fetch"
          ]
        },
        {
          "version": "2.6.0",
          "paths": [
            "storybook-chromatic>node-fetch"
          ]
        }
      ],
```

**Code changes:**
- Remove advisory 1523 from the allowlist as it has been resolved
- Add advisory 1556 to the allowlist

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
