### PR TITLE
Fix storybook deploy

### DIFF
--- a/.github/workflows/simorgh-deploy-storybook.yml
+++ b/.github/workflows/simorgh-deploy-storybook.yml
@@ -3,7 +3,7 @@ name: Deploy Storybook
 on:
   push:
     branches:
-      - latest
+      - test-storybook-deploy
 
 jobs:
   deploy-storybook:
@@ -26,6 +26,8 @@ jobs:
       - name: Deploy Storybook
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
+          GIT_CONFIG_NAME: simorgh-bbc
+          GIT_CONFIG_EMAIL: DENewsSimorghDev@bbc.co.uk
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: storybook_dist

--- a/.github/workflows/simorgh-deploy-storybook.yml
+++ b/.github/workflows/simorgh-deploy-storybook.yml
@@ -3,7 +3,7 @@ name: Deploy Storybook
 on:
   push:
     branches:
-      - test-storybook-deploy
+      - latest
 
 jobs:
   deploy-storybook:

--- a/.github/workflows/simorgh-deploy-storybook.yml
+++ b/.github/workflows/simorgh-deploy-storybook.yml
@@ -26,9 +26,7 @@ jobs:
       - name: Deploy Storybook
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
-          GIT_CONFIG_NAME: simorgh-bbc
-          GIT_CONFIG_EMAIL: DENewsSimorghDev@bbc.co.uk
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
           BRANCH: gh-pages
           FOLDER: storybook_dist
           CLEAN: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
**Overall change:**
Fixes GH action not being authorised to deploy to the `gh-pages` branch.

**Code changes:**

- Adds `SIMORGH_DEV_STORYBOOK_RELEASE` token to the deploy storybook GH action
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
