### PR TITLE
Remove empty file

### DIFF
--- a/cypress/integration/pages/onDemandTV/index.js
+++ b/cypress/integration/pages/onDemandTV/index.js
@@ -2,7 +2,6 @@ import config from '../../../support/config/services';
 import getPaths from '../../../support/helpers/getPaths';
 import serviceHasPageType from '../../../support/helpers/serviceHasPageType';
 import testsForCanonicalOnly from './testsForCanonicalOnly';
-import testsForAMPOnly from './testsForAMPOnly';
 import crossPlatformTests from './tests';
 import visitPage from '../../../support/helpers/visitPage';
 
@@ -43,11 +42,6 @@ Object.keys(config)
             pageType,
             variant,
             isAmp: true,
-          });
-          testsForAMPOnly({
-            service,
-            pageType,
-            variant,
           });
         });
       });

--- a/cypress/integration/pages/onDemandTV/testsForAMPOnly.js
+++ b/cypress/integration/pages/onDemandTV/testsForAMPOnly.js
@@ -1,1 +1,0 @@
-export default () => {};


### PR DESCRIPTION
Resolves #7816

**Overall change:**
cypress/integration/pages/onDemandTV/testsForAMPOnly.js is empty. Deleting it.

**Code changes:**

- Removing empty function

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
