### PR TITLE
Dependency update - psammead-grid and psammead-most-read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20491,18 +20491,12 @@
         "@babel/runtime": "^7.3.1",
         "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "1.21.0",
         "refractor": "^2.4.1"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -20726,17 +20720,11 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "1.21.0"
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-          "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.21.0"
         }
       }
     },
@@ -21442,14 +21430,11 @@
       "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "0.10.0"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-          "dev": true
+          "version": "0.10.0"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1510,9 +1510,9 @@
       }
     },
     "@bbc/psammead-grid": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.3.tgz",
-      "integrity": "sha512-lKD02/9c42ArQLMw48hG0D7hlqna975TjbnqYKaQ8vo9ZF9q49EtS5O7TGfKnXARCMQA7cYg114lWvYZ30lE2w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.4.tgz",
+      "integrity": "sha512-hVEOljMyXkmLdaMFCpf8+7dmvKrV4LknvyB5ESM7hcI36Une7c5EEPSJHsAQKy8L7Hh3/21l7ZBgzy/kdBdsYQ==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
         "@bbc/psammead-styles": "^6.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,13 +1599,24 @@
       }
     },
     "@bbc/psammead-most-read": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-most-read/-/psammead-most-read-6.0.4.tgz",
-      "integrity": "sha512-bv2S7kXY1QRCV/jUC8p6VHF765+AqweV1U0plzuYwjDTKeQFDJlH9q/X3bmfO4V+WBrTZ9ZlyeMaUL4iS8osxA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-most-read/-/psammead-most-read-6.0.5.tgz",
+      "integrity": "sha512-VK2/wYduJ3Th6YwZJAM72YX3REt9a/jw6kNsWzJB7MJ98DCiiVsVXQ1tlle29eW8wbteIqEd4qCFcGShHSk12Q==",
       "requires": {
         "@bbc/gel-foundations": "^5.0.1",
-        "@bbc/psammead-grid": "^3.0.3",
+        "@bbc/psammead-grid": "^3.0.4",
         "@bbc/psammead-styles": "^6.1.0"
+      },
+      "dependencies": {
+        "@bbc/psammead-grid": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-grid/-/psammead-grid-3.0.4.tgz",
+          "integrity": "sha512-hVEOljMyXkmLdaMFCpf8+7dmvKrV4LknvyB5ESM7hcI36Une7c5EEPSJHsAQKy8L7Hh3/21l7ZBgzy/kdBdsYQ==",
+          "requires": {
+            "@bbc/gel-foundations": "^5.0.1",
+            "@bbc/psammead-styles": "^6.1.0"
+          }
+        }
       }
     },
     "@bbc/psammead-navigation": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-embed-error": "^3.0.1",
     "@bbc/psammead-episode-list": "0.1.0-alpha.3",
     "@bbc/psammead-figure": "^2.0.0",
-    "@bbc/psammead-grid": "^3.0.2",
+    "@bbc/psammead-grid": "^3.0.4",
     "@bbc/psammead-heading-index": "^3.0.1",
     "@bbc/psammead-headings": "^5.0.1",
     "@bbc/psammead-image": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@bbc/psammead-locales": "^5.0.0",
     "@bbc/psammead-media-indicator": "^6.0.1",
     "@bbc/psammead-media-player": "^5.0.3",
-    "@bbc/psammead-most-read": "^6.0.2",
+    "@bbc/psammead-most-read": "^6.0.5",
     "@bbc/psammead-navigation": "^8.0.2",
     "@bbc/psammead-paragraph": "^4.0.1",
     "@bbc/psammead-radio-schedule": "^5.0.3",

--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -4,6 +4,6 @@ module.exports = {
   // Keep the MAX_SIZE +5 above the largest value and MIN_SIZE -5
   // below the smallest value in the build output; this avoids the
   // need for frequent changes as bundle sizes fluctuate.
-  MIN_SIZE: 668,
-  MAX_SIZE: 848,
+  MIN_SIZE: 675,
+  MAX_SIZE: 857,
 };

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2087,7 +2087,7 @@ exports[`Story Page should render correctly when the secondary column data is no
                   dir="ltr"
                 >
                   <div
-                    class="emotion-100 css-ng0vgl-GridComponent-GridPrimaryColumn emotion-1"
+                    class="emotion-100 css-1fhb3ud-GridComponent-GridPrimaryColumn emotion-1"
                     dir="ltr"
                   >
                     <main
@@ -3371,7 +3371,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                   dir="ltr"
                 >
                   <div
-                    class="emotion-100 css-ng0vgl-GridComponent-GridPrimaryColumn emotion-1"
+                    class="emotion-100 css-1fhb3ud-GridComponent-GridPrimaryColumn emotion-1"
                     dir="ltr"
                   >
                     <main


### PR DESCRIPTION
**Overall change:**
- Bump @bbc/psammead-grid from 3.0.3 to 3.0.4 - requires manual update - unit tests failed #8403
- Bump @bbc/psammead-most-read from 6.0.4 to 6.0.5 - requires manual update - increase bundle size #8401

**Code changes:**

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
