### PR TITLE
Bump gel-foundations to update Thai font size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4445,9 +4445,9 @@
       }
     },
     "@bbc/gel-foundations": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.2.0.tgz",
-      "integrity": "sha512-zqOGLKAjGtYI/7lCXOaNB6sEbCMQ12YyFogCsSXvNcndgxFdKCOn0037HLXkh4WXzp5Ce3oWbHIbHDNe1iKRwg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-4.3.0.tgz",
+      "integrity": "sha512-KyEDfA8ibVK6ZKhBABa+RLEkCNq7ixHxmJyz4pQwA+cqsqyW2F49CCZ6dNsHJ65HCfHa2k55rzvwnQAP21IP2Q=="
     },
     "@bbc/moment-timezone-include": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "homepage": "https://github.com/bbc/simorgh#readme",
   "dependencies": {
-    "@bbc/gel-foundations": "4.2.0",
+    "@bbc/gel-foundations": "^4.3.0",
     "@bbc/moment-timezone-include": "^1.1.4",
     "@bbc/psammead-amp-geo": "^1.2.0",
     "@bbc/psammead-assets": "^2.14.1",


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/7872.

### Overall change

Updates `@bbc/gel-foundations` to `4.3.0`, which updates Thai font sizes.

### Code changes

- Bump `@bbc/gel-foundations` to latest.
- Update snapshot tests.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~~I have added the `cross-team` label to this PR if it requires visibility across World Service teams~~
- [x] I have assigned this PR to the Simorgh project

### Testing

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] ~~If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- [ ] ~~This PR requires manual testing~~
