### PR TITLE
Emotion - ErrorPage e2e fixes

### DIFF
--- a/src/app/components/ErrorMain/index.jsx
+++ b/src/app/components/ErrorMain/index.jsx
@@ -83,7 +83,9 @@ const ErrorMain = ({
       }}
       margins={{ group0: true, group1: true, group2: true, group3: true }}
     >
-      <StatusCode script={script}>{statusCode}</StatusCode>
+      <StatusCode script={script} data-e2e="status-code">
+        {statusCode}
+      </StatusCode>
       <Heading id="content" script={script} service={service} tabIndex="-1">
         {title}
       </Heading>


### PR DESCRIPTION
**Overall change:**
- Added `data-e2e="status-code"` to `ErrorMain` `<StatusCode>`. Not sure how/why this was removed!

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
