### PR TITLE
Remove temp feature toggle for async ads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20388,67 +20388,6 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
-    "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "log-update": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",

--- a/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
@@ -4,12 +4,12 @@ exports[`CanonicalAds Ads Snapshots should correctly render a Canonical mpu ad w
 <html>
   <head>
     <script
-      async="false"
+      async="true"
       src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
       type="module"
     />
     <script
-      async="false"
+      async="true"
       nomodule="nomodule"
       src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap-legacy.js"
     />
@@ -124,12 +124,12 @@ exports[`CanonicalAds Ads Snapshots should correctly render an Canonical leaderb
 <html>
   <head>
     <script
-      async="false"
+      async="true"
       src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap.js"
       type="module"
     />
     <script
-      async="false"
+      async="true"
       nomodule="nomodule"
       src="https://gn-web-assets.api.bbc.com/ngas/test/dotcom-bootstrap-legacy.js"
     />

--- a/src/app/containers/Ad/Canonical/index.jsx
+++ b/src/app/containers/Ad/Canonical/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { oneOf, string, bool } from 'prop-types';
+import { oneOf, string } from 'prop-types';
 import styled from 'styled-components';
 import { C_LUNAR_LIGHT } from '@bbc/psammead-styles/colours';
 import pathOr from 'ramda/src/pathOr';
@@ -33,7 +33,7 @@ export const getBootstrapSrc = (queryString, useLegacy = false) => {
   return useLegacy ? adsLegacyTestScript : adsTestScript;
 };
 
-const CanonicalAd = ({ slotType, className, asyncAds }) => {
+const CanonicalAd = ({ slotType, className }) => {
   const { showAdsBasedOnLocation } = useContext(RequestContext);
   const location = useLocation();
   const queryString = location.search;
@@ -70,15 +70,11 @@ const CanonicalAd = ({ slotType, className, asyncAds }) => {
   return (
     <>
       <Helmet>
-        <script
-          type="module"
-          src={getBootstrapSrc(queryString)}
-          async={asyncAds}
-        />
+        <script type="module" src={getBootstrapSrc(queryString)} async />
         <script
           nomodule="nomodule"
           src={getBootstrapSrc(queryString, true)}
-          async={asyncAds}
+          async
         />
       </Helmet>
       <AdContainer
@@ -98,12 +94,10 @@ const CanonicalAd = ({ slotType, className, asyncAds }) => {
 CanonicalAd.propTypes = {
   slotType: oneOf(['leaderboard', 'mpu']).isRequired,
   className: string,
-  asyncAds: bool,
 };
 
 CanonicalAd.defaultProps = {
   className: null,
-  asyncAds: false,
 };
 
 export default CanonicalAd;

--- a/src/app/containers/Ad/index.jsx
+++ b/src/app/containers/Ad/index.jsx
@@ -8,14 +8,13 @@ import CanonicalAd from './Canonical';
 const AdContainer = ({ slotType, className }) => {
   const { isAmp } = useContext(RequestContext);
   const { enabled: adsEnabled } = useToggle('ads');
-  const { enabled: asyncAds } = useToggle('asyncAds'); // Temp toggle for testing async loading of the dotcom-bootstrap
 
   if (!adsEnabled) {
     return null;
   }
 
   const Ad = isAmp ? AmpAd : CanonicalAd;
-  return <Ad slotType={slotType} className={className} asyncAds={asyncAds} />;
+  return <Ad slotType={slotType} className={className} />;
 };
 
 AdContainer.propTypes = {

--- a/src/app/containers/Ad/index.test.jsx
+++ b/src/app/containers/Ad/index.test.jsx
@@ -30,9 +30,6 @@ describe('Ad Container', () => {
       ampAds: {
         enabled: true,
       },
-      asyncAds: {
-        enabled: true,
-      },
     };
 
     const mockToggleDispatch = jest.fn();

--- a/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
+++ b/src/app/lib/config/toggles/__snapshots__/index.test.js.snap
@@ -58,9 +58,6 @@ Object {
   "ampAds": Object {
     "enabled": true,
   },
-  "asyncAds": Object {
-    "enabled": true,
-  },
   "chartbeatAnalytics": Object {
     "enabled": true,
   },
@@ -111,9 +108,6 @@ Object {
     "enabled": false,
   },
   "ampAds": Object {
-    "enabled": true,
-  },
-  "asyncAds": Object {
     "enabled": true,
   },
   "chartbeatAnalytics": Object {

--- a/src/app/lib/config/toggles/localConfig.js
+++ b/src/app/lib/config/toggles/localConfig.js
@@ -47,7 +47,4 @@ export default {
   variantCookie: {
     enabled: true,
   },
-  asyncAds: {
-    enabled: true, // Temp toggle for testing async loading of the dotcom-bootstrap
-  },
 };

--- a/src/app/lib/config/toggles/testConfig.js
+++ b/src/app/lib/config/toggles/testConfig.js
@@ -44,7 +44,4 @@ export default {
   variantCookie: {
     enabled: true,
   },
-  asyncAds: {
-    enabled: true, // Temp toggle for testing async loading of the dotcom-bootstrap
-  },
 };


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Removes the temp feature toggle added yesterday that allowed us to test async ads on the test environment

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
