### PR TITLE
Improve fetchPageData logging capability

### DIFF
--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -4,6 +4,6 @@ module.exports = {
   // Keep the MAX_SIZE +5 above the largest value and MIN_SIZE -5
   // below the smallest value in the build output; this avoids the
   // need for frequent changes as bundle sizes fluctuate.
-  MIN_SIZE: 551,
-  MAX_SIZE: 848,
+  MIN_SIZE: 675,
+  MAX_SIZE: 854,
 };

--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -32,10 +32,19 @@ export const getUrl = pathname => {
   return `${baseUrl}${basePath.replace(ampRegex, '')}.json${params}`; // Remove .amp at the end of pathnames for AMP pages.
 };
 
-export default async ({ path, pageType }) => {
+/**
+ * An isomorphic fetch wrapper for pages, with error and log handling.
+ * @param {string} path The URL of a resource to fetch.
+ * @param {...string} loggerArgs Additional arguments for richer logging.
+ */
+const fetchPageData = async ({ path, ...loggerArgs }) => {
   const url = getUrl(path);
 
-  logger.info(DATA_REQUEST_RECEIVED, { data: url, pageType, path });
+  logger.info(DATA_REQUEST_RECEIVED, {
+    data: url,
+    path,
+    ...loggerArgs,
+  });
 
   try {
     const response = await fetch(url);
@@ -74,10 +83,12 @@ export default async ({ path, pageType }) => {
       data: url,
       status: simorghError.status,
       error: message,
-      pageType,
       path,
+      ...loggerArgs,
     });
 
     throw simorghError;
   }
 };
+
+export default fetchPageData;

--- a/src/app/routes/utils/fetchPageData/index.test.js
+++ b/src/app/routes/utils/fetchPageData/index.test.js
@@ -7,6 +7,7 @@ const expectedBaseUrl = 'http://localhost';
 const requestedPathname = '/path/to/asset';
 const expectedUrl = `${expectedBaseUrl}${requestedPathname}.json`;
 const pageType = 'Fetch Page Data';
+const requestOrigin = 'Jest Test';
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -33,13 +34,14 @@ describe('fetchPageData', () => {
       });
     });
 
-    it('should log pageType if passed in as a parameter', async () => {
-      await fetchPageData({ path: requestedPathname, pageType });
+    it('should log additional arguments if passed', async () => {
+      await fetchPageData({ path: requestedPathname, pageType, requestOrigin });
 
       expect(loggerMock.info).toBeCalledWith(DATA_REQUEST_RECEIVED, {
         data: expectedUrl,
         path: requestedPathname,
         pageType,
+        requestOrigin,
       });
     });
   });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/7952.

### Overall changes

Improve fetchPageData's logging capability by allowing it to accept multiple arguments.

### Code changes

- Use a rest parameter to capture additional logging arguments.
- Update test coverage.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] ~~I have added the `cross-team` label to this PR if it requires visibility across World Service teams~~
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] ~~If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)~~
- [ ] ~~This PR requires manual testing~~
