### PR TITLE
fix idt2 include test following idt2 republish

### DIFF
--- a/data/gahuza/cpsAssets/23313911.json
+++ b/data/gahuza/cpsAssets/23313911.json
@@ -1,449 +1,517 @@
 {
-  "metadata": {
-    "id": "urn:bbc:ares::asset:gahuza/23313911",
-    "locators": {
-      "assetUri": "/gahuza/23313911",
-      "cpsUrn": "urn:bbc:content:assetUri:gahuza/23313911",
-      "curie": "http://www.bbc.co.uk/asset/48fe44a1-f432-4475-942d-ab017d13b4d0",
-      "assetId": "23313911"
-    },
-    "type": "STY",
-    "createdBy": "gahuza-v6",
-    "language": "rw",
-    "lastUpdated": 1592585242524,
-    "firstPublished": 1591720017000,
-    "lastPublished": 1591722582000,
-    "timestamp": 1591722582000,
-    "options": {
-      "isIgorSeoTagsEnabled": false,
-      "includeComments": false,
-      "allowRightHandSide": true,
-      "isFactCheck": false,
-      "allowDateStamp": true,
-      "suitableForSyndication": true,
-      "hasNewsTracker": false,
-      "allowRelatedStoriesBox": true,
-      "isKeyContent": false,
-      "allowHeadline": true,
-      "allowAdvertising": true,
-      "hasContentWarning": false,
-      "isBreakingNews": false,
-      "allowPrintingSharingLinks": true
-    },
-    "analyticsLabels": {
-      "cps_asset_type": "sty",
-      "counterName": "gahuza.story.23313911.page",
-      "cps_asset_id": "23313911"
-    },
-    "tags": {},
-    "version": "v1.3.2",
-    "blockTypes": ["image", "paragraph", "include"],
-    "includeComments": false,
-    "atiAnalytics": { "producerName": "GAHUZA", "producerId": "40" }
-  },
   "content": {
     "blocks": [
       {
-        "id": "63735666",
-        "subType": "body",
-        "href": "http://b.files.bbci.co.uk/1045D/test/_63735666_3.jpg",
-        "path": "/cpsdevpb/1045D/test/_63735666_3.jpg",
-        "height": 549,
-        "width": 976,
         "altText": "Test caption for first image",
         "caption": "Test caption for image 1",
         "copyrightHolder": "BBC",
+        "height": 549,
+        "href": "http://b.files.bbci.co.uk/1045D/test/_63735666_3.jpg",
+        "id": "63735666",
+        "path": "/cpsdevpb/1045D/test/_63735666_3.jpg",
         "positionHint": "full-width",
-        "type": "image"
+        "subType": "body",
+        "type": "image",
+        "width": 976
       },
       {
-        "text": "Introduction to this story. ",
-        "role": "introduction",
         "markupType": "plain_text",
+        "role": "introduction",
+        "text": "Introduction to this story. ",
         "type": "paragraph"
       },
-      { "text": "IDT2 Map", "markupType": "plain_text", "type": "paragraph" },
+      { "markupType": "plain_text", "text": "IDT2 Map", "type": "paragraph" },
       {
-        "required": false,
-        "title": "IDT2 map",
         "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7",
-        "platform": "highweb",
         "idt2": {
           "altText": "Map: St. Albans",
+          "copyrightHolder": "",
           "dimensions": {
-            "small": {
-              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/350",
-              "width": 700,
-              "height": 700
+            "large": {
+              "height": 918,
+              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/470",
-              "width": 940,
-              "height": 940
+              "height": 720,
+              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816",
-              "width": 1632,
-              "height": 918
+            "small": {
+              "height": 920,
+              "href": "/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "",
           "published": 1591722473752
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "IDT2 map",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - Stacked column chart",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - Stacked column chart",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Stacked column chart",
         "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a stacked column chart. .  .",
+          "copyrightHolder": "Source: BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/350",
-              "width": 700,
-              "height": 820
+            "large": {
+              "height": 1280,
+              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/470",
-              "width": 940,
-              "height": 896
+              "height": 1082,
+              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/816",
-              "width": 1632,
-              "height": 1286
+            "small": {
+              "height": 878,
+              "href": "/idt2/8f1e559c-c08e-4ef7-9afb-0318969410c4/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Source: BBC",
           "published": 1592584702952
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Stacked column chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - Stacked bar chart ",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - Stacked bar chart  ",
         "type": "paragraph"
       },
       {
+        "href": "/idt2/b7a7dab7-8798-49db-824d-c871fa624031",
+        "idt2": {
+          "altText": "Data in a stacked bar chart. .  .",
+          "copyrightHolder": "Source: BBC",
+          "dimensions": {
+            "large": {
+              "height": 920,
+              "href": "/idt2/b7a7dab7-8798-49db-824d-c871fa624031/image/816",
+              "width": 1632
+            },
+            "medium": {
+              "height": 920,
+              "href": "/idt2/b7a7dab7-8798-49db-824d-c871fa624031/image/470",
+              "width": 940
+            },
+            "small": {
+              "height": 920,
+              "href": "/idt2/b7a7dab7-8798-49db-824d-c871fa624031/image/350",
+              "width": 700
+            }
+          },
+          "published": 1592584675675
+        },
+        "platform": "highweb",
         "required": false,
         "title": "Stacked bar chart",
-        "href": "/idt2/b7a7dab7-8798-49db-824d-c871fa624031",
-        "platform": "highweb",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - table",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - table",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Table chart",
         "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a table. .  .",
+          "copyrightHolder": "Source: BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208/image/350",
-              "width": 700,
-              "height": 620
+            "large": {
+              "height": 466,
+              "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208/image/816",
+              "width": 1632
             },
             "medium": {
+              "height": 466,
               "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208/image/470",
-              "width": 940,
-              "height": 466
+              "width": 940
             },
-            "large": {
-              "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208/image/816",
-              "width": 1632,
-              "height": 466
+            "small": {
+              "height": 620,
+              "href": "/idt2/8f2c1d5e-74b2-4b95-9bf6-6c9f8e415208/image/350",
+              "width": 700
             }
           },
-          "copyrightHolder": "Source: BBC",
           "published": 1592584646656
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Table chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - pie chart",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - pie chart",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Pie chart",
         "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a pie chart. .  .",
+          "copyrightHolder": "Getty",
           "dimensions": {
-            "small": {
-              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/350",
-              "width": 700,
-              "height": 862
+            "large": {
+              "height": 960,
+              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/470",
-              "width": 940,
-              "height": 946
+              "height": 960,
+              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/816",
-              "width": 1632,
-              "height": 964
+            "small": {
+              "height": 940,
+              "href": "/idt2/59993b50-74ac-4f6c-bd3f-fe0664156603/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Source: BBC",
-          "published": 1592584623524
+          "published": 1597411314864
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Pie chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - grouped bar chart",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - grouped bar chart ",
         "type": "paragraph"
       },
       {
+        "href": "/idt2/85b68cc8-fd20-48a5-8049-2421bd354617",
+        "idt2": {
+          "altText": "Data in a grouped bar chart. .  .",
+          "copyrightHolder": "Source: BBC",
+          "dimensions": {
+            "large": {
+              "height": 1114,
+              "href": "/idt2/85b68cc8-fd20-48a5-8049-2421bd354617/image/816",
+              "width": 1632
+            },
+            "medium": {
+              "height": 1114,
+              "href": "/idt2/85b68cc8-fd20-48a5-8049-2421bd354617/image/640",
+              "width": 1280
+            },
+            "small": {
+              "height": 1114,
+              "href": "/idt2/85b68cc8-fd20-48a5-8049-2421bd354617/image/460",
+              "width": 920
+            }
+          },
+          "published": 1592584585924
+        },
+        "platform": "highweb",
         "required": false,
         "title": "Grouped bar chart",
-        "href": "/idt2/85b68cc8-fd20-48a5-8049-2421bd354617",
-        "platform": "highweb",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - grouped column chart",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - grouped column chart",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Grouped column chart",
         "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a grouped column chart. .  .",
+          "copyrightHolder": "Source: BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/350",
-              "width": 700,
-              "height": 820
+            "large": {
+              "height": 1280,
+              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/470",
-              "width": 940,
-              "height": 896
+              "height": 1082,
+              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/816",
-              "width": 1632,
-              "height": 1286
+            "small": {
+              "height": 878,
+              "href": "/idt2/3c9e4620-655a-4925-b3ae-ea3412cd301d/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Source: BBC",
           "published": 1592584562637
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Grouped column chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - line chart ",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - line chart ",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Line chart",
         "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a line chart. .  .",
+          "copyrightHolder": "Source: BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/350",
-              "width": 700,
-              "height": 808
+            "large": {
+              "height": 1282,
+              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/470",
-              "width": 940,
-              "height": 896
+              "height": 1202,
+              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/816",
-              "width": 1632,
-              "height": 1286
+            "small": {
+              "height": 1202,
+              "href": "/idt2/831fc241-335a-4a54-a51e-08f08cee918c/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Source: BBC",
           "published": 1592584485715
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Line chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - column chart",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - column chart ",
         "type": "paragraph"
       },
       {
+        "href": "/idt2/a34141d5-86ea-41a9-bc7f-6a0bba422857",
+        "idt2": {
+          "altText": "Data in a column chart. .  .",
+          "copyrightHolder": "Source: Liz",
+          "dimensions": {
+            "large": {
+              "height": 1214,
+              "href": "/idt2/a34141d5-86ea-41a9-bc7f-6a0bba422857/image/816",
+              "width": 1632
+            },
+            "medium": {
+              "height": 1016,
+              "href": "/idt2/a34141d5-86ea-41a9-bc7f-6a0bba422857/image/640",
+              "width": 1280
+            },
+            "small": {
+              "height": 812,
+              "href": "/idt2/a34141d5-86ea-41a9-bc7f-6a0bba422857/image/460",
+              "width": 920
+            }
+          },
+          "published": 1592584461436
+        },
+        "platform": "highweb",
         "required": false,
         "title": "Column chart",
-        "href": "/idt2/a34141d5-86ea-41a9-bc7f-6a0bba422857",
-        "platform": "highweb",
         "type": "include"
       },
       {
-        "text": "IDT2 Chart - bar chart ",
         "markupType": "plain_text",
+        "text": "IDT2 Chart - bar chart ",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Bar chart",
         "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data in a bar chart. .  .",
+          "copyrightHolder": "Source: BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/350",
-              "width": 700,
-              "height": 714
+            "large": {
+              "height": 712,
+              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/470",
-              "width": 940,
-              "height": 714
+              "height": 712,
+              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/816",
-              "width": 1632,
-              "height": 714
+            "small": {
+              "height": 712,
+              "href": "/idt2/e4bb85f4-22fb-44c6-b055-9de0edcf0cee/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Source: BBC",
           "published": 1592585208974
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Bar chart",
         "type": "include"
       },
       {
-        "text": "IDT2 Datapic ",
         "markupType": "plain_text",
+        "text": "IDT2 Datapic ",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Datapic",
         "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485",
-        "platform": "highweb",
         "idt2": {
           "altText": "Data pic. Data pics work [ Yay data pic ] , Source: Source: Liz, Image: ",
+          "copyrightHolder": "Getty Images",
           "dimensions": {
-            "small": {
-              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/350",
-              "width": 700,
-              "height": 738
+            "large": {
+              "height": 414,
+              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/470",
-              "width": 940,
-              "height": 400
+              "height": 414,
+              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/816",
-              "width": 1632,
-              "height": 414
+            "small": {
+              "height": 738,
+              "href": "/idt2/2a6c6ba1-8750-4b65-9c65-f08254b25485/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "Getty Images",
           "published": 1592585179585
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Datapic",
         "type": "include"
       },
       {
-        "text": "IDT2 Quotepic ",
         "markupType": "plain_text",
+        "text": "IDT2 Quotepic ",
         "type": "paragraph"
       },
       {
-        "required": false,
-        "title": "Quotepic",
         "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80",
-        "platform": "highweb",
         "idt2": {
           "altText": "&quot;Quotepics work&quot;, Source: Liz, Source description: , Image: ",
+          "copyrightHolder": "BBC",
           "dimensions": {
-            "small": {
-              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/350",
-              "width": 700,
-              "height": 666
+            "large": {
+              "height": 400,
+              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/816",
+              "width": 1632
             },
             "medium": {
-              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/470",
-              "width": 940,
-              "height": 400
+              "height": 400,
+              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/640",
+              "width": 1280
             },
-            "large": {
-              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/816",
-              "width": 1632,
-              "height": 400
+            "small": {
+              "height": 664,
+              "href": "/idt2/ea818144-9a83-47cd-a4d8-80b4c28f3f80/image/460",
+              "width": 920
             }
           },
-          "copyrightHolder": "BBC",
           "published": 1591722286464
         },
+        "platform": "highweb",
+        "required": false,
+        "title": "Quotepic",
         "type": "include"
       }
     ]
   },
-  "promo": {
-    "headlines": {
-      "shortHeadline": "Test story with different IDT2 types",
-      "headline": "Test story with different IDT2 types"
+  "metadata": {
+    "analyticsLabels": {
+      "counterName": "gahuza.story.23313911.page",
+      "cps_asset_id": "23313911",
+      "cps_asset_type": "sty"
     },
+    "atiAnalytics": { "producerId": "40", "producerName": "GAHUZA" },
+    "blockTypes": ["image", "paragraph", "include"],
+    "createdBy": "gahuza-v6",
+    "firstPublished": 1591720017000,
+    "id": "urn:bbc:ares::asset:gahuza/23313911",
+    "includeComments": false,
+    "language": "rw",
+    "lastPublished": 1591722582000,
+    "lastUpdated": 1603267473579,
     "locators": {
+      "assetId": "23313911",
       "assetUri": "/gahuza/23313911",
       "cpsUrn": "urn:bbc:content:assetUri:gahuza/23313911",
-      "curie": "http://www.bbc.co.uk/asset/48fe44a1-f432-4475-942d-ab017d13b4d0",
-      "assetId": "23313911"
+      "curie": "http://www.bbc.co.uk/asset/48fe44a1-f432-4475-942d-ab017d13b4d0"
     },
-    "summary": "Testing types of IDT2",
+    "options": {
+      "allowAdvertising": true,
+      "allowDateStamp": true,
+      "allowHeadline": true,
+      "allowPrintingSharingLinks": true,
+      "allowRelatedStoriesBox": true,
+      "allowRightHandSide": true,
+      "hasContentWarning": false,
+      "hasNewsTracker": false,
+      "includeComments": false,
+      "isBreakingNews": false,
+      "isFactCheck": false,
+      "isIgorSeoTagsEnabled": false,
+      "isKeyContent": false,
+      "suitableForSyndication": true
+    },
+    "readTime": 1,
+    "siteUri": "/gahuza",
+    "tags": {},
     "timestamp": 1591722582000,
-    "language": "rw",
+    "type": "STY",
+    "version": "v1.3.8"
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Test story with different IDT2 types",
+      "shortHeadline": "Test story with different IDT2 types"
+    },
+    "id": "urn:bbc:ares::asset:gahuza/23313911",
     "indexImage": {
-      "id": "63735666",
-      "subType": "index",
-      "href": "http://b.files.bbci.co.uk/1045D/test/_63735666_3.jpg",
-      "path": "/cpsdevpb/1045D/test/_63735666_3.jpg",
-      "height": 549,
-      "width": 976,
       "altText": "Test caption for first image",
       "caption": "Test caption for image 1",
       "copyrightHolder": "BBC",
-      "type": "image"
+      "height": 549,
+      "href": "http://b.files.bbci.co.uk/1045D/test/_63735666_3.jpg",
+      "id": "63735666",
+      "path": "/cpsdevpb/1045D/test/_63735666_3.jpg",
+      "subType": "index",
+      "type": "image",
+      "width": 976
     },
-    "id": "urn:bbc:ares::asset:gahuza/23313911",
+    "language": "rw",
+    "locators": {
+      "assetId": "23313911",
+      "assetUri": "/gahuza/23313911",
+      "cpsUrn": "urn:bbc:content:assetUri:gahuza/23313911",
+      "curie": "http://www.bbc.co.uk/asset/48fe44a1-f432-4475-942d-ab017d13b4d0"
+    },
+    "summary": "Testing types of IDT2",
+    "timestamp": 1591722582000,
     "type": "cps"
   },
   "relatedContent": {
+    "groups": [],
     "section": {
-      "subType": "index",
       "name": "Urupapuro rw'itangiriro",
-      "uri": "/gahuza/front_page",
-      "type": "simple"
+      "subType": "index",
+      "type": "simple",
+      "uri": "/gahuza/front_page"
     },
     "site": {
-      "subType": "site",
       "name": "BBC Gahuza",
-      "uri": "/gahuza",
-      "type": "simple"
-    },
-    "groups": []
+      "subType": "site",
+      "type": "simple",
+      "uri": "/gahuza"
+    }
   }
 }

--- a/src/integration/pages/storyPage/ampIncludeTests.js
+++ b/src/integration/pages/storyPage/ampIncludeTests.js
@@ -3,7 +3,7 @@ export default () => {
     describe('IDT2', () => {
       it('I can see a fallback image', () => {
         const imageEl = document.querySelector(
-          'amp-img[src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/470"]',
+          'amp-img[src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640"]',
         );
 
         expect(imageEl).toBeInTheDocument();

--- a/src/integration/pages/storyPage/canonicalIncludeTests.js
+++ b/src/integration/pages/storyPage/canonicalIncludeTests.js
@@ -3,7 +3,7 @@ export default () => {
     describe('IDT2', () => {
       it('I can see a "dataPic"', () => {
         const scriptEl = document.querySelector(
-          'script[src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.64a69df2.js"]',
+          'script[src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.8f264bc5.js"]',
         );
         expect(scriptEl).toBeInTheDocument();
         expect(scriptEl).toMatchSnapshot();

--- a/src/integration/pages/storyPage/gahuza/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/gahuza/__snapshots__/amp.test.js.snap
@@ -4,10 +4,10 @@ exports[`Amp Story Page Includes IDT2 I can see a fallback image 1`] = `
 <amp-img
   alt="Map: St. Albans"
   attribution=""
-  height="940"
+  height="720"
   layout="responsive"
-  src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/470"
-  srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/350 350w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/470 470w"
-  width="940"
+  src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640"
+  srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/460 460w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640 640w"
+  width="1280"
 />
 `;

--- a/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
@@ -6,13 +6,13 @@ exports[`Canonical Story Page Includes I can see a fallback image when there are
   class="StyledImg-sc-7vx2mr-0 hIxkbt"
   id="include-1"
   src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816"
-  srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/470 470w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816 816w"
+  srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640 640w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816 816w"
 />
 `;
 
 exports[`Canonical Story Page Includes IDT2 I can see a "dataPic" 1`] = `
 <script
-  src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.64a69df2.js"
+  src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.8f264bc5.js"
   type="text/javascript"
 />
 `;


### PR DESCRIPTION
No issue

**Overall change:**
Fix tests failing in CI following IDT2 release and republish of content

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
