### PR TITLE
add a visually hidden loading message for client side routing

### DIFF
--- a/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PageHandlers/withLoading/__snapshots__/index.test.jsx.snap
@@ -9,22 +9,22 @@ exports[`withLoading HOC and no loading prop should return the passed in compone
 `;
 
 exports[`withLoading HOC and the loading prop set to true should return the loading component 1`] = `
-.emotion-5 {
+.emotion-9 {
   min-height: 100vh;
 }
 
-.emotion-3 {
+.emotion-7 {
   width: 100%;
 }
 
 @supports (display:grid) {
-  .emotion-3 {
+  .emotion-7 {
     display: grid;
     position: initial;
   }
 
 @media (max-width:14.9375rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -34,7 +34,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -44,7 +44,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -54,7 +54,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -64,7 +64,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(8,1fr);
@@ -74,7 +74,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:80rem) {
-    .emotion-3 {
+    .emotion-7 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(20,1fr);
@@ -85,66 +85,66 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .emotion-3 {
+  .emotion-7 {
     margin: 0 auto;
     max-width: 63rem;
   }
 }
 
 @media (min-width:80rem) {
-  .emotion-3 {
+  .emotion-7 {
     margin: 0 auto;
     max-width: 80rem;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-0 {
+  .emotion-4 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-  .emotion-0 {
+  .emotion-4 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-  .emotion-0 {
+  .emotion-4 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .emotion-0 {
+  .emotion-4 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .emotion-0 {
-    margin-left: 20%;
+  .emotion-4 {
+    margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width:80rem) {
-  .emotion-0 {
-    margin-left: 40%;
+  .emotion-4 {
+    margin-left: 33.333333333333336%;
   }
 }
 
 @supports (display:grid) {
-  .emotion-0 {
+  .emotion-4 {
     display: block;
   }
 
 @media (max-width:14.9375rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -155,7 +155,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:15rem) and (max-width:24.9375rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -166,7 +166,7 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:25rem) and (max-width:37.4375rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
       grid-template-columns: repeat(6,1fr);
@@ -177,50 +177,78 @@ exports[`withLoading HOC and the loading prop set to true should return the load
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
-      grid-template-columns: repeat(5,1fr);
-      grid-column-end: span 5;
+      grid-template-columns: repeat(6,1fr);
+      grid-column-end: span 6;
       padding: 0 1rem;
       grid-column-start: 1;
     }
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
-      grid-template-columns: repeat(5,1fr);
-      grid-column-end: span 5;
+      grid-template-columns: repeat(6,1fr);
+      grid-column-end: span 6;
       grid-column-start: 2;
     }
 }
 
 @media (min-width:80rem) {
-    .emotion-0 {
+    .emotion-4 {
       width: initial;
       margin: 0;
-      grid-template-columns: repeat(10,1fr);
-      grid-column-end: span 10;
+      grid-template-columns: repeat(12,1fr);
+      grid-column-end: span 12;
       grid-column-start: 5;
     }
 }
 }
 
+.emotion-2 {
+  outline: 0;
+}
+
+.emotion-0 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
 <div>
   <main
-    class="emotion-5 emotion-6"
+    class="emotion-9 emotion-10"
     role="main"
   >
     <div
-      class="emotion-2 emotion-3 emotion-1"
+      class="emotion-6 emotion-7 emotion-5"
       dir="ltr"
     >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-4 emotion-5"
         dir="ltr"
-      />
+      >
+        <div
+          class="emotion-2 emotion-3"
+          data-testid="loading-message"
+          tabindex="-1"
+        >
+          <span
+            class="emotion-0 emotion-1"
+          >
+            Loading next page.
+          </span>
+        </div>
+      </div>
     </div>
   </main>
 </div>

--- a/src/app/containers/PageHandlers/withLoading/index.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.jsx
@@ -1,23 +1,35 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { bool, element } from 'prop-types';
 import styled from '@emotion/styled';
-import { GridWrapper, GridItemMedium } from '#app/components/Grid';
+import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
+
+import { GridWrapper, GridItemLarge } from '#app/components/Grid';
 
 let timeout;
 const LoadingMain = styled.main`
   min-height: 100vh;
 `;
