### PR TITLE
Remove use of Enzyme from the Manifest container

### DIFF
--- a/src/app/containers/Manifest/index.test.jsx
+++ b/src/app/containers/Manifest/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Helmet } from 'react-helmet';
 import ManifestContainer from '.';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -10,7 +10,7 @@ const contextStub = {
 };
 
 const mountManifest = context =>
-  mount(
+  render(
     <ServiceContext.Provider value={context}>
       <ManifestContainer />
     </ServiceContext.Provider>,


### PR DESCRIPTION
Part of #8458

**Overall change:**
_Remove use of Enzyme from the Manifest container._

**Code changes:**

- _Remove import for `mount`._
- _Import `render` from `@testing-library/react` and use it instead of `mount`._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
