### PR TITLE
[PKG Bump] Update the web-vitals package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5228,9 +5228,9 @@
       "integrity": "sha512-wPaKT3qKMhn0mZmf9fQ+BFMq/SZbN8O0u7vH3pY0jJKccZlxrRf3jVY/rSJc4O0St1kBBVeCPAOIqOAgatU3HA=="
     },
     "@bbc/web-vitals": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bbc/web-vitals/-/web-vitals-1.0.1.tgz",
-      "integrity": "sha512-igU3lVODSyIvMrKPE/nxQVu6cE03yaYrMHvQL/Gf0ax63XcE3dNr9gk0PXayzqyE9TbYOkt+C/EyQH+ZM6Maeg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bbc/web-vitals/-/web-vitals-1.0.2.tgz",
+      "integrity": "sha512-7stwtxVHzvCO47A8gLcsC8C1MXRiTV2zozY/jN2BgsgjMbtiUzJ5arZP7ZrSJDrcgAbNyHANaNJAZG1kuUPAnQ==",
       "requires": {
         "cross-fetch": "^3.0.6",
         "react-adaptive-hooks": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@bbc/psammead-timestamp-container": "^4.0.13",
     "@bbc/psammead-useful-links": "^1.0.26",
     "@bbc/psammead-visually-hidden-text": "^1.3.1",
-    "@bbc/web-vitals": "^1.0.1",
+    "@bbc/web-vitals": "^1.0.2",
     "@loadable/component": "~5.12.0",
     "@loadable/server": "~5.12.0",
     "@loadable/webpack-plugin": "^5.13.0",


### PR DESCRIPTION
Resolves N/A

**Overall change:**
- Bumps the @bbc/web-vitals package to the latest version improving the CLS score collection

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
