### PR TITLE
Don't run `npm-force-resolutions` on `npm ci`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prismjs": "^1.21.0"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "[ \"$npm_config_refer\" != \"ci\" ] && npx npm-force-resolutions || exit 0",
     "amp:validate": "wait-on -t 20000 http://localhost:7080/status && node ./scripts/ampHtmlValidator/cli.js",
     "bbcA11y": "wait-on -t 20000 http://localhost:7080/status && bbc-a11y",
     "bbcA11y:ci": "wait-on -t 20000 http://localhost:7080/status && xvfb-run -a bbc-a11y",


### PR DESCRIPTION
No Issue

**Overall change:**
When investigating frequent changes to our `package-lock.json` I have identified an issue with our usage of `npx npm-force-resolutions`.

Before this PR (using commit ad58075a0fee19939addbcd2145db2f9e5a7933f) ..
...the following occurs when running `npm install`
1. The `preinstall` script runs `npx npm-force-resolutions` making modifications like this:
![image](https://user-images.githubusercontent.com/9645462/93320587-29543500-f809-11ea-8061-203928f47481.png)
2. The `npm install` process itself runs and reintroduces the resolution metadata:
![image](https://user-images.githubusercontent.com/9645462/93320838-73d5b180-f809-11ea-9bc1-263e2236e8f1.png)

...the following occurs when you run `npm ci`
1. The `preinstall` script runs `npx npm-force-resolutions` making modifications like this:
![image](https://user-images.githubusercontent.com/9645462/93320587-29543500-f809-11ea-8061-203928f47481.png)
2. The `npm ci` process itself runs and _makes no changes_ to the `package-lock.json` [as designed](https://docs.npmjs.com/cli/ci.html)

This discrepancy meant that depending the developer's workflow, we have been sometimes commiting the `package-lock.json` without the resolution metadata added by `npm install`, this is the case where the developer has chosen to run `npm ci` rather than `npm install`. In psammead, due to our usage of lerna, we run `npm ci` as matter of course so you can understand why devs choose to use `npm ci` consistently across both repos.

I will raise an issue with `npm-force-resolutions` as it probably shouldn't make any modifications to the `package-lock.json` or remove the resolution metadata in `npm install`.

**Code changes:**
- This PR modifies our `preinstall` script to only run `npx-force-resolutions` during an `npm install`
- It checks the value of `npm_config_refer` that is set to `ci` during an `npm ci` and does not exist in an `npm install`.
  - I could not find any documentation for this parameter, we may need to be wary that it could disappear in future.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing

I have tested this by running `npm ci` and observing that no changes are made to `package-lock.json`. Additionally, I've ran `npm install` and confirmed forced resolutions have been applied.