### PR TITLE
Remove storybook generation from Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ def messageColor = 'danger'
 
 def stageName = ""
 def packageName = 'simorgh.zip'
-def storybookDist = 'storybook.zip'
 def staticAssetsDist = 'static.zip'
 
 def installDependencies(){
@@ -100,32 +99,16 @@ pipeline {
         expression { env.BRANCH_NAME == 'latest' }
       }
       failFast true
-      parallel {
-        stage ('Build Static Assets') {
-          agent {
-            docker {
-              image "${nodeImage}"
-              reuseNode true
-            }
-          }
-          steps {
-            buildStaticAssets("test", "TEST")
-            buildStaticAssets("live", "LIVE")
+      stage ('Build Static Assets') {
+        agent {
+          docker {
+            image "${nodeImage}"
+            reuseNode true
           }
         }
-        stage ('Build Storybook Dist') {
-          agent {
-            docker {
-              image "${nodeImage}"
-              reuseNode true
-            }
-          }
-          steps {
-            sh "rm -f storybook.zip"
-            sh 'make buildStorybook'
-            zip archive: true, dir: 'storybook_dist', glob: '', zipFile: storybookDist
-            stash name: 'simorgh_storybook', includes: storybookDist
-          }
+        steps {
+          buildStaticAssets("test", "TEST")
+          buildStaticAssets("live", "LIVE")
         }
       }
       post {


### PR DESCRIPTION
**Overall change:**
Storybook deployment is now done as part of Github Actions when merging to latest. It is no longer required in the Simorgh Jenkins pipeline.

**Code changes:**
- Remove references to Storybook from the pipeline

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
