### PR TITLE
Dependency Updates - Psammead x media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,9 +1650,9 @@
       }
     },
     "@bbc/psammead-radio-schedule": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.5.tgz",
-      "integrity": "sha512-j3FdWvLM9q6/W9lc6CrKsd++I2uVDDBaTMbYIp9J/b72apxvCSrSOng0xX3k8NjWaJbxAxqxzgURfFc0frdy5Q==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-radio-schedule/-/psammead-radio-schedule-5.0.6.tgz",
+      "integrity": "sha512-5iCoM7ZY7nJVbXlnQWOpc09i/Lk8W34OrHqeJD3B8l4NTVDnEsSbbrH81ZB+Va3n6JDEFgZoW6vxcwlixOTG8g==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
         "@bbc/psammead-assets": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,9 +1510,9 @@
       }
     },
     "@bbc/psammead-grid": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.3.tgz",
-      "integrity": "sha512-lKD02/9c42ArQLMw48hG0D7hlqna975TjbnqYKaQ8vo9ZF9q49EtS5O7TGfKnXARCMQA7cYg114lWvYZ30lE2w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.4.tgz",
+      "integrity": "sha512-hVEOljMyXkmLdaMFCpf8+7dmvKrV4LknvyB5ESM7hcI36Une7c5EEPSJHsAQKy8L7Hh3/21l7ZBgzy/kdBdsYQ==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
         "@bbc/psammead-styles": "^6.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,13 +1599,24 @@
       }
     },
     "@bbc/psammead-most-read": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-most-read/-/psammead-most-read-6.0.4.tgz",
-      "integrity": "sha512-bv2S7kXY1QRCV/jUC8p6VHF765+AqweV1U0plzuYwjDTKeQFDJlH9q/X3bmfO4V+WBrTZ9ZlyeMaUL4iS8osxA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-most-read/-/psammead-most-read-6.0.5.tgz",
+      "integrity": "sha512-VK2/wYduJ3Th6YwZJAM72YX3REt9a/jw6kNsWzJB7MJ98DCiiVsVXQ1tlle29eW8wbteIqEd4qCFcGShHSk12Q==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
-        "@bbc/psammead-grid": "^3.0.3",
+        "@bbc/psammead-grid": "^3.0.4",
         "@bbc/psammead-styles": "^6.1.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-grid": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.4.tgz",
+          "integrity": "sha512-hVEOljMyXkmLdaMFCpf8+7dmvKrV4LknvyB5ESM7hcI36Une7c5EEPSJHsAQKy8L7Hh3/21l7ZBgzy/kdBdsYQ==",
+          "requires": {
+            "@bbc/gel-foundations": "^5.0.1",
+            "@bbc/psammead-styles": "^6.1.0"
+          }
+        }
       }
     },
     "@bbc/psammead-navigation": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1588,9 +1588,9 @@
       }
     },
     "@bbc/psammead-media-player": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-5.0.5.tgz",
-      "integrity": "sha512-OXnaqzB5f9xEl0xnlxo8UV2Pqtc63naiNMyloUuTOb5Snm4mB54qJ6wkT5EFzV4uDx7eC/4s/oTOLVC+CjjCYA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-media-player/-/psammead-media-player-5.0.6.tgz",
+      "integrity": "sha512-q1SGwBmdpztU4lnnABfXP01GU0KLxsmL4lI8+RpVlJDRiA+rAjTO13Jx4IzrzamETSRcq2KPPhMv3pjQtyMB9g==",
       "requires": {
         "@bbc/psammead-assets": "^3.0.1",
         "@bbc/psammead-image": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-embed-error": "^3.0.1",
     "@bbc/psammead-episode-list": "0.1.0-alpha.3",
     "@bbc/psammead-figure": "^2.0.0",
-    "@bbc/psammead-grid": "^3.0.2",
+    "@bbc/psammead-grid": "^3.0.4",
     "@bbc/psammead-heading-index": "^3.0.1",
     "@bbc/psammead-headings": "^5.0.1",
     "@bbc/psammead-image": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@bbc/psammead-locales": "^5.0.0",
     "@bbc/psammead-media-indicator": "^6.0.1",
     "@bbc/psammead-media-player": "^5.0.3",
-    "@bbc/psammead-most-read": "^6.0.2",
+    "@bbc/psammead-most-read": "^6.0.5",
     "@bbc/psammead-navigation": "^8.0.2",
     "@bbc/psammead-paragraph": "^4.0.1",
     "@bbc/psammead-radio-schedule": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@bbc/psammead-most-read": "^6.0.5",
     "@bbc/psammead-navigation": "^8.0.2",
     "@bbc/psammead-paragraph": "^4.0.1",
-    "@bbc/psammead-radio-schedule": "^5.0.3",
+    "@bbc/psammead-radio-schedule": "^5.0.6",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.2",
     "@bbc/psammead-section-label": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@bbc/psammead-live-label": "^2.0.2",
     "@bbc/psammead-locales": "^5.0.0",
     "@bbc/psammead-media-indicator": "^6.0.1",
-    "@bbc/psammead-media-player": "^5.0.3",
+    "@bbc/psammead-media-player": "^5.0.6",
     "@bbc/psammead-most-read": "^6.0.5",
     "@bbc/psammead-navigation": "^8.0.2",
     "@bbc/psammead-paragraph": "^4.0.1",


### PR DESCRIPTION
**Overall change:**
- Bump @bbc/psammead-radio-schedule from 5.0.5 to 5.0.6 #8402
- Bump @bbc/psammead-media-player from 5.0.5 to 5.0.6 #8404

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
