### PR TITLE
Add/remove and use pageType constants in routes

### DIFF
--- a/src/app/routes/article/index.js
+++ b/src/app/routes/article/index.js
@@ -1,11 +1,12 @@
 import { ArticlePage } from '#pages';
 import getInitialData from './getInitialData';
 import { articlePath } from '../utils/regex';
+import { ARTICLE_PAGE } from '../utils/pageTypes';
 
 export default {
   path: articlePath,
   exact: true,
   component: ArticlePage,
   getInitialData,
-  pageType: 'article',
+  pageType: ARTICLE_PAGE,
 };

--- a/src/app/routes/article/index.js
+++ b/src/app/routes/article/index.js
@@ -1,7 +1,7 @@
 import { ArticlePage } from '#pages';
 import getInitialData from './getInitialData';
-import { articlePath } from '../utils/regex';
-import { ARTICLE_PAGE } from '../utils/pageTypes';
+import { articlePath } from '#utils/regex';
+import { ARTICLE_PAGE } from '#utils/pageTypes';
 
 export default {
   path: articlePath,

--- a/src/app/routes/error/index.js
+++ b/src/app/routes/error/index.js
@@ -1,11 +1,12 @@
 import { ErrorPage } from '#pages';
 import getInitialData from './getInitialData';
 import { errorPagePath } from '../utils/regex';
+import { ERROR_PAGE } from '../utils/pageTypes';
 
 export default {
   path: errorPagePath,
   exact: true,
   component: ErrorPage,
   getInitialData: getInitialData(errorPagePath),
-  pageType: 'error',
+  pageType: ERROR_PAGE,
 };

--- a/src/app/routes/error/index.js
+++ b/src/app/routes/error/index.js
@@ -1,7 +1,7 @@
 import { ErrorPage } from '#pages';
 import getInitialData from './getInitialData';
-import { errorPagePath } from '../utils/regex';
-import { ERROR_PAGE } from '../utils/pageTypes';
+import { errorPagePath } from '#utils/regex';
+import { ERROR_PAGE } from '#utils/pageTypes';
 
 export default {
   path: errorPagePath,

--- a/src/app/routes/errorNoRouteMatch/index.js
+++ b/src/app/routes/errorNoRouteMatch/index.js
@@ -1,5 +1,5 @@
 import { ErrorPage } from '#pages';
-import { ERROR_PAGE } from '../utils/pageTypes';
+import { ERROR_PAGE } from '#utils/pageTypes';
 
 export default {
   component: ErrorPage,

--- a/src/app/routes/errorNoRouteMatch/index.js
+++ b/src/app/routes/errorNoRouteMatch/index.js
@@ -1,7 +1,8 @@
 import { ErrorPage } from '#pages';
+import { ERROR_PAGE } from '../utils/pageTypes';
 
 export default {
   component: ErrorPage,
   getInitialData: () => Promise.resolve({ status: 404, errorCode: 404 }),
-  pageType: 'error',
+  pageType: ERROR_PAGE,
 };

--- a/src/app/routes/home/index.js
+++ b/src/app/routes/home/index.js
@@ -1,11 +1,12 @@
 import { FrontPage } from '#pages';
 import getInitialData from './getInitialData';
 import { frontPagePath } from '../utils/regex';
+import { FRONT_PAGE } from '../utils/pageTypes';
 
 export default {
   path: frontPagePath,
   exact: true,
   component: FrontPage,
   getInitialData,
-  pageType: 'frontPage',
+  pageType: FRONT_PAGE,
 };

--- a/src/app/routes/home/index.js
+++ b/src/app/routes/home/index.js
@@ -1,7 +1,7 @@
 import { FrontPage } from '#pages';
 import getInitialData from './getInitialData';
-import { frontPagePath } from '../utils/regex';
-import { FRONT_PAGE } from '../utils/pageTypes';
+import { frontPagePath } from '#utils/regex';
+import { FRONT_PAGE } from '#utils/pageTypes';
 
 export default {
   path: frontPagePath,

--- a/src/app/routes/idx/index.js
+++ b/src/app/routes/idx/index.js
@@ -1,11 +1,12 @@
 import { IdxPage } from '#pages';
 import getInitialData from './getInitialData';
 import { IdxPagePath } from '../utils/regex';
+import { INDEX_PAGE } from '../utils/pageTypes';
 
 export default {
   path: IdxPagePath,
   exact: true,
   component: IdxPage,
   getInitialData,
-  pageType: 'IDX',
+  pageType: INDEX_PAGE,
 };

--- a/src/app/routes/idx/index.js
+++ b/src/app/routes/idx/index.js
@@ -1,7 +1,7 @@
 import { IdxPage } from '#pages';
 import getInitialData from './getInitialData';
-import { IdxPagePath } from '../utils/regex';
-import { INDEX_PAGE } from '../utils/pageTypes';
+import { IdxPagePath } from '#utils/regex';
+import { INDEX_PAGE } from '#utils/pageTypes';
 
 export default {
   path: IdxPagePath,

--- a/src/app/routes/liveRadio/index.js
+++ b/src/app/routes/liveRadio/index.js
@@ -1,7 +1,7 @@
 import { LiveRadioPage } from '#pages';
-import { liveRadioPath } from '../utils/regex';
+import { liveRadioPath } from '#utils/regex';
 import getInitialData from './getInitialData';
-import { MEDIA_PAGE } from '../utils/pageTypes';
+import { MEDIA_PAGE } from '#utils/pageTypes';
 
 export default {
   path: liveRadioPath,

--- a/src/app/routes/liveRadio/index.js
+++ b/src/app/routes/liveRadio/index.js
@@ -1,11 +1,12 @@
 import { LiveRadioPage } from '#pages';
 import { liveRadioPath } from '../utils/regex';
 import getInitialData from './getInitialData';
+import { MEDIA_PAGE } from '../utils/pageTypes';
 
 export default {
   path: liveRadioPath,
   exact: true,
   component: LiveRadioPage,
   getInitialData,
-  pageType: 'media',
+  pageType: MEDIA_PAGE,
 };

--- a/src/app/routes/mostRead/index.js
+++ b/src/app/routes/mostRead/index.js
@@ -1,7 +1,7 @@
 import { MostReadPage } from '#pages';
 import getInitialData from './getInitialData';
-import { mostReadPagePath } from '../utils/regex';
-import { MOST_READ_PAGE } from '../utils/pageTypes';
+import { mostReadPagePath } from '#utils/regex';
+import { MOST_READ_PAGE } from '#utils/pageTypes';
 
 export default {
   path: mostReadPagePath,

--- a/src/app/routes/mostRead/index.js
+++ b/src/app/routes/mostRead/index.js
@@ -1,11 +1,12 @@
 import { MostReadPage } from '#pages';
 import getInitialData from './getInitialData';
 import { mostReadPagePath } from '../utils/regex';
+import { MOST_READ_PAGE } from '../utils/pageTypes';
 
 export default {
   path: mostReadPagePath,
   exact: true,
   component: MostReadPage,
   getInitialData,
-  pageType: 'mostRead',
+  pageType: MOST_READ_PAGE,
 };

--- a/src/app/routes/mostWatched/index.js
+++ b/src/app/routes/mostWatched/index.js
@@ -1,7 +1,7 @@
 import { MostWatchedPage } from '#pages';
 import getInitialData from './getInitialData';
-import { mostWatchedPagePath } from '../utils/regex';
-import { MOST_WATCHED_PAGE } from '../utils/pageTypes';
+import { mostWatchedPagePath } from '#utils/regex';
+import { MOST_WATCHED_PAGE } from '#utils/pageTypes';
 
 export default {
   path: mostWatchedPagePath,

--- a/src/app/routes/mostWatched/index.js
+++ b/src/app/routes/mostWatched/index.js
@@ -1,11 +1,12 @@
 import { MostWatchedPage } from '#pages';
 import getInitialData from './getInitialData';
 import { mostWatchedPagePath } from '../utils/regex';
+import { MOST_WATCHED_PAGE } from '../utils/pageTypes';
 
 export default {
   path: mostWatchedPagePath,
   exact: true,
   component: MostWatchedPage,
   getInitialData,
-  pageType: 'mostWatched',
+  pageType: MOST_WATCHED_PAGE,
 };

--- a/src/app/routes/onDemandRadio/index.js
+++ b/src/app/routes/onDemandRadio/index.js
@@ -1,7 +1,7 @@
 import { OnDemandRadioPage } from '#pages';
-import { onDemandRadioPath } from '../utils/regex';
+import { onDemandRadioPath } from '#utils/regex';
 import getInitialData from './getInitialData';
-import { MEDIA_PAGE } from '../utils/pageTypes';
+import { MEDIA_PAGE } from '#utils/pageTypes';
 
 export default {
   path: onDemandRadioPath,

--- a/src/app/routes/onDemandRadio/index.js
+++ b/src/app/routes/onDemandRadio/index.js
@@ -1,11 +1,12 @@
 import { OnDemandRadioPage } from '#pages';
 import { onDemandRadioPath } from '../utils/regex';
 import getInitialData from './getInitialData';
+import { MEDIA_PAGE } from '../utils/pageTypes';
 
 export default {
   path: onDemandRadioPath,
   exact: true,
   component: OnDemandRadioPage,
   getInitialData,
-  pageType: 'media',
+  pageType: MEDIA_PAGE,
 };

--- a/src/app/routes/onDemandTV/index.js
+++ b/src/app/routes/onDemandTV/index.js
@@ -1,7 +1,7 @@
 import { OnDemandTvPage } from '#pages';
-import { onDemandTvPath } from '../utils/regex';
+import { onDemandTvPath } from '#utils/regex';
 import getInitialData from './getInitialData';
-import { MEDIA_PAGE } from '../utils/pageTypes';
+import { MEDIA_PAGE } from '#utils/pageTypes';
 
 export default {
   path: onDemandTvPath,

--- a/src/app/routes/onDemandTV/index.js
+++ b/src/app/routes/onDemandTV/index.js
@@ -1,11 +1,12 @@
 import { OnDemandTvPage } from '#pages';
 import { onDemandTvPath } from '../utils/regex';
 import getInitialData from './getInitialData';
+import { MEDIA_PAGE } from '../utils/pageTypes';
 
 export default {
   path: onDemandTvPath,
   exact: true,
   component: OnDemandTvPage,
   getInitialData,
-  pageType: 'media',
+  pageType: MEDIA_PAGE,
 };

--- a/src/app/routes/utils/pageTypes.js
+++ b/src/app/routes/utils/pageTypes.js
@@ -1,7 +1,9 @@
 export const ARTICLE_PAGE = 'article';
-export const MOST_POPULAR_PAGE = 'popular';
-
-export const LIVE_RADIO_PAGE = 'WS-LIVE';
+export const FRONT_PAGE = 'frontPage';
+export const MEDIA_PAGE = 'media';
+export const MOST_READ_PAGE = 'mostRead';
+export const MOST_WATCHED_PAGE = 'mostWatched';
+export const ERROR_PAGE = 'error';
 export const INDEX_PAGE = 'IDX';
 export const FEATURE_INDEX_PAGE = 'FIX';
 export const MEDIA_ASSET_PAGE = 'MAP';


### PR DESCRIPTION
Part of #6523

**Overall change:**
Adds and uses pageType constants in routes and removes unused constants.

https://github.com/bbc/simorgh/pull/8446 Decided to split this into subsequent PR's as it's pretty hefty to code review if these constants are going to be used throughout the codebase. This is the first part.

**Code changes:**

- Added missing pagetype constants
- Removed unused pageType constants
- Implements usage of pageType constants in routes

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
