### PR TITLE
Emotion unit test fixes - /routes

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.test.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.test.js
@@ -10,9 +10,11 @@ import mapJson from '#data/pidgin/cpsAssets/media-23256549.json';
 describe('getInitialData', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    delete process.env.SIMORGH_APP_ENV;
   });
 
   it('should return essential data for a page to render', async () => {
+    process.env.SIMORGH_APP_ENV = 'local';
     fetchMock.mock(
       'http://localhost/mock-map-path.json',
       JSON.stringify(mapJson),

--- a/src/app/routes/index.test.jsx
+++ b/src/app/routes/index.test.jsx
@@ -58,6 +58,7 @@ afterEach(() => {
   jest.clearAllMocks();
   fetchMock.restore();
   window.dotcom = undefined;
+  delete process.env.SIMORGH_APP_ENV;
 });
 
 const getMatchingRoute = pathname =>
@@ -213,6 +214,7 @@ it('should route to and render a front page', async () => {
 });
 
 it('should route to and render a skeleton most watched page', async () => {
+  process.env.SIMORGH_APP_ENV = 'local';
   const pathname = '/pidgin/media/video';
   fetchMock.mock('http://localhost/pidgin/mostwatched.json', mostWatchedData);
 

--- a/src/app/routes/index.test.jsx
+++ b/src/app/routes/index.test.jsx
@@ -236,6 +236,7 @@ it('should route to and render a skeleton most watched page', async () => {
 });
 
 it('should route to and render a media asset page', async () => {
+  process.env.SIMORGH_APP_ENV = 'local';
   const pathname = '/yoruba/media-23256797';
   fetchMock.mock(`http://localhost${pathname}.json`, mediaAssetPageJson);
   fetchMock.mock('http://localhost/yoruba/mostwatched.json', mostWatchedData);
@@ -259,6 +260,7 @@ it('should route to and render a media asset page', async () => {
 });
 
 it('should route to and render a media asset page', async () => {
+  process.env.SIMORGH_APP_ENV = 'local';
   const pathname = '/yoruba/media-23256797';
   fetchMock.mock(`http://localhost${pathname}.json`, mediaAssetPageJson);
   fetchMock.mock('http://localhost/yoruba/mostwatched.json', mostWatchedData);
@@ -284,6 +286,7 @@ it('should route to and render a media asset page', async () => {
 });
 
 it('should route to and render a legacy media asset page', async () => {
+  process.env.SIMORGH_APP_ENV = 'local';
   const pathname = '/azeri/multimedia/2012/09/120919_georgia_prison_video';
   fetchMock.mock(`http://localhost${pathname}.json`, legacyMediaAssetPage);
   fetchMock.mock('http://localhost/azeri/mostwatched.json', mostWatchedData);

--- a/src/app/routes/mostWatched/getInitialData/index.js
+++ b/src/app/routes/mostWatched/getInitialData/index.js
@@ -8,8 +8,6 @@ export default async ({ service, variant, pageType, toggles, path }) => {
     ? 'live'
     : process.env.SIMORGH_APP_ENV;
 
-  // process.env.SIMORGH_APP_ENV = undefined
-
   try {
     const mostWatchedUrl = getMostWatchedUrl({ service, variant, env });
     const { json, status } = await fetchPageData({

--- a/src/app/routes/mostWatched/getInitialData/index.js
+++ b/src/app/routes/mostWatched/getInitialData/index.js
@@ -8,8 +8,6 @@ export default async ({ service, variant, pageType, toggles, path }) => {
     ? 'live'
     : process.env.SIMORGH_APP_ENV;
 
-  console.log(`env is dis: ${process.env.SIMORGH_APP_ENV}`);
-
   try {
     const mostWatchedUrl = getMostWatchedUrl({ service, variant, env });
     const { json, status } = await fetchPageData({

--- a/src/app/routes/mostWatched/getInitialData/index.js
+++ b/src/app/routes/mostWatched/getInitialData/index.js
@@ -8,6 +8,8 @@ export default async ({ service, variant, pageType, toggles, path }) => {
     ? 'live'
     : process.env.SIMORGH_APP_ENV;
 
+  console.log(`env is dis: ${process.env.SIMORGH_APP_ENV}`);
+
   try {
     const mostWatchedUrl = getMostWatchedUrl({ service, variant, env });
     const { json, status } = await fetchPageData({

--- a/src/app/routes/mostWatched/getInitialData/index.js
+++ b/src/app/routes/mostWatched/getInitialData/index.js
@@ -8,6 +8,8 @@ export default async ({ service, variant, pageType, toggles, path }) => {
     ? 'live'
     : process.env.SIMORGH_APP_ENV;
 
+  // process.env.SIMORGH_APP_ENV = undefined
+
   try {
     const mostWatchedUrl = getMostWatchedUrl({ service, variant, env });
     const { json, status } = await fetchPageData({


### PR DESCRIPTION
### Remade this PR to no longer branch from `emotion-ssr-all` so that it can cleanly go into latest https://github.com/bbc/simorgh/pull/8246

**Problem**
Test fail within src/app/routes
>`it(should route to and render a skeleton most watched page')`
> Error: Unmatched GET to http://localhost/pidgin/mostwatched.json.json

**Overall change:**
- As `process.env.SIMORGH_APP_ENV` is 'undefined' in the test - .json was being added twice to the path being used by  `mostWatched/getInitialData`:
- Second .json is added by `getExtension` within `app/lib/utilities/getMostWatchedUrl` 

**Code changes:**
- Explicitly set `process.env.SIMORGH_APP_ENV` within the test to 'local'


**Notes**
Why da fuq does this pass on latest?

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
