### PR TITLE
Update Russian Hindi Chinese navs to remove elex and deprecated links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20469,18 +20469,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -20704,17 +20698,11 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "1.21.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -21420,14 +21408,11 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "0.10.0"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-          "dev": true
+          "version": "0.10.0"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20469,12 +20469,18 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "1.21.0",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -20698,11 +20704,17 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "1.21.0"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0"
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -21408,11 +21420,14 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.10.0"
+        "node-forge": "^0.10.0"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0"
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+          "dev": true
         }
       }
     },

--- a/src/app/lib/config/services/hindi.js
+++ b/src/app/lib/config/services/hindi.js
@@ -298,10 +298,6 @@ export const service = {
         title: 'वीडियो',
         url: '/hindi/media/video',
       },
-      {
-        title: 'बीबीसी स्पेशल',
-        url: '/hindi/in_depth',
-      },
     ],
   },
 };

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -290,10 +290,6 @@ export const service = {
         url: '/russian/in-depth-51962199',
       },
       {
-        title: 'Выборы в США',
-        url: '/russian/topics/c8jvq6n6kdxt',
-      },
-      {
         title: 'Истории',
         url: '/russian/features-50983593',
       },

--- a/src/app/lib/config/services/ukchina.js
+++ b/src/app/lib/config/services/ukchina.js
@@ -114,10 +114,6 @@ export const service = {
         url: '/ukchina/simp',
       },
       {
-        title: 'BBC精选',
-        url: '/ukchina/simp/horizon',
-      },
-      {
         title: '视频内容',
         url: '/ukchina/simp/media/video',
       },
@@ -325,10 +321,6 @@ export const service = {
       {
         title: '主頁',
         url: '/ukchina/trad',
-      },
-      {
-        title: 'BBC精選',
-        url: '/ukchina/trad/horizon',
       },
       {
         title: '視頻內容',

--- a/src/app/lib/config/services/zhongwen.js
+++ b/src/app/lib/config/services/zhongwen.js
@@ -115,27 +115,23 @@ export const service = {
       },
       {
         title: '国际',
-        url: '/zhongwen/simp/world',
+        url: '/zhongwen/simp/topics/ck2l9z0em07t',
       },
       {
         title: '两岸',
-        url: '/zhongwen/simp/chinese_news',
+        url: '/zhongwen/simp/topics/cxe2wdp384wt',
       },
       {
         title: '英国',
-        url: '/zhongwen/simp/uk',
-      },
-      {
-        title: '评论',
-        url: '/zhongwen/simp/indepth',
+        url: '/zhongwen/simp/topics/c1nq04exqmlt',
       },
       {
         title: '科技',
-        url: '/zhongwen/simp/science',
+        url: '/zhongwen/simp/topics/c9mjeq29pxlt',
       },
       {
         title: '财经',
-        url: '/zhongwen/simp/business',
+        url: '/zhongwen/simp/topics/cdlxq9k9nqkt',
       },
       {
         title: '视频材料',
@@ -349,27 +345,23 @@ export const service = {
       },
       {
         title: '國際',
-        url: '/zhongwen/trad/world',
+        url: '/zhongwen/trad/topics/c83plve5vmjt',
       },
       {
         title: '兩岸',
-        url: '/zhongwen/trad/chinese_news',
+        url: '/zhongwen/trad/topics/c9wpm0e5zv9t',
       },
       {
         title: '英國',
-        url: '/zhongwen/trad/uk',
-      },
-      {
-        title: '評論',
-        url: '/zhongwen/trad/indepth',
+        url: '/zhongwen/trad/topics/c1ez1k4emn0t',
       },
       {
         title: '科技',
-        url: '/zhongwen/trad/science',
+        url: '/zhongwen/trad/topics/c32p4kj2yzqt',
       },
       {
         title: '財經',
-        url: '/zhongwen/trad/business',
+        url: '/zhongwen/trad/topics/cq8nqywy37yt',
       },
       {
         title: '視頻材料',


### PR DESCRIPTION
Resolves #8361 

**Overall change:**
Nav udpates for BBC Russian, Hindi, UKChina and Zhongwen

**Code changes:**

* Removed election link in BBC Russian nav
* Removed Indepth  link in BBC Hindi nav
* Removed Horizon link in BBC UKChina nav for both script variants
* Removed Indepth link and updated all links to tipo topics in BBC Zhongwen nav for both script variants


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
