### PR TITLE
use flex grow in defaultPageWrapper instead of every page component

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -431,7 +431,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 .c0 {
-  min-height: 100vh;
+  min-height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`defaultPageWrapper should render default page wrapper with children 1`] = `
-.c12 {
+.c13 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -23,7 +23,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   font-style: normal;
 }
 
-.c12:focus {
+.c13:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
@@ -34,7 +34,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   left: 0;
 }
 
-.c11 {
+.c12 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -46,7 +46,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   margin: 0;
 }
 
-.c7 {
+.c8 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -67,7 +67,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   margin: 0 auto;
 }
 
-.c6 {
+.c7 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -75,7 +75,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border-bottom: 0.0625rem solid transparent;
 }
 
-.c27 {
+.c29 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -83,7 +83,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border-top: 0.0625rem solid transparent;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   width: 100%;
   max-width: 10.496849999999998rem;
@@ -94,7 +94,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   -ms-flex-preferred-size: 10.496849999999998rem;
 }
 
-.c10 {
+.c11 {
   box-sizing: content-box;
   color: #FFFFFF;
   fill: currentColor;
@@ -110,20 +110,20 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   -ms-flex-preferred-size: 10.496849999999998rem;
 }
 
-.c8:hover .c10,
-.c8:focus .c10 {
+.c9:hover .c11,
+.c9:focus .c11 {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.25rem solid #FFFFFF;
   margin-bottom: -0.25rem;
 }
 
-.c17 {
+.c18 {
   color: #fff;
   fill: currentColor;
 }
 
-.c23 {
+.c24 {
   background-color: #222222;
   clear: both;
   overflow: hidden;
@@ -135,24 +135,24 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   visibility: hidden;
 }
 
-.c24 {
+.c25 {
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
   border-bottom: 0.125rem solid #3F3F42;
 }
 
-.c25 {
+.c26 {
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #3F3F42;
 }
 
-.c25:last-child {
+.c26:last-child {
   padding-bottom: 1rem;
   border: 0;
 }
 
-.c26 {
+.c27 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -163,13 +163,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   text-decoration: none;
 }
 
-.c26:hover,
-.c26:focus {
+.c27:hover,
+.c27:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c16 {
+.c17 {
   position: relative;
   padding: 0;
   margin: 0;
@@ -180,14 +180,14 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   width: 2.75rem;
 }
 
-.c16:hover,
-.c16:focus {
+.c17:hover,
+.c17:focus {
   cursor: pointer;
   box-shadow: inset 0 0 0 0.25rem #FFFFFF;
 }
 
-.c16:hover::after,
-.c16:focus::after {
+.c17:hover::after,
+.c17:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -197,24 +197,24 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border: 0.25rem solid #FFFFFF;
 }
 
-.c16 svg {
+.c17 svg {
   vertical-align: middle;
 }
 
-.c14 {
+.c15 {
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.c19 {
+.c20 {
   list-style-type: none;
   padding: 0;
   margin: 0;
   position: relative;
 }
 
-.c22 {
+.c23 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -228,7 +228,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   padding: 0.75rem;
 }
 
-.c22:hover::after {
+.c23:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -237,7 +237,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.c22:focus::after {
+.c23:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -248,27 +248,27 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border: 0.25rem solid #FFFFFF;
 }
 
-.c21 {
+.c22 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
-.c13 {
+.c14 {
   position: relative;
   background-color: #B80000;
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.c13 .c20::after {
+.c14 .c21::after {
   left: 0;
 }
 
-.c15 {
+.c16 {
   position: relative;
 }
 
-.c0 {
+.c1 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -276,12 +276,12 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   padding: 1rem 0.5rem;
 }
 
-.c1 {
+.c2 {
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.c1::after {
+.c2::after {
   content: '\\0020';
   display: block;
   height: 0;
@@ -290,7 +290,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   visibility: hidden;
 }
 
-.c2 {
+.c3 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   color: #FFFFFF;
@@ -299,7 +299,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   margin: 0;
 }
 
-.c4 {
+.c5 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #F6A21D;
@@ -309,28 +309,28 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   list-style-type: none;
 }
 
-.c4 li + li {
+.c5 li + li {
   padding-top: 0.5rem;
 }
 
-.c3 {
+.c4 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   color: #BEBEBE;
 }
 
-.c3 a {
+.c4 a {
   color: #F6A21D;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c3 a:focus,
-.c3 a:hover {
+.c4 a:focus,
+.c4 a:hover {
   color: #FFFFFF;
 }
 
-.c5 button {
+.c6 button {
   font-size: 1.125rem;
   line-height: 1.375rem;
   color: #F6A21D;
@@ -342,23 +342,23 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   cursor: pointer;
 }
 
-.c5 button:focus,
-.c5 button:hover {
+.c6 button:focus,
+.c6 button:hover {
   color: #FFFFFF;
 }
 
-.c5 a {
+.c6 a {
   color: #F6A21D;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c5 a:focus,
-.c5 a:hover {
+.c6 a:focus,
+.c6 a:hover {
   color: #FFFFFF;
 }
 
-.c33 {
+.c35 {
   padding: 0.5rem 0 0.5rem;
   color: #FFFFFF;
   font-weight: 700;
@@ -367,7 +367,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   display: block;
 }
 
-.c36 {
+.c38 {
   padding: 0.5rem 0 0.5rem;
   color: #FFFFFF;
   font-weight: 700;
@@ -376,13 +376,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   display: inline;
 }
 
-.c32:hover .c34,
-.c32:focus .c34 {
+.c34:hover .c36,
+.c34:focus .c36 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c30 {
+.c32 {
   border-bottom: 0.0625rem solid #3F3F42;
   list-style-type: none;
   margin: 0;
@@ -391,7 +391,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   column-count: 4;
 }
 
-.c30 > li:first-child {
+.c32 > li:first-child {
   border-bottom: 0.0625rem solid #3F3F42;
   padding: 0.5rem 0;
   margin-bottom: 0.5rem;
@@ -401,7 +401,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   column-span: all;
 }
 
-.c31 {
+.c33 {
   min-width: 50%;
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
@@ -409,7 +409,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   break-inside: avoid-column;
 }
 
-.c28 {
+.c30 {
   background-color: #222222;
   font-size: 0.875rem;
   line-height: 1rem;
@@ -418,166 +418,189 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   font-style: normal;
 }
 
-.c29 {
+.c31 {
   max-width: 80rem;
   margin: 0 auto;
   padding-top: 0.5rem);
 }
 
-.c35 {
+.c37 {
   color: #FFFFFF;
   margin: 0;
   padding: 1rem 0;
 }
 
+.c0 {
+  min-height: 100vh;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  background-color: #FDFDFD;
+}
+
+.c28 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
+  .c13 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c12:focus {
+  .c13:focus {
     top: 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c12 {
+  .c13 {
     padding: 0.5rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c7 {
+  .c8 {
     display: block;
   }
 }
 
 @media (min-width:25rem) {
-  .c6 {
+  .c7 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c27 {
+  .c29 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c9 {
+  .c10 {
     display: block;
   }
 }
 
 @media (min-width:25rem) {
-  .c10 {
+  .c11 {
     padding-top: 1rem;
     padding-bottom: 0.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c11 {
     padding-top: 1.25rem;
     padding-bottom: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active),print {
-  .c10 {
+  .c11 {
     fill: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c23 {
+  .c24 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (prefers-reduced-motion:reduce) {
-  .c23 {
+  .c24 {
     -webkit-transition: none;
     transition: none;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c26 {
+  .c27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c26 {
+  .c27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c16 {
+  .c17 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) {
-  .c16 {
+  .c17 {
     height: 2.75rem;
     width: 2.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c20 {
     overflow: hidden;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c23 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c22 {
+  .c23 {
     padding: 0.75rem 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c21:last-child {
+  .c22:last-child {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c21::after {
+  .c22::after {
     content: '';
     position: absolute;
     bottom: -1px;
@@ -588,7 +611,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (max-width:37.4375rem) {
-  .c18 {
+  .c19 {
     white-space: nowrap;
     overflow-x: scroll;
     -webkit-scroll-behavior: auto;
@@ -603,11 +626,11 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
     -ms-overflow-style: none;
   }
 
-  .c18::-webkit-scrollbar {
+  .c19::-webkit-scrollbar {
     display: none;
   }
 
-  .c18:after {
+  .c19:after {
     content: ' ';
     height: 100%;
     width: 3rem;
@@ -622,27 +645,27 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:25rem) {
-  .c0 {
+  .c1 {
     padding: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
+  .c3 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c3 {
     float: left;
     margin-right: 3.5%;
     width: 22%;
@@ -650,42 +673,42 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c5 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c5 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c5 {
     width: 18%;
     float: right;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c4 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c3 {
+  .c4 {
     margin: 0;
     float: left;
     width: 53%;
@@ -693,28 +716,28 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 button {
+  .c6 button {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 button {
+  .c6 button {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c30 {
+  .c32 {
     display: grid;
     grid-auto-flow: column;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c30 {
+  .c32 {
     grid-auto-flow: row;
     -webkit-column-count: 1;
     column-count: 1;
@@ -722,7 +745,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:15rem) and (max-width:37.4375rem) {
-  .c30 {
+  .c32 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
     grid-template-rows: repeat( 5,auto );
@@ -732,7 +755,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c30 {
+  .c32 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
     grid-template-rows: repeat( 4,auto );
@@ -742,7 +765,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c30 {
+  .c32 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
     grid-template-rows: repeat( 3,auto );
@@ -752,7 +775,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:80rem) {
-  .c30 {
+  .c32 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
     grid-template-rows: repeat( 3,auto );
@@ -762,25 +785,25 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (max-width:25rem) {
-  .c28 {
+  .c30 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c28 {
+  .c30 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c28 {
+  .c30 {
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c28 {
+  .c30 {
     font-size: 0.8125rem;
   }
 }
@@ -800,288 +823,435 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
       <p>
         I am the ServiceWorker component
       </p>
-      <header
-        role="banner"
+      <div
+        class="c0"
+        id="main-wrapper"
       >
-        <div
-          class="c0"
-          dir="ltr"
+        <header
+          role="banner"
         >
           <div
             class="c1"
             dir="ltr"
           >
-            <h2
+            <div
               class="c2"
               dir="ltr"
             >
-              We've updated our Privacy and Cookies Policy
-            </h2>
-            <p
-              class="c3"
-              dir="ltr"
-            >
-              We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
-            </p>
-            <ul
-              class="c4"
-              dir="ltr"
-            >
-              <li
+              <h2
+                class="c3"
+                dir="ltr"
+              >
+                We've updated our Privacy and Cookies Policy
+              </h2>
+              <p
+                class="c4"
+                dir="ltr"
+              >
+                We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
+              </p>
+              <ul
                 class="c5"
                 dir="ltr"
               >
-                <button
-                  type="button"
+                <li
+                  class="c6"
+                  dir="ltr"
                 >
-                  OK
-                </button>
-              </li>
-              <li
-                class="c5"
-                dir="ltr"
-              >
-                <a
-                  href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+                  <button
+                    type="button"
+                  >
+                    OK
+                  </button>
+                </li>
+                <li
+                  class="c6"
+                  dir="ltr"
                 >
-                  Find out what's changed
-                </a>
-              </li>
-            </ul>
+                  <a
+                    href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+                  >
+                    Find out what's changed
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
-        </div>
-        <div
-          class="c6"
-        >
           <div
             class="c7"
           >
-            <a
-              class="c8 c9"
-              href="/news"
+            <div
+              class="c8"
             >
-              <svg
-                aria-hidden="true"
-                class="c10"
-                focusable="false"
-                height="24"
-                viewBox="0 0 167.95 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <a
+                class="c9 c10"
+                href="/news"
               >
-                <g
-                  fill-rule="evenodd"
-                  stroke="#000"
-                  stroke-width=".335"
-                  style="stroke: #fff;"
+                <svg
+                  aria-hidden="true"
+                  class="c11"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 167.95 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
-                  />
-                  <path
-                    d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
-                  />
-                  <path
-                    d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74z"
-                  />
-                </g>
-              </svg>
-              <span
-                class="c11"
+                  <g
+                    fill-rule="evenodd"
+                    stroke="#000"
+                    stroke-width=".335"
+                    style="stroke: #fff;"
+                  >
+                    <path
+                      d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
+                    />
+                    <path
+                      d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
+                    />
+                    <path
+                      d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74z"
+                    />
+                  </g>
+                </svg>
+                <span
+                  class="c12"
+                >
+                  BBC News
+                </span>
+              </a>
+              <a
+                class="c13"
+                dir="ltr"
+                href="#content"
               >
-                BBC News
-              </span>
-            </a>
-            <a
-              class="c12"
-              dir="ltr"
-              href="#content"
-            >
-              Skip to content
-            </a>
+                Skip to content
+              </a>
+            </div>
           </div>
-        </div>
-        <nav
-          class="c13"
-          dir="ltr"
-          role="navigation"
-        >
-          <div
+          <nav
             class="c14"
+            dir="ltr"
+            role="navigation"
           >
             <div
               class="c15"
             >
-              <button
-                aria-expanded="false"
-                class="c16"
-                dir="ltr"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="c17"
-                  focusable="false"
-                  height="2.75rem"
-                  viewBox="0 0 44 44"
-                  width="2.75rem"
-                >
-                  <path
-                    d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
-                  />
-                </svg>
-                <span
-                  class="c11"
-                >
-                  Sections
-                </span>
-              </button>
               <div
-                class="c18"
-                dir="ltr"
+                class="c16"
+              >
+                <button
+                  aria-expanded="false"
+                  class="c17"
+                  dir="ltr"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="c18"
+                    focusable="false"
+                    height="2.75rem"
+                    viewBox="0 0 44 44"
+                    width="2.75rem"
+                  >
+                    <path
+                      d="M12 29h21v-2.333H12V29zm0-5.833h21v-2.334H12v2.334zM12 15v2.333h21V15H12z"
+                    />
+                  </svg>
+                  <span
+                    class="c12"
+                  >
+                    Sections
+                  </span>
+                </button>
+                <div
+                  class="c19"
+                  dir="ltr"
+                >
+                  <ul
+                    class="c20"
+                    role="list"
+                  >
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news"
+                      >
+                        Home
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/uk"
+                      >
+                        UK
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/world"
+                      >
+                        World
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/business"
+                      >
+                        Business
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/politics"
+                      >
+                        Politics
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/technology"
+                      >
+                        Tech
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/science_and_environment"
+                      >
+                        Science
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/health"
+                      >
+                        Health
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/education"
+                      >
+                        Family & Education
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/entertainment_and_arts"
+                      >
+                        Entertainment & Arts
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/stories"
+                      >
+                        Stories
+                      </a>
+                    </li>
+                    <li
+                      class="c21 c22"
+                      dir="ltr"
+                      role="listitem"
+                    >
+                      <a
+                        class="c23"
+                        href="/news/video_and_audio/headlines"
+                      >
+                        Video & Audio
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                class="c24"
+                height="0"
               >
                 <ul
-                  class="c19"
+                  class="c25"
                   role="list"
                 >
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news"
                     >
                       Home
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/uk"
                     >
                       UK
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/world"
                     >
                       World
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/business"
                     >
                       Business
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/politics"
                     >
                       Politics
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/technology"
                     >
                       Tech
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/science_and_environment"
                     >
                       Science
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/health"
                     >
                       Health
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/education"
                     >
                       Family & Education
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/entertainment_and_arts"
                     >
                       Entertainment & Arts
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/stories"
                     >
                       Stories
                     </a>
                   </li>
                   <li
-                    class="c20 c21"
-                    dir="ltr"
+                    class="c26"
                     role="listitem"
                   >
                     <a
-                      class="c22"
+                      class="c27"
                       href="/news/video_and_audio/headlines"
                     >
                       Video & Audio
@@ -1090,357 +1260,219 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
                 </ul>
               </div>
             </div>
-            <div
-              class="c23"
-              height="0"
-            >
-              <ul
-                class="c24"
-                role="list"
-              >
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news"
-                  >
-                    Home
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/uk"
-                  >
-                    UK
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/world"
-                  >
-                    World
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/business"
-                  >
-                    Business
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/politics"
-                  >
-                    Politics
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/technology"
-                  >
-                    Tech
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/science_and_environment"
-                  >
-                    Science
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/health"
-                  >
-                    Health
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/education"
-                  >
-                    Family & Education
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/entertainment_and_arts"
-                  >
-                    Entertainment & Arts
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/stories"
-                  >
-                    Stories
-                  </a>
-                </li>
-                <li
-                  class="c25"
-                  role="listitem"
-                >
-                  <a
-                    class="c26"
-                    href="/news/video_and_audio/headlines"
-                  >
-                    Video & Audio
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </nav>
-      </header>
-      <h2>
-        Child element
-      </h2>
-      <footer
-        role="contentinfo"
-      >
-        <div
-          class="c27"
-        >
-          <div
-            class="c7"
-          >
-            <a
-              class="c8 c9"
-              href="/news"
-            >
-              <svg
-                aria-hidden="true"
-                class="c10"
-                focusable="false"
-                height="24"
-                viewBox="0 0 167.95 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill-rule="evenodd"
-                  stroke="#000"
-                  stroke-width=".335"
-                  style="stroke: #fff;"
-                >
-                  <path
-                    d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
-                  />
-                  <path
-                    d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
-                  />
-                  <path
-                    d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74z"
-                  />
-                </g>
-              </svg>
-              <span
-                class="c11"
-              >
-                BBC News
-              </span>
-            </a>
-          </div>
-        </div>
+          </nav>
+        </header>
         <div
           class="c28"
+        >
+          <h2>
+            Child element
+          </h2>
+        </div>
+        <footer
+          role="contentinfo"
         >
           <div
             class="c29"
           >
-            <ul
-              class="c30"
-              role="list"
+            <div
+              class="c8"
             >
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/news/help-41670342"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Why you can trust the BBC
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/terms"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Terms of Use
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.co.uk/aboutthebbc/"
-                >
-                  <span
-                    class="c34"
-                  >
-                    About the BBC
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/privacy/"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Privacy Policy
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/usingthebbc/cookies/"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Cookies
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/accessibility/"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Accessibility Help
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/contact/"
-                >
-                  <span
-                    class="c34"
-                  >
-                    Contact the BBC
-                  </span>
-                </a>
-              </li>
-              <li
-                class="c31"
-                role="listitem"
-              >
-                <a
-                  class="c32 c33"
-                  href="https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
-                  lang="en-GB"
-                >
-                  <span
-                    class="c34"
-                  >
-                    AdChoices / Do Not Sell My Info
-                  </span>
-                </a>
-              </li>
-            </ul>
-            <p
-              class="c35"
-            >
-              <span
-                lang="en-GB"
-              >
-                ©
-                 
-              </span>
-              2020 BBC. The BBC is not responsible for the content of external sites.
-               
               <a
-                class="c32 c36"
-                href="https://www.bbc.co.uk/help/web/links/"
+                class="c9 c10"
+                href="/news"
               >
-                <span
-                  class="c34"
+                <svg
+                  aria-hidden="true"
+                  class="c11"
+                  focusable="false"
+                  height="24"
+                  viewBox="0 0 167.95 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Read about our approach to external linking.
+                  <g
+                    fill-rule="evenodd"
+                    stroke="#000"
+                    stroke-width=".335"
+                    style="stroke: #fff;"
+                  >
+                    <path
+                      d="M76.73.28v21.85H53.51V.28zm-4.62 14.58l-.37.23a10.85 10.85 0 0 1-5.53 1.69c-3.8 0-6.31-2.27-6.32-5.55s2.62-5.58 6.22-5.59a10.93 10.93 0 0 1 5.47 1.56l.36.2V4.47l-.16-.06a15.06 15.06 0 0 0-5.65-1.27 9.62 9.62 0 0 0-6.53 2.34 7.9 7.9 0 0 0-2.59 6 7.7 7.7 0 0 0 2.16 5.17A9.1 9.1 0 0 0 66 19.28a12.73 12.73 0 0 0 6-1.37l.14-.07zM50 .28v21.85H26.75V.28zm-5.54 14.48A4.21 4.21 0 0 0 41 10.69a3.87 3.87 0 0 0 1.35-1.08A3.41 3.41 0 0 0 43 7.47a3.8 3.8 0 0 0-1.27-2.85 5.76 5.76 0 0 0-4-1.29h-4.89v15.75h5.81a6.54 6.54 0 0 0 4.46-1.39 3.88 3.88 0 0 0 1.35-2.93z"
+                    />
+                    <path
+                      d="M41.57 14.45a1.86 1.86 0 0 1-.63 1.45 3.85 3.85 0 0 1-2.6.72h-2.68v-4.3h2.56a4.45 4.45 0 0 1 2.57.62 1.76 1.76 0 0 1 .78 1.51zM39.4 9.31a1.84 1.84 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57h-1.9v4.07H37a4.21 4.21 0 0 0 2.4-.56zM23.22.28v21.85H0V.28zM17.7 14.76a4.21 4.21 0 0 0-3.43-4.07 3.86 3.86 0 0 0 1.35-1.08 3.41 3.41 0 0 0 .65-2.13A3.8 3.8 0 0 0 15 4.63a5.76 5.76 0 0 0-4-1.29H6v15.74h5.9a6.54 6.54 0 0 0 4.46-1.39 3.89 3.89 0 0 0 1.34-2.93z"
+                    />
+                    <path
+                      d="M12.64 9.31a1.85 1.85 0 0 0 .74-1.63 1.66 1.66 0 0 0-.53-1.31 3 3 0 0 0-2.05-.57H8.91v4.07h1.3a4.21 4.21 0 0 0 2.43-.56zM14 12.94a4.45 4.45 0 0 0-2.57-.62H8.91v4.29h2.68a3.85 3.85 0 0 0 2.6-.72 1.86 1.86 0 0 0 .63-1.45 1.76 1.76 0 0 0-.82-1.5zM101 3.34h2.15v15.78h-1.94L90.69 7v12.12h-2.12V3.34h1.83L101 15.6zM107.26 3.34h8.95v2h-6.69v4.81H116v2h-6.46v4.9h6.9v2h-9.16zM140.33 3.34h2.25l-6.38 15.85h-.5l-5.16-12.84-5.21 12.84h-.49l-6.36-15.85h2.28l4.35 10.88 4.38-10.88h2.14L136 14.22zM148.7 12.51l-1.72-1a7.8 7.8 0 0 1-2.3-1.94 3.68 3.68 0 0 1-.68-2.2 3.88 3.88 0 0 1 1.29-3 4.83 4.83 0 0 1 3.36-1.16 6.36 6.36 0 0 1 3.63 1.11v2.49a5.23 5.23 0 0 0-3.67-1.64 3 3 0 0 0-1.82.51 1.55 1.55 0 0 0-.71 1.32 2 2 0 0 0 .52 1.33 6.6 6.6 0 0 0 1.69 1.3l1.73 1q2.89 1.73 2.89 4.39a4 4 0 0 1-1.27 3.08 4.65 4.65 0 0 1-3.3 1.19 6.94 6.94 0 0 1-4.26-1.44V15a5.32 5.32 0 0 0 4.24 2.32 2.66 2.66 0 0 0 1.77-.59 1.85 1.85 0 0 0 .71-1.48q-.02-1.45-2.1-2.74z"
+                    />
+                  </g>
+                </svg>
+                <span
+                  class="c12"
+                >
+                  BBC News
                 </span>
               </a>
-            </p>
+            </div>
           </div>
-        </div>
-      </footer>
+          <div
+            class="c30"
+          >
+            <div
+              class="c31"
+            >
+              <ul
+                class="c32"
+                role="list"
+              >
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/news/help-41670342"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Why you can trust the BBC
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/terms"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Terms of Use
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.co.uk/aboutthebbc/"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      About the BBC
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/privacy/"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Privacy Policy
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/usingthebbc/cookies/"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Cookies
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/accessibility/"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Accessibility Help
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/contact/"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      Contact the BBC
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="c33"
+                  role="listitem"
+                >
+                  <a
+                    class="c34 c35"
+                    href="https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+                    lang="en-GB"
+                  >
+                    <span
+                      class="c36"
+                    >
+                      AdChoices / Do Not Sell My Info
+                    </span>
+                  </a>
+                </li>
+              </ul>
+              <p
+                class="c37"
+              >
+                <span
+                  lang="en-GB"
+                >
+                  ©
+                   
+                </span>
+                2020 BBC. The BBC is not responsible for the content of external sites.
+                 
+                <a
+                  class="c34 c38"
+                  href="https://www.bbc.co.uk/help/web/links/"
+                >
+                  <span
+                    class="c36"
+                  >
+                    Read about our approach to external linking.
+                  </span>
+                </a>
+              </p>
+            </div>
+          </div>
+        </footer>
+      </div>
       ,
     </div>
   </body>

--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -11,7 +11,7 @@ import { ServiceContext } from '../contexts/ServiceContext';
 import WebVitals from '#app/containers/WebVitals';
 
 const Wrapper = styled.div`
