### PR TITLE
Prevent test report being sent for forks or Simorgh

### DIFF
--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
           npm run build
 
       - name: Setup Code Climate Test Coverage
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }}
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }} # Only run if PR originates from the Simorgh repo
         run: |
           echo $GIT_BRANCH
           echo $GIT_COMMIT_SHA
@@ -57,4 +57,5 @@ jobs:
         run: npm run test:unit
 
       - name: Report Code Climate Test Coverage
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bbc/simorgh' }} # Only run if PR originates from the Simorgh repo
         run: ./cc-test-reporter after-build -t lcov --debug --exit-code 0


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Do not send CC test reports when on a fork of this repo as the CC test ID is not available

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
