### PR TITLE
Brand skip link fix for no css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20469,18 +20469,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -20704,17 +20698,11 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "1.21.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -21420,14 +21408,11 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "0.10.0"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-          "dev": true
+          "version": "0.10.0"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,9 +1400,9 @@
       "integrity": "sha512-vsrOzJRRRjy9ep9DGg+fRKp5mouVZX1+2Ujh42PwAFvdKL45Hyl5Y6T0SnVWnIyssGgzPJRzuiTpJqtKUtKG7A=="
     },
     "@bbc/psammead-brand": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-7.0.7.tgz",
-      "integrity": "sha512-3HOrXreNq3VqnfY9/WiZ/adx0rlDykaBusk9YXBB7sAHsAz+8hwdU6xGwwEczJ7fsHQaNl+pNMffcE+QDu/xBQ==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-brand/-/psammead-brand-7.0.8.tgz",
+      "integrity": "sha512-BhzaolKKEw0E9QbGBBWzQ/O1oVsbHudkfwggLhBed/GqO+MXPWxUiSSDMqi2TZ8ai2F+QlteCCecsy9kJYVmJQ==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
         "@bbc/psammead-visually-hidden-text": "^2.0.1"
@@ -17794,10 +17794,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
-    "node-forge": {
-      "dev": true,
-      "version": "0.10.0"
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -19459,13 +19455,6 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
-    "prismjs": {
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      },
-      "version": "1.21.0"
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -20480,12 +20469,18 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -20709,11 +20704,17 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -21419,11 +21420,14 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.10.0"
+        "node-forge": "^0.10.0"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0"
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@bbc/moment-timezone-include": "^1.1.4",
     "@bbc/psammead-amp-geo": "^1.2.0",
     "@bbc/psammead-assets": "^3.0.1",
-    "@bbc/psammead-brand": "^7.0.5",
+    "@bbc/psammead-brand": "^7.0.8",
     "@bbc/psammead-bulleted-list": "3.0.1",
     "@bbc/psammead-bulletin": "^5.0.3",
     "@bbc/psammead-byline": "3.0.1",

--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -916,13 +916,15 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
               BBC News
             </span>
           </a>
-          <a
-            class="emotion-20 emotion-21"
-            dir="ltr"
-            href="#content"
-          >
-            Skip to content
-          </a>
+          <div>
+            <a
+              class="emotion-20 emotion-21"
+              dir="ltr"
+              href="#content"
+            >
+              Skip to content
+            </a>
+          </div>
         </div>
       </div>
       <nav

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -727,13 +727,15 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
             Pidgin
           </span>
         </a>
-        <a
-          class="emotion-20 emotion-21"
-          dir="ltr"
-          href="#content"
-        >
-          Waka go wetin de inside
-        </a>
+        <div>
+          <a
+            class="emotion-20 emotion-21"
+            dir="ltr"
+            href="#content"
+          >
+            Waka go wetin de inside
+          </a>
+        </div>
       </div>
     </div>
     <nav
@@ -1710,13 +1712,15 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
             Pidgin
           </span>
         </a>
-        <a
-          class="emotion-20 emotion-21"
-          dir="ltr"
-          href="#content"
-        >
-          Waka go wetin de inside
-        </a>
+        <div>
+          <a
+            class="emotion-20 emotion-21"
+            dir="ltr"
+            href="#content"
+          >
+            Waka go wetin de inside
+          </a>
+        </div>
       </div>
     </div>
     <nav
@@ -2693,13 +2697,15 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
             Pidgin
           </span>
         </a>
-        <a
-          class="emotion-20 emotion-21"
-          dir="ltr"
-          href="#content"
-        >
-          Waka go wetin de inside
-        </a>
+        <div>
+          <a
+            class="emotion-20 emotion-21"
+            dir="ltr"
+            href="#content"
+          >
+            Waka go wetin de inside
+          </a>
+        </div>
       </div>
     </div>
     <nav


### PR DESCRIPTION
Resolves #7151 

**Overall change:**
Fixes skip link when css is disabled by moving it onto a new line.

**Code changes:**

- Bumped psammead-brand to 7.0.8
- Updated unit test snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
