### PR TITLE
Remove headline check

### DIFF
--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -192,31 +192,29 @@ const StoryPromoContainer = ({
 
   const Info = (
     <>
-      {headline && (
-        <StyledHeadline
-          script={script}
-          service={service}
-          promoType={promoType}
-          promoHasImage={displayImage}
-          as={headingTagOverride}
-        >
-          <StyledLink href={url}>
-            {isLive ? (
-              <LiveLabel
-                service={service}
-                dir={dir}
-                liveText={liveLabel}
-                ariaHidden={liveLabelIsEnglish}
-                offScreenText={liveLabelIsEnglish ? 'Live' : null}
-              >
-                {linkcontents}
-              </LiveLabel>
-            ) : (
-              linkcontents
-            )}
-          </StyledLink>
-        </StyledHeadline>
-      )}
+      <StyledHeadline
+        script={script}
+        service={service}
+        promoType={promoType}
+        promoHasImage={displayImage}
+        as={headingTagOverride}
+      >
+        <StyledLink href={url}>
+          {isLive ? (
+            <LiveLabel
+              service={service}
+              dir={dir}
+              liveText={liveLabel}
+              ariaHidden={liveLabelIsEnglish}
+              offScreenText={liveLabelIsEnglish ? 'Live' : null}
+            >
+              {linkcontents}
+            </LiveLabel>
+          ) : (
+            linkcontents
+          )}
+        </StyledLink>
+      </StyledHeadline>
       {promoSummary && displaySummary && !isRecommendation && (
         <Summary
           script={script}


### PR DESCRIPTION
Resolves #7766

**Overall change:**
Due to the check on line 162, `headline` on line 195 would always evaluate to true. Removing the check.
LGTM - https://lgtm.com/projects/g/bbc/simorgh/snapshot/bddf90c28fde26146d82170a7efee9e36027dd96/files/src/app/containers/StoryPromo/index.jsx?sort=name&dir=ASC&mode=heatmap#L195

**Code changes:**

- Component returns null if `headline` has a falsy value Therefore, we do not require the truthy check on line 195.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
