### PR TITLE
Add ATI Analytics to the Most Watched pages

### DIFF
--- a/src/app/containers/ATIAnalytics/index.jsx
+++ b/src/app/containers/ATIAnalytics/index.jsx
@@ -7,6 +7,7 @@ import { buildArticleATIUrl } from './params/article/buildParams';
 import { buildTvRadioATIUrl } from './params/tvRadioPage/buildParams';
 import { buildCpsAssetPageATIUrl } from './params/cpsAssetPage/buildParams';
 import { buildMostReadATIUrl } from './params/mostReadPage/buildParams';
+import { buildMostWatchedATIUrl } from './params/mostWatchedPage/buildParams';
 import { buildIndexPageATIUrl } from './params/indexPage/buildParams';
 import { pageDataPropType } from '#models/propTypes/data';
 
@@ -20,6 +21,7 @@ const ATIAnalytics = ({ data }) => {
     frontPage: buildIndexPageATIUrl,
     media: buildTvRadioATIUrl,
     mostRead: buildMostReadATIUrl,
+    mostWatched: buildMostWatchedATIUrl,
     IDX: buildIndexPageATIUrl,
     MAP: () =>
       buildCpsAssetPageATIUrl(

--- a/src/app/containers/ATIAnalytics/params/mostWatchedPage/buildParams.js
+++ b/src/app/containers/ATIAnalytics/params/mostWatchedPage/buildParams.js
@@ -1,0 +1,45 @@
+import { buildATIPageTrackPath } from '../../atiUrl';
+import { LIBRARY_VERSION } from '#lib/analyticsUtils';
+
+export const buildMostWatchedATIParams = (
+  pageData,
+  requestContext,
+  serviceContext,
+) => {
+  const { platform, statsDestination } = requestContext;
+  const {
+    atiAnalyticsAppName,
+    atiAnalyticsProducerId,
+    brandName,
+    lang,
+    service,
+    mostWatched: { header },
+  } = serviceContext;
+
+  return {
+    appName: atiAnalyticsAppName,
+    contentType: 'list-datadriven',
+    language: lang,
+    pageIdentifier: `${service}.media.video.page`,
+    pageTitle: `${header} - ${brandName}`,
+    producerId: atiAnalyticsProducerId,
+    libraryVersion: LIBRARY_VERSION,
+    statsDestination,
+    platform,
+    service,
+    timePublished: pageData.firstRecordTimeStamp,
+    timeUpdated: pageData.lastRecordTimeStamp,
+  };
+};
+
+export const buildMostWatchedATIUrl = (
+  pageData,
+  requestContext,
+  serviceContext,
+) => {
+  return buildATIPageTrackPath(
+    buildMostWatchedATIParams(pageData, requestContext, serviceContext),
+  );
+};
+
+export default buildMostWatchedATIUrl;

--- a/src/app/containers/ATIAnalytics/params/mostWatchedPage/buildParams.test.js
+++ b/src/app/containers/ATIAnalytics/params/mostWatchedPage/buildParams.test.js
@@ -1,0 +1,78 @@
+import {
+  buildMostWatchedATIParams,
+  buildMostWatchedATIUrl,
+} from './buildParams';
+import * as analyticsUtils from '#lib/analyticsUtils';
+
+analyticsUtils.getAtUserId = jest.fn();
+analyticsUtils.getCurrentTime = jest.fn().mockReturnValue('00-00-00');
+analyticsUtils.getPublishedDatetime = jest
+  .fn()
+  .mockReturnValue('1970-01-01T00:00:00.000Z');
+
+const requestContext = {
+  platform: 'platform',
+  isUK: 'isUK',
+  statsDestination: 'statsDestination',
+  previousPath: 'previousPath',
+  origin: 'origin',
+};
+
+const serviceContext = {
+  atiAnalyticsAppName: 'news-pidgin',
+  atiAnalyticsProducerId: '70',
+  service: 'pidgin',
+  brandName: 'BBC News Pidgin',
+  mostWatched: { header: 'De one we dem don look' },
+  lang: 'pcm',
+};
+
+const validURLParams = {
+  appName: serviceContext.atiAnalyticsAppName,
+  contentType: 'list-datadriven',
+  language: 'pcm',
+  pageIdentifier: 'pidgin.media.video.page',
+  pageTitle: 'De one we dem don look - BBC News Pidgin',
+  libraryVersion: analyticsUtils.LIBRARY_VERSION,
+  producerId: serviceContext.atiAnalyticsProducerId,
+  platform: requestContext.platform,
+  service: 'pidgin',
+  statsDestination: requestContext.statsDestination,
+  timePublished: '2019-11-06T15:00:00Z',
+  timeUpdated: '2030-01-01T17:00:00Z',
+};
+
+const pageData = {
+  firstRecordTimeStamp: '2019-11-06T15:00:00Z',
+  lastRecordTimeStamp: '2030-01-01T17:00:00Z',
+};
+
+describe('mostWatched buildParams', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildMostWatchedATIParams', () => {
+    it('should return the right object', () => {
+      const result = buildMostWatchedATIParams(
+        pageData,
+        requestContext,
+        serviceContext,
+      );
+      expect(result).toEqual(validURLParams);
+    });
+  });
+
+  describe('buildMostWatchedATIUrl', () => {
+    it('should return the right url', () => {
+      const result = buildMostWatchedATIUrl(
+        pageData,
+        requestContext,
+        serviceContext,
+      );
+      expect(result).toMatchInlineSnapshot(
+        `"s=598285&s2=70&p=pidgin.media.video.page&r=0x0x24x24&re=1024x768&hl=00-00-00&lng=en-US&x2=[responsive]&x3=[news-pidgin]&x4=[pcm]&x5=[http%253A%252F%252Flocalhost%252F]&x7=[list-datadriven]&x8=[simorgh]&x9=[De%2Bone%2Bwe%2Bdem%2Bdon%2Blook%2B-%2BBBC%2BNews%2BPidgin]&x11=[2019-11-06T15%3A00%3A00Z]&x12=[2030-01-01T17%3A00%3A00Z]"`,
+      );
+    });
+  });
+});

--- a/src/app/pages/MostWatchedPage/MostWatchedPage.jsx
+++ b/src/app/pages/MostWatchedPage/MostWatchedPage.jsx
@@ -22,6 +22,7 @@ import MostWatchedContainer from '#containers/MostWatched';
 import MetadataContainer from '#containers/Metadata';
 import LinkedData from '#containers/LinkedData';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
+import ATIAnalytics from '#containers/ATIAnalytics';
 
 const StyledIndexHeading = styled(IndexHeading)`
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
@@ -94,6 +95,7 @@ const MostWatchedPage = ({ pageData }) => {
         description={`${header} - ${brandName}`}
         openGraphType="website"
       />
+      <ATIAnalytics data={pageData} />
       <LinkedData type="WebPage" seoTitle={header} />
       <ChartbeatAnalytics data={pageData} />
       <IndexMain data-e2e="most-watched">


### PR DESCRIPTION
Resolves #7643
**Overall change:**
Adding the ATI Analytics component to the Most Watched pages.

**Code changes:**

- Added the ATI component to the Most Watched page
- Added new buildParams file for mostWatched pageType
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
