### PR TITLE
Updates to navigaton for Mundo and four India sites

### DIFF
--- a/src/app/lib/config/services/marathi.js
+++ b/src/app/lib/config/services/marathi.js
@@ -259,7 +259,7 @@ export const service = {
       },
       {
         title: 'आंतरराष्ट्रीय',
-        url: '/marathi/international',
+        url: '/marathi/topics/c719d2enyn3t',
       },
       {
         title: 'व्हीडिओ',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -288,10 +288,6 @@ export const service = {
         url: '/mundo/noticias-internacional-53826365',
       },
       {
-        title: '¿Hablas español?',
-        url: '/mundo/noticias-50160896',
-      },
-      {
         title: 'Hay Festival',
         url: '/mundo/noticias-36795069',
       },

--- a/src/app/lib/config/services/punjabi.js
+++ b/src/app/lib/config/services/punjabi.js
@@ -217,11 +217,11 @@ export const service = {
       },
       {
         title: 'ਭਾਰਤ',
-        url: '/punjabi/topics/5a08f030-710f-4168-acee-67294a90fc75',
+        url: '/punjabi/topics/cz74k76gjqxt',
       },
       {
         title: 'ਕੌਮਾਂਤਰੀ',
-        url: '/punjabi/international',
+        url: '/punjabi/topics/c2lej05e43lt',
       },
     ],
     footer: {

--- a/src/app/lib/config/services/tamil.js
+++ b/src/app/lib/config/services/tamil.js
@@ -267,7 +267,7 @@ export const service = {
       },
       {
         title: 'உலகம்',
-        url: '/tamil/global',
+        url: '/tamil/topics/c40379e2n2zt',
       },
       {
         title: 'இந்தியா',
@@ -283,7 +283,7 @@ export const service = {
       },
       {
         title: 'அறிவியல்',
-        url: '/tamil/science',
+        url: '/tamil/topics/c9wpm0exkdpt',
       },
       {
         title: 'சினிமா',

--- a/src/app/lib/config/services/telugu.js
+++ b/src/app/lib/config/services/telugu.js
@@ -265,11 +265,11 @@ export const service = {
       },
       {
         title: 'జాతీయం',
-        url: '/telugu/topics/5a08f030-710f-4168-acee-67294a90fc75',
+        url: '/telugu/topics/c5qvp16w7dnt',
       },
       {
         title: 'అంతర్జాతీయం',
-        url: '/telugu/international',
+        url: '/telugu/topics/cvqxn2k1xvdt',
       },
     ],
   },

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -236,61 +236,54 @@ Object {
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -103,61 +103,54 @@ Object {
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -236,61 +236,54 @@ Object {
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -103,61 +103,54 @@ Object {
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -236,61 +236,54 @@ Object {
 
 exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -110,61 +110,54 @@ Object {
 
 exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
 Object {
-  "text": "¿Hablas español?",
-  "url": "/mundo/noticias-50160896",
-}
-`;
-
-exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
-Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Remove item from Mundo nav and update links to avoid redundant redirects on Marathi, Punjabi. Tamil and Telugu

**Code changes:**

- Replaced links for International recent asset index with link to topic page on BBC Marathi Nav
- Removed link to 'Hablas español?' FIX on BBC Mundo nav
- Updated links to India and International topic pages on BBC Punjabi Nav
- Updated links to Global and Science topic pages on BBC Tamil Nav
- Updated link to International topic page on BBC Telugu Nav

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
