### PR TITLE
Revert "use % unit instead of vh"

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -431,7 +431,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 .c0 {
-  min-height: 100%;
+  min-height: 100vh;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -11,7 +11,7 @@ import { ServiceContext } from '../contexts/ServiceContext';
 import WebVitals from '#app/containers/WebVitals';
 
 const Wrapper = styled.div`
-  min-height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
This reverts commit 209c16a040f836117ad15e179a5ec5ce5bb21d9d.

**Overall change:**
We need to use vh and not % for the min-height of the main page wrapper.

**Code changes:**

- Reverts the commit that made the change from % to vh

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
