### PR TITLE
remove enzyme from ArticleFigure tests

### DIFF
--- a/src/app/containers/ArticleFigure/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleFigure/__snapshots__/index.test.jsx.snap
@@ -222,9 +222,7 @@ exports[`ArticleFigure should render a lazyloaded image when lazyLoad set to tru
             class="lazyload-placeholder"
           />
         </div>
-        <noscript>
-          &lt;img alt="Pauline Clayton" src="https://ichef.bbci.co.uk/news/640/cpsprodpb/E7DB/production/_101655395_paulineclayton.jpg" width="640" class="css-13lcmnl-StyledImg e1enwo3v0"/&gt;
-        </noscript>
+        <noscript />
       </div>
     </div>
   </div>

--- a/src/app/containers/ArticleFigure/index.test.jsx
+++ b/src/app/containers/ArticleFigure/index.test.jsx
@@ -1,6 +1,4 @@
-import { mount, render } from 'enzyme';
-import LazyLoad from 'react-lazyload';
-import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { render } from '@testing-library/react';
 import {
   FigureImage,
   FigureAmpImage,
@@ -18,84 +16,90 @@ import {
 
 describe('ArticleFigure', () => {
   it('should load lazyload component when lazyLoad prop is set to true', () => {
-    const wrapper = mount(FigureLazyLoadImage).find(LazyLoad);
-    const {
-      offset,
-      once,
-      overflow,
-      resize,
-      scroll,
-      unmountIfInvisible,
-    } = wrapper.props();
+    const { container } = render(FigureLazyLoadImage);
 
-    expect(offset).toBe(250);
-    expect(once).toBe(true);
-    expect(overflow).toBe(false);
-    expect(resize).toBe(false);
-    expect(scroll).toBe(true);
-    expect(unmountIfInvisible).toBe(false);
-    expect(Object.keys(wrapper.props()).length).toBe(8);
+    const noScriptEl = container.querySelector('noscript');
+    const imageEl = container.querySelector('img');
+
+    expect(noScriptEl).toBeInTheDocument();
+    expect(imageEl).not.toBeInTheDocument();
   });
 
   it('should render a lazyloaded image when lazyLoad set to true', () => {
     // Render using enzyme to capture noscript contents
-    const container = render(FigureLazyLoadImage);
+    const { container } = render(FigureLazyLoadImage);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should render an image with alt text', () => {
+    const { container } = render(FigureImage);
+
     expect(container).toMatchSnapshot();
   });
 
-  shouldMatchSnapshot('should render an image with alt text', FigureImage);
+  it('should render an AMP image with alt text', () => {
+    const { container } = render(FigureAmpImage);
 
-  shouldMatchSnapshot(
-    'should render an AMP image with alt text',
-    FigureAmpImage,
-  );
+    expect(container).toMatchSnapshot();
+  });
 
-  shouldMatchSnapshot(
-    'should render an image with copyright text',
-    FigureImageWithCopyright,
-  );
+  it('should render an image with copyright text', () => {
+    const { container } = render(FigureImageWithCopyright);
 
-  shouldMatchSnapshot(
-    'should render an AMP image with copyright text',
-    FigureAmpImageWithCopyright,
-  );
+    expect(container).toMatchSnapshot();
+  });
 
-  shouldMatchSnapshot(
-    'should render an image with caption text',
-    FigureImageWithCaption('news'),
-  );
+  it('should render an AMP image with copyright text', () => {
+    const { container } = render(FigureAmpImageWithCopyright);
 
-  shouldMatchSnapshot(
-    'should render an AMP image with caption text',
-    FigureAmpImageWithCaption('news'),
-  );
+    expect(container).toMatchSnapshot();
+  });
 
-  shouldMatchSnapshot(
-    'should render an image with caption text with inline link',
-    FigureImageWithCaptionContainingLink,
-  );
+  it('should render an image with caption text', () => {
+    const { container } = render(FigureImageWithCaption('news'));
 
-  shouldMatchSnapshot(
-    'should render an AMP image with caption text with inline link',
-    FigureAmpImageWithCaptionContainingLink,
-  );
+    expect(container).toMatchSnapshot();
+  });
 
-  shouldMatchSnapshot(
-    'should render an image with caption and copyright',
-    FigureImageWithCopyrightAndCaption,
-  );
+  it('should render an AMP image with caption text', () => {
+    const { container } = render(FigureAmpImageWithCaption('news'));
 
-  shouldMatchSnapshot(
-    'should render an AMP image with caption and copyright',
-    FigureAmpImageWithCopyrightAndCaption,
-  );
+    expect(container).toMatchSnapshot();
+  });
 
-  shouldMatchSnapshot(
-    'should render an image and caption for a square with nested grid',
-    FigureImageWithNestedGrid(1240, 1240),
-  );
-  shouldMatchSnapshot(
-    'should render an image and caption for a portrait with nested grid',
-    FigureImageWithNestedGrid(600, 1240),
-  );
+  it('should render an image with caption text with inline link', () => {
+    const { container } = render(FigureImageWithCaptionContainingLink);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render an AMP image with caption text with inline link', () => {
+    const { container } = render(FigureAmpImageWithCaptionContainingLink);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render an image with caption and copyright', () => {
+    const { container } = render(FigureImageWithCopyrightAndCaption);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render an AMP image with caption and copyright', () => {
+    const { container } = render(FigureAmpImageWithCopyrightAndCaption);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render an image and caption for a square with nested grid', () => {
+    const { container } = render(FigureImageWithNestedGrid(1240, 1240));
+
+    expect(container).toMatchSnapshot();
+  });
+  it('should render an image and caption for a portrait with nested grid', () => {
+    const { container } = render(FigureImageWithNestedGrid(600, 1240));
+
+    expect(container).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8458

**Overall change:**
Removes enzyme from ArticleFigure tests

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
