### PR TITLE
Fix global styles leaking between services and leading to a lot of duplication

### DIFF
--- a/src/server/Document/index.jsx
+++ b/src/server/Document/index.jsx
@@ -10,9 +10,6 @@ import { ServerApp } from '#app/containers/App';
 import getAssetOrigins from '../utilities/getAssetOrigins';
 import DocumentComponent from './component';
 
-const cache = createCache();
-const { extractCritical } = createEmotionServer(cache);
-
 const renderDocument = async ({
   bbcOrigin,
   data,
@@ -21,6 +18,9 @@ const renderDocument = async ({
   service,
   url,
 }) => {
+  const cache = createCache();
+  const { extractCritical } = createEmotionServer(cache);
+
   const statsFile = path.resolve(
     `${__dirname}/public/loadable-stats-${process.env.SIMORGH_APP_ENV}.json`,
   );


### PR DESCRIPTION
Resolves the issue reported [here](https://github.com/emotion-js/emotion/issues/2049#issuecomment-726094154) by @chris-hinds 

**Overall change:**

When dealing with "compat" caches (and when you are using `extractCritical` you are making effectively cache a "compat" one) Emotion doesn't render styles "inline" - they are only kept in the cache.
Later when `extractCritical` runs over the generated HTML it searches for rendered class names and extracts styles only for those that have been actually used on a page. 
**However**, global styles do not exist in the generated HTML so we have to grab all global styles from the cache and:
- [`fonts` are coming from the props](https://github.com/bbc/psammead/blob/76c3b1291c817f883d226a12e95473a99c29ff1c/packages/utilities/psammead-styles/src/global-styles.jsx#L17)
- [cache is defined at the top of the file](https://github.com/bbc/simorgh/blob/ea8fecce307aacfb60e5ea2028c03bc329ca9cd7/src/server/Document/index.jsx#L13-L15) and thus shared across all requests

So this leads to all different global styles being put into the cache independently and all of them are being retrieved by `extractCritical` and put into the extracted CSS.

**Code changes:**

Just moved cache creation to a per-request handler so it doesn't get shared across all requests. This should not put "duplicated" styles into your rendered HTMLs.

---

**Testing:**

- [x] This PR requires manual testing
