### PR TITLE
Remove Most Watched Page E2E settings for Russian

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -5788,24 +5788,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      mostWatchedPage: {
-        // No Most Watched page for Russian
-        environments: {
-          live: {
-            paths: [''],
-            enabled: false,
-          },
-          test: {
-            paths: [''],
-            enabled: false,
-          },
-          local: {
-            paths: [''],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      mostWatchedPage: { environments: undefined, smoke: false }, // No Most Watched page for Russian
       photoGalleryPage: {
         environments: {
           live: {

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1269,10 +1269,10 @@ module.exports = () => ({
           },
           local: {
             paths: ['/bengali/media/video'],
-            enabled: true,
+            enabled: false,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       photoGalleryPage: {
         environments: {
@@ -5789,17 +5789,18 @@ module.exports = () => ({
         smoke: false,
       },
       mostWatchedPage: {
+        // No Most Watched page for Russian
         environments: {
           live: {
-            paths: ['/russian/media/video'],
+            paths: [''],
             enabled: false,
           },
           test: {
-            paths: ['/russian/media/video'],
+            paths: [''],
             enabled: false,
           },
           local: {
-            paths: ['/russian/media/video'],
+            paths: [''],
             enabled: false,
           },
         },


### PR DESCRIPTION
**Overall change:**

The Russian service does not use the Most Watched Page [service]/media/video like the other services do. This is because the Russian team prefers to curate their own video page, rather than have a page with most watched videos which could be very old. Instead, the URL redirects to https://www.bbc.com/russian/in-depth-54439028.json

That page does not have a Most Watched component on it, so we must not run the most watched E2E test on this page. This page was already not enabled for most watched tests, but to avoid it being enabled in the future and causing a failure, I have removed the configuration within the mostWatchedPage settings for Russian and left a comment to explain why we do not have urls to run on.

**Code changes:**

mostWatchedPage: { environments: undefined, smoke: false }, // No Most Watched page for Russian

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**
Passes on test and live
