### PR TITLE
Navigation updates for Burmese and others

### DIFF
--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -264,23 +264,23 @@ export const service = {
       },
       {
         title: 'မြန်မာ့ရေးရာ',
-        url: '/burmese/burma',
+        url: '/burmese/topics/c404v08p1wxt',
       },
       {
         title: 'နိုင်ငံတကာ',
-        url: '/burmese/world',
+        url: '/burmese/topics/cnlv9j1z93wt',
       },
       {
         title: 'ဆောင်းပါး',
-        url: '/burmese/in_depth',
+        url: '/burmese/in-depth-54539126',
       },
       {
         title: 'အားကစား',
-        url: '/burmese/sport',
+        url: '/burmese/topics/cxnykndgd87t',
       },
       {
         title: 'ကုန်သွယ်စီးပွား',
-        url: '/burmese/economy',
+        url: '/burmese/topics/c9wpm0en9jdt',
       },
       {
         title: 'ဗီဒီယိုများ',

--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -255,27 +255,23 @@ export const service = {
       },
       {
         title: '日本',
-        url:
-          'https://www.bbc.com/japanese/topics/3f53c272-5b8f-4a4f-99de-a857d6726c5b',
+        url: '/japanese/topics/cyx5k201n3qt',
       },
       {
         title: 'アジア',
-        url:
-          'https://www.bbc.com/japanese/topics/ba90754a-9033-4e9c-990b-d1139e5070a3',
+        url: '/japanese/topics/cyx5k20kvd2t',
       },
       {
         title: 'イギリス',
-        url:
-          'https://www.bbc.com/japanese/topics/2e91364c-5c77-4660-b76e-d76202785e64',
+        url: '/japanese/topics/c95y3gk44nyt',
       },
       {
         title: 'アメリカ',
-        url:
-          'https://www.bbc.com/japanese/topics/82857f8e-8134-462a-bb32-b7b14f4eab75',
+        url: '/japanese/topics/cdr56kqdr70t',
       },
       {
         title: '解説・読み物',
-        url: 'https://www.bbc.com/japanese/features_and_analysis',
+        url: '/japanese/features-and-analysis-54539120',
       },
       {
         title: 'ビデオ',

--- a/src/app/lib/config/services/pashto.js
+++ b/src/app/lib/config/services/pashto.js
@@ -291,7 +291,7 @@ export const service = {
       },
       {
         title: 'ځانګړې پاڼې',
-        url: '/pashto/in_depth',
+        url: '/pashto/in-depth-54540873',
       },
       {
         title: 'کالم',

--- a/src/app/lib/config/services/somali.js
+++ b/src/app/lib/config/services/somali.js
@@ -267,20 +267,12 @@ export const service = {
         url: '/somali',
       },
       {
-        title: 'Warar dheeraad ah',
-        url: '/somali/war',
-      },
-      {
         title: 'Ganacsi',
-        url: '/somali/topics/2f2db234-3c2d-40a4-b4ac-eea661faadd0',
+        url: '/somali/topics/c2dwqd32v4yt',
       },
       {
         title: 'Cayaaraha',
-        url: '/somali/cayaaraha',
-      },
-      {
-        title: 'Aqoon Guud',
-        url: '/somali/aqoon_guud',
+        url: '/somali/topics/cpzd4zj1pn2t',
       },
       {
         title: 'Muuqaal',

--- a/src/app/lib/config/services/thai.js
+++ b/src/app/lib/config/services/thai.js
@@ -216,10 +216,6 @@ export const service = {
         url: '/thai/topics/c5v124k8lj7t',
       },
       {
-        title: 'เลือกตั้งสหรัฐฯ 2020',
-        url: '/thai/international-54245234',
-      },
-      {
         title: 'วิทยาศาสตร์',
         url: '/thai/topics/c5qvp1q33p0t',
       },

--- a/src/app/lib/config/services/vietnamese.js
+++ b/src/app/lib/config/services/vietnamese.js
@@ -249,31 +249,27 @@ export const service = {
       },
       {
         title: 'Việt Nam',
-        url: '/vietnamese/vietnam',
+        url: '/vietnamese/topics/ckdxnx1x5rnt',
       },
       {
         title: 'Thế giới',
-        url: '/vietnamese/world',
+        url: '/vietnamese/topics/cnlv9j1ekq0t',
       },
       {
         title: 'Diễn đàn',
-        url: '/vietnamese/forum',
+        url: '/vietnamese/forum-54540875',
       },
       {
         title: 'Kinh tế',
-        url: '/vietnamese/business',
+        url: '/vietnamese/topics/cez1ey7nzj3t',
       },
       {
         title: 'Nhịp sống mới',
-        url: '/vietnamese/magazine',
+        url: '/vietnamese/magazine-54029179',
       },
       {
         title: 'Thể thao',
-        url: '/vietnamese/sport',
-      },
-      {
-        title: 'Học tiếng Anh',
-        url: '/vietnamese/english',
+        url: '/vietnamese/topics/ckdxnx1k7zxt',
       },
       {
         title: 'Video',

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
@@ -216,53 +216,46 @@ Object {
 exports[`AMP Most Read Page Header Navigation link should match text and url 2`] = `
 Object {
   "text": "Việt Nam",
-  "url": "/vietnamese/vietnam",
+  "url": "/vietnamese/topics/ckdxnx1x5rnt",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "Thế giới",
-  "url": "/vietnamese/world",
+  "url": "/vietnamese/topics/cnlv9j1ekq0t",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "Diễn đàn",
-  "url": "/vietnamese/forum",
+  "url": "/vietnamese/forum-54540875",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Kinh tế",
-  "url": "/vietnamese/business",
+  "url": "/vietnamese/topics/cez1ey7nzj3t",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Nhịp sống mới",
-  "url": "/vietnamese/magazine",
+  "url": "/vietnamese/magazine-54029179",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Thể thao",
-  "url": "/vietnamese/sport",
+  "url": "/vietnamese/topics/ckdxnx1k7zxt",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
-Object {
-  "text": "Học tiếng Anh",
-  "url": "/vietnamese/english",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Video",
   "url": "/vietnamese/media/video",

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
@@ -83,53 +83,46 @@ Object {
 exports[`Canonical Most Read Page Header Navigation link should match text and url 2`] = `
 Object {
   "text": "Việt Nam",
-  "url": "/vietnamese/vietnam",
+  "url": "/vietnamese/topics/ckdxnx1x5rnt",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "Thế giới",
-  "url": "/vietnamese/world",
+  "url": "/vietnamese/topics/cnlv9j1ekq0t",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "Diễn đàn",
-  "url": "/vietnamese/forum",
+  "url": "/vietnamese/forum-54540875",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Kinh tế",
-  "url": "/vietnamese/business",
+  "url": "/vietnamese/topics/cez1ey7nzj3t",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Nhịp sống mới",
-  "url": "/vietnamese/magazine",
+  "url": "/vietnamese/magazine-54029179",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Thể thao",
-  "url": "/vietnamese/sport",
+  "url": "/vietnamese/topics/ckdxnx1k7zxt",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
-Object {
-  "text": "Học tiếng Anh",
-  "url": "/vietnamese/english",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Video",
   "url": "/vietnamese/media/video",

--- a/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/amp.test.js.snap
@@ -258,7 +258,7 @@ Object {
 exports[`AMP On Demand Radio Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashto/__snapshots__/canonical.test.js.snap
@@ -125,7 +125,7 @@ Object {
 exports[`Canonical On Demand Radio Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/amp.test.js.snap
@@ -258,7 +258,7 @@ Object {
 exports[`AMP On Demand Radio Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandRadioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -125,7 +125,7 @@ Object {
 exports[`Canonical On Demand Radio Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
@@ -258,7 +258,7 @@ Object {
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
@@ -125,7 +125,7 @@ Object {
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "ځانګړې پاڼې",
-  "url": "/pashto/in_depth",
+  "url": "/pashto/in-depth-54540873",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
@@ -215,40 +215,26 @@ Object {
 
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "Warar dheeraad ah",
-  "url": "/somali/war",
+  "text": "Ganacsi",
+  "url": "/somali/topics/c2dwqd32v4yt",
 }
 `;
 
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 3`] = `
 Object {
-  "text": "Ganacsi",
-  "url": "/somali/topics/2f2db234-3c2d-40a4-b4ac-eea661faadd0",
+  "text": "Cayaaraha",
+  "url": "/somali/topics/cpzd4zj1pn2t",
 }
 `;
 
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 4`] = `
-Object {
-  "text": "Cayaaraha",
-  "url": "/somali/cayaaraha",
-}
-`;
-
-exports[`AMP On Demand T V Page Header Navigation link should match text and url 5`] = `
-Object {
-  "text": "Aqoon Guud",
-  "url": "/somali/aqoon_guud",
-}
-`;
-
-exports[`AMP On Demand T V Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Muuqaal",
   "url": "/somali/media/video",
 }
 `;
 
-exports[`AMP On Demand T V Page Header Navigation link should match text and url 7`] = `
+exports[`AMP On Demand T V Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Barnaamijyada Idaacadda",
   "url": "/somali/media-54071665",

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
@@ -82,40 +82,26 @@ Object {
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "Warar dheeraad ah",
-  "url": "/somali/war",
+  "text": "Ganacsi",
+  "url": "/somali/topics/c2dwqd32v4yt",
 }
 `;
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 3`] = `
 Object {
-  "text": "Ganacsi",
-  "url": "/somali/topics/2f2db234-3c2d-40a4-b4ac-eea661faadd0",
+  "text": "Cayaaraha",
+  "url": "/somali/topics/cpzd4zj1pn2t",
 }
 `;
 
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 4`] = `
-Object {
-  "text": "Cayaaraha",
-  "url": "/somali/cayaaraha",
-}
-`;
-
-exports[`Canonical On Demand T V Page Header Navigation link should match text and url 5`] = `
-Object {
-  "text": "Aqoon Guud",
-  "url": "/somali/aqoon_guud",
-}
-`;
-
-exports[`Canonical On Demand T V Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Muuqaal",
   "url": "/somali/media/video",
 }
 `;
 
-exports[`Canonical On Demand T V Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical On Demand T V Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Barnaamijyada Idaacadda",
   "url": "/somali/media-54071665",


### PR DESCRIPTION
Resolves #8418 

**Overall change:**
Updates to navigation bars for Burmese, Japanese, Pashto, Somali, Thai and Vietnamese

**Code changes:**

* Replaced links to recent assets with links to topic pages on BBC Burmese Nav
* Updated Features link on BBC Japanese Nav and topic pages links
* Updated In depth link on BBC Pashto Nav
* Removed links to News and Knowledge recent assets index on BBC Somali Nav
* Removed US election link from BBC Thai nav
* Updated links on BBC Vietnamese nav and removed Learning English
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
