### PR TITLE
Emotion fix - live radio width

### DIFF
--- a/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { string, shape } from 'prop-types';
 import styled from '@emotion/styled';
 import { Headline } from '@bbc/psammead-headings';
+import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import pathOr from 'ramda/src/pathOr';
 import Paragraph from '@bbc/psammead-paragraph';
 import { useLocation } from 'react-router-dom';
@@ -24,8 +25,10 @@ const staticAssetsPath = `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN}${pr
 const audioPlaceholderImageSrc = `${staticAssetsPath}images/amp_audio_placeholder.png`;
 
 const StyledGelPageGrid = styled(GelPageGrid)`
-  width: 100%;
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    width: 100%;
+  }
 `;
 
 const LiveRadioPage = ({ pageData }) => {


### PR DESCRIPTION
**Overall change:**
- A style being inherited from Psammead grid (`width: initial`) was being set within a media query, and so the attempt to override it within LiveRadioPage's `StyledGelPageGrid` was doing nothing.
- Wrapped the `width: 100%` style within a media query to make sure it is applied.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams