### PR TITLE
Navigation updates Mundo, Gujarati, Hausa, Japanese and Serbian

### DIFF
--- a/src/app/lib/config/services/gujarati.js
+++ b/src/app/lib/config/services/gujarati.js
@@ -266,7 +266,7 @@ export const service = {
       },
       {
         title: 'આંતરરાષ્ટ્રીય',
-        url: '/gujarati/international',
+        url: '/gujarati/topics/c83plvezd90t',
       },
     ],
   },

--- a/src/app/lib/config/services/hausa.js
+++ b/src/app/lib/config/services/hausa.js
@@ -263,11 +263,11 @@ export const service = {
       },
       {
         title: 'Wasanni',
-        url: '/hausa/wasanni',
+        url: '/hausa/topics/cz74kjgv220t',
       },
       {
         title: 'Nishadi',
-        url: '/hausa/topics/1c3b60a9-14eb-484b-a750-9f5b1aeaac31',
+        url: '/hausa/topics/cg726kz37wdt',
       },
       {
         title: 'Cikakkun Rahotanni',
@@ -279,7 +279,7 @@ export const service = {
       },
       {
         title: 'Shirye-shirye na Musamman',
-        url: '/hausa/shirye_shirye_na_musamman',
+        url: '/hausa/shirye-shirye-na-musamman-54712348',
       },
       {
         title: 'Shirye-shiryen rediyo',

--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -275,7 +275,7 @@ export const service = {
       },
       {
         title: 'ビデオ',
-        url: 'https://www.bbc.com/japanese/video',
+        url: '/japanese/video-55128146',
       },
       {
         title: 'ワールドニュースTV',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -323,10 +323,6 @@ export const service = {
         title: 'Centroamérica Cuenta',
         url: '/mundo/noticias-43826245',
       },
-      {
-        title: 'BBC Extra',
-        url: '/mundo/noticias-48908206',
-      },
     ],
   },
 };

--- a/src/app/lib/config/services/serbian.js
+++ b/src/app/lib/config/services/serbian.js
@@ -127,10 +127,6 @@ export const service = {
         url: '/serbian/lat/srbija-52197807',
       },
       {
-        title: 'Izbori u SAD',
-        url: '/serbian/lat/topics/cq04kq3z44pt',
-      },
-      {
         title: 'Srbija',
         url: '/serbian/lat/topics/cr50vdy9q6wt',
       },
@@ -376,10 +372,6 @@ export const service = {
       {
         title: 'Корона вирус',
         url: '/serbian/cyr/srbija-52197807',
-      },
-      {
-        title: 'Избори у САД',
-        url: '/serbian/cyr/topics/c9mj2rzvl9xt',
       },
       {
         title: 'Србија',

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -297,13 +297,6 @@ Object {
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`AMP Most Read Page I can see the headline 1`] = `"Más leídas"`;
 
 exports[`AMP Most Read Page I can see the list items 1`] = `"1Cómo es posible que Uber sobreviva con pérdidas de US$1.200 millones y sin nunca haber obtenido beneficiosÚltima actualización: 6 noviembre 2019"`;

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -164,13 +164,6 @@ Object {
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`Canonical Most Read Page I can see the headline 1`] = `"Más leídas"`;
 
 exports[`Canonical Most Read Page I can see the list items 1`] = `"1Cómo es posible que Uber sobreviva con pérdidas de US$1.200 millones y sin nunca haber obtenido beneficiosÚltima actualización: 6 noviembre 2019"`;

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -297,13 +297,6 @@ Object {
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`AMP Photo Gallery Page Image Caption should match text 1`] = `"Pie de foto, En tenis, las competidoras en los juegos de principios del siglo XX utilizaban vestidos y medias largas, algo impensable para los estándares de la actualidad. Fue hasta 1920 en Amberes cuando las mujeres tuvieron participación reconocida oficialmente."`;
 
 exports[`AMP Photo Gallery Page Image should match snapshot 1`] = `

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -164,13 +164,6 @@ Object {
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`Canonical Photo Gallery Page Image Caption should match text 1`] = `"Pie de foto, En tenis, las competidoras en los juegos de principios del siglo XX utilizaban vestidos y medias largas, algo impensable para los estándares de la actualidad. Fue hasta 1920 en Amberes cuando las mujeres tuvieron participación reconocida oficialmente."`;
 
 exports[`Canonical Photo Gallery Page Image should match snapshot 1`] = `

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -297,13 +297,6 @@ Object {
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`AMP Story Page Image Caption should match text 1`] = `"Pie de foto, Llegó el día de la salida de Reino Unido de la UE."`;
 
 exports[`AMP Story Page Image should match snapshot 1`] = `

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -171,13 +171,6 @@ Object {
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 14`] = `
-Object {
-  "text": "BBC Extra",
-  "url": "/mundo/noticias-48908206",
-}
-`;
-
 exports[`Canonical Story Page Image Caption should match text 1`] = `"Pie de foto, Llegó el día de la salida de Reino Unido de la UE."`;
 
 exports[`Canonical Story Page Image should match snapshot 1`] = `


### PR DESCRIPTION
Resolves #8505 

**Overall change:**
Updates to navigation bars for Mundo, Gujarati, Hausa, Japanese and Serbian

**Code changes:**

Removed BBC Extra item on BBC Mundo nav
Replaced link to recent asset International index with link to topic page on BBC Gujarati Nav
Replaced links to recent assets with links to topic pages on BBC Hausa Nav
Replaced Most watched link on BBC Japanese Nav with link to Video feature index
Removed US election link from BBC Serbian Latin and Cyrillic navs


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
