### PR TITLE
Enable all checks on push to latest

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - latest
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enables all checks against latest to give feedback if latest is broken and to push a report to code climate. This change will fix codeclimate on PRs.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
