### PR TITLE
Fixing the jenkins build file - stage must include steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,22 +94,20 @@ pipeline {
         installDependencies()
       }
     }
-    stage ('Build for Release') {
+    stage ('Build Static Assets') {
       when {
         expression { env.BRANCH_NAME == 'latest' }
       }
       failFast true
-      stage ('Build Static Assets') {
-        agent {
-          docker {
-            image "${nodeImage}"
-            reuseNode true
-          }
+      agent {
+        docker {
+          image "${nodeImage}"
+          reuseNode true
         }
-        steps {
-          buildStaticAssets("test", "TEST")
-          buildStaticAssets("live", "LIVE")
-        }
+      }
+      steps {
+        buildStaticAssets("test", "TEST")
+        buildStaticAssets("live", "LIVE")
       }
       post {
         always {


### PR DESCRIPTION
**Overall change:**
The latest Jenkins build was failing with the following error message: 

```
WorkflowScript: 97: Unknown stage section "stage". Starting with version 0.5, steps in a stage must be in a ‘steps’ block. @ line 97, column 5.
       stage ('Build for Release') {
       ^
WorkflowScript: 97: Expected one of "steps", "stages", or "parallel" for stage "Build for Release" @ line 97, column 5.
       stage ('Build for Release') {
```

This was caused by #8349 

**Code changes:**
- Fix it!

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
