### PR TITLE
Fix unit tests for a11y csr

### DIFF
--- a/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
@@ -9,22 +9,22 @@ exports[`withLoading HOC and no loading prop should return the passed in compone
 `;
 
 exports[`withLoading HOC and the loading prop set to true should return the loading component 1`] = `
-.emotion-5 {
+.emotion-7 {
   min-height: 100vh;
 }
 
-.emotion-3 {
+.emotion-5 {
   width: 100%;
 }
 
 @supports (display:grid) {
-  .emotion-3 {
+  .emotion-5 {
     display: grid;
     position: initial;
   }
 
 @media (max-width:14.9375rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -34,7 +34,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -44,7 +44,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -54,7 +54,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -64,7 +64,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(8,1fr);
@@ -74,7 +74,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:80rem) {
-    .emotion-3 {
+    .emotion-5 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(20,1fr);
@@ -85,66 +85,66 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .emotion-3 {
+  .emotion-5 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .emotion-3 {
+  .emotion-5 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-0 {
+  .emotion-2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .emotion-0 {
+  .emotion-2 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .emotion-0 {
+  .emotion-2 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .emotion-0 {
+  .emotion-2 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .emotion-0 {
+  .emotion-2 {
     margin-left: 20%;
   }
 }
 
 @media (min-width:80rem) {
-  .emotion-0 {
+  .emotion-2 {
     margin-left: 40%;
   }
 }
 
 @supports (display:grid) {
-  .emotion-0 {
+  .emotion-2 {
     display: block;
   }
 
 @media (max-width:14.9375rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -155,7 +155,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -166,7 +166,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -177,7 +177,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(5,1fr);
@@ -188,7 +188,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(5,1fr);
@@ -198,7 +198,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:80rem) {
-    .emotion-0 {
+    .emotion-2 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(10,1fr);
@@ -208,19 +208,42 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 }
 
+.emotion-0 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 <div>
   <main
-    class="emotion-5 emotion-6"
+    class="emotion-7 emotion-8"
     role="main"
   >
     <div
-      class="emotion-2 emotion-3 emotion-1"
+      class="emotion-4 emotion-5 emotion-3"
       dir="ltr"
     >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
         dir="ltr"
-      />
+      >
+        <div
+          data-testid="loading"
+          tabindex="-1"
+        >
+          <span
+            class="emotion-0 emotion-1"
+          >
+            Loading next page.
+          </span>
+        </div>
+      </div>
     </div>
   </main>
 </div>

--- a/src/app/containers/PageHandlers/withLoading/index.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.jsx
@@ -34,7 +34,7 @@ const WithLoading = Component => {
       <LoadingMain role="main">
         <GridWrapper>
           <GridItemMedium>
-            <div tabIndex="-1" ref={loadingMessageRef}>
+            <div tabIndex="-1" ref={loadingMessageRef} data-testid="loading">
               <VisuallyHiddenText>Loading next page.</VisuallyHiddenText>
             </div>
           </GridItemMedium>

--- a/src/app/containers/PageHandlers/withLoading/index.test.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.test.jsx
@@ -75,5 +75,17 @@ describe('withLoading HOC', () => {
 
       expect(queryByTestId('loading')).toHaveFocus();
     });
+
+    it(`should not be focused before a set amount of time`, async () => {
+      let queryByTestId;
+
+      await act(async () => {
+        ({ queryByTestId } = render(<LoadingHOC loading />));
+
+        await wait(400);
+      });
+
+      expect(queryByTestId('loading')).not.toHaveFocus();
+    });
   });
 });

--- a/src/app/containers/PageHandlers/withLoading/index.test.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.test.jsx
@@ -27,17 +27,18 @@ describe('withLoading HOC', () => {
   });
 
   describe(`and the loading indicator`, () => {
-    it(`should not show the loading indicator before a set amount of time`, async () => {
-      let queryByTestId;
+    // Reinstate after conditional loading logic is re-added
+    // it(`should not show the loading indicator before a set amount of time`, async () => {
+    //   let queryByTestId;
 
-      await act(async () => {
-        ({ queryByTestId } = render(<LoadingHOC loading />));
+    //   await act(async () => {
+    //     ({ queryByTestId } = render(<LoadingHOC loading />));
 
-        await wait(400);
-      });
+    //     await wait(400);
+    //   });
 
-      expect(queryByTestId('loading')).not.toBeInTheDocument();
-    });
+    //   expect(queryByTestId('loading')).not.toBeInTheDocument();
+    // });
 
     it(`should show the loading indicator after a set amount of time`, async () => {
       let queryByTestId;

--- a/src/app/containers/PageHandlers/withLoading/index.test.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.test.jsx
@@ -63,5 +63,17 @@ describe('withLoading HOC', () => {
 
       expect(queryByTestId('loading')).not.toBeInTheDocument();
     });
+
+    it(`should be focused after a set amount of time`, async () => {
+      let queryByTestId;
+
+      await act(async () => {
+        ({ queryByTestId } = render(<LoadingHOC loading />));
+
+        await wait(600);
+      });
+
+      expect(queryByTestId('loading')).toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
- Commented out conditional `withLoading` unit test (based on component not rendering until a set amount of time has passed)
- Added data-testid attribute back to loading message div so that other unit tests pass.
- Added test checking that the loading message has / doesn't have focus after / before 600s
- Updated snapshots