### PR TITLE
Update integration test because IDT2 include has been updated

### DIFF
--- a/src/integration/pages/storyPage/canonicalIncludeTests.js
+++ b/src/integration/pages/storyPage/canonicalIncludeTests.js
@@ -6,7 +6,6 @@ export default () => {
           'script[src*="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic"]',
         );
         expect(scriptEl).toBeInTheDocument();
-        expect(scriptEl).toMatchSnapshot();
       });
     });
 

--- a/src/integration/pages/storyPage/canonicalIncludeTests.js
+++ b/src/integration/pages/storyPage/canonicalIncludeTests.js
@@ -3,7 +3,7 @@ export default () => {
     describe('IDT2', () => {
       it('I can see a "dataPic"', () => {
         const scriptEl = document.querySelector(
-          'script[src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.8f264bc5.js"]',
+          'script[src*="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic"]',
         );
         expect(scriptEl).toBeInTheDocument();
         expect(scriptEl).toMatchSnapshot();

--- a/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/gahuza/__snapshots__/canonical.test.js.snap
@@ -9,10 +9,3 @@ exports[`Canonical Story Page Includes I can see a fallback image when there are
   srcset="https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/640 640w,https://www.test.bbc.com/ws/includes/idt2/3686672a-0a64-4cdb-91c6-ae9ed0f214f7/image/816 816w"
 />
 `;
-
-exports[`Canonical Story Page Includes IDT2 I can see a "dataPic" 1`] = `
-<script
-  src="https://news.test.files.bbci.co.uk/include/idt2/static/js/dataPic.8f264bc5.js"
-  type="text/javascript"
-/>
-`;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Update integration tests because the datapic include has been republished

**Code changes:**
- Make query selector more robust so that it does not fail if the datapic script ID changes

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
