### PR TITLE
Remove .only from the social embeds E2E test

### DIFF
--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -29,7 +29,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.
 export const testsThatNeverRunDuringSmokeTestingForCanonicalOnly = () => {
   describe('Social Embed', () => {
-    it.only('link should render if exists on page', () => {
+    it('link should render if exists on page', () => {
       cy.window().then(win => {
         const jsonData = win.SIMORGH_DATA.pageData;
 


### PR DESCRIPTION
**Overall change:**
The social embed test is the only test which will run on all E2Es, due to the use of `it.only`

**Code changes:**
- Remove `.only` from social embed test

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
