### PR TITLE
Emotion - fix integration tests

### DIFF
--- a/src/app/components/ErrorMain/index.jsx
+++ b/src/app/components/ErrorMain/index.jsx
@@ -53,7 +53,7 @@ const ErrorMain = ({
   service,
 }) => (
   <StyledGelPageGrid
-    forwardedAs="main"
+    as="main"
     role="main"
     dir={dir}
     columns={{

--- a/src/app/components/Grid/README.md
+++ b/src/app/components/Grid/README.md
@@ -4,5 +4,5 @@
 
 When using an extended Grid component, e.g. `FrontPageGrid`, you can change the element that's rendered by using the `as` prop.
 e.g.
-`<Grid as="main" role="main ....>...</Grid>`
-`<FrontPageGrid as="main" role="main ....>...</FrontPageGrid>`
+`<Grid as="main" role="main>...</Grid>`
+`<FrontPageGrid as="main" role="main>...</FrontPageGrid>`

--- a/src/app/components/Grid/README.md
+++ b/src/app/components/Grid/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-When using one of the extended Grid components, e.g. `FrontPageGrid`, if you wish to extend it using the `as` prop, following the Emotion migration you can now just pass the `as` prop to that component: emotion does not support `forwardedAs`.
+When using an extended Grid component, e.g. `FrontPageGrid`, you can change the element that's rendered by using the `as` prop.
 e.g.
 `<Grid as="main" role="main ....>...</Grid>`
 `<FrontPageGrid as="main" role="main ....>...</FrontPageGrid>`

--- a/src/app/components/Grid/README.md
+++ b/src/app/components/Grid/README.md
@@ -2,8 +2,7 @@
 
 ## Usage
 
-When using one of the extended Grid components, e.g. `FrontPageGrid`, if you wish to extend it using the `as` prop, you'll need to use `forwardedAs`. This prop enables you to pass down the element down further than one level.
-
+When using one of the extended Grid components, e.g. `FrontPageGrid`, if you wish to extend it using the `as` prop, following the Emotion migration you can now just pass the `as` prop to that component, as emotion does not support `forwardedAs`.
 e.g.
-`<Grid forwardedAs="main" role="main ....>...</Grid>`
-`<FrontPageGrid forwardedAs="main" role="main ....>...</FrontPageGrid>`
+`<Grid as="main" role="main ....>...</Grid>`
+`<FrontPageGrid as="main" role="main ....>...</FrontPageGrid>`

--- a/src/app/components/Grid/README.md
+++ b/src/app/components/Grid/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-When using one of the extended Grid components, e.g. `FrontPageGrid`, if you wish to extend it using the `as` prop, following the Emotion migration you can now just pass the `as` prop to that component, as emotion does not support `forwardedAs`.
+When using one of the extended Grid components, e.g. `FrontPageGrid`, if you wish to extend it using the `as` prop, following the Emotion migration you can now just pass the `as` prop to that component: emotion does not support `forwardedAs`.
 e.g.
 `<Grid as="main" role="main ....>...</Grid>`
 `<FrontPageGrid as="main" role="main ....>...</FrontPageGrid>`

--- a/src/app/components/Grid/index.stories.jsx
+++ b/src/app/components/Grid/index.stories.jsx
@@ -37,7 +37,7 @@ storiesOf('Components|Grid', module)
   })
   .add('Grid as Main', () => {
     return (
-      <Grid forwardedAs="main" role="main" {...outerGridProps}>
+      <Grid as="main" role="main" {...outerGridProps}>
         <Grid {...gridItemProps}>
           <p>Item with Main element as the parent grid</p>
         </Grid>

--- a/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
@@ -82,7 +82,7 @@ const LiveRadioPage = ({ pageData }) => {
       <LinkedData type="RadioChannel" seoTitle={name} />
 
       <StyledGelPageGrid
-        forwardedAs="main"
+        as="main"
         role="main"
         dir={dir}
         columns={{

--- a/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
+++ b/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
@@ -105,7 +105,7 @@ const OnDemandRadioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
         openGraphType="website"
       />
       <StyledGelPageGrid
-        forwardedAs="main"
+        as="main"
         role="main"
         dir={dir}
         columns={getGroups(6, 6, 6, 6, 8, 20)}

--- a/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
+++ b/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
@@ -143,7 +143,7 @@ const OnDemandTvPage = ({ pageData, mediaIsAvailable, MediaError }) => {
         }
       />
       <StyledGelPageGrid
-        forwardedAs="main"
+        as="main"
         role="main"
         dir={dir}
         columns={getGroups(6, 6, 6, 6, 8, 20)}

--- a/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
@@ -169,7 +169,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"Image captio
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="group of residents"
-  class="StyledImg-sc-7vx2mr-0 dQLeqZ"
+  class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg"
   srcset="https://ichef.bbci.co.uk/news/240/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg 624w, https://ichef.bbci.co.uk/news/800/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg 800w"
   width="976"

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -183,7 +183,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"توضیح �
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="قهوه"
-  class="StyledImg-sc-7vx2mr-0 dQLeqZ"
+  class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg"
   srcset="https://ichef.bbci.co.uk/news/240/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg 624w, https://ichef.bbci.co.uk/news/800/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg 800w"
   width="1024"

--- a/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
@@ -78,7 +78,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"Image captio
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="Map of France showing Paris and Cognac"
-  class="StyledImg-sc-7vx2mr-0 dQLeqZ"
+  class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg"
   srcset="https://ichef.bbci.co.uk/news/240/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg 624w"
   width="624"

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -315,7 +315,7 @@ exports[`Canonical Feature Index page Story Promo Headline should match text 1`]
 exports[`Canonical Feature Index page Story Promo Image should match image 1`] = `
 <img
   alt="CAN 2019 : le Sénégal en huitième de finale"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/4826/production/_107707481_equipesenegal.jpg"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/4826/production/_107707481_equipesenegal.jpg 660w"

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -307,7 +307,7 @@ exports[`Canonical Feature Index page Story Promo Headline should match text 1`]
 exports[`Canonical Feature Index page Story Promo Image should match image 1`] = `
 <img
   alt="بل گیٹس"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/B04F/production/_112753154_bill.jpg"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/B04F/production/_112753154_bill.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/B04F/production/_112753154_bill.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/B04F/production/_112753154_bill.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/B04F/production/_112753154_bill.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/B04F/production/_112753154_bill.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/B04F/production/_112753154_bill.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/B04F/production/_112753154_bill.jpg 660w"

--- a/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
@@ -358,7 +358,7 @@ exports[`Story Promo Headline should match text 1`] = `"المجلس العسك�
 exports[`Story Promo Image should match image 1`] = `
 <img
   alt="متظاهرون يحتفلون بالتوصل لاتفاق بين المجلس العسكري والمتظاهرين"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/17FC4/production/_107844289_055122086-1.jpg 660w"

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -310,7 +310,7 @@ exports[`Story Promo Headline should match text 1`] = `"AS E DE HAPPEN Senators 
 exports[`Story Promo Image should match image 1`] = `
 <img
   alt="Senator Ahmad Lawan and Ali Ndume"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/16D8E/production/_107328539_ninthnationalassemblypidgin_senate_reps_1080.jpg 660w"

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
@@ -349,7 +349,7 @@ exports[`Canonical persian/afghanistan IDX page Story Promo Headline should matc
 exports[`Canonical persian/afghanistan IDX page Story Promo Image should match image 1`] = `
 <img
   alt="هبت الله آخوندزاده"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 320w, https://ichef.bbci.co.uk/news/624/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg 624w"

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
@@ -304,7 +304,7 @@ exports[`Canonical ukrainian/ukraine_in_russian IDX page Story Promo Headline sh
 exports[`Canonical ukrainian/ukraine_in_russian IDX page Story Promo Image should match image 1`] = `
 <img
   alt="Чоловік з келихом"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
   src="https://ichef.bbci.co.uk/news/660/cpsprodpb/DE34/production/_111648865_1stimage.png"
   srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/DE34/production/_111648865_1stimage.png 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/DE34/production/_111648865_1stimage.png 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/DE34/production/_111648865_1stimage.png 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/DE34/production/_111648865_1stimage.png 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/DE34/production/_111648865_1stimage.png 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/DE34/production/_111648865_1stimage.png 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/DE34/production/_111648865_1stimage.png 660w"

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -152,10 +152,10 @@ Object {
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `
 <div
-  class="LoadingImageWrapper-fuo2ed-0 gyUHhp"
+  class="css-z3isei-LoadingImageWrapper eqo19v60"
 >
   <div
-    class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+    class="css-12oj33f-ImagePlaceholder e1whu0"
   />
 </div>
 `;
@@ -360,7 +360,7 @@ exports[`Canonical Media Asset Page outer iframe has z-index of 1 1`] = `
 <iframe
   allow="autoplay; fullscreen"
   allowfullscreen=""
-  class="StyledIframe-fuo2ed-1 lfcupi"
+  class="css-4k1mri-StyledIframe eqo19v61"
   scrolling="no"
   src="https://test.bbc.com/ws/av-embeds/legacy/arabic/worldnews/2015/11/151120_t_arabic_av/17694217/ar"
   title="مشغل وسائط"

--- a/src/integration/pages/mediaAssetPage/canonicalTests.js
+++ b/src/integration/pages/mediaAssetPage/canonicalTests.js
@@ -11,7 +11,7 @@ export default service => {
 
   it('I can see the placeholder loading image', () => {
     const loadingImageWrapper = document.querySelector(
-      "div[class^='LoadingImageWrapper']",
+      "div[class*='LoadingImageWrapper']",
     );
     expect(loadingImageWrapper).toBeInTheDocument();
     expect(loadingImageWrapper).toMatchSnapshot();

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -180,10 +180,10 @@ Object {
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `
 <div
-  class="LoadingImageWrapper-fuo2ed-0 gyUHhp"
+  class="css-z3isei-LoadingImageWrapper eqo19v60"
 >
   <div
-    class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+    class="css-12oj33f-ImagePlaceholder e1whu0"
   />
 </div>
 `;
@@ -388,7 +388,7 @@ exports[`Canonical Media Asset Page outer iframe has z-index of 1 1`] = `
 <iframe
   allow="autoplay; fullscreen"
   allowfullscreen=""
-  class="StyledIframe-fuo2ed-1 lfcupi"
+  class="css-4k1mri-StyledIframe eqo19v61"
   scrolling="no"
   src="https://test.bbc.com/ws/av-embeds/cps/persian/iran-23231114/p01lmkjk/fa"
   title="پخش صدا و تصویر"

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -135,10 +135,10 @@ exports[`Canonical Media Asset Page I can see a bulleted list item with link: <M
 
 exports[`Canonical Media Asset Page I can see the placeholder loading image 1`] = `
 <div
-  class="LoadingImageWrapper-fuo2ed-0 gyUHhp"
+  class="css-z3isei-LoadingImageWrapper eqo19v60"
 >
   <div
-    class="ImagePlaceholder-sc-11u25v2-0 fNqlUz"
+    class="css-12oj33f-ImagePlaceholder e1whu0"
   />
 </div>
 `;
@@ -371,7 +371,7 @@ exports[`Canonical Media Asset Page outer iframe has z-index of 1 1`] = `
 <iframe
   allow="autoplay; fullscreen"
   allowfullscreen=""
-  class="StyledIframe-fuo2ed-1 lfcupi"
+  class="css-4k1mri-StyledIframe eqo19v61"
   scrolling="no"
   src="https://test.bbc.com/ws/av-embeds/cps/pidgin/23248703/p01kx42v/pcm"
   title="Media player"

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -175,7 +175,7 @@ exports[`Canonical Photo Gallery Page Image Caption should match text 1`] = `"Pi
 
 exports[`Canonical Photo Gallery Page Image should match snapshot 1`] = `
 <noscript>
-  &lt;img srcSet="https://ichef.bbci.co.uk/news/240/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 480w, https://ichef.bbci.co.uk/news/549/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 549w" alt="Tenista de 1904" src="https://ichef.bbci.co.uk/news/640/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg" width="549" class="StyledImg-sc-7vx2mr-0 dQLeqZ"/&gt;
+  &lt;img srcSet="https://ichef.bbci.co.uk/news/240/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 480w, https://ichef.bbci.co.uk/news/549/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg 549w" alt="Tenista de 1904" src="https://ichef.bbci.co.uk/news/640/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg" width="549" class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"/&gt;
 </noscript>
 `;
 

--- a/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Canonical Story Page Includes I can see a fallback image when there are disallowed scripts 1`] = `
 <img
   alt="Map: St. Albans"
-  class="StyledImg-sc-7vx2mr-0 hIxkbt"
+  class="css-13lcmnl-StyledImg e1enwo3v0"
   id="include-1"
   src="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816"
   srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640 640w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816 816w"

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -134,7 +134,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Сүрөт
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <img
   alt="social media"
-  class="StyledImg-sc-7vx2mr-0 dQLeqZ"
+  class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/11D53/test/_63734037_socialmedia.jpg"
   srcset="https://ichef.bbci.co.uk/news/240/cpsdevpb/11D53/test/_63734037_socialmedia.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsdevpb/11D53/test/_63734037_socialmedia.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsdevpb/11D53/test/_63734037_socialmedia.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsdevpb/11D53/test/_63734037_socialmedia.jpg 624w"
   width="624"

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -182,7 +182,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Pie de fot
 
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <noscript>
-  &lt;img srcSet="https://ichef.bbci.co.uk/news/240/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 624w, https://ichef.bbci.co.uk/news/800/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 800w" alt="A person holding a union jack umbrella in front of Big Ben" src="https://ichef.bbci.co.uk/news/640/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg" width="976" class="StyledImg-sc-7vx2mr-0 dQLeqZ"/&gt;
+  &lt;img srcSet="https://ichef.bbci.co.uk/news/240/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 320w, https://ichef.bbci.co.uk/news/480/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 480w, https://ichef.bbci.co.uk/news/624/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 624w, https://ichef.bbci.co.uk/news/800/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg 800w" alt="A person holding a union jack umbrella in front of Big Ben" src="https://ichef.bbci.co.uk/news/640/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg" width="976" class="css-1vsigzm-StyledImg-fadeIn e1enwo3v0"/&gt;
 </noscript>
 `;
 


### PR DESCRIPTION
**Overall change:**
- Updating integration snapshots
- Fixing remaining instances of using `forwardedAs` prop (incompatible with styled-components)
- Amending class selectors where applicable. Details of how the old class selectors worked and how they needed changing are in the e2e PR https://github.com/bbc/simorgh/pull/8181

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
