### PR TITLE
temporarily remove bundle min/max size

### DIFF
--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -75,8 +75,6 @@ module.exports = ({
       splitChunks: {
         chunks: 'initial',
         automaticNameDelimiter: '-',
-        minSize: 184320, // 180kb
-        maxSize: 245760, // 240kb
         cacheGroups: {
           common: {
             name: false,


### PR DESCRIPTION
**Overall change:**
Temporarily prevent page type bundles from being split up into multiple chunks.

**Code changes:**

- Removes `minSize` and `maxSize` from `splitChunks` to prevent the page type bundles being split into multiple files

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
