### PR TITLE
add visually hidden comma between title and desc

### DIFF
--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -91,6 +91,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
               <EpisodeList.Title className="episode-list__title--hover episode-list__title--visited">
                 {episode.brandTitle}
               </EpisodeList.Title>
+              <VisuallyHiddenText>, </VisuallyHiddenText>
               <EpisodeList.Description className="episode-list__description--hover episode-list__description--visited">
                 {episode.episodeTitle || formatDate(episode.timestamp)}
               </EpisodeList.Description>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8594

**Overall change:**
Adds a visually hidden comma between the brand title and episode title.

**Code changes:**

- Uses the `VisuallyHidden` component to wrap the comma used to improve screenreader UX

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
