### PR TITLE
Respect renderer_env=live for most watched data

### DIFF
--- a/src/app/containers/CpsRelatedContent/index.test.jsx
+++ b/src/app/containers/CpsRelatedContent/index.test.jsx
@@ -103,7 +103,10 @@ describe('CpsRelatedContent', () => {
       }),
     );
 
-    const { pageData } = await getInitialData('some-cps-path');
+    const { pageData } = await getInitialData({
+      path: 'some-cps-path',
+      service: 'pidgin',
+    });
 
     const transformedPromos = path(
       ['relatedContent', 'groups', 0, 'promos'],

--- a/src/app/lib/utilities/getMostWatchedUrl/index.js
+++ b/src/app/lib/utilities/getMostWatchedUrl/index.js
@@ -1,6 +1,14 @@
-const getMostWatchedEndpoint = ({ service, variant }) =>
+const getBaseUrl = env =>
+  ({
+    live: 'https://www.bbc.com/',
+    test: 'https://test.bbc.com/',
+  }[env] || '/');
+
+const getExtension = env => (env !== 'local' ? '.json' : '');
+
+const getMostWatchedEndpoint = ({ service, variant, env }) =>
   variant
-    ? `/${service}/mostwatched/${variant}.json`
-    : `/${service}/mostwatched.json`;
+    ? `${getBaseUrl(env)}${service}/mostwatched/${variant}${getExtension(env)}`
+    : `${getBaseUrl(env)}${service}/mostwatched${getExtension(env)}`;
 
 export default getMostWatchedEndpoint;

--- a/src/app/lib/utilities/getMostWatchedUrl/index.test.js
+++ b/src/app/lib/utilities/getMostWatchedUrl/index.test.js
@@ -1,14 +1,28 @@
 import getMostWatchedEndpoint from '.';
 
 describe('getMostReadEndpoint', () => {
-  it('should return endpoint when passed service', () => {
-    expect(getMostWatchedEndpoint({ service: 'hausa' })).toBe(
-      '/hausa/mostwatched.json',
+  it('should not return base path nor append .json when env is local', () => {
+    expect(getMostWatchedEndpoint({ service: 'hausa', env: 'local' })).toBe(
+      '/hausa/mostwatched',
     );
   });
-  it('should return endpoint when passed service and variant', () => {
-    expect(getMostWatchedEndpoint({ service: 'serbian', variant: 'lat' })).toBe(
-      '/serbian/mostwatched/lat.json',
+  it('should return test base path and append .json when env is test', () => {
+    expect(getMostWatchedEndpoint({ service: 'hausa', env: 'test' })).toBe(
+      'https://test.bbc.com/hausa/mostwatched.json',
     );
+  });
+  it('should return live base path and append .json when env is live', () => {
+    expect(getMostWatchedEndpoint({ service: 'hausa', env: 'live' })).toBe(
+      'https://www.bbc.com/hausa/mostwatched.json',
+    );
+  });
+  it('should return correct path when passed service and variant', () => {
+    expect(
+      getMostWatchedEndpoint({
+        service: 'serbian',
+        variant: 'lat',
+        env: 'local',
+      }),
+    ).toBe('/serbian/mostwatched/lat');
   });
 });

--- a/src/app/lib/utilities/getMostWatchedUrl/index.test.js
+++ b/src/app/lib/utilities/getMostWatchedUrl/index.test.js
@@ -1,6 +1,6 @@
 import getMostWatchedEndpoint from '.';
 
-describe('getMostReadEndpoint', () => {
+describe('getMostWatchEndpoint', () => {
   it('should not return base path nor append .json when env is local', () => {
     expect(getMostWatchedEndpoint({ service: 'hausa', env: 'local' })).toBe(
       '/hausa/mostwatched',

--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -71,13 +71,17 @@ export default async ({
   toggles,
 }) => {
   try {
+    const env = pathname.includes('renderer_env=live')
+      ? 'live'
+      : process.env.SIMORGH_APP_ENV;
     const { json, status } = await fetchPageData({ path: pathname, pageType });
 
-    const additionalPageData = await getAdditionalPageData(
-      json,
+    const additionalPageData = await getAdditionalPageData({
+      pageData: json,
       service,
       variant,
-    );
+      env,
+    });
     const processedAdditionalData = processMostWatched({
       data: additionalPageData,
       service,

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -17,6 +17,7 @@ const pageTypeUrls = async (
   variant,
   assetUri,
   pageData,
+  env,
 ) => {
   switch (assetType) {
     case STORY_PAGE:
@@ -40,10 +41,7 @@ const pageTypeUrls = async (
       return [
         {
           name: 'mostWatched',
-          path: getMostWatchedEndpoint({ service, variant }).replace(
-            '.json',
-            '',
-          ),
+          path: getMostWatchedEndpoint({ service, variant, env }),
         },
       ];
     default:
@@ -64,7 +62,7 @@ const fetchUrl = ({ name, path }) =>
     .then(response => validateResponse(response, name))
     .catch(noop);
 
-const getAdditionalPageData = async (pageData, service, variant) => {
+const getAdditionalPageData = async ({ pageData, service, variant, env }) => {
   const assetType = getAssetType(pageData);
   const assetUri = getAssetUri(pageData);
 
@@ -74,6 +72,7 @@ const getAdditionalPageData = async (pageData, service, variant) => {
     variant,
     assetUri,
     pageData,
+    env,
   );
 
   if (urlsToFetch) {

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
@@ -25,7 +25,11 @@ describe('getAdditionalPageData', () => {
 
   it('should return additional data with most watched for a MAP asset', async () => {
     fetchMock.mock('http://localhost/pidgin/mostwatched.json', mostWatchedJson);
-    const additionalPageData = await getAdditionalPageData(mapJson, 'pidgin');
+    const additionalPageData = await getAdditionalPageData({
+      pageData: mapJson,
+      service: 'pidgin',
+      env: 'local',
+    });
 
     const expectedOutput = {
       mostWatched: mostWatchedJson,
@@ -44,7 +48,10 @@ describe('getAdditionalPageData', () => {
       recommendationsJson,
     );
     hasRecommendations.mockImplementationOnce(() => true);
-    const additionalPageData = await getAdditionalPageData(styJson, 'mundo');
+    const additionalPageData = await getAdditionalPageData({
+      pageData: styJson,
+      service: 'mundo',
+    });
 
     const expectedOutput = {
       mostRead: mostReadJson,
@@ -61,10 +68,10 @@ describe('getAdditionalPageData', () => {
       foo: 'bar',
     });
     hasRecommendations.mockImplementationOnce(() => false);
-    const additionalPageData = await getAdditionalPageData(
-      noRecommendationsStyJson,
-      'pidgin',
-    );
+    const additionalPageData = await getAdditionalPageData({
+      pageData: noRecommendationsStyJson,
+      service: 'pidgin',
+    });
 
     const expectedOutput = {
       mostRead: { foo: 'bar' },
@@ -78,7 +85,10 @@ describe('getAdditionalPageData', () => {
     fetchMock.mock('http://localhost/mundo/mostread.json', 404);
     fetchMock.mock('http://localhost/mundo/sty-secondary-column.json', 404);
     fetchMock.mock('http://localhost/mundo/23263889/recommendations.json', 404);
-    const additionalPageData = await getAdditionalPageData(styJson, 'mundo');
+    const additionalPageData = await getAdditionalPageData({
+      pageData: styJson,
+      service: 'mundo',
+    });
 
     expect(additionalPageData).toEqual({});
   });

--- a/src/app/routes/mostWatched/getInitialData/index.js
+++ b/src/app/routes/mostWatched/getInitialData/index.js
@@ -3,11 +3,13 @@ import getMostWatchedUrl from '#lib/utilities/getMostWatchedUrl';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 import processMostWatched from '../../utils/processMostWatched';
 
-export default async ({ service, variant, pageType, toggles }) => {
+export default async ({ service, variant, pageType, toggles, path }) => {
+  const env = path.includes('renderer_env=live')
+    ? 'live'
+    : process.env.SIMORGH_APP_ENV;
+
   try {
-    const mostWatchedUrl = getMostWatchedUrl({ service, variant }).split(
-      '.',
-    )[0];
+    const mostWatchedUrl = getMostWatchedUrl({ service, variant, env });
     const { json, status } = await fetchPageData({
       path: mostWatchedUrl,
       pageType,

--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -33,7 +33,7 @@ export const getUrl = pathname => {
 };
 
 export default async ({ path, pageType }) => {
-  const url = getUrl(path);
+  const url = path.startsWith('http') ? path : getUrl(path);
 
   logger.info(DATA_REQUEST_RECEIVED, { data: url, pageType, path });
 

--- a/src/app/routes/utils/fetchPageData/index.test.js
+++ b/src/app/routes/utils/fetchPageData/index.test.js
@@ -93,13 +93,14 @@ describe('fetchPageData', () => {
     it('should handle a rejected Ares fetch and return an error the Simorgh app can handle', () => {
       fetch.mockRejectedValue(new Error('Failed to fetch'), { status: 500 });
 
-      return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-        ({ message, status }) =>
+      return fetchPageData
+        .default({ path: requestedPathname, pageType })
+        .catch(({ message, status }) =>
           expect({ message, status }).toEqual({
             message: 'Failed to fetch',
             status: 502,
           }),
-      );
+        );
     });
   });
 
@@ -113,8 +114,9 @@ describe('fetchPageData', () => {
       it('should return a 500 error code', () => {
         setWindowValue('location', false);
 
-        return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-          ({ message, status }) => {
+        return fetchPageData
+          .default({ path: requestedPathname, pageType })
+          .catch(({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'invalid json response body at  reason: Unexpected end of JSON input',
@@ -129,8 +131,7 @@ describe('fetchPageData', () => {
                 'invalid json response body at  reason: Unexpected end of JSON input',
               status: 500,
             });
-          },
-        );
+          });
       });
     });
 
@@ -138,8 +139,9 @@ describe('fetchPageData', () => {
       it('should return a 502 error code', () => {
         setWindowValue('location', true);
 
-        return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-          ({ message, status }) => {
+        return fetchPageData
+          .default({ path: requestedPathname, pageType })
+          .catch(({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'invalid json response body at  reason: Unexpected end of JSON input',
@@ -153,8 +155,7 @@ describe('fetchPageData', () => {
                 'invalid json response body at  reason: Unexpected end of JSON input',
               status: 502,
             });
-          },
-        );
+          });
       });
     });
   });
@@ -163,14 +164,14 @@ describe('fetchPageData', () => {
     it('should return the status code as 404', async () => {
       fetch.mockResponse('Not found', { status: 404 });
 
-      return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-        ({ message, status }) => {
+      return fetchPageData
+        .default({ path: requestedPathname, pageType })
+        .catch(({ message, status }) => {
           expect({ message, status }).toEqual({
             message: 'data_response_404',
             status: 404,
           });
-        },
-      );
+        });
     });
   });
 
@@ -187,8 +188,9 @@ describe('fetchPageData', () => {
       it('should log, and return the status code as 500', async () => {
         fetch.mockResponse("I'm a teapot", { status: 418 });
 
-        return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-          ({ message, status }) => {
+        return fetchPageData
+          .default({ path: requestedPathname, pageType })
+          .catch(({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'Unexpected upstream response (HTTP status code 418) when requesting http://localhost/path/to/asset.json',
@@ -202,15 +204,15 @@ describe('fetchPageData', () => {
               status: 500,
               message: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
             });
-          },
-        );
+          });
       });
 
       it('should log, and propogate the status code as 500', async () => {
         fetch.mockResponse('Error', { status: 500 });
 
-        return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-          ({ message, status }) => {
+        return fetchPageData
+          .default({ path: requestedPathname, pageType })
+          .catch(({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
               status: 500,
@@ -223,8 +225,7 @@ describe('fetchPageData', () => {
               status: 500,
               message: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
             });
-          },
-        );
+          });
       });
     });
   });
@@ -237,8 +238,9 @@ describe('fetchPageData', () => {
     it('should log, and return the status code as 502', async () => {
       fetch.mockResponse("I'm a teapot", { status: 418 });
 
-      return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-        ({ message, status }) => {
+      return fetchPageData
+        .default({ path: requestedPathname, pageType })
+        .catch(({ message, status }) => {
           expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
             error: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
             status: 502,
@@ -251,15 +253,15 @@ describe('fetchPageData', () => {
             status: 502,
             message: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
           });
-        },
-      );
+        });
     });
 
     it('should log, and propogate the status code as 502', async () => {
       fetch.mockResponse('Internal server error', { status: 500 });
 
-      return fetchPageData.default({ path: requestedPathname, pageType }).catch(
-        ({ message, status }) => {
+      return fetchPageData
+        .default({ path: requestedPathname, pageType })
+        .catch(({ message, status }) => {
           expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
             error: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
             status: 502,
@@ -272,8 +274,7 @@ describe('fetchPageData', () => {
             status: 502,
             message: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
           });
-        },
-      );
+        });
     });
   });
 });
@@ -321,10 +322,11 @@ describe('getUrl', () => {
         );
       });
 
-      it('should remove .amp from url with params', () => {});
-      expect(fetchPageData.getUrl('/test/article.amp?param=test')).toEqual(
-        'http://localhost/test/article.json?param=test',
-      );
+      it('should remove .amp from url with params', () => {
+        expect(fetchPageData.getUrl('/test/article.amp?param=test')).toEqual(
+          'http://localhost/test/article.json?param=test',
+        );
+      });
     });
 
     describe('is live', () => {
@@ -351,9 +353,9 @@ describe('getUrl', () => {
       });
 
       it('should remove .amp and multiple query string parameters from url', () => {
-        expect(fetchPageData.getUrl('/test/article.amp?first=1&second=2')).toEqual(
-          'http://localhost/test/article.json',
-        );
+        expect(
+          fetchPageData.getUrl('/test/article.amp?first=1&second=2'),
+        ).toEqual('http://localhost/test/article.json');
       });
     });
 

--- a/src/app/routes/utils/fetchPageData/index.test.js
+++ b/src/app/routes/utils/fetchPageData/index.test.js
@@ -1,20 +1,18 @@
 import { setWindowValue, resetWindowValue } from '@bbc/psammead-test-helpers';
 import loggerMock from '#testHelpers/loggerMock'; // Must be imported before fetchPageData
-import * as fetchPageData from '.';
+import fetchPageData, { getUrl } from '.';
 import { DATA_FETCH_ERROR, DATA_REQUEST_RECEIVED } from '#lib/logger.const';
-
-const originalGetUrl = fetchPageData.getUrl;
-fetchPageData.getUrl = jest.fn();
 
 const expectedBaseUrl = 'http://localhost';
 const requestedPathname = '/path/to/asset';
+const fullTestPath = 'https://test.bbc.com/hausa/mostwatched.json';
+const fullLivePath = 'https://www.bbc.com/hausa/mostwatched.json';
 const expectedUrl = `${expectedBaseUrl}${requestedPathname}.json`;
 const pageType = 'Fetch Page Data';
 
 afterEach(() => {
   jest.clearAllMocks();
   fetch.resetMocks();
-  fetchPageData.getUrl.mockImplementation(originalGetUrl);
 });
 
 describe('fetchPageData', () => {
@@ -30,8 +28,7 @@ describe('fetchPageData', () => {
     });
 
     it('should always log data url and path', async () => {
-      await fetchPageData.default({ path: requestedPathname });
-      expect(fetchPageData.getUrl).toHaveBeenCalled();
+      await fetchPageData({ path: requestedPathname });
       expect(loggerMock.info).toBeCalledWith(DATA_REQUEST_RECEIVED, {
         data: expectedUrl,
         path: requestedPathname,
@@ -39,7 +36,7 @@ describe('fetchPageData', () => {
     });
 
     it('should log pageType if passed in as a parameter', async () => {
-      await fetchPageData.default({ path: requestedPathname, pageType });
+      await fetchPageData({ path: requestedPathname, pageType });
 
       expect(loggerMock.info).toBeCalledWith(DATA_REQUEST_RECEIVED, {
         data: expectedUrl,
@@ -60,20 +57,32 @@ describe('fetchPageData', () => {
       );
     });
 
-    it('should call fetch with correct url', async () => {
-      await fetchPageData.default({ path: requestedPathname, pageType });
+    it('should call fetch with the correct url when passed the pathname', async () => {
+      await fetchPageData({ path: requestedPathname, pageType });
 
       expect(fetch).toHaveBeenCalledWith(expectedUrl);
     });
 
+    it('should call fetch with correct url when passed the full test path', async () => {
+      await fetchPageData({ path: fullTestPath, pageType });
+
+      expect(fetch).toHaveBeenCalledWith(fullTestPath);
+    });
+
+    it('should call fetch with correct url when passed the full live path', async () => {
+      await fetchPageData({ path: fullLivePath, pageType });
+
+      expect(fetch).toHaveBeenCalledWith(fullLivePath);
+    });
+
     it('should call fetch on amp pages without .amp in pathname', async () => {
-      await fetchPageData.default({ path: requestedPathname, pageType });
+      await fetchPageData({ path: requestedPathname, pageType });
 
       expect(fetch).toHaveBeenCalledWith(expectedUrl);
     });
 
     it('should return expected response', async () => {
-      const response = await fetchPageData.default({
+      const response = await fetchPageData({
         path: requestedPathname,
         pageType,
       });
@@ -93,14 +102,13 @@ describe('fetchPageData', () => {
     it('should handle a rejected Ares fetch and return an error the Simorgh app can handle', () => {
       fetch.mockRejectedValue(new Error('Failed to fetch'), { status: 500 });
 
-      return fetchPageData
-        .default({ path: requestedPathname, pageType })
-        .catch(({ message, status }) =>
+      return fetchPageData({ path: requestedPathname, pageType }).catch(
+        ({ message, status }) =>
           expect({ message, status }).toEqual({
             message: 'Failed to fetch',
             status: 502,
           }),
-        );
+      );
     });
   });
 
@@ -114,9 +122,8 @@ describe('fetchPageData', () => {
       it('should return a 500 error code', () => {
         setWindowValue('location', false);
 
-        return fetchPageData
-          .default({ path: requestedPathname, pageType })
-          .catch(({ message, status }) => {
+        return fetchPageData({ path: requestedPathname, pageType }).catch(
+          ({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'invalid json response body at  reason: Unexpected end of JSON input',
@@ -131,7 +138,8 @@ describe('fetchPageData', () => {
                 'invalid json response body at  reason: Unexpected end of JSON input',
               status: 500,
             });
-          });
+          },
+        );
       });
     });
 
@@ -139,9 +147,8 @@ describe('fetchPageData', () => {
       it('should return a 502 error code', () => {
         setWindowValue('location', true);
 
-        return fetchPageData
-          .default({ path: requestedPathname, pageType })
-          .catch(({ message, status }) => {
+        return fetchPageData({ path: requestedPathname, pageType }).catch(
+          ({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'invalid json response body at  reason: Unexpected end of JSON input',
@@ -155,7 +162,8 @@ describe('fetchPageData', () => {
                 'invalid json response body at  reason: Unexpected end of JSON input',
               status: 502,
             });
-          });
+          },
+        );
       });
     });
   });
@@ -164,14 +172,14 @@ describe('fetchPageData', () => {
     it('should return the status code as 404', async () => {
       fetch.mockResponse('Not found', { status: 404 });
 
-      return fetchPageData
-        .default({ path: requestedPathname, pageType })
-        .catch(({ message, status }) => {
+      return fetchPageData({ path: requestedPathname, pageType }).catch(
+        ({ message, status }) => {
           expect({ message, status }).toEqual({
             message: 'data_response_404',
             status: 404,
           });
-        });
+        },
+      );
     });
   });
 
@@ -188,9 +196,8 @@ describe('fetchPageData', () => {
       it('should log, and return the status code as 500', async () => {
         fetch.mockResponse("I'm a teapot", { status: 418 });
 
-        return fetchPageData
-          .default({ path: requestedPathname, pageType })
-          .catch(({ message, status }) => {
+        return fetchPageData({ path: requestedPathname, pageType }).catch(
+          ({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error:
                 'Unexpected upstream response (HTTP status code 418) when requesting http://localhost/path/to/asset.json',
@@ -204,15 +211,15 @@ describe('fetchPageData', () => {
               status: 500,
               message: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
             });
-          });
+          },
+        );
       });
 
       it('should log, and propogate the status code as 500', async () => {
         fetch.mockResponse('Error', { status: 500 });
 
-        return fetchPageData
-          .default({ path: requestedPathname, pageType })
-          .catch(({ message, status }) => {
+        return fetchPageData({ path: requestedPathname, pageType }).catch(
+          ({ message, status }) => {
             expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
               error: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
               status: 500,
@@ -225,7 +232,8 @@ describe('fetchPageData', () => {
               status: 500,
               message: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
             });
-          });
+          },
+        );
       });
     });
   });
@@ -238,9 +246,8 @@ describe('fetchPageData', () => {
     it('should log, and return the status code as 502', async () => {
       fetch.mockResponse("I'm a teapot", { status: 418 });
 
-      return fetchPageData
-        .default({ path: requestedPathname, pageType })
-        .catch(({ message, status }) => {
+      return fetchPageData({ path: requestedPathname, pageType }).catch(
+        ({ message, status }) => {
           expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
             error: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
             status: 502,
@@ -253,15 +260,15 @@ describe('fetchPageData', () => {
             status: 502,
             message: `Unexpected upstream response (HTTP status code 418) when requesting ${expectedUrl}`,
           });
-        });
+        },
+      );
     });
 
     it('should log, and propogate the status code as 502', async () => {
       fetch.mockResponse('Internal server error', { status: 500 });
 
-      return fetchPageData
-        .default({ path: requestedPathname, pageType })
-        .catch(({ message, status }) => {
+      return fetchPageData({ path: requestedPathname, pageType }).catch(
+        ({ message, status }) => {
           expect(loggerMock.error).toBeCalledWith(DATA_FETCH_ERROR, {
             error: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
             status: 502,
@@ -274,32 +281,33 @@ describe('fetchPageData', () => {
             status: 502,
             message: `Unexpected upstream response (HTTP status code 500) when requesting ${expectedUrl}`,
           });
-        });
+        },
+      );
     });
   });
 });
 
 describe('getUrl', () => {
   it('should return empty string when pathname empty', () => {
-    expect(fetchPageData.getUrl('')).toEqual('');
+    expect(getUrl('')).toEqual('');
   });
 
   it('should return empty string when pathname null', () => {
-    expect(fetchPageData.getUrl(null)).toEqual('');
+    expect(getUrl(null)).toEqual('');
   });
 
   it('should return empty string when pathname undefined', () => {
-    expect(fetchPageData.getUrl(undefined)).toEqual('');
+    expect(getUrl(undefined)).toEqual('');
   });
 
   it('should return url', () => {
-    expect(fetchPageData.getUrl('/test/article')).toEqual(
+    expect(getUrl('/test/article')).toEqual(
       'http://localhost/test/article.json',
     );
   });
 
   it('should remove .amp from url', () => {
-    expect(fetchPageData.getUrl('/test/article.amp')).toEqual(
+    expect(getUrl('/test/article.amp')).toEqual(
       'http://localhost/test/article.json',
     );
   });
@@ -311,22 +319,21 @@ describe('getUrl', () => {
       });
 
       it('should append single query string parameter', () => {
-        expect(fetchPageData.getUrl('/test/article?param=test')).toEqual(
+        expect(getUrl('/test/article?param=test')).toEqual(
           'http://localhost/test/article.json?param=test',
         );
       });
 
       it('should append multiple query string parameters', () => {
-        expect(fetchPageData.getUrl('/test/article?first=1&second=2')).toEqual(
+        expect(getUrl('/test/article?first=1&second=2')).toEqual(
           'http://localhost/test/article.json?first=1&second=2',
         );
       });
 
-      it('should remove .amp from url with params', () => {
-        expect(fetchPageData.getUrl('/test/article.amp?param=test')).toEqual(
-          'http://localhost/test/article.json?param=test',
-        );
-      });
+      it('should remove .amp from url with params', () => {});
+      expect(getUrl('/test/article.amp?param=test')).toEqual(
+        'http://localhost/test/article.json?param=test',
+      );
     });
 
     describe('is live', () => {
@@ -335,27 +342,27 @@ describe('getUrl', () => {
       });
 
       it('should remove single query string parameter from url', () => {
-        expect(fetchPageData.getUrl('/test/article?param=test')).toEqual(
+        expect(getUrl('/test/article?param=test')).toEqual(
           'http://localhost/test/article.json',
         );
       });
 
       it('should remove multiple query string parameter from url', () => {
-        expect(fetchPageData.getUrl('/test/article?first=1&second=2')).toEqual(
+        expect(getUrl('/test/article?first=1&second=2')).toEqual(
           'http://localhost/test/article.json',
         );
       });
 
       it('should remove .amp and single query string parameter from url', () => {
-        expect(fetchPageData.getUrl('/test/article.amp?param=test')).toEqual(
+        expect(getUrl('/test/article.amp?param=test')).toEqual(
           'http://localhost/test/article.json',
         );
       });
 
       it('should remove .amp and multiple query string parameters from url', () => {
-        expect(
-          fetchPageData.getUrl('/test/article.amp?first=1&second=2'),
-        ).toEqual('http://localhost/test/article.json');
+        expect(getUrl('/test/article.amp?first=1&second=2')).toEqual(
+          'http://localhost/test/article.json',
+        );
       });
     });
 

--- a/src/app/routes/utils/fetchPageData/index.test.js
+++ b/src/app/routes/utils/fetchPageData/index.test.js
@@ -63,13 +63,13 @@ describe('fetchPageData', () => {
       expect(fetch).toHaveBeenCalledWith(expectedUrl);
     });
 
-    it('should call fetch with correct url when passed the full test path', async () => {
+    it('should call fetch with the correct url when passed the full test path', async () => {
       await fetchPageData({ path: fullTestPath, pageType });
 
       expect(fetch).toHaveBeenCalledWith(fullTestPath);
     });
 
-    it('should call fetch with correct url when passed the full live path', async () => {
+    it('should call fetch with the correct url when passed the full live path', async () => {
       await fetchPageData({ path: fullLivePath, pageType });
 
       expect(fetch).toHaveBeenCalledWith(fullLivePath);


### PR DESCRIPTION
Resolves #7711 

**Overall change:**
_Respect renderer_env=live for most-watched data._

**Code changes:**

- Update `fetchPageData` to not attach a base path if one is provided.
- Update getMostWatchedUrl to include the base path, and adapt it to the existence of the `renderer_env=live` override.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