-  min-height: 100vh;
+  min-height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -1,12 +1,26 @@
 import React, { useContext } from 'react';
 import { node } from 'prop-types';
 import GlobalStyles from '@bbc/psammead-styles/global-styles';
+import styled from 'styled-components';
+import { C_GHOST } from '@bbc/psammead-styles/colours';
 import HeaderContainer from '../containers/Header';
 import FooterContainer from '../containers/Footer';
 import ManifestContainer from '../containers/Manifest';
 import ServiceWorkerContainer from '../containers/ServiceWorker';
 import { ServiceContext } from '../contexts/ServiceContext';
 import WebVitals from '#app/containers/WebVitals';
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: ${C_GHOST};
+`;
+
+const Content = styled.div`
+  flex-grow: 1;
+`;
 
 const PageWrapper = ({ children }) => {
   const { fonts: fontFunctions } = useContext(ServiceContext);
@@ -19,9 +33,11 @@ const PageWrapper = ({ children }) => {
       <ServiceWorkerContainer />
       <ManifestContainer />
       <WebVitals />
-      <HeaderContainer />
-      {children}
-      <FooterContainer />
+      <Wrapper id="main-wrapper">
+        <HeaderContainer />
+        <Content>{children}</Content>
+        <FooterContainer />
+      </Wrapper>
     </>
   );
 };

--- a/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -42,10 +42,6 @@ exports[`ErrorMain should correctly render for an error page for News 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -265,10 +261,6 @@ exports[`ErrorMain should correctly render for an error page for arabic 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -488,10 +480,6 @@ exports[`ErrorMain should correctly render for an error page for pashto 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -711,10 +699,6 @@ exports[`ErrorMain should correctly render for an error page for persian 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -934,10 +918,6 @@ exports[`ErrorMain should correctly render for an error page for urdu 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {

--- a/src/app/components/ErrorMain/index.jsx
+++ b/src/app/components/ErrorMain/index.jsx
@@ -32,7 +32,6 @@ const Heading = styled.h1`
 
 const StyledGelPageGrid = styled(GelPageGrid)`
   padding-bottom: 4rem;
-  flex-grow: 1;
 `;
 
 const CustomParagraph = styled(Paragraph)`

--- a/src/app/components/PageLayout/IndexMain.jsx
+++ b/src/app/components/PageLayout/IndexMain.jsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
 
-const IndexMain = styled.main.attrs({ role: 'main' })`
-  flex-grow: 1;
-`;
+const IndexMain = styled.main.attrs({ role: 'main' })``;
 
 export default IndexMain;

--- a/src/app/lib/utilities/darkMode/index.jsx
+++ b/src/app/lib/utilities/darkMode/index.jsx
@@ -2,7 +2,7 @@ import { createGlobalStyle } from 'styled-components';
 import { C_MIDNIGHT_BLACK } from '@bbc/psammead-styles/colours';
 
 export default createGlobalStyle`
-#root {
+#main-wrapper {
   background-color: ${C_MIDNIGHT_BLACK};
 }
 `;

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -57,10 +57,6 @@ const componentsToRender = {
   timestamp,
 };
 
-const StyledMain = styled.main`
-  flex-grow: 1;
-`;
-
 const ArticlePageMostReadSection = styled(MostReadSection)`
   @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
     margin: 0 ${GEL_MARGIN_BELOW_400PX} ${GEL_SPACING_TRPL};
@@ -124,7 +120,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
         dateModified={lastPublished}
         aboutTags={aboutTags}
       />
-      <StyledMain role="main">
+      <main role="main">
         <GelPageGrid
           enableGelGutters
           columns={{
@@ -141,7 +137,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
             componentsToRender={componentsToRender}
           />
         </GelPageGrid>
-      </StyledMain>
+      </main>
       <MostReadContainer
         mostReadEndpointOverride={mostReadEndpointOverride}
         wrapper={MostReadWrapper}

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
-.c2 {
+.c1 {
   width: 100%;
 }
 
-.c4 {
+.c3 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -18,11 +18,11 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   overflow-wrap: anywhere;
 }
 
-.c4:focus {
+.c3:focus {
   outline: none;
 }
 
-.c6 {
+.c5 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -33,7 +33,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c23 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -43,7 +43,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   font-style: normal;
 }
 
-.c15 {
+.c14 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -51,7 +51,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   grid-template-rows: repeat(10,auto);
 }
 
-.c20 {
+.c19 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -63,7 +63,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   padding: 0;
 }
 
-.c22 {
+.c21 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -76,13 +76,13 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   margin-bottom: 0.5rem;
 }
 
-.c22:hover,
-.c22:focus {
+.c21:hover,
+.c21:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c22:before {
+.c21:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -94,17 +94,17 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   z-index: 1;
 }
 
-.c21 {
+.c20 {
   padding-top: 0.375rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
-.c23 {
+.c22 {
   padding-top: 0.5rem;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -116,12 +116,12 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   padding: 0;
 }
 
-.c17 {
+.c16 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +131,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -150,7 +150,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   align-items: baseline;
 }
 
-.c14 {
+.c13 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -169,131 +169,124 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   align-items: center;
 }
 
-.c10 {
+.c9 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c8 {
+.c7 {
   position: relative;
   z-index: 0;
   color: #3F3F42;
   margin-top: 2rem;
 }
 
-.c11 {
+.c10 {
   margin: 0;
   padding: 0;
 }
 
-.c0 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 @supports (display:grid) {
-  .c1 {
+  .c0 {
     display: grid;
     position: initial;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c3 {
+  .c2 {
     margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width:80rem) {
-  .c3 {
+  .c2 {
     margin-left: 33.333333333333336%;
   }
 }
 
 @supports (display:grid) {
-  .c3 {
+  .c2 {
     display: block;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c5 {
+  .c4 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c5 {
+  .c4 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c5 {
+  .c4 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c5 {
+  .c4 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c5 {
+  .c4 {
     margin-left: 20%;
   }
 }
 
 @media (min-width:80rem) {
-  .c5 {
+  .c4 {
     margin-left: 40%;
   }
 }
 
 @supports (display:grid) {
-  .c5 {
+  .c4 {
     display: block;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -301,7 +294,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -309,7 +302,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -317,7 +310,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -325,7 +318,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -333,7 +326,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:80rem) {
-  .c16 {
+  .c15 {
     width: calc(20%);
     display: inline-block;
     vertical-align: top;
@@ -341,117 +334,153 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @supports (display:grid) {
-  .c16 {
+  .c15 {
     display: block;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c2 {
+  .c1 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c1 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c3 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
+  .c23 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c23 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c14 {
     grid-template-rows: repeat( 5,auto );
   }
 }
 
 @media (min-width:80rem) {
-  .c15 {
+  .c14 {
     grid-auto-flow: row;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c19 {
+  .c18 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c19 {
+  .c18 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c19 {
+  .c18 {
     min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     min-width: 4rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c19 {
+  .c18 {
+    min-width: 2rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c24 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c24 {
+    min-width: 2.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c24 {
+    min-width: 3rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    min-width: 4rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    min-width: 4rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c24 {
     min-width: 2rem;
   }
 }
@@ -482,13 +511,13 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c25 {
-    min-width: 4rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c25 {
-    min-width: 2rem;
+    min-width: 4rem;
   }
 }
 
@@ -518,13 +547,13 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c26 {
-    min-width: 2rem;
+    min-width: 4rem;
   }
 }
 
 @media (min-width:80rem) {
   .c26 {
-    min-width: 4rem;
+    min-width: 2rem;
   }
 }
 
@@ -554,7 +583,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c27 {
-    min-width: 4rem;
+    min-width: 2rem;
   }
 }
 
@@ -590,95 +619,59 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c28 {
-    min-width: 2rem;
+    min-width: 4rem;
   }
 }
 
 @media (min-width:80rem) {
   .c28 {
-    min-width: 2rem;
-  }
-}
-
-@media (max-width:14.9375rem) {
-  .c29 {
-    min-width: 2.5rem;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c29 {
-    min-width: 2.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c29 {
-    min-width: 3rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    min-width: 4rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    min-width: 4rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c29 {
     min-width: 4rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c20 {
+  .c19 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c20 {
+  .c19 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c21 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c21 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c22 {
+  .c21 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c21 {
+  .c20 {
     padding-right: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -687,39 +680,39 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c14 {
+  .c13 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     padding-right: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c10 {
+  .c9 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c9 {
     position: absolute;
     left: 0;
     right: 0;
@@ -728,43 +721,43 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c7 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c8 {
+  .c7 {
     margin-bottom: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c9 {
+  .c8 {
     margin-bottom: 1rem;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 0.5rem 1.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 1rem 2rem;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 1rem 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c7 {
+  .c6 {
     width: 100%;
     margin: 0 auto 1.5rem;
     padding: 0 1rem;
@@ -778,19 +771,18 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
     chartbeat
   </div>
   <main
-    class="c0"
     role="main"
   >
     <div
-      class="c1 c2"
+      class="c0 c1"
       dir="ltr"
     >
       <div
-        class="c3"
+        class="c2"
         dir="ltr"
       >
         <h1
-          class="c4"
+          class="c3"
           id="content"
           tabindex="-1"
         >
@@ -798,11 +790,11 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </h1>
       </div>
       <div
-        class="c5"
+        class="c4"
         dir="ltr"
       >
         <p
-          class="c6"
+          class="c5"
         >
           A paragraph in Pidgin.
         </p>
@@ -811,27 +803,27 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   </main>
   <section
     aria-labelledby="Most-Read"
-    class="c7"
+    class="c6"
     data-e2e="most-read"
     role="region"
   >
     <div
-      class="c8 c9"
+      class="c7 c8"
     >
       <div
-        class="c10"
+        class="c9"
       />
       <h2
-        class="c11"
+        class="c10"
       >
         <span
-          class="c12"
+          class="c11"
         >
           <span
-            class="c13"
+            class="c12"
           >
             <span
-              class="c14"
+              class="c13"
               dir="ltr"
               id="Most-Read"
             >
@@ -842,43 +834,43 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
       </h2>
     </div>
     <ol
-      class="c1 c15"
+      class="c0 c14"
       dir="ltr"
       role="list"
     >
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c19"
+            class="c18"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               1
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-46729879"
             >
               Public Holidays wey go happun for 2019
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-05-21"
               >
                 De one we dem update for: 21st May 2019
@@ -888,38 +880,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c25"
+            class="c24"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               2
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-50304653"
             >
               Liberia banks don run out of money
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-05"
               >
                 De one we dem update for: 5th November 2019
@@ -929,38 +921,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c19"
+            class="c18"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               3
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-50298882"
             >
               Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-05"
               >
                 De one we dem update for: 5th November 2019
@@ -970,38 +962,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c25"
+            class="c24"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               4
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-50315150"
             >
               Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 De one we dem update for: 6th November 2019
@@ -1011,79 +1003,79 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
+        >
+          <div
+            class="c25"
+            dir="ltr"
+          >
+            <span
+              class="c19"
+            >
+              5
+            </span>
+          </div>
+          <div
+            class="c20"
+            dir="ltr"
+          >
+            <a
+              class="c21"
+              href="/pidgin/tori-50315157"
+            >
+              How Balogun market fire kill Policeman for Lagos
+            </a>
+            <div
+              class="c22"
+            >
+              <time
+                class="c23"
+                datetime="2019-11-06"
+              >
+                De one we dem update for: 6th November 2019
+              </time>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li
+        class="c15 c16"
+        dir="ltr"
+        role="listitem"
+      >
+        <div
+          class="c17"
         >
           <div
             class="c26"
             dir="ltr"
           >
             <span
-              class="c20"
-            >
-              5
-            </span>
-          </div>
-          <div
-            class="c21"
-            dir="ltr"
-          >
-            <a
-              class="c22"
-              href="/pidgin/tori-50315157"
-            >
-              How Balogun market fire kill Policeman for Lagos
-            </a>
-            <div
-              class="c23"
-            >
-              <time
-                class="c24"
-                datetime="2019-11-06"
-              >
-                De one we dem update for: 6th November 2019
-              </time>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li
-        class="c16 c17"
-        dir="ltr"
-        role="listitem"
-      >
-        <div
-          class="c18"
-        >
-          <div
-            class="c27"
-            dir="ltr"
-          >
-            <span
-              class="c20"
+              class="c19"
             >
               6
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-50093818"
             >
               Labour, FG finally agree minimum wage salary adjustment
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-10-18"
               >
                 De one we dem update for: 18th October 2019
@@ -1093,38 +1085,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c28"
+            class="c27"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               7
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-50187218"
             >
               Naira Marley na 'Bad Influence'?
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-10-25"
               >
                 De one we dem update for: 25th October 2019
@@ -1134,38 +1126,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c27"
+            class="c26"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               8
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-48347911"
             >
               Tins you suppose know about Naira Marley
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-05-23"
               >
                 De one we dem update for: 23rd May 2019
@@ -1175,38 +1167,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c28"
+            class="c27"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               9
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/sport-50312710"
             >
               Golden Eaglets crash out of Fifa U17 World Cup
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 De one we dem update for: 6th November 2019
@@ -1216,38 +1208,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="ltr"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c29"
+            class="c28"
             dir="ltr"
           >
             <span
-              class="c20"
+              class="c19"
             >
               10
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="ltr"
           >
             <a
-              class="c22"
+              class="c21"
               href="/pidgin/tori-42945173"
             >
               Tiger nut drink fit wake up your sex drive - Nutritionist
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-05-21"
               >
                 De one we dem update for: 21st May 2019
@@ -1262,11 +1254,11 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 `;
 
 exports[`should render a news article correctly 1`] = `
-.c2 {
+.c1 {
   width: 100%;
 }
 
-.c4 {
+.c3 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
@@ -1279,11 +1271,11 @@ exports[`should render a news article correctly 1`] = `
   overflow-wrap: anywhere;
 }
 
-.c4:focus {
+.c3:focus {
   outline: none;
 }
 
-.c6 {
+.c5 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -1294,155 +1286,148 @@ exports[`should render a news article correctly 1`] = `
   margin: 0;
 }
 
-.c0 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 @supports (display:grid) {
-  .c1 {
+  .c0 {
     display: grid;
     position: initial;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-left: 0%;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c3 {
-    margin-left: 16.666666666666668%;
-  }
-}
-
-@media (min-width:80rem) {
-  .c3 {
-    margin-left: 33.333333333333336%;
-  }
-}
-
-@supports (display:grid) {
-  .c3 {
-    display: block;
-  }
-}
-
-@media (max-width:14.9375rem) {
-  .c5 {
-    padding: 0 0.5rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c5 {
-    padding: 0 0.5rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c5 {
-    padding: 0 1rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c5 {
-    padding: 0 1rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c5 {
-    margin-left: 20%;
-  }
-}
-
-@media (min-width:80rem) {
-  .c5 {
-    margin-left: 40%;
-  }
-}
-
-@supports (display:grid) {
-  .c5 {
-    display: block;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .c2 {
+    margin-left: 16.666666666666668%;
+  }
+}
+
+@media (min-width:80rem) {
+  .c2 {
+    margin-left: 33.333333333333336%;
+  }
+}
+
+@supports (display:grid) {
+  .c2 {
+    display: block;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c4 {
+    padding: 0 0.5rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c4 {
+    padding: 0 0.5rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c4 {
+    padding: 0 1rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c4 {
+    padding: 0 1rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c4 {
+    margin-left: 20%;
+  }
+}
+
+@media (min-width:80rem) {
+  .c4 {
+    margin-left: 40%;
+  }
+}
+
+@supports (display:grid) {
+  .c4 {
+    display: block;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c1 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c3 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c5 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
@@ -1454,19 +1439,18 @@ exports[`should render a news article correctly 1`] = `
     chartbeat
   </div>
   <main
-    class="c0"
     role="main"
   >
     <div
-      class="c1 c2"
+      class="c0 c1"
       dir="ltr"
     >
       <div
-        class="c3"
+        class="c2"
         dir="ltr"
       >
         <h1
-          class="c4"
+          class="c3"
           id="content"
           tabindex="-1"
         >
@@ -1474,11 +1458,11 @@ exports[`should render a news article correctly 1`] = `
         </h1>
       </div>
       <div
-        class="c5"
+        class="c4"
         dir="ltr"
       >
         <p
-          class="c6"
+          class="c5"
         >
           A paragraph.
         </p>
@@ -1489,11 +1473,11 @@ exports[`should render a news article correctly 1`] = `
 `;
 
 exports[`should render a rtl article (persian) with most read correctly 1`] = `
-.c2 {
+.c1 {
   width: 100%;
 }
 
-.c4 {
+.c3 {
   font-size: 2rem;
   line-height: 2.625rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -1506,11 +1490,11 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   overflow-wrap: anywhere;
 }
 
-.c4:focus {
+.c3:focus {
   outline: none;
 }
 
-.c6 {
+.c5 {
   font-size: 1.125rem;
   line-height: 1.75rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -1521,7 +1505,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   margin: 0;
 }
 
-.c24 {
+.c23 {
   font-size: 1rem;
   line-height: 1.25rem;
   color: #6E6E73;
@@ -1531,7 +1515,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   font-style: normal;
 }
 
-.c15 {
+.c14 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1539,7 +1523,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   grid-template-rows: repeat(10,auto);
 }
 
-.c20 {
+.c19 {
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1551,7 +1535,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   padding: 0;
 }
 
-.c22 {
+.c21 {
   font-size: 1rem;
   line-height: 1.625rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -1564,13 +1548,13 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   margin-bottom: 0.5rem;
 }
 
-.c22:hover,
-.c22:focus {
+.c21:hover,
+.c21:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c22:before {
+.c21:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1582,17 +1566,17 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   z-index: 1;
 }
 
-.c21 {
+.c20 {
   padding-top: 0.375rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
 
-.c23 {
+.c22 {
   padding-top: 0.5rem;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1604,12 +1588,12 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   padding: 0;
 }
 
-.c17 {
+.c16 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1619,7 +1603,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1638,7 +1622,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   align-items: baseline;
 }
 
-.c14 {
+.c13 {
   font-size: 1.5rem;
   line-height: 2rem;
   font-family: "BBC Nassim Persian",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -1657,39 +1641,32 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   align-items: center;
 }
 
-.c10 {
+.c9 {
   border-top: 0.0625rem solid #AEAEB5;
   z-index: -1;
 }
 
-.c8 {
+.c7 {
   position: relative;
   z-index: 0;
   color: #3F3F42;
   margin-top: 2rem;
 }
 
-.c11 {
+.c10 {
   margin: 0;
   padding: 0;
 }
 
-.c0 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 @supports (display:grid) {
-  .c1 {
+  .c0 {
     display: grid;
     position: initial;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -1697,7 +1674,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -1705,7 +1682,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c16 {
+  .c15 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -1713,7 +1690,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -1721,7 +1698,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c16 {
+  .c15 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -1729,7 +1706,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:80rem) {
-  .c16 {
+  .c15 {
     width: calc(20%);
     display: inline-block;
     vertical-align: top;
@@ -1737,209 +1714,245 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @supports (display:grid) {
-  .c16 {
+  .c15 {
     display: block;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-right: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 0.5rem;
     margin-right: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-right: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c3 {
+  .c2 {
     padding: 0 1rem;
     margin-right: 0%;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c3 {
-    margin-right: 16.666666666666668%;
-  }
-}
-
-@media (min-width:80rem) {
-  .c3 {
-    margin-right: 33.333333333333336%;
-  }
-}
-
-@supports (display:grid) {
-  .c3 {
-    display: block;
-  }
-}
-
-@media (max-width:14.9375rem) {
-  .c5 {
-    padding: 0 0.5rem;
-    margin-right: 0%;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c5 {
-    padding: 0 0.5rem;
-    margin-right: 0%;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c5 {
-    padding: 0 1rem;
-    margin-right: 0%;
-  }
-}
-
-@media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c5 {
-    padding: 0 1rem;
-    margin-right: 0%;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c5 {
-    margin-right: 20%;
-  }
-}
-
-@media (min-width:80rem) {
-  .c5 {
-    margin-right: 40%;
-  }
-}
-
-@supports (display:grid) {
-  .c5 {
-    display: block;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .c2 {
+    margin-right: 16.666666666666668%;
+  }
+}
+
+@media (min-width:80rem) {
+  .c2 {
+    margin-right: 33.333333333333336%;
+  }
+}
+
+@supports (display:grid) {
+  .c2 {
+    display: block;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c4 {
+    padding: 0 0.5rem;
+    margin-right: 0%;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c4 {
+    padding: 0 0.5rem;
+    margin-right: 0%;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c4 {
+    padding: 0 1rem;
+    margin-right: 0%;
+  }
+}
+
+@media (min-width:37.5rem) and (max-width:62.9375rem) {
+  .c4 {
+    padding: 0 1rem;
+    margin-right: 0%;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c4 {
+    margin-right: 20%;
+  }
+}
+
+@media (min-width:80rem) {
+  .c4 {
+    margin-right: 40%;
+  }
+}
+
+@supports (display:grid) {
+  .c4 {
+    display: block;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c1 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c3 {
     font-size: 2.375rem;
     line-height: 2.875rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     font-size: 2.75rem;
     line-height: 3.375rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c4 {
+  .c3 {
     padding: 2.5rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c5 {
     font-size: 1.375rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c6 {
+  .c5 {
     font-size: 1.375rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
+  .c23 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c23 {
     font-size: 1.125rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c14 {
     grid-template-rows: repeat( 5,auto );
   }
 }
 
 @media (min-width:80rem) {
-  .c15 {
+  .c14 {
     grid-auto-flow: row;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c19 {
+  .c18 {
     min-width: 1rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c19 {
+  .c18 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c19 {
+  .c18 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c19 {
+  .c18 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c19 {
+  .c18 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (max-width:14.9375rem) {
+  .c24 {
+    min-width: 1rem;
+  }
+}
+
+@media (min-width:15rem) and (max-width:24.9375rem) {
+  .c24 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:25rem) and (max-width:37.4375rem) {
+  .c24 {
+    min-width: 1.5rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    min-width: 2rem;
+  }
+}
+
+@media (min-width:37.5rem) {
+  .c24 {
+    min-width: 2rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c24 {
     min-width: 1.5rem;
   }
 }
@@ -1970,13 +1983,13 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c25 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
 @media (min-width:80rem) {
   .c25 {
-    min-width: 1.5rem;
+    min-width: 2rem;
   }
 }
 
@@ -2006,13 +2019,13 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c26 {
-    min-width: 1.5rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c26 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -2042,7 +2055,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c27 {
-    min-width: 2rem;
+    min-width: 1.5rem;
   }
 }
 
@@ -2078,95 +2091,59 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 
 @media (min-width:37.5rem) {
   .c28 {
-    min-width: 1.5rem;
+    min-width: 2rem;
   }
 }
 
 @media (min-width:80rem) {
   .c28 {
-    min-width: 1.5rem;
-  }
-}
-
-@media (max-width:14.9375rem) {
-  .c29 {
-    min-width: 1rem;
-  }
-}
-
-@media (min-width:15rem) and (max-width:24.9375rem) {
-  .c29 {
-    min-width: 1.5rem;
-  }
-}
-
-@media (min-width:25rem) and (max-width:37.4375rem) {
-  .c29 {
-    min-width: 1.5rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    min-width: 2rem;
-  }
-}
-
-@media (min-width:37.5rem) {
-  .c29 {
-    min-width: 2rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c29 {
     min-width: 2rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c20 {
+  .c19 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c20 {
+  .c19 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c22 {
+  .c21 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c22 {
+  .c21 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c22 {
+  .c21 {
     font-size: 1.375rem;
     line-height: 1.75rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c21 {
+  .c20 {
     padding-left: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2175,39 +2152,39 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c14 {
+  .c13 {
     font-size: 1.625rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     font-size: 1.75rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     margin: 0;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c14 {
+  .c13 {
     padding-left: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active) {
-  .c10 {
+  .c9 {
     border-color: windowText;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c10 {
+  .c9 {
     position: absolute;
     left: 0;
     right: 0;
@@ -2216,43 +2193,43 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .c8 {
+  .c7 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c8 {
+  .c7 {
     margin-bottom: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c9 {
+  .c8 {
     margin-bottom: 1rem;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 0.5rem 1.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:62.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 1rem 2rem;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c7 {
+  .c6 {
     margin: 0 1rem 2.5rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c7 {
+  .c6 {
     width: 100%;
     margin: 0 auto 1.5rem;
     padding: 0 1rem;
@@ -2266,19 +2243,18 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
     chartbeat
   </div>
   <main
-    class="c0"
     role="main"
   >
     <div
-      class="c1 c2"
+      class="c0 c1"
       dir="rtl"
     >
       <div
-        class="c3"
+        class="c2"
         dir="rtl"
       >
         <h1
-          class="c4"
+          class="c3"
           id="content"
           tabindex="-1"
         >
@@ -2286,11 +2262,11 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </h1>
       </div>
       <div
-        class="c5"
+        class="c4"
         dir="rtl"
       >
         <p
-          class="c6"
+          class="c5"
         >
           یک پاراگراف.
         </p>
@@ -2299,27 +2275,27 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   </main>
   <section
     aria-labelledby="Most-Read"
-    class="c7"
+    class="c6"
     data-e2e="most-read"
     role="region"
   >
     <div
-      class="c8 c9"
+      class="c7 c8"
     >
       <div
-        class="c10"
+        class="c9"
       />
       <h2
-        class="c11"
+        class="c10"
       >
         <span
-          class="c12"
+          class="c11"
         >
           <span
-            class="c13"
+            class="c12"
           >
             <span
-              class="c14"
+              class="c13"
               dir="rtl"
               id="Most-Read"
             >
@@ -2330,43 +2306,43 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
       </h2>
     </div>
     <ol
-      class="c1 c15"
+      class="c0 c14"
       dir="rtl"
       role="list"
     >
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c19"
+            class="c18"
             dir="rtl"
           >
             <span
-              class="c20"
+              class="c19"
             >
               ۱
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
+              class="c21"
               href="/persian/world-50317704"
             >
               توافق با جدایی‌طلبان یمن؛ ایران اعتراض کرد، سازمان ملل استقبال
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2376,38 +2352,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c25"
+            class="c24"
             dir="rtl"
           >
             <span
-              class="c20"
+              class="c19"
             >
               ۲
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
+              class="c21"
               href="/persian/iran-50319870"
             >
               فراخوان آذری جهرمی برای مناظره اینستاگرامی - زرآبادی: در مجلس مناظره کنیم
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2417,38 +2393,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
-            class="c19"
+            class="c18"
             dir="rtl"
           >
             <span
-              class="c20"
+              class="c19"
             >
               ۳
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
+              class="c21"
               href="/persian/world-50320610"
             >
               ترکیه: همسر ابوبکر بغدادی را 'دستگیر کردیم'
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2458,38 +2434,79 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
+        >
+          <div
+            class="c24"
+            dir="rtl"
+          >
+            <span
+              class="c19"
+            >
+              ۴
+            </span>
+          </div>
+          <div
+            class="c20"
+            dir="rtl"
+          >
+            <a
+              class="c21"
+              href="/persian/world-50316456"
+            >
+              غنی سازی مجدد در فردو: مکرون اقدام ایران را 'عمیقا مایه نگرانی' خواند
+            </a>
+            <div
+              class="c22"
+            >
+              <time
+                class="c23"
+                datetime="2019-11-06"
+              >
+                به روز شده در ۶ نوامبر ۲۰۱۹
+              </time>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li
+        class="c15 c16"
+        dir="rtl"
+        role="listitem"
+      >
+        <div
+          class="c17"
         >
           <div
             class="c25"
             dir="rtl"
           >
             <span
-              class="c20"
+              class="c19"
             >
-              ۴
+              ۵
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
-              href="/persian/world-50316456"
+              class="c21"
+              href="/persian/magazine-50249226"
             >
-              غنی سازی مجدد در فردو: مکرون اقدام ایران را 'عمیقا مایه نگرانی' خواند
+              دوازده دلیل حکمرانی حشرات: سوسک می‌تواند دو هفته بدون سر زنده بماند
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2499,120 +2516,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
             class="c26"
             dir="rtl"
           >
             <span
-              class="c20"
-            >
-              ۵
-            </span>
-          </div>
-          <div
-            class="c21"
-            dir="rtl"
-          >
-            <a
-              class="c22"
-              href="/persian/magazine-50249226"
-            >
-              دوازده دلیل حکمرانی حشرات: سوسک می‌تواند دو هفته بدون سر زنده بماند
-            </a>
-            <div
-              class="c23"
-            >
-              <time
-                class="c24"
-                datetime="2019-11-06"
-              >
-                به روز شده در ۶ نوامبر ۲۰۱۹
-              </time>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li
-        class="c16 c17"
-        dir="rtl"
-        role="listitem"
-      >
-        <div
-          class="c18"
-        >
-          <div
-            class="c27"
-            dir="rtl"
-          >
-            <span
-              class="c20"
+              class="c19"
             >
               ۶
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
+              class="c21"
               href="/persian/world-50317700"
             >
               انتخابات ایالتی آمریکا؛ دموکرات‌ها از جمهوری‌خواهان پیش افتادند
             </a>
             <div
-              class="c23"
-            >
-              <time
-                class="c24"
-                datetime="2019-11-06"
-              >
-                به روز شده در ۶ نوامبر ۲۰۱۹
-              </time>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li
-        class="c16 c17"
-        dir="rtl"
-        role="listitem"
-      >
-        <div
-          class="c18"
-        >
-          <div
-            class="c28"
-            dir="rtl"
-          >
-            <span
-              class="c20"
-            >
-              ۷
-            </span>
-          </div>
-          <div
-            class="c21"
-            dir="rtl"
-          >
-            <a
               class="c22"
-              href="/persian/sport-50322486"
-            >
-              عراق اردن را به عنوان میزبان بازی با ایران معرفی کرد
-            </a>
-            <div
-              class="c23"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2622,38 +2557,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
         >
           <div
             class="c27"
             dir="rtl"
           >
             <span
-              class="c20"
+              class="c19"
             >
-              ۸
+              ۷
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
-              href="/persian/iran-features-50310665"
+              class="c21"
+              href="/persian/sport-50322486"
             >
-              آیا تهران بازی هسته ای را به هم می‌زند؟
+              عراق اردن را به عنوان میزبان بازی با ایران معرفی کرد
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹
@@ -2663,79 +2598,120 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </div>
       </li>
       <li
-        class="c16 c17"
+        class="c15 c16"
         dir="rtl"
         role="listitem"
       >
         <div
-          class="c18"
+          class="c17"
+        >
+          <div
+            class="c26"
+            dir="rtl"
+          >
+            <span
+              class="c19"
+            >
+              ۸
+            </span>
+          </div>
+          <div
+            class="c20"
+            dir="rtl"
+          >
+            <a
+              class="c21"
+              href="/persian/iran-features-50310665"
+            >
+              آیا تهران بازی هسته ای را به هم می‌زند؟
+            </a>
+            <div
+              class="c22"
+            >
+              <time
+                class="c23"
+                datetime="2019-11-06"
+              >
+                به روز شده در ۶ نوامبر ۲۰۱۹
+              </time>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li
+        class="c15 c16"
+        dir="rtl"
+        role="listitem"
+      >
+        <div
+          class="c17"
+        >
+          <div
+            class="c27"
+            dir="rtl"
+          >
+            <span
+              class="c19"
+            >
+              ۹
+            </span>
+          </div>
+          <div
+            class="c20"
+            dir="rtl"
+          >
+            <a
+              class="c21"
+              href="/persian/world-50316450"
+            >
+              آمریکا: دو ایرانی اتهام جمع‌آوری اطلاعات علیه سازمان مجاهدین در خاک آمریکا را پذیرفتند
+            </a>
+            <div
+              class="c22"
+            >
+              <time
+                class="c23"
+                datetime="2019-11-06"
+              >
+                به روز شده در ۶ نوامبر ۲۰۱۹
+              </time>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li
+        class="c15 c16"
+        dir="rtl"
+        role="listitem"
+      >
+        <div
+          class="c17"
         >
           <div
             class="c28"
             dir="rtl"
           >
             <span
-              class="c20"
-            >
-              ۹
-            </span>
-          </div>
-          <div
-            class="c21"
-            dir="rtl"
-          >
-            <a
-              class="c22"
-              href="/persian/world-50316450"
-            >
-              آمریکا: دو ایرانی اتهام جمع‌آوری اطلاعات علیه سازمان مجاهدین در خاک آمریکا را پذیرفتند
-            </a>
-            <div
-              class="c23"
-            >
-              <time
-                class="c24"
-                datetime="2019-11-06"
-              >
-                به روز شده در ۶ نوامبر ۲۰۱۹
-              </time>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li
-        class="c16 c17"
-        dir="rtl"
-        role="listitem"
-      >
-        <div
-          class="c18"
-        >
-          <div
-            class="c29"
-            dir="rtl"
-          >
-            <span
-              class="c20"
+              class="c19"
             >
               ۱۰
             </span>
           </div>
           <div
-            class="c21"
+            class="c20"
             dir="rtl"
           >
             <a
-              class="c22"
+              class="c21"
               href="/persian/sport-50318030"
             >
               فوتبال ایران و عراق؛ ایران: امن است بازی می‌کنیم، فیفا: ناامن است بازی نکنید
             </a>
             <div
-              class="c23"
+              class="c22"
             >
               <time
-                class="c24"
+                class="c23"
                 datetime="2019-11-06"
               >
                 به روز شده در ۶ نوامبر ۲۰۱۹

--- a/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -42,10 +42,6 @@ exports[`ErrorPage should correctly render for 404 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -374,10 +370,6 @@ exports[`ErrorPage should correctly render for 404 for persian 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -656,10 +648,6 @@ exports[`ErrorPage should correctly render for 500 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -933,10 +921,6 @@ exports[`ErrorPage should correctly render for 500 for persian 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {
@@ -1210,10 +1194,6 @@ exports[`ErrorPage should correctly render for other status code 1`] = `
 .c1 {
   width: 100%;
   padding-bottom: 4rem;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c5 {

--- a/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { string, shape } from 'prop-types';
-import styled from 'styled-components';
 import { Headline } from '@bbc/psammead-headings';
 import pathOr from 'ramda/src/pathOr';
 import Paragraph from '@bbc/psammead-paragraph';
@@ -22,10 +21,6 @@ import getEmbedUrl from '#lib/utilities/getEmbedUrl';
 const staticAssetsPath = `${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN}${process.env.SIMORGH_PUBLIC_STATIC_ASSETS_PATH}`;
 
 const audioPlaceholderImageSrc = `${staticAssetsPath}images/amp_audio_placeholder.png`;
-
-const StyledGelPageGrid = styled(GelPageGrid)`
-  flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
-`;
 
 const LiveRadioPage = ({ pageData }) => {
   const {
@@ -79,7 +74,7 @@ const LiveRadioPage = ({ pageData }) => {
       />
       <LinkedData type="RadioChannel" seoTitle={name} />
 
-      <StyledGelPageGrid
+      <GelPageGrid
         forwardedAs="main"
         role="main"
         columns={{
@@ -133,7 +128,7 @@ const LiveRadioPage = ({ pageData }) => {
             placeholderSrc={audioPlaceholderImageSrc}
           />
         </Grid>
-      </StyledGelPageGrid>
+      </GelPageGrid>
       {hasRadioScheduleData && (
         <RadioScheduleContainer initialData={radioScheduleData} />
       )}

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -245,6 +245,10 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
   margin: 0;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c6 {
   height: 165px;
   position: relative;
@@ -255,14 +259,6 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
 .c5 div > iframe {
   width: calc(100% + 1rem);
   margin: 0 -0.5rem;
-}
-
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
@@ -352,20 +348,6 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
   }
 }
 
-@media (min-width:63rem) {
-  .c6 {
-    margin-bottom: 2rem;
-  }
-}
-
-@media (min-width:25rem) {
-  .c5 amp-iframe,
-  .c5 div > iframe {
-    width: calc(100% + 2rem);
-    margin: 0 -1rem;
-  }
-}
-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .c1 {
     margin: 0 auto;
@@ -377,6 +359,20 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
   .c1 {
     margin: 0 auto;
     max-width: 80rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c6 {
+    margin-bottom: 2rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c5 amp-iframe,
+  .c5 div > iframe {
+    width: calc(100% + 2rem);
+    margin: 0 -1rem;
   }
 }
 
@@ -865,6 +861,10 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   color: #6E6E73;
 }
 
+.c1 {
+  width: 100%;
+}
+
 .c6 {
   height: 165px;
   position: relative;
@@ -875,14 +875,6 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 .c5 div > iframe {
   width: calc(100% + 1rem);
   margin: 0 -0.5rem;
-}
-
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c7 {
@@ -1320,20 +1312,6 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 }
 
-@media (min-width:63rem) {
-  .c6 {
-    margin-bottom: 2rem;
-  }
-}
-
-@media (min-width:25rem) {
-  .c5 amp-iframe,
-  .c5 div > iframe {
-    width: calc(100% + 2rem);
-    margin: 0 -1rem;
-  }
-}
-
 @media (min-width:63rem) and (max-width:79.9375rem) {
   .c1 {
     margin: 0 auto;
@@ -1345,6 +1323,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   .c1 {
     margin: 0 auto;
     max-width: 80rem;
+  }
+}
+
+@media (min-width:63rem) {
+  .c6 {
+    margin-bottom: 2rem;
+  }
+}
+
+@media (min-width:25rem) {
+  .c5 amp-iframe,
+  .c5 div > iframe {
+    width: calc(100% + 2rem);
+    margin: 0 -1rem;
   }
 }
 

--- a/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Most Read Page Main should match snapshot for most read page 1`] = `
-.c8 {
+.c7 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -9,7 +9,7 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   grid-template-rows: repeat(10,auto);
 }
 
-.c13 {
+.c12 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -21,7 +21,7 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   padding: 0;
 }
 
-.c15 {
+.c14 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -34,13 +34,13 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   margin-bottom: 0.5rem;
 }
 
-.c15:hover,
-.c15:focus {
+.c14:hover,
+.c14:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c15:before {
+.c14:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -52,17 +52,17 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   z-index: 1;
 }
 
-.c14 {
+.c13 {
   padding-top: 0.375rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
-.c16 {
+.c15 {
   padding-top: 0.5rem;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,12 +74,12 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   padding: 0;
 }
 
-.c10 {
+.c9 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
-.c17 {
+.c16 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -89,24 +89,17 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
   font-style: normal;
 }
 
-.c5 {
+.c4 {
   width: 100%;
 }
 
 .c0 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c1 {
   margin: 0 0.5rem;
   padding-top: 0.5rem;
   padding-bottom: 2rem;
 }
 
-.c2 {
+.c1 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -118,218 +111,218 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
 }
 
 @supports (display:grid) {
-  .c4 {
+  .c3 {
     display: grid;
     position: initial;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c6 {
+  .c5 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c6 {
+  .c5 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c6 {
+  .c5 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c6 {
+  .c5 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c6 {
+  .c5 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:80rem) {
-  .c6 {
+  .c5 {
     margin-left: 18.181818181818183%;
   }
 }
 
 @supports (display:grid) {
-  .c6 {
+  .c5 {
     display: block;
   }
 }
 
 @supports (display:grid) {
-  .c7 {
+  .c6 {
     display: grid;
     position: initial;
   }
 }
 
 @supports (display:grid) {
-  .c9 {
+  .c8 {
     display: block;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c12 {
+  .c11 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c12 {
+  .c11 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c12 {
+  .c11 {
     min-width: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c12 {
+  .c11 {
     min-width: 4rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c13 {
+  .c12 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c13 {
+  .c12 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c15 {
+  .c14 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c15 {
+  .c14 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c15 {
+  .c14 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c14 {
+  .c13 {
     padding-right: 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c16 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c16 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c5 {
+  .c4 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c5 {
+  .c4 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c1 {
+  .c0 {
     margin: 0 1rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c1 {
+  .c0 {
     padding-top: 1rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c1 {
+  .c0 {
     padding-bottom: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c0 {
     padding-top: 0;
   }
 }
 
 @media (min-width:63rem) {
-  .c1 {
+  .c0 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c2 {
+  .c1 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c2 {
+  .c1 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c2 {
+  .c1 {
     padding: 1.5rem 0 0.5rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c2 {
+  .c1 {
     padding: 1.5rem 0 0;
   }
 }
 
 @media (min-width:80rem) {
-  .c2 {
+  .c1 {
     width: 100%;
     margin: 0 auto;
     max-width: 80rem;
@@ -337,19 +330,19 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c3 {
+  .c2 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c3 {
+  .c2 {
     margin-top: 2rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c3 {
+  .c2 {
     margin-top: 2rem;
   }
 }
@@ -582,15 +575,15 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
         chartbeat
       </div>
       <main
-        class="c0"
+        class=""
         data-e2e="most-read"
         role="main"
       >
         <div
-          class="c1"
+          class="c0"
         >
           <h1
-            class="c2"
+            class="c1"
             dir="ltr"
             id="content"
             tabindex="-1"
@@ -598,54 +591,54 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
             De one we dem de read well well
           </h1>
           <div
-            class="c3"
+            class="c2"
           >
             <div
-              class="c4 c5"
+              class="c3 c4"
               dir="ltr"
             >
               <div
-                class="c6"
+                class="c5"
                 dir="ltr"
               >
                 <ol
-                  class="c7 c8"
+                  class="c6 c7"
                   dir="ltr"
                   role="list"
                 >
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           1
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-46729879"
                         >
                           Public Holidays wey go happun for 2019
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-05-21"
                           >
                             De one we dem update for: 21st May 2019
@@ -655,38 +648,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           2
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50304653"
                         >
                           Liberia banks don run out of money
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-11-05"
                           >
                             De one we dem update for: 5th November 2019
@@ -696,38 +689,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           3
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50298882"
                         >
                           Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-11-05"
                           >
                             De one we dem update for: 5th November 2019
@@ -737,38 +730,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           4
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50315150"
                         >
                           Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-11-06"
                           >
                             De one we dem update for: 6th November 2019
@@ -778,38 +771,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           5
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50315157"
                         >
                           How Balogun market fire kill Policeman for Lagos
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-11-06"
                           >
                             De one we dem update for: 6th November 2019
@@ -819,38 +812,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           6
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50093818"
                         >
                           Labour, FG finally agree minimum wage salary adjustment
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-10-18"
                           >
                             De one we dem update for: 18th October 2019
@@ -860,38 +853,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           7
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-50187218"
                         >
                           Naira Marley na 'Bad Influence'?
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-10-25"
                           >
                             De one we dem update for: 25th October 2019
@@ -901,38 +894,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           8
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-48347911"
                         >
                           Tins you suppose know about Naira Marley
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-05-23"
                           >
                             De one we dem update for: 23rd May 2019
@@ -942,38 +935,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           9
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/sport-50312710"
                         >
                           Golden Eaglets crash out of Fifa U17 World Cup
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-11-06"
                           >
                             De one we dem update for: 6th November 2019
@@ -983,38 +976,38 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11"
+                      class="c10"
                     >
                       <div
-                        class="c12"
+                        class="c11"
                         dir="ltr"
                       >
                         <span
-                          class="c13"
+                          class="c12"
                         >
                           10
                         </span>
                       </div>
                       <div
-                        class="c14"
+                        class="c13"
                         dir="ltr"
                       >
                         <a
-                          class="c15"
+                          class="c14"
                           href="/pidgin/tori-42945173"
                         >
                           Tiger nut drink fit wake up your sex drive - Nutritionist
                         </a>
                         <div
-                          class="c16"
+                          class="c15"
                         >
                           <time
-                            class="c17"
+                            class="c16"
                             datetime="2019-05-21"
                           >
                             De one we dem update for: 21st May 2019

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Most Watched Page Main should match snapshot for the Most Watched page 1`] = `
-.c19 {
+.c18 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -10,18 +10,11 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   height: 0.75rem;
 }
 
-.c3 {
+.c2 {
   width: 100%;
 }
 
-.c0 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c5 {
+.c4 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -32,7 +25,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   padding-bottom: 1.5rem;
 }
 
-.c23 {
+.c22 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -44,34 +37,34 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   margin: 0;
 }
 
-.c13 {
+.c12 {
   display: inline-block;
   vertical-align: top;
   position: relative;
   width: 33.33%;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
   padding: 0 0.5rem;
 }
 
-.c11 {
+.c10 {
   position: relative;
 }
 
-.c14 {
+.c13 {
   position: relative;
 }
 
-.c16 > * {
+.c15 > * {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.c24 {
+.c23 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -81,7 +74,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   font-style: normal;
 }
 
-.c15 {
+.c14 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -94,7 +87,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
 }
 
-.c17 {
+.c16 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -105,7 +98,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   display: block;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -117,36 +110,36 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   height: 100%;
 }
 
-.c9 {
+.c8 {
   padding: 0.5rem 0 1rem;
 }
 
-.c9:last-child {
+.c8:last-child {
   border: none;
 }
 
-.c9:first-child {
+.c8:first-child {
   padding-top: 0;
 }
 
-.c9:last-child {
+.c8:last-child {
   padding-bottom: 0;
 }
 
-.c7 {
+.c6 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.c1 {
+.c0 {
   margin: 0 0.5rem;
   padding-top: 0.5rem;
   padding-bottom: 2rem;
   padding-bottom: 3rem;
 }
 
-.c21 {
+.c20 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -157,7 +150,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   line-height: 1.25rem;
 }
 
-.c22 {
+.c21 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -166,7 +159,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   overflow-wrap: anywhere;
 }
 
-.c22:before {
+.c21:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -178,120 +171,120 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
   z-index: 1;
 }
 
-.c22:hover,
-.c22:focus {
+.c21:hover,
+.c21:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c22:visited {
+.c21:visited {
   color: #6E6E73;
 }
 
 @supports (display:grid) {
-  .c2 {
+  .c1 {
     display: grid;
     position: initial;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .c4 {
+  .c3 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .c4 {
+  .c3 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .c4 {
+  .c3 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c4 {
+  .c3 {
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c4 {
+  .c3 {
     margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width:80rem) {
-  .c4 {
+  .c3 {
     margin-left: 9.090909090909092%;
   }
 }
 
 @supports (display:grid) {
-  .c4 {
+  .c3 {
     display: block;
   }
 }
 
 @supports (display:grid) {
-  .c8 {
+  .c7 {
     display: grid;
     position: initial;
   }
 }
 
 @supports (display:grid) {
-  .c10 {
+  .c9 {
     display: block;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .c3 {
+  .c2 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .c3 {
+  .c2 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c5 {
+  .c4 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c5 {
+  .c4 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c5 {
+  .c4 {
     padding: 1.5rem 0 0.5rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c5 {
+  .c4 {
     padding: 1.5rem 0 0;
   }
 }
 
 @media (min-width:80rem) {
-  .c5 {
+  .c4 {
     width: 100%;
     margin: 0 auto;
     max-width: 80rem;
@@ -299,27 +292,27 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
 }
 
 @media (min-width:63rem) {
-  .c13 {
+  .c12 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c13 {
+  .c12 {
     width: initial;
     grid-column: 1 / span 2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c20 {
+  .c19 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c20 {
+  .c19 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -327,7 +320,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c20 {
+  .c19 {
     display: block;
     width: initial;
     padding: initial;
@@ -336,7 +329,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .c11 {
+  .c10 {
     display: grid;
     grid-template-columns: repeat(6,1fr);
     grid-column-gap: 0.5rem;
@@ -344,142 +337,142 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
 }
 
 @media (min-width:25rem) {
-  .c16 {
+  .c15 {
     position: absolute;
     bottom: 0;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c16 > * {
+  .c15 > * {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c24 {
+  .c23 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c24 {
+  .c23 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c17 {
+  .c16 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c17 {
+  .c16 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c12 {
+  .c11 {
     display: grid;
   }
 }
 
 @media (max-width:62.9375rem) {
-  .c9 {
+  .c8 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c9 {
+  .c8 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c9 {
+  .c8 {
     padding: 0 0 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c9:first-child {
+  .c8:first-child {
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c9 {
+  .c8 {
     border-bottom: 0.0625rem solid #F2F2F2;
     padding: 1rem 0 1rem;
   }
 }
 
 @media (max-width:24.9375rem) {
-  .c6 {
+  .c5 {
     padding-top: 0.5rem;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .c6 {
+  .c5 {
     padding-bottom: 0.5rem;
     padding-top: 1rem;
   }
 }
 
 @media (min-width:63rem) {
-  .c6 {
+  .c5 {
     padding-bottom: 2rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c1 {
+  .c0 {
     margin: 0 1rem;
   }
 }
 
 @media (min-width:25rem) {
-  .c1 {
+  .c0 {
     padding-top: 1rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .c1 {
+  .c0 {
     padding-bottom: 1.5rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c1 {
+  .c0 {
     padding-top: 0;
   }
 }
 
 @media (min-width:63rem) {
-  .c1 {
+  .c0 {
     padding-bottom: 2.5rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .c21 {
+  .c20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .c21 {
+  .c20 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -705,23 +698,23 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
         chartbeat
       </div>
       <main
-        class="c0"
+        class=""
         data-e2e="most-watched"
         role="main"
       >
         <div
-          class="c1"
+          class="c0"
         >
           <div
-            class="c2 c3"
+            class="c1 c2"
             dir="ltr"
           >
             <div
-              class="c4"
+              class="c3"
               dir="ltr"
             >
               <h1
-                class="c5 c6"
+                class="c4 c5"
                 dir="ltr"
                 id="content"
                 tabindex="-1"
@@ -733,28 +726,28 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                 data-e2e="most-watched-heading"
               >
                 <ol
-                  class="c7 c8"
+                  class="c6 c7"
                   dir="ltr"
                   role="list"
                 >
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11 c12"
+                      class="c10 c11"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="c13"
+                        class="c12"
                         dir="ltr"
                       >
                         <div
-                          class="c14"
+                          class="c13"
                         >
                           <div
-                            class="c15"
+                            class="c14"
                           >
                             <div
                               class="lazyload-wrapper"
@@ -765,19 +758,19 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                             </div>
                           </div>
                           <div
-                            class="c16"
+                            class="c15"
                           >
                             <div
                               aria-hidden="true"
-                              class="c17"
+                              class="c16"
                               dir="ltr"
                             >
                               <div
-                                class="c18"
+                                class="c17"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="c19"
+                                  class="c18"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 32 32"
@@ -793,21 +786,21 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                         </div>
                       </div>
                       <div
-                        class="c20"
+                        class="c19"
                         dir="ltr"
                       >
                         <h2
-                          class="c21"
+                          class="c20"
                         >
                           <a
-                            class="c22"
+                            class="c21"
                             href="/pidgin/media-53580248"
                           >
                             <span
                               role="text"
                             >
                               <span
-                                class="c23"
+                                class="c22"
                               >
                                 Video
                                 , 
@@ -819,7 +812,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                           </a>
                         </h2>
                         <time
-                          class="c24"
+                          class="c23"
                           datetime="2020-07-29"
                         >
                           29th July 2020
@@ -828,23 +821,23 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11 c12"
+                      class="c10 c11"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="c13"
+                        class="c12"
                         dir="ltr"
                       >
                         <div
-                          class="c14"
+                          class="c13"
                         >
                           <div
-                            class="c15"
+                            class="c14"
                           >
                             <div
                               class="lazyload-wrapper"
@@ -855,19 +848,19 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                             </div>
                           </div>
                           <div
-                            class="c16"
+                            class="c15"
                           >
                             <div
                               aria-hidden="true"
-                              class="c17"
+                              class="c16"
                               dir="ltr"
                             >
                               <div
-                                class="c18"
+                                class="c17"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="c19"
+                                  class="c18"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 32 32"
@@ -883,21 +876,21 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                         </div>
                       </div>
                       <div
-                        class="c20"
+                        class="c19"
                         dir="ltr"
                       >
                         <h2
-                          class="c21"
+                          class="c20"
                         >
                           <a
-                            class="c22"
+                            class="c21"
                             href="/pidgin/media-53591139"
                           >
                             <span
                               role="text"
                             >
                               <span
-                                class="c23"
+                                class="c22"
                               >
                                 Video
                                 , 
@@ -909,7 +902,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                           </a>
                         </h2>
                         <time
-                          class="c24"
+                          class="c23"
                           datetime="2020-07-30"
                         >
                           30th July 2020
@@ -918,23 +911,23 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                     </div>
                   </li>
                   <li
-                    class="c9 c10"
+                    class="c8 c9"
                     dir="ltr"
                     role="listitem"
                   >
                     <div
-                      class="c11 c12"
+                      class="c10 c11"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="c13"
+                        class="c12"
                         dir="ltr"
                       >
                         <div
-                          class="c14"
+                          class="c13"
                         >
                           <div
-                            class="c15"
+                            class="c14"
                           >
                             <div
                               class="lazyload-wrapper"
@@ -945,19 +938,19 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                             </div>
                           </div>
                           <div
-                            class="c16"
+                            class="c15"
                           >
                             <div
                               aria-hidden="true"
-                              class="c17"
+                              class="c16"
                               dir="ltr"
                             >
                               <div
-                                class="c18"
+                                class="c17"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="c19"
+                                  class="c18"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 32 32"
@@ -973,21 +966,21 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                         </div>
                       </div>
                       <div
-                        class="c20"
+                        class="c19"
                         dir="ltr"
                       >
                         <h2
-                          class="c21"
+                          class="c20"
                         >
                           <a
-                            class="c22"
+                            class="c21"
                             href="/pidgin/tori-53509788"
                           >
                             <span
                               role="text"
                             >
                               <span
-                                class="c23"
+                                class="c22"
                               >
                                 Video
                                 , 
@@ -999,7 +992,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                           </a>
                         </h2>
                         <time
-                          class="c24"
+                          class="c23"
                           datetime="2020-07-23"
                         >
                           23rd July 2020

--- a/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
+++ b/src/app/pages/OnDemandRadioPage/OnDemandRadioPage.jsx
@@ -37,10 +37,6 @@ const getGroups = (zero, one, two, three, four, five) => ({
   group5: five,
 });
 
-const StyledGelPageGrid = styled(GelPageGrid)`
-  flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
-`;
-
 const StyledGelWrapperGrid = styled(GelPageGrid)`
   @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
     padding-top: ${GEL_SPACING_TRPL};
@@ -103,7 +99,7 @@ const OnDemandRadioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
         description={shortSynopsis}
         openGraphType="website"
       />
-      <StyledGelPageGrid
+      <GelPageGrid
         forwardedAs="main"
         role="main"
         columns={getGroups(6, 6, 6, 6, 8, 20)}
@@ -166,7 +162,7 @@ const OnDemandRadioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
             }
           />
         </Grid>
-      </StyledGelPageGrid>
+      </GelPageGrid>
       {radioScheduleData && (
         <RadioScheduleContainer initialData={radioScheduleData} />
       )}

--- a/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandRadioPage/__snapshots__/index.test.jsx.snap
@@ -222,7 +222,11 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
     </script>
   </head>
   <body>
-    .c6 {
+    .c1 {
+  width: 100%;
+}
+
+.c6 {
   font-size: 2rem;
   line-height: 2.625rem;
   font-family: "BBC Nassim Pashto",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -307,14 +311,6 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   padding-right: 1rem;
 }
 
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 .c4 {
   width: 100%;
 }
@@ -388,6 +384,20 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 @supports (display:grid) {
   .c12 {
     display: block;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 63rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 80rem;
   }
 }
 
@@ -470,20 +480,6 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 @media (max-width:24.9375rem) {
   .c13 {
     display: none;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 63rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 80rem;
   }
 }
 
@@ -635,6 +631,10 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 `;
 
 exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
+.c1 {
+  width: 100%;
+}
+
 .c6 {
   font-size: 2rem;
   line-height: 2.625rem;
@@ -726,14 +726,6 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   padding-right: 1rem;
 }
 
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 .c4 {
   width: 100%;
 }
@@ -820,6 +812,20 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   }
 }
 
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 63rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 80rem;
+  }
+}
+
 @media (min-width:20rem) and (max-width:37.4375rem) {
   .c6 {
     font-size: 2.375rem;
@@ -899,20 +905,6 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 @media (max-width:24.9375rem) {
   .c13 {
     display: none;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 63rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 80rem;
   }
 }
 
@@ -1264,6 +1256,10 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 `;
 
 exports[`OnDemand Radio Page  should show the 'content not yet available' message if episode is not yet available 1`] = `
+.c1 {
+  width: 100%;
+}
+
 .c6 {
   font-size: 1.75rem;
   line-height: 2rem;
@@ -1375,14 +1371,6 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   padding-right: 1rem;
 }
 
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 .c4 {
   width: 100%;
 }
@@ -1462,6 +1450,20 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
 @supports (display:grid) {
   .c2 {
     display: block;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 63rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 80rem;
   }
 }
 
@@ -1554,20 +1556,6 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
 @media (max-width:24.9375rem) {
   .c13 {
     display: none;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 63rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 80rem;
   }
 }
 
@@ -1690,6 +1678,10 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
 `;
 
 exports[`OnDemand Radio Page  should show the expired content message if episode is expired 1`] = `
+.c1 {
+  width: 100%;
+}
+
 .c6 {
   font-size: 1.75rem;
   line-height: 2rem;
@@ -1801,14 +1793,6 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   padding-right: 1rem;
 }
 
-.c1 {
-  width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
 .c4 {
   width: 100%;
 }
@@ -1888,6 +1872,20 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 @supports (display:grid) {
   .c2 {
     display: block;
+  }
+}
+
+@media (min-width:63rem) and (max-width:79.9375rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 63rem;
+  }
+}
+
+@media (min-width:80rem) {
+  .c1 {
+    margin: 0 auto;
+    max-width: 80rem;
   }
 }
 
@@ -1980,20 +1978,6 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 @media (max-width:24.9375rem) {
   .c13 {
     display: none;
-  }
-}
-
-@media (min-width:63rem) and (max-width:79.9375rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 63rem;
-  }
-}
-
-@media (min-width:80rem) {
-  .c1 {
-    margin: 0 auto;
-    max-width: 80rem;
   }
 }
 

--- a/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
+++ b/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
@@ -44,7 +44,6 @@ const getGroups = (zero, one, two, three, four, five) => ({
 const StyledGelPageGrid = styled(GelPageGrid)`
   padding-bottom: ${GEL_SPACING_QUAD};
   width: 100%;
-  flex-grow: 1; /* needed to ensure footer positions at bottom of viewport */
 `;
 
 const StyledVideoPlayer = styled(AVPlayer)`

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
@@ -70,10 +70,6 @@ exports[`OnDemand TV Brand Page  Dark Mode Design - should match snapshot 1`] = 
   width: 100%;
   padding-bottom: 2rem;
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c7 {
@@ -462,10 +458,6 @@ exports[`should show the expired content message if episode is expired 1`] = `
   width: 100%;
   padding-bottom: 2rem;
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c4 {
@@ -863,10 +855,6 @@ exports[`should show the future content message if episode is not yet available 
   width: 100%;
   padding-bottom: 2rem;
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c4 {
@@ -1264,10 +1252,6 @@ exports[`should show the future content message if episode is pending 1`] = `
   width: 100%;
   padding-bottom: 2rem;
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
 }
 
 .c4 {

--- a/src/app/pages/PhotoGalleryPage/PhotoGalleryPage.jsx
+++ b/src/app/pages/PhotoGalleryPage/PhotoGalleryPage.jsx
@@ -69,7 +69,6 @@ const PhotoGalleryPage = ({ pageData }) => {
   };
 
   const StyledGelPageGrid = styled(GelPageGrid)`
-    flex-grow: 1;
     padding-bottom: ${GEL_SPACING_TRPL};
 
     @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -113,10 +113,6 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
 
 .c1 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   padding-bottom: 1.5rem;
 }
 
@@ -1709,10 +1705,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
 
 .c1 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   padding-bottom: 1.5rem;
 }
 
@@ -3498,10 +3490,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 
 .c1 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   padding-bottom: 1.5rem;
 }
 
@@ -5016,10 +5004,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
 
 .c1 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   padding-bottom: 1.5rem;
 }
 
@@ -6812,10 +6796,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 
 .c1 {
   width: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   padding-bottom: 1.5rem;
 }
 

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -200,7 +200,6 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
   `;
 
   const StoryPageGrid = styled(Grid)`
-    flex-grow: 1;
     width: 100%; /* Needed for IE11 */
     margin: 0 auto;
     @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -511,10 +511,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 .c1 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   width: 100%;
   margin: 0 auto;
 }
@@ -3884,10 +3880,6 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 .c1 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   width: 100%;
   margin: 0 auto;
 }
@@ -6194,10 +6186,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 .c1 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   width: 100%;
   margin: 0 auto;
 }

--- a/src/server/Document/__snapshots__/component.test.jsx.snap
+++ b/src/server/Document/__snapshots__/component.test.jsx.snap
@@ -76,7 +76,6 @@ exports[`Document Component should render AMP version correctly 1`] = `
     class="amp-geo-pending"
   >
     <div
-      class="StyledDiv-sc-1dngwtn-0 riLLS"
       id="root"
     >
       <h1
@@ -133,7 +132,6 @@ exports[`Document Component should render correctly 1`] = `
   </head>
   <body>
     <div
-      class="StyledDiv-sc-1dngwtn-0 riLLS"
       id="root"
     >
       <h1

--- a/src/server/Document/component.jsx
+++ b/src/server/Document/component.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 import {
   AMP_SCRIPT,
   AMP_NO_SCRIPT,
@@ -8,7 +7,6 @@ import {
   AMP_CONSENT_JS,
   AMP_ANALYTICS_JS,
 } from '@bbc/psammead-assets/amp-boilerplate';
-import { C_GHOST } from '@bbc/psammead-styles/colours';
 import serialiseForScript from '#lib/utilities/serialiseForScript';
 import ResourceHints from '#app/components/ResourceHints';
 import IfAboveIE9 from '#app/components/IfAboveIE9Comment';
@@ -30,13 +28,6 @@ const Document = ({
   const headScript = helmet.script.toComponent();
   const serialisedData = serialiseForScript(data);
   const scriptsAllowed = !isAmp;
-  const StyledDiv = styled.div`
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    background-color: ${C_GHOST};
-  `;
-
   // The JS to remove the no-js class will not run on AMP, therefore only add it to canonical
   const noJsHtmlAttrs = !isAmp && { className: 'no-js' };
 
@@ -80,7 +71,7 @@ const Document = ({
       <body {...ampGeoPendingAttrs}>
         {/* disabling the rule that bans the use of dangerouslySetInnerHTML until a more appropriate implementation can be implemented */}
         {/* eslint-disable-next-line react/no-danger */}
-        <StyledDiv id="root" dangerouslySetInnerHTML={{ __html: app }} />
+        <div id="root" dangerouslySetInnerHTML={{ __html: app }} />
         {scriptsAllowed && (
           <script
             /* eslint-disable-next-line react/no-danger */


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Removes the need to apply flex grow to every page's main wrapper to ensure the footer positions at bottom of viewport. This was also refactor made in the [collab week PR](https://github.com/bbc/simorgh/pull/7812/files#diff-4f82528856466b0813073ea62a3551a49641c3d9818f5482d70ce68d21331584) which helped the footer stay at the bottom between page transitions.

This also removes all style handling from `src/server/Document/component.jsx` and moves it to a more appropriate location in `src/app/Layouts/defaultPageWrapper.jsx`

**Code changes:**
- move footer positioning `flex-grow: 1` style to `defaultPageWrapper.jsx`
- remove `flex-grow: 1` from all page type wrappers that use it
- apply ghost background colour to the new wrapper in `defaultPageWrapper.jsx` and change the dark mode override CSS selector in `src/app/lib/utilities/darkMode/index.jsx`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