+const LoadingMessageWrapper = styled.div`
+  outline: 0;
+`;
 
 const WithLoading = Component => {
   const LoadingContainer = ({ loading, ...props }) => {
-    const [showLoading, setShowLoading] = useState(false);
+    const loadingMessageRef = useRef();
+
     useEffect(() => {
       if (loading) {
         timeout = setTimeout(() => {
-          setShowLoading(true);
+          if (loadingMessageRef.current) {
+            loadingMessageRef.current.focus();
+            window.scrollTo(0, 0);
+          }
         }, 500);
       }
-      return () => clearTimeout(timeout);
+
+      return () => {
+        clearTimeout(timeout);
+      };
     }, [loading]);
 
     if (!loading) return <Component {...props} />;
@@ -25,9 +37,15 @@ const WithLoading = Component => {
     return (
       <LoadingMain role="main">
         <GridWrapper>
-          <GridItemMedium>
-            {showLoading && <div data-testid="loading" />}
-          </GridItemMedium>
+          <GridItemLarge>
+            <LoadingMessageWrapper
+              tabIndex="-1"
+              ref={loadingMessageRef}
+              data-testid="loading-message"
+            >
+              <VisuallyHiddenText>Loading next page.</VisuallyHiddenText>
+            </LoadingMessageWrapper>
+          </GridItemLarge>
         </GridWrapper>
       </LoadingMain>
     );

--- a/src/app/containers/PageHandlers/withLoading/index.test.jsx
+++ b/src/app/containers/PageHandlers/withLoading/index.test.jsx
@@ -3,6 +3,8 @@ import { render, act } from '@testing-library/react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 import WithLoading from '.';
 
+global.scrollTo = jest.fn();
+
 const wait = duration =>
   new Promise(resolve => {
     setTimeout(resolve, duration);
@@ -26,8 +28,26 @@ describe('withLoading HOC', () => {
     );
   });
 
-  describe(`and the loading indicator`, () => {
-    it(`should not show the loading indicator before a set amount of time`, async () => {
+  describe(`and visually hidden loading message`, () => {
+    it(`should render a visually hidden loading message`, async () => {
+      const { queryByTestId } = render(<LoadingHOC loading />);
+
+      expect(queryByTestId('loading-message')).toBeInTheDocument();
+    });
+
+    it(`should focus on the visually hidden loading message after a set amount of time`, async () => {
+      let queryByTestId;
+
+      await act(async () => {
+        ({ queryByTestId } = render(<LoadingHOC loading />));
+
+        await wait(600);
+      });
+
+      expect(queryByTestId('loading-message')).toHaveFocus();
+    });
+
+    it(`should not focus on the visually hidden loading message before a set amount of time`, async () => {
       let queryByTestId;
 
       await act(async () => {
@@ -36,31 +56,7 @@ describe('withLoading HOC', () => {
         await wait(400);
       });
 
-      expect(queryByTestId('loading')).not.toBeInTheDocument();
-    });
-
-    it(`should show the loading indicator after a set amount of time`, async () => {
-      let queryByTestId;
-
-      await act(async () => {
-        ({ queryByTestId } = render(<LoadingHOC loading />));
-
-        await wait(600);
-      });
-
-      expect(queryByTestId('loading')).toBeInTheDocument();
-    });
-
-    it(`should not show the loading indicator if loading is false (even after a set amount of time)`, async () => {
-      let queryByTestId;
-
-      await act(async () => {
-        ({ queryByTestId } = render(<LoadingHOC loading={false} />));
-
-        await wait(600);
-      });
-
-      expect(queryByTestId('loading')).not.toBeInTheDocument();
+      expect(queryByTestId('loading-message')).not.toHaveFocus();
     });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8531

**Overall change:**
Improves assistive tech user experience by focusing on a visually hidden span containing the text "Loading next page..." so that the text is announced and the screen reader user is made aware of the loading state.

The focus is set after 500ms has passed, so on fast connections, where loading a new page is almost instant then there's less chance of screenreaders reading the loading message and being cut off immediately by announcing the next page's headline when that is focused on.

**Code changes:**

- Adds visually hidden element in `withLoading.jsx` and focuses on this after 500ms
- Adds unit tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
