### PR TITLE
[US Election] Do not render banner when on AMP

### DIFF
--- a/src/app/containers/USElectionBanner/index.jsx
+++ b/src/app/containers/USElectionBanner/index.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { number, string, shape } from 'prop-types';
 import styled from 'styled-components';
+import { RequestContext } from '#contexts/RequestContext';
 
 // Styling
 import {
@@ -39,9 +40,10 @@ const StyledWrapper = styled.div`
 `;
 
 const USElectionBanner = ({ oembed }) => {
+  const { isAmp } = useContext(RequestContext);
   const { enabled } = useToggle('us2020ElectionBanner');
 
-  if (!enabled || !oembed) return null;
+  if (!enabled || !oembed || isAmp) return null;
 
   return (
     <FrontPageSection>

--- a/src/app/containers/USElectionBanner/index.jsx
+++ b/src/app/containers/USElectionBanner/index.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { number, string, shape } from 'prop-types';
 import styled from 'styled-components';
-import { RequestContext } from '#contexts/RequestContext';
 
 // Styling
 import {
@@ -14,6 +13,9 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MAX,
 } from '@bbc/gel-foundations/breakpoints';
+
+// Contexts
+import { RequestContext } from '#contexts/RequestContext';
 
 // Utilities
 import useToggle from '#hooks/useToggle';

--- a/src/app/containers/USElectionBanner/index.test.jsx
+++ b/src/app/containers/USElectionBanner/index.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { isNull, shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import ElectionBanner from './index';
+
+// Contexts
 import { ToggleContext } from '#contexts/ToggleContext';
+import { RequestContext } from '#contexts/RequestContext';
 
 const MockOembedData = {
   version: '1.0',
@@ -12,21 +15,30 @@ const MockOembedData = {
 };
 
 // eslint-disable-next-line react/prop-types
-const ElectionsBannerWithContext = ({ oembed }) => (
-  <ToggleContext.Provider
-    value={{
-      toggleState: {
-        us2020ElectionBanner: { enabled: true },
-      },
-    }}
-  >
-    <ElectionBanner oembed={oembed} />
-  </ToggleContext.Provider>
+const ElectionsBannerWithContext = ({ oembed, isAmp = false }) => (
+  <RequestContext.Provider value={{ isAmp: isAmp }}>
+    <ToggleContext.Provider
+      value={{
+        toggleState: {
+          us2020ElectionBanner: { enabled: true },
+        },
+      }}
+    >
+      <ElectionBanner oembed={oembed} />
+    </ToggleContext.Provider>
+  </RequestContext.Provider>
 );
 
 describe('ElectionBanner', () => {
   describe('with no oEmbed data', () => {
     isNull('should return null', <ElectionsBannerWithContext />);
+  });
+
+  describe('when on AMP', () => {
+    isNull(
+      'should return null',
+      <ElectionsBannerWithContext oembed={MockOembedData} isAmp={true} />,
+    );
   });
 
   describe('with oEmbed data', () => {

--- a/src/app/containers/USElectionBanner/index.test.jsx
+++ b/src/app/containers/USElectionBanner/index.test.jsx
@@ -16,7 +16,7 @@ const MockOembedData = {
 
 // eslint-disable-next-line react/prop-types
 const ElectionsBannerWithContext = ({ oembed, isAmp = false }) => (
-  <RequestContext.Provider value={{ isAmp: isAmp }}>
+  <RequestContext.Provider value={{ isAmp }}>
     <ToggleContext.Provider
       value={{
         toggleState: {
@@ -37,7 +37,7 @@ describe('ElectionBanner', () => {
   describe('when on AMP', () => {
     isNull(
       'should return null',
-      <ElectionsBannerWithContext oembed={MockOembedData} isAmp={true} />,
+      <ElectionsBannerWithContext oembed={MockOembedData} isAmp />,
     );
   });
 


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Stops rendering the elections banner on AMP pages

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
