### PR TITLE
Int tests flag only run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:unit": "test -z $CI && jest --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\" || jest --ci --runInBand --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\"",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:integration": "node src/integration/utils/runTests/index.js",
-    "test:integration:ci": "JEST_SILENT_REPORTER_DOTS=true npm run test:integration -- --ci --reporters=jest-silent-reporter",
+    "test:integration:ci": "JEST_SILENT_REPORTER_DOTS=true npm run test:integration -- --ci --onlyRunTests --reporters=jest-silent-reporter",
     "test:linkey": "node scripts/linkeySetup.js && jest src/app/lib/config/services/*.test.js --verbose true; npm run test:linkey:cleanup",
     "test:linkey:cleanup": "find src/app/lib/config/services -type f -name '*.test.js' -delete",
     "updateMinorPatch": "rm -rf node_modules/ && npm install && npm update && npm install",

--- a/src/integration/README.md
+++ b/src/integration/README.md
@@ -46,6 +46,12 @@ To run tests updating existing snapshots
 npm run test:integration -- -u
 ```
 
+To run tests without building and starting the app
+
+```
+npm run test:integration -- --onlyRunTests
+```
+
 Any other Jest CLI args and flags can be passed along in the `test:integration` script.
 
 ## How to write tests

--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -4,7 +4,7 @@ const { exec, spawn } = require('child_process');
 const argv = require('minimist')(process.argv.slice(2));
 const ora = require('ora');
 
-const isCI = argv.ci;
+const onlyRunTests = Boolean(argv.onlyRunTests);
 const isDev = Boolean(argv.dev);
 process.env.DEV_MODE = isDev;
 
@@ -12,7 +12,8 @@ const getJestArgs = () =>
   process.argv
     .slice(2)
     .filter(flag => !flag.startsWith('--pageTypes='))
-    .filter(flag => !flag.startsWith('--dev'));
+    .filter(flag => !flag.startsWith('--dev'))
+    .filter(flag => !flag.startsWith('--onlyRunTests'));
 
 const getFilesToTest = pageTypes => {
   if (pageTypes) {
@@ -66,7 +67,7 @@ const runTests = () =>
     });
   });
 
-if (isCI) {
+if (onlyRunTests) {
   runTests().catch(() => {
     process.exit(1);
   });


### PR DESCRIPTION
**Overall change:**
Uses a separate flag from `--ci` to run integration tests without building the app and running it. This is so we can we can still pass the Jest `--ci` flag (detailed [here](https://jestjs.io/docs/en/cli#--ci)) to fail on new snapshots in combination with `npm run test:integration` which builds and starts the app. This is required functionality to run int tests in github actions.

**Code changes:**

- Add `onlyRunTests` flag to src/integration/utils/runTests/index.js
- Use it in npm `test:integration:ci` script so that the scripts behaviour is unchanged
- add it to the readme
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
