### PR TITLE
Emotion - fix most read section styling

### DIFF
--- a/src/app/containers/MostRead/section.jsx
+++ b/src/app/containers/MostRead/section.jsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { node } from 'prop-types';
+import { node, string } from 'prop-types';
 
-const MostReadSection = ({ children }) => (
+const MostReadSection = ({ children, className }) => (
   // eslint-disable-next-line jsx-a11y/no-redundant-roles
-  <section role="region" aria-labelledby="Most-Read" data-e2e="most-read">
+  <section
+    className={className}
+    role="region"
+    aria-labelledby="Most-Read"
+    data-e2e="most-read"
+  >
     {children}
   </section>
 );
 
 MostReadSection.propTypes = {
   children: node.isRequired,
+  className: string,
+};
+
+MostReadSection.defaultProps = {
+  className: '',
 };
 
 export default MostReadSection;


### PR DESCRIPTION
**Overall change:**
- Pages importing our `section.jsx` container were attempting to style the component, but these styles weren't being applied
- Passing the 'className' prop into the component being styled means these styles are applied successfully.
- **Note: I suspect this unsuccessful attempts to import & style Simorgh components will be happening in a lot of places.**

**To test:**
- Visit http://localhost:7080/hausa/articles/c2nr6xqmnewo
- Notice 'most read' styles now match http://test.bbc.com/hausa/articles/c2nr6xqmnewo

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
