### PR TITLE
enable code climate setup on branch push

### DIFF
--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Chromatic UI Tests
-        if: ${{ github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }}
         run: npx chromatic test run --build-script-name build:storybook --exit-once-uploaded --no-interactive --project-token "$CHROMATIC_APP_CODE"
 
       - name: Apache License Checker

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
           npm run build
 
       - name: Setup Code Climate Test Coverage
-        if: ${{ github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter	
           chmod +x ./cc-test-reporter	


### PR DESCRIPTION
Allow code climate setup to run on branch push, this was skipped previously causing code climate reporting to subsequently fail

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
