### PR TITLE
Add GH Actions for unit and integration tests

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,0 +1,18 @@
+name: Auto Cancel Previous CI Runs
+on:
+  push:
+    branches:
+      - '**'
+      - '!latest'
+  pull_request:
+    branches:
+      - '**'
+      - '!latest'
+  jobs:
+    cleanup-runs:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: rokroskar/workflow-run-cleanup-action@master
+          env:
+            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      if: "github.ref != 'refs/heads/latest'"

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -8,11 +8,11 @@ on:
     branches:
       - '**'
       - '!latest'
-  jobs:
-    cleanup-runs:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: rokroskar/workflow-run-cleanup-action@master
-          env:
-            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      if: "github.ref != 'refs/heads/latest'"
+jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    if: "github.ref != 'refs/heads/latest'"

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -1,5 +1,8 @@
 name: Simorgh CI - E2E Tests
-on: [push]
+on:
+  push:
+    branches:
+      - '!latest'
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -2,6 +2,11 @@ name: Simorgh CI - E2E Tests
 on:
   push:
     branches:
+      - '**'
+      - '!latest'
+  pull_request:
+    branches:
+      - '**'
       - '!latest'
 jobs:
   cypress-run:

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -16,3 +16,5 @@ jobs:
           CI: true
           LOG_LEVEL: 'error'
           CYPRESS_SKIP_EU: true
+          CYPRESS_SMOKE: true
+          CYPRESS_APP_ENV: 'local'

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -9,13 +9,6 @@ on:
       - '**'
       - '!latest'
 jobs:
-  env:
-    CI: true
-    LOG_LEVEL: 'error'
-    CYPRESS_SKIP_EU: true
-    CYPRESS_SMOKE: true
-    CYPRESS_APP_ENV: 'local'
-
   cypress-run:
     runs-on: ubuntu-latest
     steps:
@@ -26,3 +19,10 @@ jobs:
         with:
           build: npm run build
           start: npm start
+
+  env:
+    CI: true
+    LOG_LEVEL: 'error'
+    CYPRESS_SKIP_EU: true
+    CYPRESS_SMOKE: true
+    CYPRESS_APP_ENV: 'local'

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -9,6 +9,13 @@ on:
       - '**'
       - '!latest'
 jobs:
+  env:
+    CI: true
+    LOG_LEVEL: 'error'
+    CYPRESS_SKIP_EU: true
+    CYPRESS_SMOKE: true
+    CYPRESS_APP_ENV: 'local'
+
   cypress-run:
     runs-on: ubuntu-latest
     steps:
@@ -19,10 +26,3 @@ jobs:
         with:
           build: npm run build
           start: npm start
-
-        env:
-          CI: true
-          LOG_LEVEL: 'error'
-          CYPRESS_SKIP_EU: true
-          CYPRESS_SMOKE: true
-          CYPRESS_APP_ENV: 'local'

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -1,0 +1,18 @@
+name: Simorgh CI - E2E Tests
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          build: npm run build
+          start: npm start
+
+        env:
+          CI: true
+          LOG_LEVEL: 'error'
+          CYPRESS_SKIP_EU: true

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -11,6 +11,13 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    env:
+      CI: true
+      LOG_LEVEL: 'error'
+      CYPRESS_SKIP_EU: true
+      CYPRESS_SMOKE: true
+      CYPRESS_APP_ENV: 'local'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -19,10 +26,3 @@ jobs:
         with:
           build: npm run build
           start: npm start
-
-  env:
-    CI: true
-    LOG_LEVEL: 'error'
-    CYPRESS_SKIP_EU: true
-    CYPRESS_SMOKE: true
-    CYPRESS_APP_ENV: 'local'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node Modules
         run: npm ci
       - name: Integration Tests
-        run: npm run test:integration
+        run: npm run start && npm run test:integration:ci
         env:
           CI: true
           LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+    env:
+      CI: true
+      LOG_LEVEL: 'error'
+
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -24,6 +28,3 @@ jobs:
         run: npm ci
       - name: Integration Tests
         run: npm run test:integration -- --ci
-  env:
-    CI: true
-    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -2,6 +2,11 @@ name: Simorgh CI - Integration Tests
 on:
   push:
     branches:
+      - '**'
+      - '!latest'
+  pull_request:
+    branches:
+      - '**'
       - '!latest'
 jobs:
   build:

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -14,6 +14,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Node Modules
         run: npm ci
+      - name: Build Simorgh
+        run: npm run build
       - name: Integration Tests
         run: npm run start && npm run test:integration:ci
         env:

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -9,6 +9,10 @@ on:
       - '**'
       - '!latest'
 jobs:
+  env:
+    CI: true
+    LOG_LEVEL: 'error'
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -24,6 +28,3 @@ jobs:
         run: npm ci
       - name: Integration Tests
         run: npm run test:integration -- --ci
-        env:
-          CI: true
-          LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -14,10 +14,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Node Modules
         run: npm ci
-      - name: Build Simorgh
-        run: npm run build
       - name: Integration Tests
-        run: npm run start && npm run test:integration:ci
+        run: npm run test:integration -- --ci
         env:
           CI: true
           LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Node Modules
