### PR TITLE
Change Recent TV episodes Timestamp wrapping element

### DIFF
--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -105,7 +105,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
               </VisuallyHiddenText>
             </EpisodeList.Link>
             {episode.episodeTitle && (
-              <div>
+              <span role="text">
                 <EpisodeList.Metadata
                   as={Timestamp}
                   timestamp={episode.timestamp}
@@ -117,7 +117,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
                   service={service}
                   timezone={timezone}
                 />
-              </div>
+              </span>
             )}
           </EpisodeList.Episode>
         ))}

--- a/src/app/containers/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/RecentVideoEpisodes/index.jsx
@@ -105,7 +105,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
               </VisuallyHiddenText>
             </EpisodeList.Link>
             {episode.episodeTitle && (
-              <span role="text">
+              <div>
                 <EpisodeList.Metadata
                   as={Timestamp}
                   timestamp={episode.timestamp}
@@ -117,7 +117,7 @@ const RecentVideoEpisodes = ({ episodes }) => {
                   service={service}
                   timezone={timezone}
                 />
-              </span>
+              </div>
             )}
           </EpisodeList.Episode>
         ))}


### PR DESCRIPTION
Resolves https://github.com/bbc/psammead/issues/4149

**Overall change:**
- Resolves a tiny issue highlighted by an a11y review of the Psammead Storybook fixture composition

**Code changes:**
- Change the `span` wrapping the timestamp into a `div`, which makes it a block element - meaning when css is disabled, it still correctly breaks onto the next line
- `role=text` attribute is unnecessary because there is only one nested text element.


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] This PR requires manual testing
