### PR TITLE
Use ARTICLE_PAGE string constant pageType throughout codebase

### DIFF
--- a/src/app/containers/ATIAnalytics/index.test.jsx
+++ b/src/app/containers/ATIAnalytics/index.test.jsx
@@ -20,6 +20,7 @@ import ATIAnalytics from '.';
 import * as amp from './amp';
 import * as canonical from './canonical';
 import * as analyticsUtils from '#lib/analyticsUtils';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 analyticsUtils.getAtUserId = jest.fn();
 analyticsUtils.getCurrentTime = jest.fn().mockReturnValue('00-00-00');
@@ -61,7 +62,11 @@ describe('ATI Analytics Container', () => {
       canonical.default = mockCanonical;
 
       render(
-        <ContextWrap platform="canonical" pageType="article" service="news">
+        <ContextWrap
+          platform="canonical"
+          pageType={ARTICLE_PAGE}
+          service="news"
+        >
           <ATIAnalytics data={articleDataNews} />
         </ContextWrap>,
       );
@@ -78,7 +83,7 @@ describe('ATI Analytics Container', () => {
       amp.default = mockAmp;
 
       render(
-        <ContextWrap platform="amp" pageType="article" service="news">
+        <ContextWrap platform="amp" pageType={ARTICLE_PAGE} service="news">
           <ATIAnalytics data={articleDataNews} />
         </ContextWrap>,
       );

--- a/src/app/containers/ATIAnalytics/params/index.test.js
+++ b/src/app/containers/ATIAnalytics/params/index.test.js
@@ -1,5 +1,6 @@
 import { buildATIUrl, buildATIClickParams } from '.';
 import * as analyticsUtils from '#lib/analyticsUtils';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 analyticsUtils.getAtUserId = jest.fn();
 analyticsUtils.getCurrentTime = jest.fn().mockReturnValue('00-00-00');
@@ -151,7 +152,7 @@ describe('ATIAnalytics params', () => {
     it('should return the right article url', () => {
       const url = buildATIUrl(
         article,
-        { ...requestContext, pageType: 'article' },
+        { ...requestContext, pageType: ARTICLE_PAGE },
         serviceContext,
       );
       expect(url).toMatchInlineSnapshot(
@@ -217,7 +218,7 @@ describe('ATIAnalytics params', () => {
     it('should have both ref parameter and x6 referrer url parameter, if referrer url exists', () => {
       const atiUrl = buildATIUrl(
         article,
-        { ...requestContext, pageType: 'article' },
+        { ...requestContext, pageType: ARTICLE_PAGE },
         serviceContext,
       );
       const params = atiUrl.split('&');
@@ -229,7 +230,7 @@ describe('ATIAnalytics params', () => {
     it('should have ref parameter as the last parameter, if referrer url exists', () => {
       const atiUrl = buildATIUrl(
         article,
-        { ...requestContext, pageType: 'article' },
+        { ...requestContext, pageType: ARTICLE_PAGE },
         serviceContext,
       );
       const params = atiUrl.split('&');
@@ -240,7 +241,7 @@ describe('ATIAnalytics params', () => {
     it('should not have ref and x6 parameters, if referrer url does not exist', () => {
       const atiUrl = buildATIUrl(
         article,
-        { ...requestContext, pageType: 'article', previousPath: '' },
+        { ...requestContext, pageType: ARTICLE_PAGE, previousPath: '' },
         serviceContext,
       );
       const params = atiUrl.split('&');
@@ -254,7 +255,7 @@ describe('ATIAnalytics params', () => {
     it('should return the right article params', () => {
       const params = buildATIClickParams(
         article,
-        { ...requestContext, pageType: 'article' },
+        { ...requestContext, pageType: ARTICLE_PAGE },
         serviceContext,
       );
       expect(params).toEqual({

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -4,6 +4,7 @@ import { render, act } from '@testing-library/react';
 import { App } from './App';
 import getToggles from '#app/lib/utilities/getToggles';
 import routes from '#app/routes';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 jest.mock('react-router-config');
 jest.mock('#app/lib/utilities/getToggles');
@@ -28,7 +29,7 @@ describe('App', () => {
 
   const route = {
     getInitialData: jest.fn().mockResolvedValue({}),
-    pageType: 'article',
+    pageType: { ARTICLE_PAGE },
   };
 
   reactRouterConfig.matchRoutes.mockReturnValue([{ route, match }]);

--- a/src/app/containers/App/App.test.jsx
+++ b/src/app/containers/App/App.test.jsx
@@ -29,7 +29,7 @@ describe('App', () => {
 
   const route = {
     getInitialData: jest.fn().mockResolvedValue({}),
-    pageType: { ARTICLE_PAGE },
+    pageType: ARTICLE_PAGE,
   };
 
   reactRouterConfig.matchRoutes.mockReturnValue([{ route, match }]);

--- a/src/app/containers/ArticleFigure/fixtureData.jsx
+++ b/src/app/containers/ArticleFigure/fixtureData.jsx
@@ -12,6 +12,7 @@ import FigureContainer from '.';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { blockContainingText } from '#models/blocks';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const imageAlt = 'Pauline Clayton';
 const imageHeight = 360;
@@ -167,7 +168,7 @@ const GenerateFixtureData = ({
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       isAmp={platform === 'amp'}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       pathname="/pathname"
       service="news"
       statusCode={200}

--- a/src/app/containers/ArticleMediaPlayer/index.test.jsx
+++ b/src/app/containers/ArticleMediaPlayer/index.test.jsx
@@ -5,6 +5,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import ArticleMediaPlayerContainer from '.';
 import { validAresMediaVideoBlock } from '../MediaPlayer/fixtureData';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const GenerateMediaPlayer = ({
   /* eslint-disable react/prop-types */
@@ -18,7 +19,7 @@ const GenerateMediaPlayer = ({
     statusCode={200}
     platform={platform}
     id="c1234567890"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/pathname"
   >
     <ServiceContextProvider service="news">

--- a/src/app/containers/ArticleMetadata/index.test.jsx
+++ b/src/app/containers/ArticleMetadata/index.test.jsx
@@ -9,6 +9,7 @@ import {
   articleDataNews,
   articleDataPersian,
 } from '#pages/ArticlePage/fixtureData';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const getISOStringDate = date => new Date(date).toISOString();
 
@@ -20,7 +21,7 @@ const Context = ({ service, children }) => (
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         pathname="/pathname"
         service={service}
         statusCode={200}

--- a/src/app/containers/ChartbeatAnalytics/index.test.jsx
+++ b/src/app/containers/ChartbeatAnalytics/index.test.jsx
@@ -10,6 +10,7 @@ import * as testUtils from './utils';
 import * as amp from './amp';
 import { localBaseUrl } from '../../../testHelpers/config';
 import frontPageData from '../../../../data/news/frontpage';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const defaultToggleState = {
   chartbeatAnalytics: {
@@ -89,7 +90,7 @@ describe('Charbeats Analytics Container', () => {
     const { container } = render(
       <ContextWrap
         platform="amp"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         origin="bbc.com"
         toggleState={toggleState}
       >
@@ -117,7 +118,7 @@ describe('Charbeats Analytics Container', () => {
     const { container } = render(
       <ContextWrap
         platform="canonical"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         origin="bbc.com"
         toggleState={toggleState}
       >
@@ -133,7 +134,7 @@ describe('Charbeats Analytics Container', () => {
     const { container } = render(
       <ContextWrap
         platform="canonical"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         origin={localBaseUrl}
       >
         <ChartbeatAnalytics data={frontPageData} />
@@ -173,7 +174,7 @@ describe('Charbeats Analytics Container', () => {
     render(
       <ContextWrap
         platform="canonical"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         origin="test.bbc.com"
         toggleState={toggleState}
       >

--- a/src/app/containers/ChartbeatAnalytics/utils/index.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.js
@@ -4,6 +4,7 @@ import onClient from '#lib/utilities/onClient';
 import { getPromoHeadline } from '#lib/analyticsUtils/article';
 import { getPageTitle } from '#lib/analyticsUtils/indexPage';
 import { getReferrer } from '#lib/analyticsUtils';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const ID_COOKIE = 'ckns_sylphid';
 
@@ -29,7 +30,7 @@ export const getType = (pageType, shorthand = false) => {
     case 'IDX':
     case 'index':
       return shorthand ? 'IDX' : 'Index';
-    case 'article':
+    case ARTICLE_PAGE:
       return shorthand ? 'ART' : 'New Article';
     case 'MAP':
       return 'article-media-asset';
@@ -109,7 +110,7 @@ export const getTitle = ({ pageType, pageData, brandName, title }) => {
     case 'IDX':
     case 'index':
       return getPageTitle(pageData, brandName);
-    case 'article':
+    case ARTICLE_PAGE:
       return getPromoHeadline(pageData);
     case 'MAP':
       return path(['promo', 'headlines', 'headline'], pageData);

--- a/src/app/containers/ChartbeatAnalytics/utils/index.test.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.test.js
@@ -11,6 +11,7 @@ import {
 import onClient from '#lib/utilities/onClient';
 import * as articleUtils from '#lib/analyticsUtils/article';
 import * as frontPageUtils from '#lib/analyticsUtils/indexPage';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 let isOnClient = false;
 
@@ -47,7 +48,7 @@ describe('Chartbeat utilities', () => {
   describe('Chartbeat Page Type', () => {
     const types = [
       {
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         expectedDefaultType: 'New Article',
         expectedShortType: 'ART',
       },
@@ -117,7 +118,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: 'wales',
         chapter: 'election 2017',
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         description: 'should add chapter and producer to article type',
         expected:
           'News, News - ART, News - wales, News - wales - ART, News - election 2017, News - election 2017 - ART',
@@ -126,7 +127,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: 'business',
         chapter: 'market data',
-        pageType: 'index',
+        pageType: ARTICLE_PAGE,
         description: 'should add chapter and producer to index type',
         expected:
           'News, News - IDX, News - business, News - business - IDX, News - market data, News - market data - IDX',
@@ -135,7 +136,7 @@ describe('Chartbeat utilities', () => {
         service: 'persian',
         producer: null,
         chapter: null,
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         description: 'should not add chapter and producer when not present',
         expected: 'Persian, Persian - ART',
       },
@@ -143,7 +144,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: 'foo',
         chapter: null,
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         description: 'should not add chapter when not present',
         expected: 'News, News - ART, News - foo, News - foo - ART',
       },
@@ -151,7 +152,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: null,
         chapter: 'bar',
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         description: 'should not add producer when not present',
         expected: 'News, News - ART, News - bar, News - bar - ART',
       },
@@ -159,7 +160,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: 'news',
         chapter: 'baz',
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         description: 'should not add producer when producer == service',
         expected: 'News, News - ART, News - baz, News - baz - ART',
       },
@@ -265,13 +266,13 @@ describe('Chartbeat utilities', () => {
     });
 
     test.each`
-      pageType       | brandName        | pageTitle                        | expectedNumberOfCalls
-      ${'index'}     | ${'BBC News'}    | ${'This is an index page title'} | ${1}
-      ${'IDX'}       | ${'BBC Persian'} | ${'This is an IDX page title'}   | ${1}
-      ${'FIX'}       | ${'BBC Afrique'} | ${'This is an FIX page title'}   | ${1}
-      ${'frontPage'} | ${'BBC News'}    | ${'This is a frontpage title'}   | ${1}
-      ${'article'}   | ${null}          | ${'This is an article title'}    | ${1}
-      ${'foo'}       | ${'BBC News'}    | ${null}                          | ${0}
+      pageType        | brandName        | pageTitle                        | expectedNumberOfCalls
+      ${'index'}      | ${'BBC News'}    | ${'This is an index page title'} | ${1}
+      ${'IDX'}        | ${'BBC Persian'} | ${'This is an IDX page title'}   | ${1}
+      ${'FIX'}        | ${'BBC Afrique'} | ${'This is an FIX page title'}   | ${1}
+      ${'frontPage'}  | ${'BBC News'}    | ${'This is a frontpage title'}   | ${1}
+      ${ARTICLE_PAGE} | ${null}          | ${'This is an article title'}    | ${1}
+      ${'foo'}        | ${'BBC News'}    | ${null}                          | ${0}
     `(
       'should call getPageTitle when pageType is $pageType',
       ({ brandName, pageType, pageTitle, expectedNumberOfCalls }) => {
@@ -279,7 +280,7 @@ describe('Chartbeat utilities', () => {
 
         const mockTitle = jest.fn().mockImplementation(() => pageTitle);
 
-        if (pageType === 'article') {
+        if (pageType === ARTICLE_PAGE) {
           articleUtils.getPromoHeadline = mockTitle;
         } else {
           frontPageUtils.getPageTitle = mockTitle;
@@ -334,7 +335,7 @@ describe('Chartbeat utilities', () => {
       const fixtureData = {
         isAmp: true,
         platform: 'amp',
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         data: {},
         brandName: '',
         chartbeatDomain: 'bbc.co.uk',

--- a/src/app/containers/ChartbeatAnalytics/utils/index.test.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.test.js
@@ -127,7 +127,7 @@ describe('Chartbeat utilities', () => {
         service: 'news',
         producer: 'business',
         chapter: 'market data',
-        pageType: ARTICLE_PAGE,
+        pageType: 'index',
         description: 'should add chapter and producer to index type',
         expected:
           'News, News - IDX, News - business, News - business - IDX, News - market data, News - market data - IDX',

--- a/src/app/containers/ChartbeatAnalytics/utils/index.test.js
+++ b/src/app/containers/ChartbeatAnalytics/utils/index.test.js
@@ -47,65 +47,65 @@ describe('Chartbeat utilities', () => {
   describe('Chartbeat Page Type', () => {
     const types = [
       {
-        type: 'article',
+        pageType: 'article',
         expectedDefaultType: 'New Article',
         expectedShortType: 'ART',
       },
       {
-        type: 'index',
+        pageType: 'index',
         expectedDefaultType: 'Index',
         expectedShortType: 'IDX',
       },
       {
-        type: 'FIX',
+        pageType: 'FIX',
         expectedDefaultType: 'FIX',
         expectedShortType: 'FIX',
       },
       {
-        type: 'MAP',
+        pageType: 'MAP',
         expectedDefaultType: 'article-media-asset',
         expectedShortType: 'article-media-asset',
       },
       {
-        type: 'media',
+        pageType: 'media',
         expectedDefaultType: 'Radio',
         expectedShortType: 'Radio',
       },
       {
-        type: 'mostRead',
+        pageType: 'mostRead',
         expectedDefaultType: 'Most Read',
         expectedShortType: 'Most Read',
       },
       {
-        type: 'mostWatched',
+        pageType: 'mostWatched',
         expectedDefaultType: 'Most Watched',
         expectedShortType: 'Most Watched',
       },
       {
-        type: 'STY',
+        pageType: 'STY',
         expectedDefaultType: 'STY',
         expectedShortType: 'STY',
       },
       {
-        type: 'PGL',
+        pageType: 'PGL',
         expectedDefaultType: 'PGL',
         expectedShortType: 'PGL',
       },
       {
-        type: null,
+        pageType: null,
         expectedDefaultType: null,
         expectedShortType: null,
       },
     ];
 
     types.forEach(
-      ({ type: rawType, expectedDefaultType, expectedShortType }) => {
-        it(`Type ${rawType} should return ${expectedDefaultType} as default`, () => {
-          expect(getType(rawType)).toBe(expectedDefaultType);
+      ({ pageType: rawPageType, expectedDefaultType, expectedShortType }) => {
+        it(`Page type ${rawPageType} should return ${expectedDefaultType} as default`, () => {
+          expect(getType(rawPageType)).toBe(expectedDefaultType);
         });
 
-        it(`Type ${rawType} should return ${expectedShortType} as shorthand`, () => {
-          expect(getType(rawType, true)).toBe(expectedShortType);
+        it(`Page type ${rawPageType} should return ${expectedShortType} as shorthand`, () => {
+          expect(getType(rawPageType, true)).toBe(expectedShortType);
         });
       },
     );

--- a/src/app/containers/ComscoreAnalytics/index.test.jsx
+++ b/src/app/containers/ComscoreAnalytics/index.test.jsx
@@ -7,6 +7,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { ToggleContext } from '#contexts/ToggleContext';
 import { UserContext } from '#contexts/UserContext';
 import ComscoreAnalytics from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const mockToggleDispatch = jest.fn();
 
@@ -66,7 +67,7 @@ describe('Comscore Analytics Container', () => {
       const { container } = render(
         <ContextWrap
           platform="amp"
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           origin="bbc.com"
           comscoreAnalyticsToggle={false}
         >
@@ -81,7 +82,7 @@ describe('Comscore Analytics Container', () => {
       const { container } = render(
         <ContextWrap
           platform="amp"
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           origin="bbc.com"
           comscoreAnalyticsToggle
         >
@@ -99,7 +100,7 @@ describe('Comscore Analytics Container', () => {
       'should render comscore script when on canonical',
       <ContextWrap
         platform="amp"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         origin="bbc.com"
         comscoreAnalyticsToggle
       >
@@ -111,7 +112,7 @@ describe('Comscore Analytics Container', () => {
       const { container } = render(
         <ContextWrap
           platform="canonical"
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           origin="bbc.com"
           comscoreAnalyticsToggle={false}
         >

--- a/src/app/containers/ConsentBanner/Banner/Text.test.jsx
+++ b/src/app/containers/ConsentBanner/Banner/Text.test.jsx
@@ -3,6 +3,7 @@ import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import BannerText from './Text';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const bannerMessaging = {
   uk: {
@@ -34,7 +35,7 @@ const bannerTextWithContext = (message, topLevelDomain) => (
       bbcOrigin={`https://www.test.bbc.${topLevelDomain}`}
       id="c0000000000o"
       isAmp={false}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service="news"
       statusCode={200}
       pathname="/pathname"

--- a/src/app/containers/ConsentBanner/index.stories.jsx
+++ b/src/app/containers/ConsentBanner/index.stories.jsx
@@ -4,6 +4,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import ConsentBanner from '.';
 import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const getConsentBanner = platform => (
   <ServiceContextProvider service="news">
@@ -12,7 +13,7 @@ const getConsentBanner = platform => (
       isUK
       isAmp={platform === 'amp'}
       origin="https://www.bbc.co.uk"
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       id="c0000000000o"
       service="news"
       statsDestination="NEWS_PS_TEST"

--- a/src/app/containers/ConsentBanner/index.test.jsx
+++ b/src/app/containers/ConsentBanner/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { RequestContextProvider } from '#contexts/RequestContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 jest.mock('./index.canonical', () => () => <div>Canonical Cookie banner</div>);
 jest.mock('./index.amp', () => () => <div>Amp Cookie banner</div>);
@@ -14,7 +15,7 @@ describe('Consent Banner Container', () => {
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       isAmp
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service="news"
       statusCode={200}
       pathname="/pathname"
@@ -29,7 +30,7 @@ describe('Consent Banner Container', () => {
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       isAmp={false}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service="news"
       statusCode={200}
       pathname="/pathname"

--- a/src/app/containers/CpsMetadata/index.test.jsx
+++ b/src/app/containers/CpsMetadata/index.test.jsx
@@ -6,6 +6,7 @@ import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import CpsMetadata from './index';
 import { articleDataNews } from '#pages/ArticlePage/fixtureData';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const getISOStringDate = date => new Date(date).toISOString();
 
@@ -23,7 +24,7 @@ const Context = ({ service, children, toggles = defaultToggles }) => (
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         pathname="/pathname"
         service={service}
         statusCode={200}

--- a/src/app/containers/FrontPageStoryRows/index.stories.jsx
+++ b/src/app/containers/FrontPageStoryRows/index.stories.jsx
@@ -7,6 +7,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { topStoryColumns } from './storyColumns';
 import { TopRow, LeadingRow, RegularRow } from '.';
 import getNumberPromoFixtures from './testHelpers';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 // eslint-disable-next-line react/prop-types
 const TopRowStory = ({ dir, displayImages }) => (
@@ -43,7 +44,7 @@ const getRow = (RowType, dir = 'ltr', displayImages = true) => {
         id="c0000000000o"
         isAmp={false}
         pathname="/pathname"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
       >
         <Grid enableGelGutters columns={topStoryColumns}>

--- a/src/app/containers/Header/index.jsx
+++ b/src/app/containers/Header/index.jsx
@@ -8,6 +8,7 @@ import ConsentBanner from '../ConsentBanner';
 import ScriptLink from './ScriptLink';
 import useToggle from '#hooks/useToggle';
 import useOperaMiniDetection from '#hooks/useOperaMiniDetection';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const HeaderContainer = () => {
   const { pageType } = useContext(RequestContext);
@@ -27,7 +28,7 @@ const HeaderContainer = () => {
   const showNavOnArticles = useToggle('navOnArticles').enabled;
 
   // All other page types show the nav bar at all times
-  const showNav = showNavOnArticles || pageType !== 'article';
+  const showNav = showNavOnArticles || pageType !== ARTICLE_PAGE;
 
   const isOperaMini = useOperaMiniDetection();
 

--- a/src/app/containers/Header/index.test.jsx
+++ b/src/app/containers/Header/index.test.jsx
@@ -9,6 +9,7 @@ import { ToggleContext } from '#contexts/ToggleContext';
 import { service as pidginServiceConfig } from '#lib/config/services/pidgin';
 import { service as serbianServiceConfig } from '#lib/config/services/serbian';
 import { service as ukrainianServiceConfig } from '#lib/config/services/ukrainian';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const defaultToggleState = {
   navOnArticles: {
@@ -59,7 +60,7 @@ describe(`Header`, () => {
     shouldMatchSnapshot(
       'should render correctly for news article',
       HeaderContainerWithContext({
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         service: 'news',
       }),
     );
@@ -86,7 +87,7 @@ describe(`Header`, () => {
     });
 
     it('should output a nav bar for articles', () => {
-      render(HeaderContainerWithContext({ pageType: 'article' }));
+      render(HeaderContainerWithContext({ pageType: ARTICLE_PAGE }));
       expect(document.querySelector(`header nav`)).not.toBeNull();
     });
 

--- a/src/app/containers/LinkedData/index.test.jsx
+++ b/src/app/containers/LinkedData/index.test.jsx
@@ -4,6 +4,7 @@ import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import LinkedData from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 // eslint-disable-next-line react/prop-types
 const Context = ({ children, service }) => (
@@ -12,7 +13,7 @@ const Context = ({ children, service }) => (
       bbcOrigin="https://www.test.bbc.com"
       id="c0000000000o"
       isAmp={false}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       pathname="/pathname"
       service="news"
       statusCode={200}

--- a/src/app/containers/MediaPlayer/fixtureData.jsx
+++ b/src/app/containers/MediaPlayer/fixtureData.jsx
@@ -5,6 +5,7 @@ import { singleTextBlock } from '#models/blocks';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import MediaPlayerContainer from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const captionBlock = {
   model: {
@@ -463,7 +464,7 @@ const GenerateFixtureData = ({
     statusCode={200}
     platform={platform}
     id="foo"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/pathname"
   >
     <ServiceContextProvider service="news">

--- a/src/app/containers/MediaPlayer/index.stories.jsx
+++ b/src/app/containers/MediaPlayer/index.stories.jsx
@@ -9,6 +9,7 @@ import { validVideoWithCaptionBlock } from './fixtureData';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContext } from '#contexts/ToggleContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const defaultToggles = {
   mediaPlayer: {
@@ -30,7 +31,7 @@ storiesOf('Containers|Media Player/Canonical', module)
         platform="canonical"
         pathname="/pathname"
         id={articleID}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         bbcOrigin="https://www.test.bbc.com"
       >
         <ServiceContextProvider service="news">
@@ -61,7 +62,7 @@ storiesOf('Containers|Media Player/AMP', module)
         service={service}
         platform="amp"
         id="c3wmq4d1y3wo"
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         pathname="/pathname"
         bbcOrigin="https://www.test.bbc.com"
       >

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import MetadataContainer from './index';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 
@@ -80,7 +81,7 @@ const CanonicalNewsInternationalOrigin = () => (
     bbcOrigin={dotComOrigin}
     platform="canonical"
     id="c0000000001o"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/news/articles/c0000000001o"
     {...newsArticleMetadataProps}
   />
@@ -94,7 +95,7 @@ const CanonicalMapInternationalOrigin = () => (
     bbcOrigin={dotComOrigin}
     platform="canonical"
     id="23248703"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/pigdin/23248703"
     {...newsArticleMetadataProps}
   />
@@ -585,7 +586,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotCoDotUKOrigin}
     platform="amp"
     id="c0000000001o"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/news/articles/c0000000001o.amp"
     {...newsArticleMetadataProps}
   />,
@@ -598,7 +599,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotComOrigin}
     platform="canonical"
     id="c4vlle3q337o"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/persian/articles/c4vlle3q337o"
     {...persianArticleMetadataProps}
   />,
@@ -611,7 +612,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotCoDotUKOrigin}
     platform="amp"
     id="c4vlle3q337o"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/persian/articles/c4vlle3q337o.amp"
     {...persianArticleMetadataProps}
   />,
@@ -657,7 +658,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotComOrigin}
     platform="canonical"
     id="news-53577781"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/ukrainian/news-53577781"
     description="BBC Ukrainian"
     openGraphType="website"
@@ -673,7 +674,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotComOrigin}
     platform="amp"
     id="news-53577781"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/ukrainian/news-53577781.amp"
     description="BBC Ukrainian"
     openGraphType="website"
@@ -689,7 +690,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotComOrigin}
     platform="canonical"
     id="news-53577781"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/ukrainian/news-53577781"
     description="BBC Ukrainian"
     openGraphType="website"
@@ -705,7 +706,7 @@ shouldMatchSnapshot(
     bbcOrigin={dotComOrigin}
     platform="amp"
     id="news-53577781"
-    pageType="article"
+    pageType={ARTICLE_PAGE}
     pathname="/ukrainian/news-53577781.amp"
     description="BBC Ukrainian"
     openGraphType="website"

--- a/src/app/containers/MostRead/index.stories.jsx
+++ b/src/app/containers/MostRead/index.stories.jsx
@@ -9,6 +9,7 @@ import MostReadContainer from '.';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const staticMostReadURL = (service, variant) =>
   variant !== 'default'
@@ -21,7 +22,7 @@ const renderMostReadContainer = (service, variant, columnLayout) => (
       bbcOrigin={`http://localhost/${service}/articles/c0000000000o`}
       id="c0000000000o"
       isAmp={false}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service={service}
       statusCode={200}
       pathname={`/${service}`}

--- a/src/app/containers/Navigation/index.test.jsx
+++ b/src/app/containers/Navigation/index.test.jsx
@@ -5,6 +5,7 @@ import { service as newsConfig } from '#lib/config/services/news';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import Navigation from './index';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 describe('Navigation Container', () => {
   shouldMatchSnapshot(
@@ -14,7 +15,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/news"
@@ -31,7 +32,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/news"
@@ -48,7 +49,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/uk"
@@ -65,7 +66,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/uk"
@@ -82,7 +83,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/not-a-navigation-page"
@@ -99,7 +100,7 @@ describe('Navigation Container', () => {
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         service="news"
         statusCode={200}
         pathname="/not-a-navigation-page"
@@ -118,7 +119,7 @@ describe('Navigation Container', () => {
           bbcOrigin="https://www.test.bbc.co.uk"
           id="c0000000000o"
           isAmp={false}
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           service="news"
           statusCode={200}
           pathname="/news"

--- a/src/app/containers/PageHandlers/withContexts.test.jsx
+++ b/src/app/containers/PageHandlers/withContexts.test.jsx
@@ -10,6 +10,7 @@ import * as requestContextImports from '#contexts/RequestContext';
 import * as serviceContextImports from '#contexts/ServiceContext';
 import { ToggleContext } from '#contexts/ToggleContext';
 import { UserContext } from '#contexts/UserContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 jest.mock('#contexts/RequestContext/getOriginContext', () => jest.fn());
 
@@ -45,7 +46,7 @@ describe('withContexts HOC', () => {
     id: 'c0000000000o',
     service: 'news',
     isAmp: true,
-    pageType: 'article',
+    pageType: ARTICLE_PAGE,
     pathname: '/pathname',
     status: 200,
     showAdsBasedOnLocation: true,
@@ -78,7 +79,7 @@ describe('withContexts HOC', () => {
       jest.clearAllMocks();
     });
 
-    const pageTypes = ['article', 'frontPage', 'chicken'];
+    const pageTypes = [ARTICLE_PAGE, 'frontPage', 'chicken'];
 
     pageTypes.forEach(pageType => {
       it(`passing pageType==${pageType} should pass along`, () => {
@@ -120,7 +121,7 @@ describe('withContexts HOC', () => {
         id: 'c0000000000o',
         service: 'zhongwen',
         isAmp: true,
-        pageType: 'article',
+        pageType: ARTICLE_PAGE,
         pathname: '/pathname',
         variant: 'trad',
         status: 200,

--- a/src/app/containers/PageHandlers/withPageWrapper/index.test.jsx
+++ b/src/app/containers/PageHandlers/withPageWrapper/index.test.jsx
@@ -5,12 +5,13 @@ import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { UserContextProvider } from '#contexts/UserContext';
 import { ToggleContext } from '#contexts/ToggleContext';
 import WithPageWrapper from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const dataProps = {
   isAmp: false,
   service: 'news',
   status: 200,
-  route: { pageType: 'article' },
+  route: { pageType: ARTICLE_PAGE },
 };
 
 // eslint-disable-next-line react/prop-types
@@ -40,7 +41,7 @@ describe('with pageWrapper', () => {
       <ServiceContextProvider service="news">
         <RequestContextProvider
           isAmp={false}
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           service="news"
           statusCode={200}
           bbcOrigin="https://www.test.bbc.com"

--- a/src/app/containers/StoryPromo/index.stories.jsx
+++ b/src/app/containers/StoryPromo/index.stories.jsx
@@ -7,6 +7,7 @@ import StoryPromoContainer from '.';
 import fixture from '#data/pidgin/frontpage';
 import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
 import { guideLinkItem } from './helpers/fixtureData';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const mediaFixture = type =>
   pathOr(null, ['content', 'groups'], fixture)
@@ -62,7 +63,7 @@ const getStoryPromo = (
       id="c0000000000o"
       isAmp={platform === 'amp'}
       pathname="/pathname"
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service="news"
     >
       <StoryPromoContainer

--- a/src/app/containers/StoryPromo/index.test.jsx
+++ b/src/app/containers/StoryPromo/index.test.jsx
@@ -23,6 +23,7 @@ import {
   mapWithoutMediaError,
 } from './helpers/fixtureData';
 import StoryPromoContainer from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 const onlyOneRelatedItem = {
   ...indexAlsosItem,
@@ -49,7 +50,7 @@ const WrappedStoryPromo = ({ service, platform, ...props }) => (
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       isAmp={platform === 'amp'}
-      pageType="article"
+      pageType={ARTICLE_PAGE}
       service={service}
       statusCode={200}
       pathname="/pathname"

--- a/src/app/contexts/RequestContext/getStatsPageIdentifier/index.js
+++ b/src/app/contexts/RequestContext/getStatsPageIdentifier/index.js
@@ -1,5 +1,7 @@
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+
 const getStatsPageIdentifier = ({ pageType, service, id }) => {
-  if (pageType === 'article') {
+  if (pageType === ARTICLE_PAGE) {
     return `${service}.articles.${id}.page`;
   }
   if (pageType === 'frontPage') {

--- a/src/app/contexts/RequestContext/getStatsPageIdentifier/index.test.js
+++ b/src/app/contexts/RequestContext/getStatsPageIdentifier/index.test.js
@@ -19,7 +19,7 @@ describe('getStatsPageIdentifier', () => {
     },
     {
       service: 'persian',
-      pageType: ARTICLE_PAGE,
+      pageType: 'frontPage',
       expected: 'persian.page',
       summary: 'should return for WS Front Page',
     },

--- a/src/app/contexts/RequestContext/getStatsPageIdentifier/index.test.js
+++ b/src/app/contexts/RequestContext/getStatsPageIdentifier/index.test.js
@@ -1,24 +1,25 @@
 import getStatsPageIdentifier from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 describe('getStatsPageIdentifier', () => {
   const testScenarios = [
     {
       service: 'news',
-      pageType: 'article',
+      pageType: ARTICLE_PAGE,
       id: 'c0000000000o',
       expected: 'news.articles.c0000000000o.page',
       summary: 'should return for News Article',
     },
     {
       service: 'persian',
-      pageType: 'article',
+      pageType: ARTICLE_PAGE,
       id: 'c0000000001o',
       expected: 'persian.articles.c0000000001o.page',
       summary: 'should return for WS Article',
     },
     {
       service: 'persian',
-      pageType: 'frontPage',
+      pageType: ARTICLE_PAGE,
       expected: 'persian.page',
       summary: 'should return for WS Front Page',
     },

--- a/src/app/contexts/RequestContext/index.jsx
+++ b/src/app/contexts/RequestContext/index.jsx
@@ -6,6 +6,7 @@ import getOriginContext from './getOriginContext';
 import getEnv from './getEnv';
 import getMetaUrls from './getMetaUrls';
 import variantPropType from '../../models/propTypes/variants';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 export const RequestContext = React.createContext({});
 
@@ -66,7 +67,7 @@ RequestContextProvider.propTypes = {
   id: string,
   isAmp: bool.isRequired,
   pageType: oneOf([
-    'article',
+    ARTICLE_PAGE,
     'frontPage',
     'media',
     'mostRead',

--- a/src/app/lib/analyticsUtils/indexPage/index.test.js
+++ b/src/app/lib/analyticsUtils/indexPage/index.test.js
@@ -5,6 +5,7 @@ import {
   getPageTitle,
   getContentType,
 } from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 describe('getPageIdentifier', () => {
   const goodData = {
@@ -165,7 +166,7 @@ describe('getContentType', () => {
   });
 
   it('should return null when pageType is not frontPage or IDX', () => {
-    const contentType = getContentType('article');
+    const contentType = getContentType(ARTICLE_PAGE);
 
     expect(contentType).toBeNull();
   });

--- a/src/app/pages/ArticlePage/index.stories.jsx
+++ b/src/app/pages/ArticlePage/index.stories.jsx
@@ -6,6 +6,7 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { UserContextProvider } from '#contexts/UserContext';
 import ArticlePage from './ArticlePage';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 // article c5jje4ejkqvo contains a Headline, a Paragraph, a timestamp
 // a Portrait Image with Caption, a Landscape Image with Caption and Square Image with Caption.
@@ -22,7 +23,7 @@ storiesOf('Pages|Article Page', module)
       <ServiceContextProvider service="pidgin">
         <RequestContextProvider
           isAmp={false}
-          pageType="article"
+          pageType={ARTICLE_PAGE}
           service="pidgin"
         >
           <UserContextProvider>

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -14,6 +14,7 @@ import newsMostReadData from '#data/news/mostRead';
 import persianMostReadData from '#data/persian/mostRead';
 import pidginMostReadData from '#data/pidgin/mostRead';
 import { textBlock } from '#models/blocks/index';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 // temporary: will be removed with https://github.com/bbc/simorgh/issues/836
 const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
@@ -32,7 +33,7 @@ const Context = ({ service, children }) => (
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
         isAmp={false}
-        pageType="article"
+        pageType={ARTICLE_PAGE}
         pathname="/pathname"
         service={service}
         statusCode={200}

--- a/src/app/routes/article/getInitialData/index.test.js
+++ b/src/app/routes/article/getInitialData/index.test.js
@@ -1,12 +1,13 @@
 import getInitialData from '.';
 import articleJson from '#data/pidgin/articles/cwl08rd38l6o.json';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 
 fetch.mockResponse(JSON.stringify(articleJson));
 
 it('should return essential data for a page to render', async () => {
   const { pageData } = await getInitialData({
     path: 'mock-article-path',
-    pageType: 'article',
+    pageType: ARTICLE_PAGE,
   });
 
   expect(pageData.metadata.id).toEqual('urn:bbc:ares::article:cwl08rd38l6o');


### PR DESCRIPTION
Part of #6523

**Overall change:**
Imports and uses `ARTICLE_PAGE` string constant pageType in relevant places throughout the codebase.

**Code changes:**

- Imported and used `ARTICLE_PAGE` constant in various files
- Tweaked chartbeat test for `pageType` to make it more clear

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
