### PR TITLE
GitHub action to create a tag and release when pushing to latest

### DIFF
--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -15,7 +15,8 @@ jobs:
         uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
+          RELEASE_BRANCHES: 'github-release-action, latest'
+          VERBOSE: true
 
       - name: Create Release
         id: create_release
@@ -27,7 +28,8 @@ jobs:
           release_name: Release ${{ steps.release_tag.outputs.new_tag }}
           body: |
             Changes in this Release
-            - First Change
-            - Second Change
+            ${{ steps.release_tag.outputs.tag }}
+            ${{ steps.release_tag.outputs.new_tag }}
+            ${{ steps.release_tag.outputs.part }}
           draft: true
           prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -1,6 +1,9 @@
 name: Simorgh CD - Create Release Tag
 
-on: ['push']
+on:
+  push:
+    branches:
+      - 'latest'
 
 jobs:
   build:
@@ -15,7 +18,7 @@ jobs:
         uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_BRANCHES: 'github-release-action, latest'
+          RELEASE_BRANCHES: 'latest'
 
       - name: Create Release
         id: create_release
@@ -25,10 +28,6 @@ jobs:
         with:
           tag_name: ${{ steps.release_tag.outputs.new_tag }}
           release_name: Release ${{ steps.release_tag.outputs.new_tag }}
-          body: |
-            Changes in this Release
-            ${{ steps.release_tag.outputs.tag }}
-            ${{ steps.release_tag.outputs.new_tag }}
-            ${{ steps.release_tag.outputs.part }}
-          draft: true
+          body: Version: ${{ steps.release_tag.outputs.new_tag }}
+          draft: false
           prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           tag_name: ${{ steps.release_tag.outputs.new_tag }}
           release_name: Release ${{ steps.release_tag.outputs.new_tag }}
-          body: Version: ${{ steps.release_tag.outputs.new_tag }}
+          body: |
+            Version: ${{ steps.release_tag.outputs.new_tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: 'github-release-action, latest'
-          VERBOSE: true
+          INITIAL_VERSION: 1.332.0
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -1,25 +1,38 @@
-name: Simorgh CD - Create Release Tag
+name: Simorgh CD - Create Release Tag & Release
 
 on: ['push']
 
 jobs:
-  build:
+  create_tag:
     name: Create Release Tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.26.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ needs.create_tag.outputs.new_tag }}
+          release_name: Release ${{ needs.create_tag.outputs.new_tag }}
           body: |
             Changes in this Release
             - First Change
             - Second Change
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -6,6 +6,8 @@ jobs:
   create_tag:
     name: Create Release Tag
     runs-on: ubuntu-latest
+    outputs:
+      next_tag: ${{steps.step2.outputs.new_tag}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -28,8 +30,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ needs.create_tag.outputs.new_tag }}
-          release_name: Release ${{ needs.create_tag.outputs.new_tag }}
+          tag_name: ${{ needs.create_tag.outputs.next_tag}}
+          release_name: Release ${{ needs.create_tag.outputs.next_tag }}
           body: |
             Changes in this Release
             - First Change

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -16,7 +16,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: 'github-release-action, latest'
-          INITIAL_VERSION: 1.332.0
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -1,0 +1,25 @@
+name: Simorgh CD - Create Release Tag
+
+on: ['push']
+
+jobs:
+  build:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+            - First Change
+            - Second Change
+          draft: false
+          prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -29,6 +29,6 @@ jobs:
           tag_name: ${{ steps.release_tag.outputs.new_tag }}
           release_name: Release ${{ steps.release_tag.outputs.new_tag }}
           body: |
-            Version: ${{ steps.release_tag.outputs.new_tag }}
+            ${{ github.event.commits[github.event.commits.distinct_size].message }}
           draft: false
           prerelease: false

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -1,13 +1,11 @@
-name: Simorgh CD - Create Release Tag & Release
+name: Simorgh CD - Create Release Tag
 
 on: ['push']
 
 jobs:
-  create_tag:
+  build:
     name: Create Release Tag
     runs-on: ubuntu-latest
-    outputs:
-      next_tag: ${{steps.release_tag.outputs.new_tag}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -17,13 +15,7 @@ jobs:
         uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  create_release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+          WITH_V: true
 
       - name: Create Release
         id: create_release
@@ -31,8 +23,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ needs.create_tag.outputs.next_tag}}
-          release_name: Release ${{ needs.create_tag.outputs.next_tag }}
+          tag_name: ${{ steps.release_tag.outputs.new_tag }}
+          release_name: Release ${{ steps.release_tag.outputs.new_tag }}
           body: |
             Changes in this Release
             - First Change

--- a/.github/workflows/simorgh-create-github-release.yml
+++ b/.github/workflows/simorgh-create-github-release.yml
@@ -7,12 +7,13 @@ jobs:
     name: Create Release Tag
     runs-on: ubuntu-latest
     outputs:
-      next_tag: ${{steps.step2.outputs.new_tag}}
+      next_tag: ${{steps.release_tag.outputs.new_tag}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Bump version and push tag
+        id: release_tag
         uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves N/A

Our release creation logic hasnt been working for a long time, this was some custom python script. Its time we removed that!

**Overall change:**
- Add new GH Action to bump release tags and create a release when pushing to the latest branch

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