-        run: npm ci
+        run: |
+          npm ci
+          npm run build
       - name: Integration Tests
         run: npm run test:integration:ci
         env:

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -13,11 +13,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Node Modules
-        run: |
-          npm ci
-          npm run build
+        run: npm ci
       - name: Integration Tests
-        run: npm run test:integration:ci
+        run: npm run test:integration
         env:
           CI: true
           LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -9,10 +9,6 @@ on:
       - '**'
       - '!latest'
 jobs:
-  env:
-    CI: true
-    LOG_LEVEL: 'error'
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -28,3 +24,6 @@ jobs:
         run: npm ci
       - name: Integration Tests
         run: npm run test:integration -- --ci
+  env:
+    CI: true
+    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -1,5 +1,8 @@
 name: Simorgh CI - Integration Tests
-on: [push]
+on:
+  push:
+    branches:
+      - '!latest'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -1,0 +1,21 @@
+name: Simorgh CI - Integration Tests
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Node Modules
+        run: npm ci
+      - name: Integration Tests
+        run: npm run test:integration:ci
+        env:
+          CI: true
+          LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -1,4 +1,4 @@
-name: Simorgh CI - Miscellaneous Checks
+name: Simorgh CI - Licences, Dependencies, Lint, Chromatic UI
 on:
   push:
     branches:

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -16,7 +16,6 @@ jobs:
         node-version: [12.x]
     env:
       CI: true
-      LOG_LEVEL: 'error'
 
     steps:
       - uses: actions/checkout@v1
@@ -38,4 +37,4 @@ jobs:
         run: npm run test:lint
 
       - name: Chromatic UI Tests # we should only run these one, they currently run on codebuild
-        run: # npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive
+        run: echo "run chromatic QA tests"

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -9,10 +9,6 @@ on:
       - '**'
       - '!latest'
 jobs:
-  env:
-    CI: true
-    LOG_LEVEL: 'error'
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -39,3 +35,7 @@ jobs:
 
       - name: Chromatic UI Tests # we should only run these one, they currently run on codebuild
         run: # npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive
+
+  env:
+    CI: true
+    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -24,9 +24,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install & Build Simorgh
-        run: |
-          npm ci
-          npm run build
-      - name: Unit Tests
-        run: npm run test:unit
+
+      - name: Install Node Modules
+        run: npm ci
+
+      - name: Apache License Checker
+        run: npx apache2-license-checker
+
+      - name: Duplicate Dependency Checker
+        run: npm run test:dependencies
+
+      - name: Linting
+        run: npm run test:lint
+
+      - name: Chromatic UI Tests # we should only run these one, they currently run on codebuild
+        run: # npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+    env:
+      CI: true
+      LOG_LEVEL: 'error'
+
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -35,7 +39,3 @@ jobs:
 
       - name: Chromatic UI Tests # we should only run these one, they currently run on codebuild
         run: # npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive
-
-  env:
-    CI: true
-    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -1,4 +1,4 @@
-name: Simorgh CI - Unit Tests
+name: Simorgh CI - Miscellaneous Checks
 on:
   push:
     branches:

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Simorgh CI - Integration Tests
+name: Simorgh CI - Unit Tests
 on: [push]
 jobs:
   build:
@@ -12,8 +12,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Node Modules
-        run: npm ci
+      - name: Install & Build Simorgh
+        run: |
+          npm ci
+          npm run build
       - name: Unit Tests
         run: npm run test:unit
         env:

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           npm ci
           npm run build
       - name: Unit Tests
-        run: npm run test:unit -- --changedSince=latest
+        run: npm run test:unit
         env:
           CI: true
           LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           npm ci
           npm run build
       - name: Unit Tests
-        run: npm run test:unit
+        run: npm run test:unit -- --changedSince=latest
         env:
           CI: true
           LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -9,10 +9,6 @@ on:
       - '**'
       - '!latest'
 jobs:
-  env:
-    CI: true
-    LOG_LEVEL: 'error'
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -30,3 +26,7 @@ jobs:
           npm run build
       - name: Unit Tests
         run: npm run test:unit
+
+  env:
+    CI: true
+    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+    env:
+      CI: true
+      LOG_LEVEL: 'error'
+
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -26,7 +30,3 @@ jobs:
           npm run build
       - name: Unit Tests
         run: npm run test:unit
-
-  env:
-    CI: true
-    LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -1,5 +1,8 @@
 name: Simorgh CI - Unit Tests
-on: [push]
+on:
+  push:
+    branches:
+      - '!latest'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -1,0 +1,21 @@
+name: Simorgh CI - Integration Tests
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Node Modules
+        run: npm ci
+      - name: Unit Tests
+        run: npm run test:unit
+        env:
+          CI: true
+          LOG_LEVEL: 'error'

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -2,6 +2,11 @@ name: Simorgh CI - Unit Tests
 on:
   push:
     branches:
+      - '**'
+      - '!latest'
+  pull_request:
+    branches:
+      - '**'
       - '!latest'
 jobs:
   build:


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Adds a GH Action for running unit tests
- Adds a GH Action for running integration tests
- Adds a GH Action for running E2E tests with Cypress
- Adds a GH Action for cancelling previously running builds if a new one starts
- Adds a GH Action for running, licence checker, dependencies checker and chromatic QA (Chromatic QA is disabled now though as CodeBuild runs this for now)

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
