### PR TITLE
Add action to run amp validation

### DIFF
--- a/.github/workflows/simorgh-amp-a11y-validation.yml
+++ b/.github/workflows/simorgh-amp-a11y-validation.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run AMP Validator
         run: npm run amp:validate
       - name: Run bbc-a11y
-        run: npm run bbcA11y
+        run: npm run bbcA11y:ci

--- a/.github/workflows/simorgh-amp-a11y-validation.yml
+++ b/.github/workflows/simorgh-amp-a11y-validation.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run AMP Validator
         run: npm run amp:validate
       - name: Run bbc-a11y
-        run: npm run bbc-a11y
+        run: npm run bbcA11y

--- a/.github/workflows/simorgh-amp-validator.yml
+++ b/.github/workflows/simorgh-amp-validator.yml
@@ -32,3 +32,5 @@ jobs:
         run: nohup node build/server.js > /dev/null 2>&1 &
       - name: Run AMP Validator
         run: npm run amp:validate
+      - name: Run bbc-a11y
+        run: npm run bbc-a11y

--- a/.github/workflows/simorgh-amp-validator.yml
+++ b/.github/workflows/simorgh-amp-validator.yml
@@ -1,0 +1,35 @@
+name: Simorgh CI - AMP Validation
+on:
+  push:
+    branches:
+      - '**'
+      - '!latest'
+  pull_request:
+    branches:
+      - '**'
+      - '!latest'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    env:
+      CI: true
+      NODE_ENV: 'production'
+      LOG_LEVEL: 'error'
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install & Build Simorgh
+        run: |
+          npm ci
+          npm run build
+      - name: Start Simorgh Server
+        run: nohup node build/server.js > /dev/null 2>&1 &
+      - name: Run AMP Validator
+        run: npm run amp:validate

--- a/.github/workflows/simorgh-amp-validator.yml
+++ b/.github/workflows/simorgh-amp-validator.yml
@@ -1,4 +1,4 @@
-name: Simorgh CI - AMP Validation
+name: Simorgh CI - AMP Validation & bbc-a11y
 on:
   push:
     branches:

--- a/.github/workflows/simorgh-amp-validator.yml
+++ b/.github/workflows/simorgh-amp-validator.yml
@@ -16,7 +16,6 @@ jobs:
         node-version: [12.x]
     env:
       CI: true
-      NODE_ENV: 'production'
       LOG_LEVEL: 'error'
 
     steps:
@@ -28,7 +27,7 @@ jobs:
       - name: Install & Build Simorgh
         run: |
           npm ci
-          npm run build
+          npm run build:local
       - name: Start Simorgh Server
         run: nohup node build/server.js > /dev/null 2>&1 &
       - name: Run AMP Validator


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Add new GH Action to run our AMP validator script
- Run the Simorgh local server in the background in order to run the amp validator script
- At the moment if AMP validation fails it does not fail the build (this is intended)

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
