### PR TITLE
bump psammead episode list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,9 +1536,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.16.tgz",
-      "integrity": "sha512-3mWIgVofJAA0/nMZ85A8okNaAUtQa2x3OXqQ8VUnhyeKxoS8VXoK1zMObLXlPgYRTlr1JA1VjeCRNAXqQI5FWQ==",
+      "version": "0.1.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.18.tgz",
+      "integrity": "sha512-FqMV+I9eAub95KJHYmzor4K/xOE8ITs7BzU9puEDyVd2uTkcco4JJfdmkz/N/nlk3PfhyN4kn7GwrhPeoHs2Gw==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-assets": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,9 +1536,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.14.tgz",
-      "integrity": "sha512-jEm5VO3wLeJJt5aWVX7zl/LZCV1esmJpHb4LQ2uY8OrMdGseKUn59uec4hiQHdNciWwQm7P361KRUiREH8LuuA==",
+      "version": "0.1.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.15.tgz",
+      "integrity": "sha512-AmqFJDUFS/C+h9WTfeZU3t3gKzWk42upGpNea928OiE7kAXnZLJz0ENfSq2AJE+nj8TYxrmeqalDM1ACVcSNGg==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-assets": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,9 +1536,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.15.tgz",
-      "integrity": "sha512-AmqFJDUFS/C+h9WTfeZU3t3gKzWk42upGpNea928OiE7kAXnZLJz0ENfSq2AJE+nj8TYxrmeqalDM1ACVcSNGg==",
+      "version": "0.1.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.16.tgz",
+      "integrity": "sha512-3mWIgVofJAA0/nMZ85A8okNaAUtQa2x3OXqQ8VUnhyeKxoS8VXoK1zMObLXlPgYRTlr1JA1VjeCRNAXqQI5FWQ==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-assets": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.6",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.15",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.16",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.6",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.16",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.18",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.6",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.14",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.15",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",

--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -75,6 +75,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
         {episodes.map(episode => (
           <EpisodeList.Episode key={episode.id} dir={dir}>
             <EpisodeList.Image
+              dir={dir}
               src={episode.image}
               alt={episode.altText}
               duration={formatDuration({

--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -73,7 +73,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
       </StyledSectionLabel>
       <EpisodeList script={script} service={service} dir={dir} darkMode>
         {episodes.map(episode => (
-          <EpisodeList.Episode key={episode.id}>
+          <EpisodeList.Episode key={episode.id} dir={dir}>
             <EpisodeList.Image
               src={episode.image}
               alt={episode.altText}

--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -84,8 +84,8 @@ const RecentVideoEpisodes = ({ episodes }) => {
               })}
             />
             {/* these must be concatenated for screen reader UX */}
-            <VisuallyHiddenText>{`${videoLabel}, `}</VisuallyHiddenText>
             <EpisodeList.Link href={episode.url}>
+              <VisuallyHiddenText>{`${videoLabel}, `}</VisuallyHiddenText>
               <EpisodeList.Title className="episode-list__title--hover episode-list__title--visited">
                 {episode.brandTitle}
               </EpisodeList.Title>


### PR DESCRIPTION
**Overall change:**
Bumps psammead episode list component so we have a11y fixes from this PR https://github.com/bbc/psammead/pull/4050

**Code changes:**
- Bumps psammead episode list component to v0.1.0-alpha.15
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
