### PR TITLE
Emotion - Fix e2es

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -111,9 +111,9 @@ export const testsThatFollowSmokeTestConfig = ({
                   // If an image has a BBC copyright, the copyright holder (<p>) does not appear on images.
                   // This is why we're asserting the value. If the copyright does not appear and is not
                   // 'BBC' then it is clear there is an error with this component.
-                  cy.get('p[class^="Copyright"]').should('not.exist');
+                  cy.get('p[class*="Copyright"]').should('not.exist');
                 } else {
-                  cy.get('p[class^="Copyright"]')
+                  cy.get('p[class*="Copyright"]')
                     .should('be.visible')
                     .and('contain', copyrightHolder);
                 }
@@ -132,7 +132,7 @@ export const testsThatFollowSmokeTestConfig = ({
 
       if (serviceHasInlineLink(service) && Cypress.env('APP_ENV') === 'local') {
         it('should have an inlink link to an article page', () => {
-          cy.get('[class^="InlineLink"]')
+          cy.get('[class*="InlineLink"]')
             .eq(1)
             .should('have.attr', 'href')
             .then(href => {

--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -34,7 +34,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
           const media = getBlockData('video', body);
           if (media && media.type === 'video') {
-            cy.get('div[class^="StyledVideoContainer"]').within(() => {
+            cy.get('div[class*="StyledVideoContainer"]').within(() => {
               cy.get('amp-img')
                 .should('have.attr', 'src')
                 .should('not.be.empty');

--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -87,8 +87,8 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
         cy.window().then(win => {
           const media = getBlockData('video', win.SIMORGH_DATA.pageData);
           if (media) {
-            cy.get('div[class^="StyledVideoContainer"]').within(() => {
-              cy.get('div[class^="StyledPlaceholder"] > img')
+            cy.get('div[class*="StyledVideoContainer"]').within(() => {
+              cy.get('div[class*="StyledPlaceholder"] > img')
                 .should('be.visible')
                 .should('have.attr', 'src')
                 .should('not.be.empty');
@@ -106,12 +106,12 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
               media.model.blocks[1].model.blocks[0].model.versions[0].warnings
                 .long;
 
-            cy.get('div[class^="StyledVideoContainer"]')
+            cy.get('div[class*="StyledVideoContainer"]')
               .eq(0)
               .within(() => {
                 // Check for video with guidance message
                 if (longGuidanceWarning) {
-                  cy.get('div[class^="StyledPlaceholder"]')
+                  cy.get('div[class*="StyledPlaceholder"]')
                     .within(() => {
                       cy.get('strong');
                     })
@@ -119,7 +119,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
                     .and('contain', longGuidanceWarning);
                   // Check for video with no guidance message
                 } else {
-                  cy.get('div[class^="StyledGuidance"]').should('not.exist');
+                  cy.get('div[class*="StyledGuidance"]').should('not.exist');
                 }
               });
           }
@@ -133,7 +133,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
             const aresMediaBlocks = media.model.blocks[1].model.blocks[0];
             const { durationISO8601 } = aresMediaBlocks.model.versions[0];
 
-            cy.get('div[class^="StyledVideoContainer"]').within(() => {
+            cy.get('div[class*="StyledVideoContainer"]').within(() => {
               cy.get('button')
                 .should('be.visible')
                 .within(() => {

--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -35,23 +35,23 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
     if (serviceHasCaption(service)) {
       describe('Image with placeholder', () => {
         it('should have a visible image that is not lazyloaded', () => {
-          cy.get('div[class^="ImagePlaceholder"]')
+          cy.get('div[class*="ImagePlaceholder"]')
             .eq(0)
             .should('be.visible')
             .should('to.have.descendants', 'img')
             .within(() => {
-              cy.get('div[class^="lazyload-placeholder"]').should('not.exist');
+              cy.get('div[class*="lazyload-placeholder"]').should('not.exist');
             });
         });
 
         it('should have a visible image that is lazyloaded and has a noscript fallback image', () => {
-          cy.get('div[class^="ImagePlaceholder"]')
+          cy.get('div[class*="ImagePlaceholder"]')
             .eq(1)
             .scrollIntoView()
             .should('be.visible')
             .within(() => {
               cy.get('noscript').contains('<img ');
-              cy.get('div[class^="lazyload-placeholder"]').should('exist');
+              cy.get('div[class*="lazyload-placeholder"]').should('exist');
             });
         });
 

--- a/cypress/integration/pages/errorPage404/tests.js
+++ b/cypress/integration/pages/errorPage404/tests.js
@@ -113,7 +113,7 @@ export const testsThatFollowSmokeTestConfig = ({
               'text/html',
             );
             cy.visit(`${config[service].name}/404`)
-              .get('[class^="StatusCode"]')
+              .get('[data-e2e="status-code"]')
               .should(
                 'contain',
                 appConfig[config[service].name][variant].translations.error[404]
@@ -127,7 +127,7 @@ export const testsThatFollowSmokeTestConfig = ({
               'text/html',
             );
             cy.visit(`${config[service].name}/500`)
-              .get('[class^="StatusCode"]')
+              .get('[data-e2e="status-code"]')
               .should(
                 'contain',
                 appConfig[config[service].name][variant].translations.error[500]

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -108,13 +108,13 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
                 );
                 if (mostWatchedJson.totalRecords === 1) {
                   cy.get('[data-e2e=most-watched-heading]').within(() => {
-                    cy.get('[class^="StoryPromoWrapper"]')
+                    cy.get('[data-e2e="story-promo-wrapper"]')
                       .its('length')
                       .should('eq', 1);
                   });
                 } else {
                   cy.get('[data-e2e=most-watched-heading]').within(() => {
-                    cy.get('[class^="MostWatchedOl"]')
+                    cy.get('[data-e2e="most-watched-ol"]')
                       .find('>li')
                       .its('length')
                       .should('eq', expectedNumberOfItems);

--- a/cypress/integration/pages/mostWatchedPage/tests.js
+++ b/cypress/integration/pages/mostWatchedPage/tests.js
@@ -23,15 +23,15 @@ export default ({ service, pageType, variant }) => {
           if (mostWatchedIsEnabled) {
             cy.request(mostWatchedPath).then(({ body: mostWatchedJson }) => {
               if (mostWatchedJson.totalRecords > 0) {
-                cy.get('[data-e2e=most-watched-heading]').should('exist');
+                cy.get('[data-e2e="most-watched-heading"]').should('exist');
               } else {
                 cy.log('Not enough records to show component');
 
-                cy.get('[data-e2e=most-watched-heading]').should('not.exist');
+                cy.get('[data-e2e="most-watched-heading"]').should('not.exist');
               }
             });
           } else {
-            cy.get('[data-e2e=most-watched-heading]').should('not.exist');
+            cy.get('[data-e2e="most-watched-heading"]').should('not.exist');
           }
         });
       });
@@ -64,15 +64,15 @@ export default ({ service, pageType, variant }) => {
                 mostWatchedJson.totalRecords === 1 ||
                 maxNumberofItems === '1'
               ) {
-                cy.get('[data-e2e=most-watched-heading]').within(() => {
-                  cy.get('[data-e2e=story-promo]')
+                cy.get('[data-e2e="most-watched-heading"]').within(() => {
+                  cy.get('[data-e2e="story-promo"]')
                     .its('length')
                     .should('eq', 1);
                 });
               } else {
                 cy.log(maxNumberofItems);
-                cy.get('[data-e2e=most-watched-heading]').within(() => {
-                  cy.get('[data-e2e=most-watched-ol]')
+                cy.get('[data-e2e="most-watched-heading"]').within(() => {
+                  cy.get('[data-e2e="most-watched-ol"]')
                     .find('>li')
                     .its('length')
                     .should('eq', expectedNumberOfItems);

--- a/cypress/integration/pages/mostWatchedPage/tests.js
+++ b/cypress/integration/pages/mostWatchedPage/tests.js
@@ -72,7 +72,7 @@ export default ({ service, pageType, variant }) => {
               } else {
                 cy.log(maxNumberofItems);
                 cy.get('[data-e2e=most-watched-heading]').within(() => {
-                  cy.get('[class^="MostWatchedOl"]')
+                  cy.get('[data-e2e=most-watched-ol]')
                     .find('>li')
                     .its('length')
                     .should('eq', expectedNumberOfItems);

--- a/cypress/integration/pages/onDemandRadio/tests.js
+++ b/cypress/integration/pages/onDemandRadio/tests.js
@@ -11,13 +11,13 @@ export default ({ service, pageType, variant, isAmp }) => {
   describe(`Tests for ${service} ${pageType}`, () => {
     describe('Brand image visible above 400px, not visible below 400px', () => {
       it(`Should display image on default viewport (1000x660))`, () => {
-        cy.get('div[class^="ImageContainer"]').find('img');
+        cy.get('div[data-e2e="on-demand-image"]').find('img');
       });
 
       it(`Should not display image on iphone-6 screen (375x667)`, () => {
         cy.viewport('iphone-6');
 
-        cy.get('div[class^="ImageContainer"]')
+        cy.get('div[data-e2e="on-demand-image"]')
           .find('img')
           .should('not.be.visible');
       });

--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -22,20 +22,20 @@ export const testsThatFollowSmokeTestConfigforAllPages = ({
         it('should show dropdown menu and hide scrollable menu when menu button is clicked', () => {
           cy.viewport(320, 480);
           cy.get('nav')
-            .find('div[class^="StyledScrollableNav"]')
+            .find('div[class*="StyledScrollableNav"]')
             .should('be.visible');
 
           cy.get('nav')
-            .find('ul[class^="DropdownUl"]')
+            .find('ul[class*="DropdownUl"]')
             .should('not.be.visible');
 
           cy.get('nav button').click();
 
           cy.get('nav')
-            .find('div[class^="StyledScrollableNav"]')
+            .find('div[class*="StyledScrollableNav"]')
             .should('not.be.visible');
 
-          cy.get('nav').find('ul[class^="DropdownUl"]').should('be.visible');
+          cy.get('nav').find('ul[class*="DropdownUl"]').should('be.visible');
         });
       }
     });

--- a/cypress/integration/specialFeatures/utilities/scriptSwitchingJourneyActions/index.js
+++ b/cypress/integration/specialFeatures/utilities/scriptSwitchingJourneyActions/index.js
@@ -1,13 +1,13 @@
 const clickFirstLink = () => {
-  cy.get('a[class^="Link"]').first().click();
+  cy.get('a[class*="Link"]').first().click();
 };
 
 const clickFirstMapLink = () => {
-  cy.get('div[class^="StyledMediaIndicator"]').then($styledMediaIndicators => {
+  cy.get('div[class*="StyledMediaIndicator"]').then($styledMediaIndicators => {
     if ($styledMediaIndicators.length > 0) {
-      cy.get('div[class^="StyledMediaIndicator"]')
+      cy.get('div[class*="StyledMediaIndicator"]')
         .first()
-        .parentsUntil('li[class^="StoryPromoLi"]')
+        .parentsUntil('li[class*="StoryPromoLi"]')
         .within(() => {
           clickFirstLink();
         });
@@ -29,7 +29,7 @@ export const clickHomePageLink = product => {
 };
 
 export const clickPromoLinkOnHomePage = pageType => {
-  cy.get('li[class^="StoryPromoLi"]').within(() => {
+  cy.get('li[class*="StoryPromoLi"]').within(() => {
     // If it is a MAP test, find first MAP within a StoryPromoLi item and click it
     if (pageType === 'mediaAssetPage') {
       clickFirstMapLink();

--- a/src/app/components/ErrorMain/index.jsx
+++ b/src/app/components/ErrorMain/index.jsx
@@ -87,7 +87,9 @@ const ErrorMain = ({
       }}
       margins={{ group0: true, group1: true, group2: true, group3: true }}
     >
-      <StatusCode script={script}>{statusCode}</StatusCode>
+      <StatusCode data-e2e="status-code" script={script}>
+        {statusCode}
+      </StatusCode>
       <Heading id="content" script={script} service={service} tabIndex="-1">
         {title}
       </Heading>

--- a/src/app/containers/CpsRecommendations/RecommendationsPromo/index.jsx
+++ b/src/app/containers/CpsRecommendations/RecommendationsPromo/index.jsx
@@ -33,7 +33,7 @@ const RecommendationsPromo = ({ promo, dir }) => {
       enableGelGutters
       dir={dir}
     >
-      <StyledStoryPromoWrapper>
+      <StyledStoryPromoWrapper data-e2e="story-promo-wrapper">
         <StoryPromo
           item={promo}
           dir={dir}

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromoList/index.jsx
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromoList/index.jsx
@@ -24,6 +24,7 @@ const MostWatchedOl = styled.ol`
 
 MostWatchedOl.defaultProps = {
   role: 'list',
+  'data-e2e': 'most-watched-ol',
 };
 
 const RelatedContentPromoList = ({ promoItems, dir, isMediaContent }) => {

--- a/src/app/containers/OnDemandImage/index.jsx
+++ b/src/app/containers/OnDemandImage/index.jsx
@@ -41,7 +41,7 @@ const OnDemandImage = ({ imageUrl, dir }) => {
   const sizes = '(min-width: 1008px) 228px, 30vw';
 
   return (
-    <ImageContainer dir={dir}>
+    <ImageContainer data-e2e="on-demand-image" dir={dir}>
       <ImageWithPlaceholder
         src={src}
         alt={alt}


### PR DESCRIPTION
**Overall change:**
- Fixing the e2e tests following the emotion migration for AMP and Canonical across:

👌 : _(no changes were needed)_
- [x] Articles
- [x] ErrorPage404 
- [x] FIX 👌
- [x] frontPage 👌
- [x] idxPage 👌  
- [x] liveRadio 👌 
- [x] mediaAssetPage
- [x] mostReadPage 👌 
- [x] mostWatchedPage  
- [x] onDemandRadio 👌 
- [x] onDemandTV 👌 
- [x] photoGalleryPage 👌
- [x] storyPage👌
- [x] cookieBanner 👌
- [x] scriptSwitching 👌
--
- [x] Migrate remaining Simorgh component class selectors to use `data-e2e`

**Code changes:**
- I have migrated class selectors to `data-e2e` selectors where it is a Simorgh component being selected. _[...in progress]_

Emotion has tweaked the ordering of classnames, which are often used in e2es for element selection.

styled-components:
```html
<div class="StyledPlaceholder-sc-11nyhtu-0 dDNqOp">
```

emotion:
```html
<div class="css-1c6mers-StyledVideoContainer eveuav30">
```

- Previously we used `[class^=value]` a lot, as we were selecting class names that **begin** with 'StyledXyZ-', whereas after the emotion migration - the classname **begins** with the hash, ending with '-StyledXyZ'. I have migrated these selectors to `[class*=value]` - selecting elements whose class name contains the value substring _anywhere_.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
