### PR TITLE
Adding Most Watched pages to bbcA11y run

### DIFF
--- a/a11y.js
+++ b/a11y.js
@@ -69,6 +69,7 @@ const pageTypes = {
   ],
   photoGalleryPage: ["//div[@id='root']/header/nav/div/div[1]/div/ul"],
   mostReadPage: ["//div[@id='root']/header/nav/div/div[1]/div/ul"],
+  mostWatchedPage: ["//div[@id='root']/header/nav/div/div[1]/div/ul"],
   storyPage: [
     "//div[@id='root']/header/nav/div/div[1]/div/ul",
     '/iframe', // same issues as in mediaEmbedErrorsToSuppress but the DOM path is different


### PR DESCRIPTION
Resolves #7958

**Overall change:**
Adding Most Watched pagetype for bbcA11y tool

**Code changes:**

- Added Most Watched pagetype with same suppressed issue as Most Read

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
