### PR TITLE
Override sampleRate with toggles value

### DIFF
--- a/envConfig/live.env
+++ b/envConfig/live.env
@@ -22,4 +22,4 @@ AWS_EMF_ENVIRONMENT=EC2
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-prod-4591.cloudfunctions.net/report-endpoint
-SIMORGH_WEBVITALS_SAMPLING_RATE=5
+SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=20

--- a/envConfig/local.env
+++ b/envConfig/local.env
@@ -22,5 +22,5 @@ AWS_EMF_ENVIRONMENT=Local
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net/report-endpoint
-SIMORGH_WEBVITALS_SAMPLING_RATE=5
+SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=100
 

--- a/envConfig/test.env
+++ b/envConfig/test.env
@@ -22,5 +22,4 @@ AWS_EMF_ENVIRONMENT=EC2
 
 ## WebVitals Reporting
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net/report-endpoint
-SIMORGH_WEBVITALS_SAMPLING_RATE=100
-
+SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=100

--- a/src/app/containers/WebVitals/index.jsx
+++ b/src/app/containers/WebVitals/index.jsx
@@ -12,8 +12,6 @@ const WebVitals = () => {
   const { pageType } = useContext(RequestContext);
   const { enabled, value: toggleSampleRate } = useToggle('webVitalsMonitoring');
 
-  // console.log(sampleRate);
-
   // Checks if readers have opted into performance tracking and if the feature toggle is enabled
   const isWebVitalsEnabled = personalisationEnabled && enabled;
 

--- a/src/app/containers/WebVitals/index.jsx
+++ b/src/app/containers/WebVitals/index.jsx
@@ -15,9 +15,8 @@ const WebVitals = () => {
   // Checks if readers have opted into performance tracking and if the feature toggle is enabled
   const isWebVitalsEnabled = personalisationEnabled && enabled;
 
-  const sampleRate = parseInt(
+  const sampleRate = Number(
     toggleSampleRate || process.env.SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE,
-    10,
   );
 
   const webVitalsConfig = {

--- a/src/app/containers/WebVitals/index.jsx
+++ b/src/app/containers/WebVitals/index.jsx
@@ -10,15 +10,22 @@ import { RequestContext } from '#contexts/RequestContext';
 const WebVitals = () => {
   const { personalisationEnabled } = useContext(UserContext);
   const { pageType } = useContext(RequestContext);
-  const { enabled } = useToggle('webVitalsMonitoring');
+  const { enabled, value: toggleSampleRate } = useToggle('webVitalsMonitoring');
+
+  // console.log(sampleRate);
 
   // Checks if readers have opted into performance tracking and if the feature toggle is enabled
   const isWebVitalsEnabled = personalisationEnabled && enabled;
 
+  const sampleRate = parseInt(
+    toggleSampleRate || process.env.SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE,
+    10,
+  );
+
   const webVitalsConfig = {
     enabled: isWebVitalsEnabled,
     reportingEndpoint: process.env.SIMORGH_WEBVITALS_REPORTING_ENDPOINT,
-    sampleRate: process.env.SIMORGH_WEBVITALS_SAMPLING_RATE,
+    sampleRate,
     reportParams: { pageType },
   };
 

--- a/src/app/containers/WebVitals/index.test.jsx
+++ b/src/app/containers/WebVitals/index.test.jsx
@@ -20,11 +20,12 @@ const WebVitalsWithContext = ({
   featureToggle,
   personalisationEnabled,
   pageType,
+  sampleRate,
 }) => (
   <ToggleContext.Provider
     value={{
       toggleState: {
-        webVitalsMonitoring: { enabled: featureToggle },
+        webVitalsMonitoring: { enabled: featureToggle, value: sampleRate },
       },
     }}
   >
@@ -44,20 +45,22 @@ describe('WebVitals', () => {
   describe('calls the useWebVitals hook', () => {
     beforeEach(() => {
       process.env.SIMORGH_WEBVITALS_REPORTING_ENDPOINT = 'endpoint';
-      process.env.SIMORGH_WEBVITALS_SAMPLING_RATE = '5';
+      process.env.SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE = 20;
     });
 
-    afterAll(() => {
+    afterEach(() => {
+      jest.clearAllMocks();
       delete process.env.SIMORGH_WEBVITALS_REPORTING_ENDPOINT;
-      delete process.env.SIMORGH_WEBVITALS_SAMPLING_RATE;
+      delete process.env.SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE;
     });
 
     it.each`
-      testDescription                                | testConfig                                                                  | webVitalsParams
-      ${'feature toggle and personalisation off'}    | ${{ featureToggle: false, personalisationEnabled: false, pageType: 'STY' }} | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: '5' }}
-      ${'feature toggle on and personalisation off'} | ${{ featureToggle: true, personalisationEnabled: false, pageType: 'STY' }}  | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: '5' }}
-      ${'feature toggle off and personalisation on'} | ${{ featureToggle: false, personalisationEnabled: true, pageType: 'STY' }}  | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: '5' }}
-      ${'feature toggle and personalisation on'}     | ${{ featureToggle: true, personalisationEnabled: true, pageType: 'STY' }}   | ${{ enabled: true, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: '5' }}
+      testDescription                                | testConfig                                                                                | webVitalsParams
+      ${'feature toggle and personalisation off'}    | ${{ featureToggle: false, personalisationEnabled: false, pageType: 'STY' }}               | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: 20 }}
+      ${'feature toggle on and personalisation off'} | ${{ featureToggle: true, personalisationEnabled: false, pageType: 'STY' }}                | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: 20 }}
+      ${'feature toggle off and personalisation on'} | ${{ featureToggle: false, personalisationEnabled: true, pageType: 'STY' }}                | ${{ enabled: false, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: 20 }}
+      ${'feature toggle and personalisation on'}     | ${{ featureToggle: true, personalisationEnabled: true, pageType: 'STY' }}                 | ${{ enabled: true, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: 20 }}
+      ${'sample rate override'}                      | ${{ featureToggle: true, personalisationEnabled: true, pageType: 'STY', sampleRate: 65 }} | ${{ enabled: true, reportParams: { pageType: 'STY' }, reportingEndpoint: 'endpoint', sampleRate: 65 }}
     `(`$testDescription`, ({ testConfig, webVitalsParams }) => {
       render(<WebVitalsWithContext {...testConfig} />);
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
This PR ups the default sample rate and allow it to be overridden with the value from the feature toggle

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
