### PR TITLE
bump @bbc/psammead-episode-list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,9 +1682,9 @@
       }
     },
     "@bbc/psammead-episode-list": {
-      "version": "0.1.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.18.tgz",
-      "integrity": "sha512-FqMV+I9eAub95KJHYmzor4K/xOE8ITs7BzU9puEDyVd2uTkcco4JJfdmkz/N/nlk3PfhyN4kn7GwrhPeoHs2Gw==",
+      "version": "0.1.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-episode-list/-/psammead-episode-list-0.1.0-alpha.21.tgz",
+      "integrity": "sha512-LzWxuwZ9FuQ/T3A3zcxc33+G5X7nJ+ZHqUFwGbCPTtdy9fLSqZkV0o/qhbbxlU8KYNEvL9fu9oek0sAyBlKXDQ==",
       "requires": {
         "@bbc/gel-foundations": "^6.0.0",
         "@bbc/psammead-assets": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bbc/psammead-copyright": "^3.0.5",
     "@bbc/psammead-detokeniser": "^1.0.0",
     "@bbc/psammead-embed-error": "^3.0.6",
-    "@bbc/psammead-episode-list": "0.1.0-alpha.18",
+    "@bbc/psammead-episode-list": "0.1.0-alpha.21",
     "@bbc/psammead-figure": "^2.0.1",
     "@bbc/psammead-grid": "^3.0.7",
     "@bbc/psammead-heading-index": "^3.0.5",


### PR DESCRIPTION
**Overall change:**
Bumps `@bbc/psammead-episode-list` from `0.1.0-alpha.18` to `0.1.0-alpha.21`

Includes these fixes

`0.1.0-alpha.21` Refactor Episode List HoC implementations
`0.1.0-alpha.20` Use CSS border for episode duration separator
`0.1.0-alpha.19` Improve handling of text-resize

**Code changes:**

- Updates `package-lock.json` and `package.json`
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
