### PR TITLE
fix grid wrapper's width not filling 100%

### DIFF
--- a/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`ErrorMain should correctly render for an error page for News 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -262,6 +263,7 @@ exports[`ErrorMain should correctly render for an error page for arabic 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -484,6 +486,7 @@ exports[`ErrorMain should correctly render for an error page for pashto 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -706,6 +709,7 @@ exports[`ErrorMain should correctly render for an error page for persian 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -928,6 +932,7 @@ exports[`ErrorMain should correctly render for an error page for urdu 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;

--- a/src/app/components/Grid/index.jsx
+++ b/src/app/components/Grid/index.jsx
@@ -72,6 +72,7 @@ const layoutGridItemSmall = css`
 `;
 
 export const GelPageGrid = styled(Grid)`
+  width: 100%;
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
     margin: 0 auto;
     max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN};

--- a/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
@@ -89,6 +89,10 @@ exports[`CpsRelatedContent should render Story Feature components when given app
   padding: 0;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -656,6 +660,10 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 .c7 {
   margin: 0;
   padding: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {

--- a/src/app/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CpsOnwardJourney Creates multiple promos with minimal props 1`] = `
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -126,6 +130,10 @@ exports[`CpsOnwardJourney Creates multiple promos with minimal props 1`] = `
 `;
 
 exports[`CpsOnwardJourney Creates single promo with minimal props 1`] = `
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -298,6 +306,10 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
 .c7 {
   margin: 0;
   padding: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {
@@ -573,6 +585,10 @@ exports[`CpsOnwardJourney renders section label with with alternative background
   padding: 0;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -839,6 +855,10 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
 .c6 {
   margin: 0;
   padding: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {
@@ -1142,6 +1162,10 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {
@@ -1508,6 +1532,10 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
   position: absolute;
   width: 1px;
   margin: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -79,6 +79,10 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   margin: 0;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -762,6 +766,10 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   position: absolute;
   width: 1px;
   margin: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -89,6 +89,10 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   padding: 0;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c3 {
   margin-bottom: 1rem;
   padding-bottom: 2rem;
@@ -569,6 +573,10 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 .c7 {
   margin: 0;
   padding: 0;
+}
+
+.c1 {
+  width: 100%;
 }
 
 .c3 {

--- a/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
@@ -7,6 +7,10 @@ exports[`withLoading HOC and no loading prop should return the passed in compone
 `;
 
 exports[`withLoading HOC and the loading prop set to true should return the loading component 1`] = `
+.c2 {
+  width: 100%;
+}
+
 .c0 {
   min-height: 100vh;
 }

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
+.c2 {
+  width: 100%;
+}
+
 .c4 {
   font-size: 1.75rem;
   line-height: 2rem;
@@ -1258,6 +1262,10 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 `;
 
 exports[`should render a news article correctly 1`] = `
+.c2 {
+  width: 100%;
+}
+
 .c4 {
   font-size: 1.75rem;
   line-height: 2rem;
@@ -1481,6 +1489,10 @@ exports[`should render a news article correctly 1`] = `
 `;
 
 exports[`should render a rtl article (persian) with most read correctly 1`] = `
+.c2 {
+  width: 100%;
+}
+
 .c4 {
   font-size: 2rem;
   line-height: 2.625rem;

--- a/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`ErrorPage should correctly render for 404 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -371,6 +372,7 @@ exports[`ErrorPage should correctly render for 404 for persian 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -652,6 +654,7 @@ exports[`ErrorPage should correctly render for 500 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -928,6 +931,7 @@ exports[`ErrorPage should correctly render for 500 for persian 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1204,6 +1208,7 @@ exports[`ErrorPage should correctly render for other status code 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 4rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;

--- a/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
@@ -24,7 +24,6 @@ const staticAssetsPath = `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN}${pr
 const audioPlaceholderImageSrc = `${staticAssetsPath}images/amp_audio_placeholder.png`;
 
 const StyledGelPageGrid = styled(GelPageGrid)`
-  width: 100%;
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 

--- a/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
+++ b/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
@@ -130,7 +130,6 @@ const MediaAssetPage = ({ pageData }) => {
   };
 
   const StyledGelPageGrid = styled(GelPageGrid)`
-    width: 100%;
     padding-bottom: ${GEL_SPACING_TRPL};
     @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
       padding-bottom: ${GEL_SPACING_QUAD};

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -956,6 +956,10 @@ exports[`Media Asset Page should render component 1`] = `
   overflow: hidden;
 }
 
+.c29 {
+  width: 100%;
+}
+
 .c11 {
   font-size: 1.75rem;
   line-height: 2rem;

--- a/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
@@ -89,6 +89,10 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   font-style: normal;
 }
 
+.c5 {
+  width: 100%;
+}
+
 .c0 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -10,6 +10,10 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   height: 0.75rem;
 }
 
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;

--- a/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
+++ b/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
@@ -38,7 +38,6 @@ const getGroups = (zero, one, two, three, four, five) => ({
 });
 
 const StyledGelPageGrid = styled(GelPageGrid)`
-  width: 100%;
   flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -315,6 +315,10 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   flex-grow: 1;
 }
 
+.c4 {
+  width: 100%;
+}
+
 @supports (display:grid) {
   .c0 {
     display: grid;
@@ -728,6 +732,10 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+}
+
+.c4 {
+  width: 100%;
 }
 
 .c18 {
@@ -1375,6 +1383,10 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   flex-grow: 1;
 }
 
+.c4 {
+  width: 100%;
+}
+
 .c16 {
   position: relative;
   min-height: 165px;
@@ -1795,6 +1807,10 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+}
+
+.c4 {
+  width: 100%;
 }
 
 .c16 {

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
@@ -67,6 +67,7 @@ exports[`OnDemand TV Brand Page  Dark Mode Design - should match snapshot 1`] = 
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 2rem;
   width: 100%;
   -webkit-box-flex: 1;
@@ -458,6 +459,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 2rem;
   width: 100%;
   -webkit-box-flex: 1;
@@ -858,6 +860,7 @@ exports[`should show the future content message if episode is not yet available 
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 2rem;
   width: 100%;
   -webkit-box-flex: 1;
@@ -1258,6 +1261,7 @@ exports[`should show the future content message if episode is pending 1`] = `
 }
 
 .c1 {
+  width: 100%;
   padding-bottom: 2rem;
   width: 100%;
   -webkit-box-flex: 1;

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -112,6 +112,7 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
 }
 
 .c1 {
+  width: 100%;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -1707,6 +1708,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
 }
 
 .c1 {
+  width: 100%;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -3223,6 +3225,10 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   height: 0.8125rem;
 }
 
+.c16 {
+  width: 100%;
+}
+
 .c3 {
   font-size: 1.75rem;
   line-height: 2rem;
@@ -3491,6 +3497,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 .c1 {
+  width: 100%;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -5008,6 +5015,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
 }
 
 .c1 {
+  width: 100%;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -6358,7 +6366,11 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
     </script>
   </head>
   <body>
-    .c3 {
+    .c35 {
+  width: 100%;
+}
+
+.c3 {
   font-size: 1.75rem;
   line-height: 2.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -6799,6 +6811,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 .c1 {
+  width: 100%;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;


### PR DESCRIPTION
**Overall change:**
This fixes a visual bug where the grid wrapper doesn't fill it's max-width when it's children doesn't sufficiently expand the width enough to it's max. This is a problem for images loading in in the most watched component as shown in the example below.

![ezgif-2-7ccfa86e681a](https://user-images.githubusercontent.com/4798332/97447962-09e01a00-1928-11eb-83e8-b9ab79fb2145.gif)

**Code changes:**

- Add `width: 100%` style to `GelPageGrid` component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
