### PR TITLE
Remove erroneous IncludeGrid component

### DIFF
--- a/src/app/containers/Include/amp/VjAmp.jsx
+++ b/src/app/containers/Include/amp/VjAmp.jsx
@@ -24,10 +24,6 @@ const AmpHead = () => (
   </Helmet>
 );
 
-const IncludeGrid = styled(GridItemMedium)`
-  display: grid;
-`;
-
 const AmpIframe = ({ children, className, width, height, src }) => (
   <amp-iframe
     class={className}
@@ -88,7 +84,7 @@ const VjAmp = ({ ampMetadata: { imageWidth, imageHeight, image, src } }) => {
   return (
     <>
       <AmpHead />
-      <IncludeGrid>
+      <GridItemMedium>
         <StyledAmpIframe
           width={imageWidth}
           height={imageHeight}
@@ -100,7 +96,7 @@ const VjAmp = ({ ampMetadata: { imageWidth, imageHeight, image, src } }) => {
           </div>
           <amp-img layout="fill" src={image} placeholder />
         </StyledAmpIframe>
-      </IncludeGrid>
+      </GridItemMedium>
     </>
   );
 };

--- a/src/app/containers/Include/amp/__snapshots__/VjAmp.test.jsx.snap
+++ b/src/app/containers/Include/amp/__snapshots__/VjAmp.test.jsx.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VJ include container on Amp should render an amp-iframe with an image placeholder 1`] = `
-.c1 {
-  display: grid;
-}
-
-.c2 > [overflow] {
+.c1 > [overflow] {
   background: linear-gradient( 0deg,#fff 0%,rgba(255,255,255,1) 75%,rgba(255,255,255,0) 100% );
   display: -webkit-box;
   display: -webkit-flex;
@@ -17,7 +13,7 @@ exports[`VJ include container on Amp should render an amp-iframe with an image p
   justify-content: center;
 }
 
-.c2 > [overflow]::after {
+.c1 > [overflow]::after {
   background-color: #fff;
   border-top: 0.125rem solid #222222;
   content: '';
@@ -30,7 +26,7 @@ exports[`VJ include container on Amp should render an amp-iframe with an image p
   z-index: -10;
 }
 
-.c2 > [overflow] button {
+.c1 > [overflow] button {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   background-color: #222222;
@@ -41,8 +37,8 @@ exports[`VJ include container on Amp should render an amp-iframe with an image p
   padding: 0.5rem 1rem;
 }
 
-.c2 > [overflow] button:hover,
-.c2 > [overflow] button:focus {
+.c1 > [overflow] button:hover,
+.c1 > [overflow] button:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -94,7 +90,7 @@ exports[`VJ include container on Amp should render an amp-iframe with an image p
 }
 
 @media (min-width:20rem) {
-  .c2 > [overflow] button {
+  .c1 > [overflow] button {
     font-size: 1rem;
     line-height: 1.25rem;
   }
@@ -102,11 +98,11 @@ exports[`VJ include container on Amp should render an amp-iframe with an image p
 
 <div>
   <div
-    class="c0 c1"
+    class="c0"
     dir="ltr"
   >
     <amp-iframe
-      class="c2"
+      class="c1"
       height="360"
       layout="responsive"
       resizable=""


### PR DESCRIPTION
No issue.

**Overall change:**

This PR resolves a bug with VjAmp styles leading to them to span a single column:

![Image from iOS](https://user-images.githubusercontent.com/1430787/97712867-f1ead080-1ab6-11eb-983a-08fdd2171779.jpg)

**Code changes:**

- Remove IncludeGrid component, which applies an unnecessary style.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
