### PR TITLE
Add some api context details to cps asset data fetches

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -74,7 +74,12 @@ export default async ({
     const env = pathname.includes('renderer_env=live')
       ? 'live'
       : process.env.SIMORGH_APP_ENV;
-    const { json, status } = await fetchPageData({ path: pathname, pageType, api: 'asset', apiContext: 'primary_data' });
+    const { json, status } = await fetchPageData({
+      path: pathname,
+      pageType,
+      api: 'asset',
+      apiContext: 'primary_data',
+    });
 
     const additionalPageData = await getAdditionalPageData({
       pageData: json,

--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -74,7 +74,7 @@ export default async ({
     const env = pathname.includes('renderer_env=live')
       ? 'live'
       : process.env.SIMORGH_APP_ENV;
-    const { json, status } = await fetchPageData({ path: pathname, pageType });
+    const { json, status } = await fetchPageData({ path: pathname, pageType, api: 'asset', apiContext: 'primary_data' });
 
     const additionalPageData = await getAdditionalPageData({
       pageData: json,

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -27,17 +27,23 @@ const pageTypeUrls = async (
           name: 'mostRead',
           path: getMostReadEndpoint({ service, variant }).replace('.json', ''),
           assetUri,
+          api: 'mostread',
+          apiContext: 'secondary_data'
         },
         {
           name: 'secondaryColumn',
           path: getSecondaryColumnUrl({ service, variant }),
           assetUri,
+          api: 'secondary_column',
+          apiContext: 'secondary_data'
         },
         (await hasRecommendations(service, variant, pageData))
           ? {
               name: 'recommendations',
               path: getRecommendationsUrl({ assetUri, variant }),
               assetUri,
+              api: 'recommendations',
+              apiContext: 'secondary_data'
             }
           : null,
       ].filter(i => i);
@@ -47,6 +53,8 @@ const pageTypeUrls = async (
           name: 'mostWatched',
           path: getMostWatchedEndpoint({ service, variant, env }),
           assetUri,
+          api: 'mostwatched',
+          apiContext: 'secondary_data'
         },
       ];
     default:

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -28,14 +28,14 @@ const pageTypeUrls = async (
           path: getMostReadEndpoint({ service, variant }).replace('.json', ''),
           assetUri,
           api: 'mostread',
-          apiContext: 'secondary_data'
+          apiContext: 'secondary_data',
         },
         {
           name: 'secondaryColumn',
           path: getSecondaryColumnUrl({ service, variant }),
           assetUri,
           api: 'secondary_column',
-          apiContext: 'secondary_data'
+          apiContext: 'secondary_data',
         },
         (await hasRecommendations(service, variant, pageData))
           ? {
@@ -43,7 +43,7 @@ const pageTypeUrls = async (
               path: getRecommendationsUrl({ assetUri, variant }),
               assetUri,
               api: 'recommendations',
-              apiContext: 'secondary_data'
+              apiContext: 'secondary_data',
             }
           : null,
       ].filter(i => i);
@@ -54,7 +54,7 @@ const pageTypeUrls = async (
           path: getMostWatchedEndpoint({ service, variant, env }),
           assetUri,
           api: 'mostwatched',
-          apiContext: 'secondary_data'
+          apiContext: 'secondary_data',
         },
       ];
     default:

--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -56,6 +56,7 @@ const fetchPageData = async ({
         path,
         status,
         nanoseconds: elapsedHrTime[0] * NS_PER_SEC + elapsedHrTime[1],
+        ...loggerArgs,
       });
     }
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Add extra logging arguments for cps data fetches including:
- API type e.g. `mostread`, `secondary_col`
- API Context: e.g. primary or secondary data. primary data will stop the page from rendering thus is of higher importance.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

Log Output:

```
{
  "timestamp": "2020-12-04 16:40:31.791",
  "level": "info",
  "message": {
    "path": "/mundo/noticias-55176072",
    "status": 200,
    "nanoseconds": 107050986,
    "pageType": "cpsAsset",
    "api": "asset",
    "apiContext": "primary_data"
  },
  "metadata": {
    "file": "fetchPageData/index.js",
    "event": "data_fetch_response_time"
  }
}

```

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
