### PR TITLE
Improve episode validity check

### DIFF
--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -2,21 +2,25 @@ import pathOr from 'ramda/src/pathOr';
 import is from 'ramda/src/is';
 
 const validateEpisode = episode => {
-  const checks = [
-    episode,
-    is(String, episode.id),
-    episode.id.includes(':'),
-    episode.brand,
-    is(String, episode.brand.title),
-    episode.media,
-    is(String, episode.media.id),
-    is(Array, episode.media.versions),
-    episode.media.versions[0],
-    is(String, episode.media.versions[0].durationISO8601),
-    is(Number, episode.media.versions[0].availableFrom),
-  ];
+  try {
+    const checks = [
+      episode,
+      is(String, episode.id),
+      episode.id.includes(':'),
+      episode.brand,
+      is(String, episode.brand.title),
+      episode.media,
+      is(String, episode.media.id),
+      is(Array, episode.media.versions),
+      episode.media.versions.length > 0,
+      is(String, episode.media.versions[0].durationISO8601),
+      is(Number, episode.media.versions[0].availableFrom),
+    ];
 
-  return checks.every(Boolean);
+    return checks.every(Boolean);
+  } catch {
+    return false;
+  }
 };
 
 const formatEpisode = (episode, { serviceName, urlFormatter }) => {

--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -12,7 +12,7 @@ const validateEpisode = episode => {
       episode.media,
       is(String, episode.media.id),
       is(Array, episode.media.versions),
-      episode.media.versions.length > 0,
+      episode.media.versions[0],
       is(String, episode.media.versions[0].durationISO8601),
       is(Number, episode.media.versions[0].availableFrom),
     ];

--- a/src/app/routes/utils/processRecentEpisodes/index.test.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.test.jsx
@@ -1,3 +1,4 @@
+import assocPath from 'ramda/src/assocPath';
 import processRecentEpisodes from '.';
 import videoPageData from '#data/afrique/bbc_afrique_tv/tv_programmes/w13xttmz.json';
 import audioPageData from '#data/indonesia/bbc_indonesian_radio/w13xtt0s.json';
@@ -63,5 +64,19 @@ describe('processRecentEpisodes', () => {
         enabled: true,
       }).length,
     ).toEqual(episodeCountInPageData - 1);
+  });
+
+  it('should correctly handle episodes with missing versions', () => {
+    const pageWithMissingVersions = assocPath(
+      ['relatedContent', 'groups', 0, 'promos', 0, 'media', 'id'],
+      [],
+      videoPageData,
+    );
+    expect(
+      processRecentEpisodes(pageWithMissingVersions, {
+        recentEpisodesLimit: 3,
+        enabled: true,
+      }).length,
+    ).toEqual(3);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8420

**Overall change:**
_Assume an episode is invalid if the validity check throws an exception_

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
