### PR TITLE
Russian and Turkce configs: Amend a few public facing strings

### DIFF
--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -63,7 +63,7 @@ const headerFooterTranslations = {
             'https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/',
         },
       },
-      accept: 'Да, согласен',
+      accept: 'Да',
       reject: 'Нет, мне надо посмотреть настройки',
       rejectUrl:
         'https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/',
@@ -152,7 +152,7 @@ export const mainTranslations = {
       linkText: 'Смотреть еще в %provider_name%',
       linkTextSuffixVisuallyHidden: ', внешняя ссылка',
       warningText:
-        'Би-би-си на несет ответственности за содержание других сайтов.',
+        'Би-би-си не несёт ответственности за содержание других сайтов.',
     },
     skipLink: {
       text: 'Пропустить контент из %provider_name%',

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -193,7 +193,7 @@ export const service = {
         linkText: 'Tüm içeriği görmek için sayfanın tüm sürümünü görüntüleyin ',
       },
       topStoriesTitle: 'Manşet haber',
-      featuresAnalysisTitle: 'Aramızda Kalmasın',
+      featuresAnalysisTitle: 'Seçtiklerimiz',
     },
     brandSVG,
     mostRead: {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Amendments and typo fixes on public facing labels

**Code changes:**

* BBC Russian: fix typo in social embed fallback message, amend text for cookie 'accept' option to make it gender neutral
* BBC Turkce: Amend heading for Features box on STYs


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
