### PR TITLE
Add static.bbci.co.uk to the CSP headers

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -329,6 +329,7 @@ const directives = {
   styleSrc: {
     ampLive: [
       'https://news.files.bbci.co.uk', // STY include styles
+      'https://static.bbci.co.uk', // STY Includes
       "'unsafe-inline'",
     ],
     canonicalLive: [
@@ -337,10 +338,12 @@ const directives = {
       'https://ton.twimg.com', // Social Embeds
       'https://news.files.bbci.co.uk', // STY includes
       'https://static.bbc.co.uk', // STY include
+      'https://static.bbci.co.uk', // STY Includes
       "'unsafe-inline'",
     ],
     ampNonLive: [
       'https://news.files.bbci.co.uk', // STY include styles
+      'https://static.bbci.co.uk', // STY Includes
       "'unsafe-inline'",
     ],
     canonicalNonLive: [
@@ -351,6 +354,7 @@ const directives = {
       'https://news.test.files.bbci.co.uk', // STY includes
       'https://static.bbc.co.uk', // STY include
       'http://static.bbc.co.uk', // STY include
+      'https://static.bbci.co.uk', // STY Includes
       "'unsafe-inline'",
     ],
   },

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -104,7 +104,11 @@ describe('cspHeader', () => {
         "'self'",
         "'unsafe-inline'",
       ],
-      styleSrcExpectation: ['https://news.files.bbci.co.uk', "'unsafe-inline'"],
+      styleSrcExpectation: [
+        'https://news.files.bbci.co.uk',
+        'https://static.bbci.co.uk',
+        "'unsafe-inline'",
+      ],
       mediaSrcExpectation: ['https://news.files.bbci.co.uk'],
       workerSrcExpectation: ['blob:'],
     },
@@ -240,6 +244,7 @@ describe('cspHeader', () => {
         'https://ton.twimg.com',
         'https://news.files.bbci.co.uk',
         'https://static.bbc.co.uk',
+        'https://static.bbci.co.uk',
         "'unsafe-inline'",
       ],
       mediaSrcExpectation: ['https://news.files.bbci.co.uk'],
@@ -338,7 +343,11 @@ describe('cspHeader', () => {
         "'self'",
         "'unsafe-inline'",
       ],
-      styleSrcExpectation: ['https://news.files.bbci.co.uk', "'unsafe-inline'"],
+      styleSrcExpectation: [
+        'https://news.files.bbci.co.uk',
+        'https://static.bbci.co.uk',
+        "'unsafe-inline'",
+      ],
       mediaSrcExpectation: [
         'https://news.files.bbci.co.uk',
         'https://news.test.files.bbci.co.uk',
@@ -496,6 +505,7 @@ describe('cspHeader', () => {
         'https://news.test.files.bbci.co.uk',
         'https://static.bbc.co.uk',
         'http://static.bbc.co.uk',
+        'https://static.bbci.co.uk',
         "'unsafe-inline'",
       ],
       mediaSrcExpectation: [


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Updates CSP headers to include static.bbci.co.uk for IDT includes that are fetched from S3

**Code changes:**

- Adds static.bbci.co.uk to the csp headers

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
