### PR TITLE
Updated OD Radio fixture data to include recent episodes data

### DIFF
--- a/cypress/integration/pages/onDemandRadio/tests.js
+++ b/cypress/integration/pages/onDemandRadio/tests.js
@@ -60,74 +60,69 @@ export default ({ service, pageType, variant, isAmp }) => {
       });
       describe('Recent Episodes component', () => {
         it('should be displayed if the toggle is on, and shows the expected number of items (does not run on local)', function test() {
-          // I can enable tests running on local when I have updated all the fixture data to show the component
-          if (Cypress.env('APP_ENV') === 'local') {
-            cy.log('Does not run on local');
-          } else {
-            cy.fixture(`toggles/${service}.json`).then(toggles => {
-              const recentEpisodesEnabled = path(
-                ['recentAudioEpisodes', 'enabled'],
+          cy.fixture(`toggles/${service}.json`).then(toggles => {
+            const recentEpisodesEnabled = path(
+              ['recentAudioEpisodes', 'enabled'],
+              toggles,
+            );
+            cy.log(
+              `Recent Episodes component enabled? ${recentEpisodesEnabled}`,
+            );
+            // There cannot be more episodes shown than the max allowed
+            if (recentEpisodesEnabled) {
+              const recentEpisodesMaxNumber = path(
+                ['recentAudioEpisodes', 'value'],
                 toggles,
               );
-              cy.log(
-                `Recent Episodes component enabled? ${recentEpisodesEnabled}`,
-              );
-              // There cannot be more episodes shown than the max allowed
-              if (recentEpisodesEnabled) {
-                const recentEpisodesMaxNumber = path(
-                  ['recentAudioEpisodes', 'value'],
-                  toggles,
+              const currentPath = Cypress.env('currentPath');
+              const url =
+                Cypress.env('APP_ENV') === 'test'
+                  ? `${currentPath}?renderer_env=live`
+                  : `${currentPath}`;
+
+              cy.request(getDataUrl(url)).then(({ body }) => {
+                // Count the number of episodes that are available and so will show (there can be unavailable episodes in the list)
+                const expectedNumberOfEpisodes = body.relatedContent.groups[0].promos
+                  .filter(({ media }) => media.versions.length)
+                  .slice(0, recentEpisodesMaxNumber).length;
+
+                cy.log(
+                  `Number of available episodes? ${expectedNumberOfEpisodes}`,
                 );
-                const currentPath = Cypress.env('currentPath');
-                const url =
-                  Cypress.env('APP_ENV') === 'test'
-                    ? `${currentPath}?renderer_env=live`
-                    : `${currentPath}`;
+                // More than one episode expected
+                if (expectedNumberOfEpisodes > 1) {
+                  cy.get('[data-e2e=recent-episodes-list]').should('exist');
 
-                cy.request(getDataUrl(url)).then(({ body }) => {
-                  // Count the number of episodes that are available and so will show (there can be unavailable episodes in the list)
-                  const expectedNumberOfEpisodes = body.relatedContent.groups[0].promos
-                    .filter(({ media }) => media.versions.length)
-                    .slice(0, recentEpisodesMaxNumber).length;
-
-                  cy.log(
-                    `Number of available episodes? ${expectedNumberOfEpisodes}`,
+                  cy.get('[data-e2e=recent-episodes-list]').within(() => {
+                    cy.get('[data-e2e=recent-episodes-list-item]')
+                      .its('length')
+                      .should('eq', expectedNumberOfEpisodes);
+                  });
+                }
+                // If there is only one item, it is not in a list
+                else if (expectedNumberOfEpisodes === 1) {
+                  cy.get('aside[aria-labelledby=recent-episodes]').within(
+                    () => {
+                      cy.get('div[class*="Wrapper"]').should('exist');
+                    },
                   );
-                  // More than one episode expected
-                  if (expectedNumberOfEpisodes > 1) {
-                    cy.get('[data-e2e=recent-episodes-list]').should('exist');
+                }
+                // No items expected
+                else {
+                  cy.get('aside[aria-labelledby=recent-episodes]').should(
+                    'not.exist',
+                  );
 
-                    cy.get('[data-e2e=recent-episodes-list]').within(() => {
-                      cy.get('[data-e2e=recent-episodes-list-item]')
-                        .its('length')
-                        .should('eq', expectedNumberOfEpisodes);
-                    });
-                  }
-                  // If there is only one item, it is not in a list
-                  else if (expectedNumberOfEpisodes === 1) {
-                    cy.get('aside[aria-labelledby=recent-episodes]').within(
-                      () => {
-                        cy.get('div[class*="Wrapper"]').should('exist');
-                      },
-                    );
-                  }
-                  // No items expected
-                  else {
-                    cy.get('aside[aria-labelledby=recent-episodes]').should(
-                      'not.exist',
-                    );
-
-                    cy.log('No episodes present or available');
-                  }
-                });
-              }
-              // Not toggled on for this service
-              else {
-                cy.get('[data-e2e=recent-episodes-list]').should('not.exist');
-                cy.log('Recent episodes is not toggled on for this service');
-              }
-            });
-          }
+                  cy.log('No episodes present or available');
+                }
+              });
+            }
+            // Not toggled on for this service
+            else {
+              cy.get('[data-e2e=recent-episodes-list]').should('not.exist');
+              cy.log('Recent episodes is not toggled on for this service');
+            }
+          });
         });
       });
     });

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -9826,7 +9826,7 @@ module.exports = () => ({
             paths: [
               '/zhongwen/simp/bbc_cantonese_radio/w172xn6l7ng41qb', // Brand
             ],
-            enabled: false,
+            enabled: true,
           },
         },
         smoke: false,

--- a/data/afaanoromoo/bbc_afaanoromoo_radio/w3cszx1y.json
+++ b/data/afaanoromoo/bbc_afaanoromoo_radio/w3cszx1y.json
@@ -5,28 +5,28 @@
     "type": "WSRADIO",
     "createdBy": "bbc_oromo_radio",
     "language": "om",
-    "lastUpdated": 1588318279115,
+    "lastUpdated": 1608291112283,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
     "timestamp": 1582565117000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Oduu BBC Afaan Oromoo - BBC News Afaan Oromoo",
-      "pageIdentifier": "Afaan Oromoo.bbc_oromo_radio.w3cszx1y.page",
+      "pageIdentifier": "afaanoromoo.bbc_afaanoromoo_radio.w3cszx1y.page",
       "producerId": "2",
       "contentType": "player-episode",
       "producer": "AFAAN_OROMOO"
     },
     "tags": {},
-    "version": "v1.2.1",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Oduu BBC Afaan Oromoo",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3cszx1y",
         "subType": "episode",
         "format": "Audio",
@@ -35,10 +35,12 @@
           "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
           "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -55,23 +57,26 @@
         "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 ",
         "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15 "
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
       "height": 0,
       "width": 0,
       "altText": null,
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
     "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3cszx1y",
     "type": "ws_radio"
@@ -79,8 +84,8 @@
   "relatedContent": {
     "site": {
       "subType": "site",
-      "name": "Afaan oromoo",
-      "uri": "/afaan oromoo",
+      "name": "Afaanoromoo",
+      "uri": "/afaanoromoo",
       "type": "simple"
     },
     "groups": [
@@ -89,22 +94,22 @@
         "promos": [
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0lbw", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y29", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0lbw",
+              "id": "w3ct0y29",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw56f",
+                  "versionId": "w4hqwm42",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -114,45 +119,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591909470000,
-                  "availableFrom": 1589306670000
+                  "availableUntil": 1610831070000,
+                  "availableFrom": 1608228270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lbw",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y29",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0l8m", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y4k", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0l8m",
+              "id": "w3ct0y4k",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw545",
+                  "versionId": "w4hqwm6b",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -162,45 +171,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591823070000,
-                  "availableFrom": 1589220270000
+                  "availableUntil": 1610744670000,
+                  "availableFrom": 1608141870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l8m",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y4k",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0l7g", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y3f", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0l7g",
+              "id": "w3ct0y3f",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw530",
+                  "versionId": "w4hqwm56",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -210,45 +223,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591563870000,
-                  "availableFrom": 1588961070000
+                  "availableUntil": 1610658270000,
+                  "availableFrom": 1608055470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l7g",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y3f",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0l9q", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y15", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0l9q",
+              "id": "w3ct0y15",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw558",
+                  "versionId": "w4hqwm2y",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -258,45 +275,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591477470000,
-                  "availableFrom": 1588874670000
+                  "availableUntil": 1610571870000,
+                  "availableFrom": 1607969070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l9q",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y15",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0lcz", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y00", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0lcz",
+              "id": "w3ct0y00",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw57j",
+                  "versionId": "w4hqwm1s",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -306,45 +327,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591391070000,
-                  "availableFrom": 1588788270000
+                  "availableUntil": 1610312670000,
+                  "availableFrom": 1607709870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lcz",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y00",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0lbv", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y28", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0lbv",
+              "id": "w3ct0y28",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw56d",
+                  "versionId": "w4hqwm41",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -354,45 +379,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591304670000,
-                  "availableFrom": 1588701870000
+                  "availableUntil": 1610226270000,
+                  "availableFrom": 1607623470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0lbv",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y28",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0l8l", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y4j", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0l8l",
+              "id": "w3ct0y4j",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw544",
+                  "versionId": "w4hqwm69",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -402,45 +431,49 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591218270000,
-                  "availableFrom": 1588615470000
+                  "availableUntil": 1610139870000,
+                  "availableFrom": 1607537070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l8l",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y4j",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Oduu BBC Afaan Oromoo" },
-            "locators": { "pid": "w3ct0l7f", "brandPid": "w13xttnw" },
+            "locators": { "pid": "w3ct0y3d", "brandPid": "w13xttnw" },
             "media": {
-              "id": "w3ct0l7f",
+              "id": "w3ct0y3d",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
                 "short": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15",
                 "medium": "Sagantaa Oduu fi Dhimmota Wayitaawoo daqiiqaa 15"
               },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw52z",
+                  "versionId": "w4hqwm55",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -450,25 +483,29 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1590959070000,
-                  "availableFrom": 1588356270000
+                  "availableUntil": 1610053470000,
+                  "availableFrom": 1607450670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
               "id": "",
               "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p05ws2zm.png",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8njz.png",
               "height": 0,
               "width": 0,
               "altText": null,
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": { "pid": "w13xttnw", "title": "Oduu BBC Afaan Oromoo" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0l7f",
+            "id": "urn:bbc:ares:ws_media:page:bbc_oromo_radio/w3ct0y3d",
             "type": "ws_radio"
           }
         ]

--- a/data/amharic/bbc_amharic_radio/w3csz5r9.json
+++ b/data/amharic/bbc_amharic_radio/w3csz5r9.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_amharic_radio",
     "language": "am",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608292168207,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
     "timestamp": 1582565117000,
@@ -18,15 +18,15 @@
       "producer": "AMHARIC"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "ቢቢሲ አማርኛ ዜና",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "available",
         "id": "w3csz5r9",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
     "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3csz5r9",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07cd", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xr8", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07cd",
+              "id": "w3ct0xr8",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt59",
+                  "versionId": "w4hqwlt1",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592081070000,
-                  "availableFrom": 1589478270000
+                  "availableUntil": 1610829870000,
+                  "availableFrom": 1608227070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07cd",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xr8",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07fn", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xtj", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07fn",
+              "id": "w3ct0xtj",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt7k",
+                  "versionId": "w4hqwlw9",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591994670000,
-                  "availableFrom": 1589391870000
+                  "availableUntil": 1610743470000,
+                  "availableFrom": 1608140670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07fn",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xtj",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07dj", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xsd", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07dj",
+              "id": "w3ct0xsd",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt6f",
+                  "versionId": "w4hqwlv5",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591908270000,
-                  "availableFrom": 1589305470000
+                  "availableUntil": 1610657070000,
+                  "availableFrom": 1608054270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07dj",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xsd",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07b8", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xq4", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07b8",
+              "id": "w3ct0xq4",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt45",
+                  "versionId": "w4hqwlrx",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591821870000,
-                  "availableFrom": 1589219070000
+                  "availableUntil": 1610570670000,
+                  "availableFrom": 1607967870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07b8",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xq4",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct0793", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xnz", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct0793",
+              "id": "w3ct0xnz",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt30",
+                  "versionId": "w4hqwlqr",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591562670000,
-                  "availableFrom": 1588959870000
+                  "availableUntil": 1610311470000,
+                  "availableFrom": 1607708670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0793",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xnz",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07cc", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xr7", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07cc",
+              "id": "w3ct0xr7",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt58",
+                  "versionId": "w4hqwlt0",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591476270000,
-                  "availableFrom": 1588873470000
+                  "availableUntil": 1610225070000,
+                  "availableFrom": 1607622270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07cc",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xr7",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07fm", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xth", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07fm",
+              "id": "w3ct0xth",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt7j",
+                  "versionId": "w4hqwlw8",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591389870000,
-                  "availableFrom": 1588787070000
+                  "availableUntil": 1610138670000,
+                  "availableFrom": 1607535870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07fm",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xth",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ አማርኛ ዜና" },
-            "locators": { "pid": "w3ct07dh", "brandPid": "w13xttnt" },
+            "locators": { "pid": "w3ct0xsc", "brandPid": "w13xttnt" },
             "media": {
-              "id": "w3ct07dh",
+              "id": "w3ct0xsc",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
                 "short": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም",
                 "medium": "የ15 ደቂቃ ዜናና ወቅታዊ ጉዳዮችን የሚዳስስ ፕሮግራም"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvt6d",
+                  "versionId": "w4hqwlv4",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591303470000,
-                  "availableFrom": 1588700670000
+                  "availableUntil": 1610052270000,
+                  "availableFrom": 1607449470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": { "pid": "w13xttnt", "title": "ቢቢሲ አማርኛ ዜና" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct07dh",
+            "id": "urn:bbc:ares:ws_media:page:bbc_amharic_radio/w3ct0xsc",
             "type": "ws_radio"
           }
         ]

--- a/data/arabic/bbc_arabic_radio/w3ct01yb.json
+++ b/data/arabic/bbc_arabic_radio/w3ct01yb.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_arabic_radio",
     "language": "ar",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608292285998,
     "firstPublished": 1582584617000,
     "lastPublished": 1582584617000,
     "timestamp": 1582584617000,
@@ -18,15 +18,15 @@
       "producer": "ARABIC"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "نقطة حوار",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "available",
         "id": "w3ct01yb",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
     "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct01yb",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct094h", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct197f", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct094h",
+              "id": "w3ct197f",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvyd",
+                  "versionId": "w4hqwzrn",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592134200000,
-                  "availableFrom": 1589412600000
+                  "availableUntil": 1610883000000,
+                  "availableFrom": 1608172200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094h",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197f",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct093c", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct1969", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct093c",
+              "id": "w3ct1969",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvx8",
+                  "versionId": "w4hqwzqj",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591961400000,
-                  "availableFrom": 1589239800000
+                  "availableUntil": 1610710200000,
+                  "availableFrom": 1607999400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct093c",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1969",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct0908", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct1940", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct0908",
+              "id": "w3ct1940",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "12/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvt5",
+                  "versionId": "w4hqwzn7",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591795800000,
-                  "availableFrom": 1588980600000
+                  "availableUntil": 1610537400000,
+                  "availableFrom": 1607740200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607731200000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0908",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1940",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct094g", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct197d", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct094g",
+              "id": "w3ct197d",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvyc",
+                  "versionId": "w4hqwzrm",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591691400000,
-                  "availableFrom": 1588807800000
+                  "availableUntil": 1610418600000,
+                  "availableFrom": 1607567400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094g",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197d",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct093b", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct1968", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct093b",
+              "id": "w3ct1968",
               "subType": "episode",
               "format": "Audio",
-              "title": "04/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvx7",
+                  "versionId": "w4hqwzqh",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591356600000,
-                  "availableFrom": 1588635000000
+                  "availableUntil": 1610105400000,
+                  "availableFrom": 1607394600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct093b",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1968",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct0907", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct193z", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct0907",
+              "id": "w3ct193z",
               "subType": "episode",
               "format": "Audio",
-              "title": "01/05/2020 GMT",
+              "title": "05/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvt4",
+                  "versionId": "w4hqwzn6",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591191000000,
-                  "availableFrom": 1588375800000
+                  "availableUntil": 1609932600000,
+                  "availableFrom": 1607135400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607126400000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0907",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct193z",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct094f", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct197c", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct094f",
+              "id": "w3ct197c",
               "subType": "episode",
               "format": "Audio",
-              "title": "29/04/2020 GMT",
+              "title": "03/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvyb",
+                  "versionId": "w4hqwzrl",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591086600000,
-                  "availableFrom": 1588203000000
+                  "availableUntil": 1609813800000,
+                  "availableFrom": 1606962600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1606953600000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct094f",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct197c",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "نقطة حوار" },
-            "locators": { "pid": "w3ct0939", "brandPid": "p030vh39" },
+            "locators": { "pid": "w3ct1967", "brandPid": "p030vh39" },
             "media": {
-              "id": "w3ct0939",
+              "id": "w3ct1967",
               "subType": "episode",
               "format": "Audio",
-              "title": "27/04/2020 GMT",
+              "title": "01/12/2020 GMT",
               "synopses": {
                 "short": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت",
                 "medium": "برنامج حواري تفاعلي مع الجمهور للمشاركة بآرائهم في القضايا المختلفة ويبث عبر التليفزيون والإذاعة والأنترنت"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvvx6",
+                  "versionId": "w4hqwzqg",
                   "types": ["Original"],
                   "duration": 1440,
                   "durationISO8601": "PT24M",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1590751800000,
-                  "availableFrom": 1588030200000
+                  "availableUntil": 1609500600000,
+                  "availableFrom": 1606789800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1606780800000,
             "brand": { "pid": "p030vh39", "title": "نقطة حوار" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct0939",
+            "id": "urn:bbc:ares:ws_media:page:bbc_arabic_radio/w3ct1967",
             "type": "ws_radio"
           }
         ]

--- a/data/bengali/bbc_bangla_radio/w172x0562jxntqx.json
+++ b/data/bengali/bbc_bangla_radio/w172x0562jxntqx.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_bangla_radio",
     "language": "bn",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608292380065,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
     "timestamp": 1583569000000,
@@ -18,15 +18,15 @@
       "producer": "BENGALI"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "প্রবাহ",
-    "releaseDateTimeStamp": 1583539200000
+    "releaseDateTimeStamp": 1583539200000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x0562jxntqx",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583539200000,
     "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
     "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172x0562jxntqx",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhxtlr99v", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzz7rgkl6l", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhxtlr99v",
+              "id": "w172xmzz7rgkl6l",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1fcl72kc",
+                  "versionId": "w1mshv25p737dym",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592056770000,
-                  "availableFrom": 1589464770000
+                  "availableUntil": 1610805570000,
+                  "availableFrom": 1608213570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlr99v",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzz7rgkl6l",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhxtlnddr", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzz7rggp9h", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhxtlnddr",
+              "id": "w172xmzz7rggp9h",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1fcl45n8",
+                  "versionId": "w1mshv25p734j1j",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591970370000,
-                  "availableFrom": 1589378370000
+                  "availableUntil": 1610719170000,
+                  "availableFrom": 1608127170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlnddr",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzz7rggp9h",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhxtlkhhn", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzz7rgcsdd", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhxtlkhhn",
+              "id": "w172xmzz7rgcsdd",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1fcl18r5",
+                  "versionId": "w1mshv25p731m4f",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591883970000,
-                  "availableFrom": 1589291970000
+                  "availableUntil": 1610632770000,
+                  "availableFrom": 1608040770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlkhhn",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzz7rgcsdd",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhxtlgllk", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzz7rg8wh9", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhxtlgllk",
+              "id": "w172xmzz7rg8wh9",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1fckycv2",
+                  "versionId": "w1mshv25p72yq7b",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591797570000,
-                  "availableFrom": 1589205570000
+                  "availableUntil": 1610546370000,
+                  "availableFrom": 1607954370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhxtlgllk",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzz7rg8wh9",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhkk97vf9", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzywh524b1", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhkk97vf9",
+              "id": "w172xmzywh524b1",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "13/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1238qmnt",
+                  "versionId": "w1mshv259ysqz22",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591711170000,
-                  "availableFrom": 1589119170000
+                  "availableUntil": 1610459970000,
+                  "availableFrom": 1607867970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607817600000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk97vf9",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzywh524b1",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhkk94yj6", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzywh4z7dy", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhkk94yj6",
+              "id": "w172xmzywh4z7dy",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "12/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1238mqrq",
+                  "versionId": "w1mshv259ysn24z",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591624770000,
-                  "availableFrom": 1589032770000
+                  "availableUntil": 1610373570000,
+                  "availableFrom": 1607781570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607731200000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk94yj6",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzywh4z7dy",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhkk921m3", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzywh4wbhv", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhkk921m3",
+              "id": "w172xmzywh4wbhv",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1238jtvm",
+                  "versionId": "w1mshv259ysk57w",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591538370000,
-                  "availableFrom": 1588946370000
+                  "availableUntil": 1610287170000,
+                  "availableFrom": 1607695170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk921m3",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzywh4wbhv",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "প্রবাহ" },
-            "locators": { "pid": "w172xdwhkk8z4q0", "brandPid": "p030vjwg" },
+            "locators": { "pid": "w172xmzywh4sflr", "brandPid": "p030vjwg" },
             "media": {
-              "id": "w172xdwhkk8z4q0",
+              "id": "w172xmzywh4sflr",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক",
                 "medium": "বিবিসি বাংলা থেকে সংবাদ, সমসাময়িক ঘটনা, বিশেষ প্রতিবেদন, খেলা-ধুলা, ফোন-ইন আর বিতর্ক"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshks1238fxyj",
+                  "versionId": "w1mshv259ysg8bs",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591451970000,
-                  "availableFrom": 1588859970000
+                  "availableUntil": 1610200770000,
+                  "availableFrom": 1607608770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p030vjwg", "title": "প্রবাহ" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xdwhkk8z4q0",
+            "id": "urn:bbc:ares:ws_media:page:bbc_bangla_radio/w172xmzywh4sflr",
             "type": "ws_radio"
           }
         ]

--- a/data/burmese/bbc_burmese_radio/w3csz62h.json
+++ b/data/burmese/bbc_burmese_radio/w3csz62h.json
@@ -1,102 +1,68 @@
 {
   "metadata": {
-    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4l",
-    "locators": {
-      "pid": "w3ct0b4l",
-      "brandPid": "p0340rnm"
-    },
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz62h",
+    "locators": { "pid": "w3csz62h", "brandPid": "p0340rnm" },
     "type": "WSRADIO",
     "createdBy": "bbc_burmese_radio",
     "language": "my",
-    "lastUpdated": 1589529753485,
-    "firstPublished": 1588872411000,
-    "lastPublished": 1588872411000,
-    "timestamp": 1588872411000,
+    "lastUpdated": 1608292495740,
+    "firstPublished": 1583569000000,
+    "lastPublished": 1583569000000,
+    "timestamp": 1583569000000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။ - BBC News မြန်မာ",
-      "pageIdentifier": "burmese.bbc_burmese_radio.w3ct0b4l.page",
+      "pageIdentifier": "burmese.bbc_burmese_radio.w3csz62h.page",
       "producerId": "35",
       "contentType": "player-episode",
       "producer": "BURMESE"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။",
-    "releaseDateTimeStamp": 1588809600000
+    "releaseDateTimeStamp": 1583539200000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "available",
-        "id": "w3ct0b4l",
+        "id": "w3csz62h",
         "subType": "episode",
         "format": "Audio",
-        "title": "07/05/2020 GMT",
+        "title": "07/03/2020 GMT",
         "synopses": {
-          "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-          "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+          "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+          "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
         },
         "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
         "embedding": false,
         "advertising": false,
-        "versions": [
-          {
-            "versionId": "w4hqvwyh",
-            "types": ["Original"],
-            "duration": 900,
-            "durationISO8601": "PT15M",
-            "warnings": {},
-            "availableTerritories": {
-              "uk": false,
-              "nonUk": false,
-              "world": true
-            },
-            "availableUntil": 1591451970000,
-            "availableFrom": 1588859070000
-          }
-        ],
+        "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-    },
-    "locators": {
-      "pid": "w3ct0b4l",
-      "brandPid": "p0340rnm"
-    },
+    "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+    "locators": { "pid": "w3csz62h", "brandPid": "p0340rnm" },
     "media": {
-      "id": "w3ct0b4l",
+      "id": "w3csz62h",
       "subType": "episode",
       "format": "Audio",
-      "title": "07/05/2020 GMT",
+      "title": "07/03/2020 GMT",
       "synopses": {
-        "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-        "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+        "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+        "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
       },
       "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
       "embedding": false,
       "advertising": false,
-      "versions": [
-        {
-          "versionId": "w4hqvwyh",
-          "types": ["Original"],
-          "duration": 900,
-          "durationISO8601": "PT15M",
-          "warnings": {},
-          "availableTerritories": {
-            "uk": false,
-            "nonUk": false,
-            "world": true
-          },
-          "availableUntil": 1591451970000,
-          "availableFrom": 1588859070000
-        }
-      ],
+      "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -110,11 +76,9 @@
       "copyrightHolder": null,
       "type": "image"
     },
-    "brand": {
-      "pid": "p0340rnm",
-      "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-    },
-    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4l",
+    "releaseDateTimestamp": 1583539200000,
+    "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3csz62h",
     "type": "ws_radio"
   },
   "relatedContent": {
@@ -129,28 +93,23 @@
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b4m",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0yq5", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b4m",
+              "id": "w3ct0yq5",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvwyj",
+                  "versionId": "w4hqwmrz",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -160,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592056770000,
-                  "availableFrom": 1589463870000
+                  "availableUntil": 1610805570000,
+                  "availableFrom": 1608212670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -177,36 +139,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b4m",
+            "releaseDateTimestamp": 1608163200000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0yq5",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b6w",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0ysf", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b6w",
+              "id": "w3ct0ysf",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvx0s",
+                  "versionId": "w4hqwmv7",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -216,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591970370000,
-                  "availableFrom": 1589377470000
+                  "availableUntil": 1610719170000,
+                  "availableFrom": 1608126270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -233,36 +191,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b6w",
+            "releaseDateTimestamp": 1608076800000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0ysf",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b5r",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0yr9", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b5r",
+              "id": "w3ct0yr9",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvwzn",
+                  "versionId": "w4hqwmt3",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -272,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591883970000,
-                  "availableFrom": 1589291070000
+                  "availableUntil": 1610632770000,
+                  "availableFrom": 1608039870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -289,36 +243,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b5r",
+            "releaseDateTimestamp": 1607990400000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0yr9",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b17",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0yls", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b17",
+              "id": "w3ct0yls",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvwv4",
+                  "versionId": "w4hqwmnl",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -328,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591797570000,
-                  "availableFrom": 1589204670000
+                  "availableUntil": 1610546370000,
+                  "availableFrom": 1607953470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -345,36 +295,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b17",
+            "releaseDateTimestamp": 1607904000000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0yls",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b3g",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0yp0", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b3g",
+              "id": "w3ct0yp0",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "13/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvwxc",
+                  "versionId": "w4hqwmqt",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -384,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591711170000,
-                  "availableFrom": 1589118270000
+                  "availableUntil": 1610459970000,
+                  "availableFrom": 1607867070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -401,36 +347,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b3g",
+            "releaseDateTimestamp": 1607817600000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0yp0",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b2b",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0ymw", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b2b",
+              "id": "w3ct0ymw",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "12/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvww7",
+                  "versionId": "w4hqwmpp",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -440,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591624770000,
-                  "availableFrom": 1589031870000
+                  "availableUntil": 1610373570000,
+                  "availableFrom": 1607780670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -457,36 +399,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b2b",
+            "releaseDateTimestamp": 1607731200000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0ymw",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b02",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0ykm", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b02",
+              "id": "w3ct0ykm",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvwsz",
+                  "versionId": "w4hqwmmf",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -496,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591538370000,
-                  "availableFrom": 1588945470000
+                  "availableUntil": 1610287170000,
+                  "availableFrom": 1607694270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -513,36 +451,29 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b02",
+            "releaseDateTimestamp": 1607644800000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0ykm",
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "locators": {
-              "pid": "w3ct0b6v",
-              "brandPid": "p0340rnm"
-            },
+            "headlines": { "headline": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "locators": { "pid": "w3ct0yq4", "brandPid": "p0340rnm" },
             "media": {
-              "id": "w3ct0b6v",
+              "id": "w3ct0yq4",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
-                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
-                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
+                "short": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ",
+                "medium": "သတင်းနှင့်ကမ္ဘာ့မျက်မှောက်ရေးရာ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p088hgd7.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvx0r",
+                  "versionId": "w4hqwmry",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -552,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591365570000,
-                  "availableFrom": 1588772670000
+                  "availableUntil": 1610200770000,
+                  "availableFrom": 1607607870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -569,11 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "brand": {
-              "pid": "p0340rnm",
-              "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0b6v",
+            "releaseDateTimestamp": 1607558400000,
+            "brand": { "pid": "p0340rnm", "title": "ကမ္ဘာ့မျက်မှောက်ရေးရာ။" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/w3ct0yq4",
             "type": "ws_radio"
           }
         ]

--- a/data/gahuza/bbc_gahuza_radio/w172x7rkcj6v0vz.json
+++ b/data/gahuza/bbc_gahuza_radio/w172x7rkcj6v0vz.json
@@ -1,14 +1,11 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6v0vz",
-    "locators": {
-      "pid": "w172x7rkcj6v0vz",
-      "brandPid": "p0340x2n"
-    },
+    "locators": { "pid": "w172x7rkcj6v0vz", "brandPid": "p0340x2n" },
     "type": "WSRADIO",
     "createdBy": "bbc_gahuza_radio",
     "language": "rw",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608292590089,
     "firstPublished": 1582561533000,
     "lastPublished": 1582561533000,
     "timestamp": 1582561533000,
@@ -21,15 +18,15 @@
       "producer": "GAHUZA"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Amakuru ya Gahuzamiryango",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x7rkcj6v0vz",
         "subType": "episode",
         "format": "Audio",
@@ -42,18 +39,15 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": {
-      "headline": "Amakuru ya Gahuzamiryango"
-    },
-    "locators": {
-      "pid": "w172x7rkcj6v0vz",
-      "brandPid": "p0340x2n"
-    },
+    "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+    "locators": { "pid": "w172x7rkcj6v0vz", "brandPid": "p0340x2n" },
     "media": {
       "id": "w172x7rkcj6v0vz",
       "subType": "episode",
@@ -67,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -80,10 +76,8 @@
       "copyrightHolder": null,
       "type": "image"
     },
-    "brand": {
-      "pid": "p0340x2n",
-      "title": "Amakuru ya Gahuzamiryango"
-    },
+    "releaseDateTimestamp": 1583452800000,
+    "brand": { "pid": "p0340x2n", "title": "Amakuru ya Gahuzamiryango" },
     "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172x7rkcj6v0vz",
     "type": "ws_radio"
   },
@@ -99,13 +93,173 @@
         "type": "other-episode",
         "promos": [
           {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp11bjg01g4", "brandPid": "p0340x2n" },
+            "media": {
+              "id": "w172xp11bjg01g4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "17/12/2020 GMT",
+              "synopses": {
+                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
+                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshw3g9tcx3y2",
+                  "types": ["Original"],
+                  "duration": 1800,
+                  "durationISO8601": "PT30M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610816370000,
+                  "availableFrom": 1608224370000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
             },
-            "locators": {
-              "pid": "w172xp11bjfqbqv",
-              "brandPid": "p0340x2n"
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
+            "brand": {
+              "pid": "p0340x2n",
+              "title": "Amakuru ya Gahuzamiryango"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp11bjg01g4",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp11bjfx4k1", "brandPid": "p0340x2n" },
+            "media": {
+              "id": "w172xp11bjfx4k1",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "16/12/2020 GMT",
+              "synopses": {
+                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
+                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshw3g9tct70z",
+                  "types": ["Original"],
+                  "duration": 1800,
+                  "durationISO8601": "PT30M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610729970000,
+                  "availableFrom": 1608137970000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1608076800000,
+            "brand": {
+              "pid": "p0340x2n",
+              "title": "Amakuru ya Gahuzamiryango"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp11bjfx4k1",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp11bjft7my", "brandPid": "p0340x2n" },
+            "media": {
+              "id": "w172xp11bjft7my",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "15/12/2020 GMT",
+              "synopses": {
+                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
+                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshw3g9tcqb3w",
+                  "types": ["Original"],
+                  "duration": 1800,
+                  "durationISO8601": "PT30M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610643570000,
+                  "availableFrom": 1608051570000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607990400000,
+            "brand": {
+              "pid": "p0340x2n",
+              "title": "Amakuru ya Gahuzamiryango"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp11bjft7my",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp11bjfqbqv", "brandPid": "p0340x2n" },
             "media": {
               "id": "w172xp11bjfqbqv",
               "subType": "episode",
@@ -159,13 +313,8 @@
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10z849srd",
-              "brandPid": "p0340x2n"
-            },
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp10z849srd", "brandPid": "p0340x2n" },
             "media": {
               "id": "w172xp10z849srd",
               "subType": "episode",
@@ -219,13 +368,8 @@
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10z846wv9",
-              "brandPid": "p0340x2n"
-            },
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp10z846wv9", "brandPid": "p0340x2n" },
             "media": {
               "id": "w172xp10z846wv9",
               "subType": "episode",
@@ -279,13 +423,8 @@
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10z843zy6",
-              "brandPid": "p0340x2n"
-            },
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp10z843zy6", "brandPid": "p0340x2n" },
             "media": {
               "id": "w172xp10z843zy6",
               "subType": "episode",
@@ -339,13 +478,8 @@
             "type": "ws_radio"
           },
           {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10z841313",
-              "brandPid": "p0340x2n"
-            },
+            "headlines": { "headline": "Amakuru ya Gahuzamiryango" },
+            "locators": { "pid": "w172xp10z841313", "brandPid": "p0340x2n" },
             "media": {
               "id": "w172xp10z841313",
               "subType": "episode",
@@ -396,186 +530,6 @@
               "title": "Amakuru ya Gahuzamiryango"
             },
             "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp10z841313",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10z83y640",
-              "brandPid": "p0340x2n"
-            },
-            "media": {
-              "id": "w172xp10z83y640",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "07/12/2020 GMT",
-              "synopses": {
-                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
-                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshw3fyk1v8ly",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609952370000,
-                  "availableFrom": 1607360370000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607299200000,
-            "brand": {
-              "pid": "p0340x2n",
-              "title": "Amakuru ya Gahuzamiryango"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp10z83y640",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10lztjn4k",
-              "brandPid": "p0340x2n"
-            },
-            "media": {
-              "id": "w172xp10lztjn4k",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "04/12/2020 GMT",
-              "synopses": {
-                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
-                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshw3fl8rfqmh",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609693170000,
-                  "availableFrom": 1607101170000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1607040000000,
-            "brand": {
-              "pid": "p0340x2n",
-              "title": "Amakuru ya Gahuzamiryango"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp10lztjn4k",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": {
-              "headline": "Amakuru ya Gahuzamiryango"
-            },
-            "locators": {
-              "pid": "w172xp10lztfr7g",
-              "brandPid": "p0340x2n"
-            },
-            "media": {
-              "id": "w172xp10lztfr7g",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "03/12/2020 GMT",
-              "synopses": {
-                "short": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu.",
-                "medium": "Amakuru yo hirya no hino yibanda cyane cyane ku karere k'ibiyaga bigari muri Afrika, n'amakuru mpuzamakungu."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "w1mshw3fl8rbtqd",
-                  "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": false,
-                    "nonUk": false,
-                    "world": true
-                  },
-                  "availableUntil": 1609606770000,
-                  "availableFrom": 1607014770000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b8lg4.png",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1606953600000,
-            "brand": {
-              "pid": "p0340x2n",
-              "title": "Amakuru ya Gahuzamiryango"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_gahuza_radio/w172xp10lztfr7g",
             "type": "ws_radio"
           }
         ]

--- a/data/hausa/bbc_hausa_radio/w3cszrwm.json
+++ b/data/hausa/bbc_hausa_radio/w3cszrwm.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_hausa_radio",
     "language": "ha",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608293733267,
     "firstPublished": 1582486516000,
     "lastPublished": 1582486516000,
     "timestamp": 1582486516000,
@@ -18,15 +18,15 @@
       "producer": "HAUSA"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Shirin Yamma",
-    "releaseDateTimeStamp": 1583366400000
+    "releaseDateTimeStamp": 1583366400000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3cszrwm",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583366400000,
     "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
     "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3cszrwm",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hvq", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct104c", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hvq",
+              "id": "w3ct104c",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2pc",
+                  "versionId": "w4hqwp6r",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592078370000,
-                  "availableFrom": 1589486370000
+                  "availableUntil": 1610827170000,
+                  "availableFrom": 1608235170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hvq",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct104c",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hxz", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct106m", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hxz",
+              "id": "w3ct106m",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2rm",
+                  "versionId": "w4hqwp90",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591991970000,
-                  "availableFrom": 1589399970000
+                  "availableUntil": 1610740770000,
+                  "availableFrom": 1608148770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hxz",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct106m",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hwv", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct105h", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hwv",
+              "id": "w3ct105h",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2qh",
+                  "versionId": "w4hqwp7w",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591905570000,
-                  "availableFrom": 1589313570000
+                  "availableUntil": 1610654370000,
+                  "availableFrom": 1608062370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hwv",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct105h",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hr7", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct100z", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hr7",
+              "id": "w3ct100z",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2ks",
+                  "versionId": "w4hqwp3c",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591819170000,
-                  "availableFrom": 1589227170000
+                  "availableUntil": 1610567970000,
+                  "availableFrom": 1607975970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hr7",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct100z",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0htk", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct1036", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0htk",
+              "id": "w3ct1036",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "13/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2n3",
+                  "versionId": "w4hqwp5l",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591732770000,
-                  "availableFrom": 1589140770000
+                  "availableUntil": 1610481570000,
+                  "availableFrom": 1607889570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607817600000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0htk",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct1036",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hsb", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct1022", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hsb",
+              "id": "w3ct1022",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "12/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2lw",
+                  "versionId": "w4hqwp4g",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591646370000,
-                  "availableFrom": 1589054370000
+                  "availableUntil": 1610395170000,
+                  "availableFrom": 1607803170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607731200000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hsb",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct1022",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hvp", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct104b", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hvp",
+              "id": "w3ct104b",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2pb",
+                  "versionId": "w4hqwp6q",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591473570000,
-                  "availableFrom": 1588881570000
+                  "availableUntil": 1610222370000,
+                  "availableFrom": 1607630370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hvp",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct104b",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Shirin Yamma" },
-            "locators": { "pid": "w3ct0hxy", "brandPid": "p030s4mx" },
+            "locators": { "pid": "w3ct106l", "brandPid": "p030s4mx" },
             "media": {
-              "id": "w3ct0hxy",
+              "id": "w3ct106l",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya.",
                 "medium": "Shiri ne na minti 30 wanda ya kunshi labaru da rahotanni daga sassa daban na duniya."
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw2rl",
+                  "versionId": "w4hqwp8z",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591387170000,
-                  "availableFrom": 1588795170000
+                  "availableUntil": 1610135970000,
+                  "availableFrom": 1607543970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "p030s4mx", "title": "Shirin Yamma" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct0hxy",
+            "id": "urn:bbc:ares:ws_media:page:bbc_hausa_radio/w3ct106l",
             "type": "ws_radio"
           }
         ]

--- a/data/korean/bbc_korean_radio/w3ct0kn5.json
+++ b/data/korean/bbc_korean_radio/w3ct0kn5.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_korean_radio",
     "language": "ko",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294121623,
     "firstPublished": 1588580293000,
     "lastPublished": 1588580293000,
     "timestamp": 1588580293000,
@@ -18,15 +18,15 @@
       "producer": "KOREAN"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "BBC 코리아 라디오",
-    "releaseDateTimeStamp": 1588550400000
+    "releaseDateTimeStamp": 1588550400000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3ct0kn5",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1588550400000,
     "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
     "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn5",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "BBC 코리아 라디오" },
-            "locators": { "pid": "w3ct0kpb", "brandPid": "w13xttll" },
+            "locators": { "pid": "w3ct11yt", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kpb",
+              "id": "w3ct11yt",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/14 GMT",
+              "title": "2020/12/17 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4j1",
+                  "versionId": "w4hqwr16",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1590085140000,
-                  "availableFrom": 1589471340000
+                  "availableUntil": 1608833940000,
+                  "availableFrom": 1608220140000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kpb",
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct11yt",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "BBC 코리아 라디오" },
-            "locators": { "pid": "w3ct0krl", "brandPid": "w13xttll" },
+            "locators": { "pid": "w3ct1212", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0krl",
+              "id": "w3ct1212",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/13 GMT",
+              "title": "2020/12/16 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4l9",
+                  "versionId": "w4hqwr3g",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589998740000,
-                  "availableFrom": 1589384940000
+                  "availableUntil": 1608747540000,
+                  "availableFrom": 1608133740000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0krl",
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct1212",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "BBC 코리아 라디오" },
-            "locators": { "pid": "w3ct0kqg", "brandPid": "w13xttll" },
+            "locators": { "pid": "w3ct11zy", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kqg",
+              "id": "w3ct11zy",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/12 GMT",
+              "title": "2020/12/15 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4k5",
+                  "versionId": "w4hqwr2b",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589912340000,
-                  "availableFrom": 1589298540000
+                  "availableUntil": 1608661140000,
+                  "availableFrom": 1608047340000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kqg",
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct11zy",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "BBC 코리아 라디오" },
-            "locators": { "pid": "w3ct0kn6", "brandPid": "w13xttll" },
+            "locators": { "pid": "w3ct11xp", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0kn6",
+              "id": "w3ct11xp",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/11 GMT",
+              "title": "2020/12/14 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4gx",
+                  "versionId": "w4hqwr02",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589825940000,
-                  "availableFrom": 1589212140000
+                  "availableUntil": 1608574740000,
+                  "availableFrom": 1607960940000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0kn6",
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct11xp",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "BBC 코리아 라디오" },
-            "locators": { "pid": "w3ct0km1", "brandPid": "w13xttll" },
+            "locators": { "pid": "w3ct11wj", "brandPid": "w13xttll" },
             "media": {
-              "id": "w3ct0km1",
+              "id": "w3ct11wj",
               "subType": "episode",
               "format": "Audio",
-              "title": "2020/05/08 GMT",
+              "title": "2020/12/11 GMT",
               "synopses": {
                 "short": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다.",
                 "medium": "한반도와 세계 곳곳의 다양한 소식을 공정하고 객관적으로 전달해 드립니다."
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4fr",
+                  "versionId": "w4hqwqyx",
                   "types": ["Original"],
                   "duration": 1140,
                   "durationISO8601": "PT19M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589566740000,
-                  "availableFrom": 1588952940000
+                  "availableUntil": 1608315540000,
+                  "availableFrom": 1607701740000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,8 +347,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct0km1",
+            "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3ct11wj",
             "type": "ws_radio"
           },
           {
@@ -354,9 +379,12 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableFrom": 1508860140000
+                  "availableFrom": 1508860140000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -370,6 +398,7 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1508803200000,
             "brand": { "pid": "w13xttll", "title": "BBC 코리아 라디오" },
             "id": "urn:bbc:ares:ws_media:page:bbc_korean_radio/w3csvzmp",
             "type": "ws_radio"

--- a/data/kyrgyz/bbc_kyrgyz_radio/w3cszwmc.json
+++ b/data/kyrgyz/bbc_kyrgyz_radio/w3cszwmc.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_kyrgyz_radio",
     "language": "ky",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294253119,
     "firstPublished": 1582550741000,
     "lastPublished": 1582550741000,
     "timestamp": 1582550741000,
@@ -18,15 +18,15 @@
       "producer": "KYRGYZ"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Лондон сүйлөйт",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3cszwmc",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
     "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3cszwmc",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0ky7", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16fs", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0ky7",
+              "id": "w3ct16fs",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4ry",
+                  "versionId": "w4hqwwlb",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592062200000,
-                  "availableFrom": 1589463000000
+                  "availableUntil": 1610811000000,
+                  "availableFrom": 1608211800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0ky7",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16fs",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0l0h", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16j1", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0l0h",
+              "id": "w3ct16j1",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4v6",
+                  "versionId": "w4hqwwnl",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591975800000,
-                  "availableFrom": 1589376600000
+                  "availableUntil": 1610724600000,
+                  "availableFrom": 1608125400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0l0h",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16j1",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0kzc", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16gx", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0kzc",
+              "id": "w3ct16gx",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4t2",
+                  "versionId": "w4hqwwmg",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591889400000,
-                  "availableFrom": 1589290200000
+                  "availableUntil": 1610638200000,
+                  "availableFrom": 1608039000000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kzc",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16gx",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0kx3", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16dn", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0kx3",
+              "id": "w3ct16dn",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4qt",
+                  "versionId": "w4hqwwk6",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591803000000,
-                  "availableFrom": 1589203800000
+                  "availableUntil": 1610551800000,
+                  "availableFrom": 1607952600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kx3",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16dn",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0kvy", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16ch", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0kvy",
+              "id": "w3ct16ch",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4pn",
+                  "versionId": "w4hqwwj1",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591543800000,
-                  "availableFrom": 1588944600000
+                  "availableUntil": 1610292600000,
+                  "availableFrom": 1607693400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kvy",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16ch",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0ky6", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16fr", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0ky6",
+              "id": "w3ct16fr",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4rx",
+                  "versionId": "w4hqwwl9",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591457400000,
-                  "availableFrom": 1588858200000
+                  "availableUntil": 1610206200000,
+                  "availableFrom": 1607607000000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0ky6",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16fr",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0l0g", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16j0", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0l0g",
+              "id": "w3ct16j0",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4v5",
+                  "versionId": "w4hqwwnk",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591371000000,
-                  "availableFrom": 1588771800000
+                  "availableUntil": 1610119800000,
+                  "availableFrom": 1607520600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0l0g",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16j0",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Лондон сүйлөйт" },
-            "locators": { "pid": "w3ct0kzb", "brandPid": "p0340xth" },
+            "locators": { "pid": "w3ct16gw", "brandPid": "p0340xth" },
             "media": {
-              "id": "w3ct0kzb",
+              "id": "w3ct16gw",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
                 "short": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү",
                 "medium": "Би-Би-Си Кыргыз кызматынын соңку кабарларды талдаган радио берүүсү"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw4t1",
+                  "versionId": "w4hqwwmf",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591284600000,
-                  "availableFrom": 1588685400000
+                  "availableUntil": 1610033400000,
+                  "availableFrom": 1607434200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": { "pid": "p0340xth", "title": "Лондон сүйлөйт" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct0kzb",
+            "id": "urn:bbc:ares:ws_media:page:bbc_kyrgyz_radio/w3ct16gw",
             "type": "ws_radio"
           }
         ]

--- a/data/nepali/bbc_nepali_radio/w172x83pnptp1s8.json
+++ b/data/nepali/bbc_nepali_radio/w172x83pnptp1s8.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_nepali_radio",
     "language": "ne",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294455391,
     "firstPublished": 1582508121000,
     "lastPublished": 1582508121000,
     "timestamp": 1582508121000,
@@ -18,10 +18,11 @@
       "producer": "NEPALI"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "विहानीपख",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
@@ -38,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -58,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -71,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
     "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172x83pnptp1s8",
     "type": "ws_radio"
@@ -88,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtm2rj2htn", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9nh5s7tnv", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtm2rj2htn",
+              "id": "w172xp9nh5s7tnv",
               "subType": "episode",
               "format": "Audio",
-              "title": "15/05/2020 GMT",
+              "title": "18/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -103,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqfnzvngn6",
+                  "versionId": "w1mshwd2ggq4x4s",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -113,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592099070000,
-                  "availableFrom": 1589507070000
+                  "availableUntil": 1610847870000,
+                  "availableFrom": 1608255870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -130,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608249600000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rj2htn",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9nh5s7tnv",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtm2rhzlxk", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9nh5s4xrr", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtm2rhzlxk",
+              "id": "w172xp9nh5s4xrr",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -151,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqfnzvkkr3",
+                  "versionId": "w1mshwd2ggq207p",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -161,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592012670000,
-                  "availableFrom": 1589420670000
+                  "availableUntil": 1610761470000,
+                  "availableFrom": 1608169470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -178,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhzlxk",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9nh5s4xrr",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtm2rhwq0g", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9nh5s20vn", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtm2rhwq0g",
+              "id": "w172xp9nh5s20vn",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -199,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqfnzvgnv0",
+                  "versionId": "w1mshwd2ggpz3bl",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -209,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591926270000,
-                  "availableFrom": 1589334270000
+                  "availableUntil": 1610675070000,
+                  "availableFrom": 1608083070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -226,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhwq0g",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9nh5s20vn",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtm2rhst3c", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9nh5rz3yk", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtm2rhst3c",
+              "id": "w172xp9nh5rz3yk",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -247,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqfnzvcrxx",
+                  "versionId": "w1mshwd2ggpw6fh",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -257,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591839870000,
-                  "availableFrom": 1589247870000
+                  "availableUntil": 1610588670000,
+                  "availableFrom": 1607996670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -274,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhst3c",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9nh5rz3yk",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtm2rhpx68", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9nh5rw71g", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtm2rhpx68",
+              "id": "w172xp9nh5rw71g",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -295,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqfnzv8w0t",
+                  "versionId": "w1mshwd2ggps9jd",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -305,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591753470000,
-                  "availableFrom": 1589161470000
+                  "availableUntil": 1610502270000,
+                  "availableFrom": 1607910270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -322,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtm2rhpx68",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9nh5rw71g",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtlqh69c6t", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9n3xggp20", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtlqh69c6t",
+              "id": "w172xp9n3xggp20",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -343,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqf9qjwb1c",
+                  "versionId": "w1mshwd236dcrjy",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -353,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591494270000,
-                  "availableFrom": 1588902270000
+                  "availableUntil": 1610243070000,
+                  "availableFrom": 1607651070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -370,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh69c6t",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9n3xggp20",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtlqh66g9q", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9n3xgcs4x", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtlqh66g9q",
+              "id": "w172xp9n3xgcs4x",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -391,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqf9qjsf48",
+                  "versionId": "w1mshwd236d8vmv",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -401,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591407870000,
-                  "availableFrom": 1588815870000
+                  "availableUntil": 1610156670000,
+                  "availableFrom": 1607564670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -418,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh66g9q",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9n3xgcs4x",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "विहानीपख" },
-            "locators": { "pid": "w172xhtlqh63kdm", "brandPid": "p0340xzt" },
+            "locators": { "pid": "w172xp9n3xg8w7t", "brandPid": "p0340xzt" },
             "media": {
-              "id": "w172xhtlqh63kdm",
+              "id": "w172xp9n3xg8w7t",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम",
                 "medium": "बीबीसी नेेपाली सेवाको हरेक दिन  विहान सवा सात बजे प्रसारण हुने कार्यक्रम"
@@ -439,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshnqf9qjpj75",
+                  "versionId": "w1mshwd236d5yqr",
                   "types": ["Original"],
                   "duration": 900,
                   "durationISO8601": "PT15M",
@@ -449,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591321470000,
-                  "availableFrom": 1588729470000
+                  "availableUntil": 1610070270000,
+                  "availableFrom": 1607478270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -466,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "p0340xzt", "title": "विहानीपख" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xhtlqh63kdm",
+            "id": "urn:bbc:ares:ws_media:page:bbc_nepali_radio/w172xp9n3xg8w7t",
             "type": "ws_radio"
           }
         ]

--- a/data/persian/bbc_dari_radio/w3csz7mf.json
+++ b/data/persian/bbc_dari_radio/w3csz7mf.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_dari_radio",
     "language": "fa",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294645586,
     "firstPublished": 1583482631000,
     "lastPublished": 1583482631000,
     "timestamp": 1583482631000,
@@ -18,15 +18,15 @@
       "producer": "PERSIAN"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "چشم انداز بامدادی 1",
-    "releaseDateTimeStamp": 1583539200000
+    "releaseDateTimeStamp": 1583539200000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3csz7mf",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583539200000,
     "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
     "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3csz7mf",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0bqc", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct130k", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0bqc",
+              "id": "w3ct130k",
               "subType": "episode",
               "format": "Audio",
-              "title": "15/05/2020 GMT",
+              "title": "18/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxj8",
+                  "versionId": "w4hqws35",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592117970000,
-                  "availableFrom": 1589507970000
+                  "availableUntil": 1610866770000,
+                  "availableFrom": 1608260370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608249600000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bqc",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct130k",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0bvw", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct12rn", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0bvw",
+              "id": "w3ct12rn",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "18/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxns",
+                  "versionId": "w4hqwrv8",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592031570000,
-                  "availableFrom": 1589421570000
+                  "availableUntil": 1610863170000,
+                  "availableFrom": 1608256770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608249600000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bvw",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct12rn",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0by4", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct1352", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0by4",
+              "id": "w3ct1352",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxr1",
+                  "versionId": "w4hqws7p",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591945170000,
-                  "availableFrom": 1589335170000
+                  "availableUntil": 1610780370000,
+                  "availableFrom": 1608173970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0by4",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct1352",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0bx0", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct12x5", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0bx0",
+              "id": "w3ct12x5",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxpx",
+                  "versionId": "w4hqwrzs",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591858770000,
-                  "availableFrom": 1589248770000
+                  "availableUntil": 1610776770000,
+                  "availableFrom": 1608170370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bx0",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct12x5",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0brh", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct137b", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0brh",
+              "id": "w3ct137b",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxkd",
+                  "versionId": "w4hqws9y",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591772370000,
-                  "availableFrom": 1589162370000
+                  "availableUntil": 1610693970000,
+                  "availableFrom": 1608087570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0brh",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct137b",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0btq", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct12zf", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0btq",
+              "id": "w3ct12zf",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxmm",
+                  "versionId": "w4hqws21",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591685970000,
-                  "availableFrom": 1589075970000
+                  "availableUntil": 1610690370000,
+                  "availableFrom": 1608083970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0btq",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct12zf",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0bsl", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct1366", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0bsl",
+              "id": "w3ct1366",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxlh",
+                  "versionId": "w4hqws8t",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591599570000,
-                  "availableFrom": 1588989570000
+                  "availableUntil": 1610607570000,
+                  "availableFrom": 1608001170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bsl",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct1366",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی 1" },
-            "locators": { "pid": "w3ct0bqb", "brandPid": "p04xz36l" },
+            "locators": { "pid": "w3ct12y9", "brandPid": "p04xz36l" },
             "media": {
-              "id": "w3ct0bqb",
+              "id": "w3ct12y9",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.",
                 "medium": "تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان."
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqvxj7",
+                  "versionId": "w4hqws0x",
                   "types": ["Original"],
                   "duration": 1770,
                   "durationISO8601": "PT29M30S",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591513170000,
-                  "availableFrom": 1588903170000
+                  "availableUntil": 1610603970000,
+                  "availableFrom": 1607997570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p04xz36l", "title": "چشم انداز بامدادی 1" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct0bqb",
+            "id": "urn:bbc:ares:ws_media:page:bbc_dari_radio/w3ct12y9",
             "type": "ws_radio"
           }
         ]

--- a/data/persian/bbc_persian_radio/w172x32355t5635.json
+++ b/data/persian/bbc_persian_radio/w172x32355t5635.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_persian_radio",
     "language": "fa",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294696594,
     "firstPublished": 1582518913000,
     "lastPublished": 1582518913000,
     "timestamp": 1582518913000,
@@ -18,15 +18,15 @@
       "producer": "PERSIAN"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "چشم انداز بامدادی",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x32355t5635",
         "subType": "episode",
         "format": "Audio",
@@ -40,6 +40,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -61,6 +63,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -74,6 +78,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
     "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w172x32355t5635",
     "type": "ws_radio"
@@ -91,12 +96,12 @@
         "promos": [
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2x", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1clt", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2x",
+              "id": "w3ct1clt",
               "subType": "episode",
               "format": "Audio",
-              "title": "15/05/2020 GMT",
+              "title": "18/12/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -107,7 +112,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpm",
+                  "versionId": "w4hqx275",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -117,10 +122,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592108970000,
-                  "availableFrom": 1589513400000
+                  "availableUntil": 1610861370000,
+                  "availableFrom": 1608265800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -134,18 +142,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608249600000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2x",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1clt",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2w", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1cls", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2w",
+              "id": "w3ct1cls",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -156,7 +165,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpl",
+                  "versionId": "w4hqx274",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -166,10 +175,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592022570000,
-                  "availableFrom": 1589427000000
+                  "availableUntil": 1610774970000,
+                  "availableFrom": 1608179400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -183,18 +195,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2w",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1cls",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2v", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1clr", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2v",
+              "id": "w3ct1clr",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -205,7 +218,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpk",
+                  "versionId": "w4hqx273",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -215,10 +228,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591936170000,
-                  "availableFrom": 1589340600000
+                  "availableUntil": 1610688570000,
+                  "availableFrom": 1608093000000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -232,18 +248,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2v",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1clr",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2t", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1clq", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2t",
+              "id": "w3ct1clq",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -254,7 +271,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpj",
+                  "versionId": "w4hqx272",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -264,10 +281,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591849770000,
-                  "availableFrom": 1589254200000
+                  "availableUntil": 1610602170000,
+                  "availableFrom": 1608006600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -281,18 +301,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2t",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1clq",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2s", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1clp", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2s",
+              "id": "w3ct1clp",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -303,7 +324,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdph",
+                  "versionId": "w4hqx271",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -313,10 +334,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591763370000,
-                  "availableFrom": 1589167800000
+                  "availableUntil": 1610515770000,
+                  "availableFrom": 1607920200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -330,18 +354,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2s",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1clp",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2r", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1cl6", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2r",
+              "id": "w3ct1cl6",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "29/11/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -352,7 +377,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpg",
+                  "versionId": "w4hqx26k",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -362,10 +387,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591676970000,
-                  "availableFrom": 1589081400000
+                  "availableUntil": 1609219770000,
+                  "availableFrom": 1606624200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -379,18 +407,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1606608000000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2r",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1cl6",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2q", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1cl5", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2q",
+              "id": "w3ct1cl5",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "28/11/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -401,7 +430,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpf",
+                  "versionId": "w4hqx26j",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -411,10 +440,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591590570000,
-                  "availableFrom": 1588995000000
+                  "availableUntil": 1609133370000,
+                  "availableFrom": 1606537800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -428,18 +460,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1606521600000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2q",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1cl5",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "چشم انداز بامدادی" },
-            "locators": { "pid": "w3ct0s2p", "brandPid": "p0340vyx" },
+            "locators": { "pid": "w3ct1cl4", "brandPid": "p0340vyx" },
             "media": {
-              "id": "w3ct0s2p",
+              "id": "w3ct1cl4",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "27/11/2020 GMT",
               "synopses": {
                 "short": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
                 "medium": "چشم انداز بامدادی مجله خبری رادیو فارسی بی‌بی‌سی است که شامل خبر، گزارش، گفتگو و تحلیل درباره رویدادهای ایران، منطقه و جهان است.",
@@ -450,7 +483,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqwdpd",
+                  "versionId": "w4hqx26h",
                   "types": ["Original"],
                   "duration": 3330,
                   "durationISO8601": "PT55M30S",
@@ -460,10 +493,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591504170000,
-                  "availableFrom": 1588908600000
+                  "availableUntil": 1609046970000,
+                  "availableFrom": 1606451400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -477,8 +513,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1606435200000,
             "brand": { "pid": "p0340vyx", "title": "چشم انداز بامدادی" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct0s2p",
+            "id": "urn:bbc:ares:ws_media:page:bbc_persian_radio/w3ct1cl4",
             "type": "ws_radio"
           }
         ]

--- a/data/sinhala/bbc_sinhala_radio/w172x8zn8th1lwb.json
+++ b/data/sinhala/bbc_sinhala_radio/w172x8zn8th1lwb.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_sinhala_radio",
     "language": "si",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608294845217,
     "firstPublished": 1582561533000,
     "lastPublished": 1582561533000,
     "timestamp": 1582561533000,
@@ -18,15 +18,15 @@
       "producer": "SINHALA"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "බීබීසී සිරස ඔස්සේ",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x8zn8th1lwb",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
     "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172x8zn8th1lwb",
     "type": "ws_radio"
@@ -83,6 +88,428 @@
       "uri": "/sinhala",
       "type": "simple"
     },
-    "groups": [{ "type": "other-episode", "promos": [] }]
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgxxcx219", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgxxcx219",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "17/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwx69t4j7",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610815500000,
+                  "availableFrom": 1608223500000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1608163200000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgxxcx219",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgxxct546", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgxxct546",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "16/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwx69q7m4",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610729100000,
+                  "availableFrom": 1608137100000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1608076800000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgxxct546",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgxxcq873", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgxxcq873",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "15/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwx69mbq1",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610642700000,
+                  "availableFrom": 1608050700000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607990400000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgxxcq873",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgxxcmcb0", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgxxcmcb0",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "14/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwx69jfsy",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610556300000,
+                  "availableFrom": 1607964300000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607904000000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgxxcmcb0",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgkn26tbk", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgkn26tbk",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "11/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwjy03wth",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610297100000,
+                  "availableFrom": 1607705100000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607644800000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgkn26tbk",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgkn23xfg", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgkn23xfg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "10/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwjy00zxd",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610210700000,
+                  "availableFrom": 1607618700000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607558400000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgkn23xfg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgkn210jc", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgkn210jc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "09/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwjxzy309",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610124300000,
+                  "availableFrom": 1607532300000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607472000000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgkn210jc",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "බීබීසී සිරස ඔස්සේ" },
+            "locators": { "pid": "w172xpbgkn1y3m8", "brandPid": "p0341109" },
+            "media": {
+              "id": "w172xpbgkn1y3m8",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "08/12/2020 GMT",
+              "synopses": {
+                "short": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය",
+                "medium": "සිරස ගුවන් විදුලිය ඔස්සේ ගුවන් ගන්නා බීබීසී සිංහල පුවත් සංග්‍රහය"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "w1mshwdwjxzv636",
+                  "types": ["Original"],
+                  "duration": 300,
+                  "durationISO8601": "PT5M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": false,
+                    "nonUk": false,
+                    "world": true
+                  },
+                  "availableUntil": 1610037900000,
+                  "availableFrom": 1607445900000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08b24pq.png",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1607385600000,
+            "brand": { "pid": "p0341109", "title": "බීබීසී සිරස ඔස්සේ" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_sinhala_radio/w172xpbgkn1y3m8",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/data/somali/bbc_somali_radio/w172x90wfxd2qh4.json
+++ b/data/somali/bbc_somali_radio/w172x90wfxd2qh4.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_somali_radio",
     "language": "so",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608294988841,
     "firstPublished": 1582565117000,
     "lastPublished": 1582565117000,
     "timestamp": 1582565117000,
@@ -18,15 +18,15 @@
       "producer": "SOMALI"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Caawa Iyo Caalamka",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x90wfxd2qh4",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p034117l", "title": "Caawa Iyo Caalamka" },
     "id": "urn:bbc:ares:ws_media:page:bbc_somali_radio/w172x90wfxd2qh4",
     "type": "ws_radio"

--- a/data/swahili/bbc_swahili_radio/w172x94ky63591m.json
+++ b/data/swahili/bbc_swahili_radio/w172x94ky63591m.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_swahili_radio",
     "language": "sw",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608295189657,
     "firstPublished": 1582557978000,
     "lastPublished": 1582557978000,
     "timestamp": 1582557978000,
@@ -18,15 +18,15 @@
       "producer": "SWAHILI"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Dira Ya Dunia",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x94ky63591m",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
     "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172x94ky63591m",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtkn3jnxd5", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbzgh9h4c", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtkn3jnxd5",
+              "id": "w172xpfbzgh9h4c",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqn77bzj08",
+                  "versionId": "w1mshwhryrf6km9",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592065770000,
-                  "availableFrom": 1589473770000
+                  "availableUntil": 1610814570000,
+                  "availableFrom": 1608222570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jnxd5",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbzgh9h4c",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtkn3jl0h2", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbzgh6l78", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtkn3jl0h2",
+              "id": "w172xpfbzgh6l78",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqn77bwm35",
+                  "versionId": "w1mshwhryrf3nq6",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591979370000,
-                  "availableFrom": 1589387370000
+                  "availableUntil": 1610728170000,
+                  "availableFrom": 1608136170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jl0h2",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbzgh6l78",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtkn3jh3kz", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbzgh3pb5", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtkn3jh3kz",
+              "id": "w172xpfbzgh3pb5",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqn77bsq62",
+                  "versionId": "w1mshwhryrf0rt3",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591892970000,
-                  "availableFrom": 1589300970000
+                  "availableUntil": 1610641770000,
+                  "availableFrom": 1608049770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jh3kz",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbzgh3pb5",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtkn3jd6nw", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbzgh0sf2", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtkn3jd6nw",
+              "id": "w172xpfbzgh0sf2",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqn77bpt8z",
+                  "versionId": "w1mshwhryrdxvx0",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591806570000,
-                  "availableFrom": 1589214570000
+                  "availableUntil": 1610555370000,
+                  "availableFrom": 1607963370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtkn3jd6nw",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbzgh0sf2",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtk8v6znpf", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbm65m7fm", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtk8v6znpf",
+              "id": "w172xpfbm65m7fm",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqmvz1989j",
+                  "versionId": "w1mshwhrlh3j9xk",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591547370000,
-                  "availableFrom": 1588955370000
+                  "availableUntil": 1610296170000,
+                  "availableFrom": 1607704170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6znpf",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbm65m7fm",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtk8v6wrsb", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbm65jbjj", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtk8v6wrsb",
+              "id": "w172xpfbm65jbjj",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqmvz16cdf",
+                  "versionId": "w1mshwhrlh3ff0g",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591460970000,
-                  "availableFrom": 1588868970000
+                  "availableUntil": 1610209770000,
+                  "availableFrom": 1607617770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6wrsb",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbm65jbjj",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtk8v6svw7", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbm65ffmf", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtk8v6svw7",
+              "id": "w172xpfbm65ffmf",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqmvz13ghb",
+                  "versionId": "w1mshwhrlh3bj3c",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591374570000,
-                  "availableFrom": 1588782570000
+                  "availableUntil": 1610123370000,
+                  "availableFrom": 1607531370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6svw7",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbm65ffmf",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Dira Ya Dunia" },
-            "locators": { "pid": "w172xjtk8v6pyz4", "brandPid": "p03411ml" },
+            "locators": { "pid": "w172xpfbm65bjqb", "brandPid": "p03411ml" },
             "media": {
-              "id": "w172xjtk8v6pyz4",
+              "id": "w172xpfbm65bjqb",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
                 "short": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki",
                 "medium": "Kipindi cha habari, makala na mahojiano cha kila siku kuanzia saa kumi na mbili unusu jioni Afrika Mashariki"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpqmvz10kl7",
+                  "versionId": "w1mshwhrlh37m68",
                   "types": ["Original"],
                   "duration": 3600,
                   "durationISO8601": "PT1H",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591288170000,
-                  "availableFrom": 1588696170000
+                  "availableUntil": 1610036970000,
+                  "availableFrom": 1607444970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": { "pid": "p03411ml", "title": "Dira Ya Dunia" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xjtk8v6pyz4",
+            "id": "urn:bbc:ares:ws_media:page:bbc_swahili_radio/w172xpfbm65bjqb",
             "type": "ws_radio"
           }
         ]

--- a/data/tamil/bbc_tamil_radio/w172x966tn9jwmh.json
+++ b/data/tamil/bbc_tamil_radio/w172x966tn9jwmh.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_tamil_radio",
     "language": "ta",
-    "lastUpdated": 1589529870679,
+    "lastUpdated": 1608295359992,
     "firstPublished": 1582557978000,
     "lastPublished": 1582557978000,
     "timestamp": 1582557978000,
@@ -18,15 +18,15 @@
       "producer": "TAMIL"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "பிபிசி தமிழோசை செய்தியறிக்கை",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x966tn9jwmh",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "p03412jh", "title": "பிபிசி தமிழோசை செய்தியறிக்கை" },
     "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172x966tn9jwmh",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
-            "locators": { "pid": "w172xjw6jkr1hz1", "brandPid": "p03412jh" },
+            "locators": { "pid": "w172xpgzvxpp2q7", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172xjw6jkr1hz1",
+              "id": "w172xpgzvxpp2q7",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshps93pkc3l4",
+                  "versionId": "w1mshwkhd2pg319",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1590075000000,
-                  "availableFrom": 1589470200000
+                  "availableUntil": 1608823800000,
+                  "availableFrom": 1608219000000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,21 +139,22 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkr1hz1",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xpgzvxpp2q7",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
-            "locators": { "pid": "w172xjw6jkqym1y", "brandPid": "p03412jh" },
+            "locators": { "pid": "w172xpgzvxpl5t4", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172xjw6jkqym1y",
+              "id": "w172xpgzvxpl5t4",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
@@ -155,7 +164,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshps93pk86p1",
+                  "versionId": "w1mshwkhd2pc646",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -165,10 +174,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589988600000,
-                  "availableFrom": 1589383800000
+                  "availableUntil": 1608737400000,
+                  "availableFrom": 1608132600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -182,21 +194,22 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqym1y",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xpgzvxpl5t4",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
-            "locators": { "pid": "w172xjw6jkqvq4v", "brandPid": "p03412jh" },
+            "locators": { "pid": "w172xpgzvxph8x1", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172xjw6jkqvq4v",
+              "id": "w172xpgzvxph8x1",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
@@ -206,7 +219,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshps93pk59ry",
+                  "versionId": "w1mshwkhd2p8973",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -216,10 +229,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589902200000,
-                  "availableFrom": 1589297400000
+                  "availableUntil": 1608651000000,
+                  "availableFrom": 1608046200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -233,21 +249,22 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqvq4v",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xpgzvxph8x1",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
-            "locators": { "pid": "w172xjw6jkqrt7r", "brandPid": "p03412jh" },
+            "locators": { "pid": "w172xpgzvxpdczy", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172xjw6jkqrt7r",
+              "id": "w172xpgzvxpdczy",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
@@ -257,7 +274,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshps93pk2dvv",
+                  "versionId": "w1mshwkhd2p5db0",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -267,10 +284,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589815800000,
-                  "availableFrom": 1589211000000
+                  "availableUntil": 1608564600000,
+                  "availableFrom": 1607959800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -284,21 +304,22 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw6jkqrt7r",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xpgzvxpdczy",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "பிபிசி தமிழோசை செய்தியறிக்கை" },
-            "locators": { "pid": "w172xjw659fc889", "brandPid": "p03412jh" },
+            "locators": { "pid": "w172xpgzhnczv0h", "brandPid": "p03412jh" },
             "media": {
-              "id": "w172xjw659fc889",
+              "id": "w172xpgzhnczv0h",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி",
                 "medium": "வார நாட்களில் மட்டும் ஒலிபரப்பாகும் ஐந்து நிமிட உலகச் செய்தியறிக்கை. ஒலிபரப்பாகும் நேரம் 1525 - 1530 ஜிஎம்டி"
@@ -308,7 +329,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshps8rf7nvwd",
+                  "versionId": "w1mshwkh0tcrvbk",
                   "types": ["Original"],
                   "duration": 300,
                   "durationISO8601": "PT5M",
@@ -318,10 +339,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1589556600000,
-                  "availableFrom": 1588951800000
+                  "availableUntil": 1608305400000,
+                  "availableFrom": 1607700600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -335,11 +359,12 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": {
               "pid": "p03412jh",
               "title": "பிபிசி தமிழோசை செய்தியறிக்கை"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xjw659fc889",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tamil_radio/w172xpgzhnczv0h",
             "type": "ws_radio"
           }
         ]

--- a/data/tigrinya/bbc_tigrinya_radio/w3cszzz1.json
+++ b/data/tigrinya/bbc_tigrinya_radio/w3cszzz1.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_tigrinya_radio",
     "language": "ti",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608295508348,
     "firstPublished": 1582568719000,
     "lastPublished": 1582568719000,
     "timestamp": 1582568719000,
@@ -18,27 +18,29 @@
       "producer": "TIGRINYA"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ",
-    "releaseDateTimeStamp": 1583452800000
+    "releaseDateTimeStamp": 1583452800000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w3cszzz1",
         "subType": "episode",
         "format": "Audio",
         "title": "06/03/2020 GMT",
         "synopses": {
-          "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-          "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+          "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+          "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
         },
         "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -52,13 +54,15 @@
       "format": "Audio",
       "title": "06/03/2020 GMT",
       "synopses": {
-        "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-        "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+        "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+        "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
       },
       "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583452800000,
     "brand": { "pid": "w13xttny", "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
     "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3cszzz1",
     "type": "ws_radio"
@@ -89,22 +94,22 @@
         "promos": [
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p52", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0ycz", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p52",
+              "id": "w3ct0ycz",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw80h",
+                  "versionId": "w4hqwmfr",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592083470000,
-                  "availableFrom": 1589480670000
+                  "availableUntil": 1610832270000,
+                  "availableFrom": 1608229470000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,31 +139,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p52",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0ycz",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p7b", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0yg7", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p7b",
+              "id": "w3ct0yg7",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw82r",
+                  "versionId": "w4hqwmj0",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -165,10 +174,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591997070000,
-                  "availableFrom": 1589394270000
+                  "availableUntil": 1610745870000,
+                  "availableFrom": 1608143070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -182,31 +194,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p7b",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0yg7",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p66", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0yf3", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p66",
+              "id": "w3ct0yf3",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw81m",
+                  "versionId": "w4hqwmgw",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -216,10 +229,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591910670000,
-                  "availableFrom": 1589307870000
+                  "availableUntil": 1610659470000,
+                  "availableFrom": 1608056670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -233,31 +249,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p66",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0yf3",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p3y", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0ybv", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p3y",
+              "id": "w3ct0ybv",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw7zc",
+                  "versionId": "w4hqwmdm",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -267,10 +284,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591824270000,
-                  "availableFrom": 1589221470000
+                  "availableUntil": 1610573070000,
+                  "availableFrom": 1607970270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -284,31 +304,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p3y",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0ybv",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p2s", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0y9p", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p2s",
+              "id": "w3ct0y9p",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw7y6",
+                  "versionId": "w4hqwmcg",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -318,10 +339,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591565070000,
-                  "availableFrom": 1588962270000
+                  "availableUntil": 1610313870000,
+                  "availableFrom": 1607711070000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -335,31 +359,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p2s",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0y9p",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p51", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0ycy", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p51",
+              "id": "w3ct0ycy",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw80g",
+                  "versionId": "w4hqwmfq",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -369,10 +394,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591478670000,
-                  "availableFrom": 1588875870000
+                  "availableUntil": 1610227470000,
+                  "availableFrom": 1607624670000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -386,31 +414,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p51",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0ycy",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p79", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0yg6", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p79",
+              "id": "w3ct0yg6",
               "subType": "episode",
               "format": "Audio",
-              "title": "06/05/2020 GMT",
+              "title": "09/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw82q",
+                  "versionId": "w4hqwmhz",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -420,10 +449,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591392270000,
-                  "availableFrom": 1588789470000
+                  "availableUntil": 1610141070000,
+                  "availableFrom": 1607538270000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -437,31 +469,32 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607472000000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p79",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0yg6",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ" },
-            "locators": { "pid": "w3ct0p65", "brandPid": "w13xttny" },
+            "locators": { "pid": "w3ct0yf2", "brandPid": "w13xttny" },
             "media": {
-              "id": "w3ct0p65",
+              "id": "w3ct0yf2",
               "subType": "episode",
               "format": "Audio",
-              "title": "05/05/2020 GMT",
+              "title": "08/12/2020 GMT",
               "synopses": {
-                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
-                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
+                "short": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም",
+                "medium": "ናይ 15 ደቒቕ ዜናን እዋናዊ ዛዕባታትን ዝሽፍን ፕሮግራም"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08b8p12.png",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w4hqw81l",
+                  "versionId": "w4hqwmgv",
                   "types": ["Original"],
                   "duration": 883,
                   "durationISO8601": "PT14M43S",
@@ -471,10 +504,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591305870000,
-                  "availableFrom": 1588703070000
+                  "availableUntil": 1610054670000,
+                  "availableFrom": 1607451870000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -488,11 +524,12 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607385600000,
             "brand": {
               "pid": "w13xttny",
               "title": "ቢቢሲ ትግርኛ ዜና / ዜና፡ ካብ ቢቢሲ ትግርኛ"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0p65",
+            "id": "urn:bbc:ares:ws_media:page:bbc_tigrinya_radio/w3ct0yf2",
             "type": "ws_radio"
           }
         ]

--- a/data/urdu/bbc_urdu_radio/w172x9dx052c8sr.json
+++ b/data/urdu/bbc_urdu_radio/w172x9dx052c8sr.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_urdu_radio",
     "language": "ur",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608295667463,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
     "timestamp": 1583569000000,
@@ -18,15 +18,15 @@
       "producer": "URDU"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "بی بی سی اردو نیوز بلیٹن",
-    "releaseDateTimeStamp": 1583539200000
+    "releaseDateTimeStamp": 1583539200000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x9dx052c8sr",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583539200000,
     "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
     "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172x9dx052c8sr",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r81vh", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl903716", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r81vh",
+              "id": "w172xphdl903716",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "18/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -104,7 +109,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kkngl",
+                  "versionId": "w1mshwkx3fzw7c8",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -114,10 +119,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592057400000,
-                  "availableFrom": 1589465400000
+                  "availableUntil": 1610885400000,
+                  "availableFrom": 1608293400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608249600000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r81vh",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl903716",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r7y3c", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl900kmc", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r7y3c",
+              "id": "w172xphdl900kmc",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -152,7 +161,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kkjqg",
+                  "versionId": "w1mshwkx3fzskyf",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -162,10 +171,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592053800000,
-                  "availableFrom": 1589461800000
+                  "availableUntil": 1610806200000,
+                  "availableFrom": 1608214200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r7y3c",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl900kmc",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r7tc7", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl900fw7", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r7tc7",
+              "id": "w172xphdl900fw7",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -200,7 +213,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kkdzb",
+                  "versionId": "w1mshwkx3fzsg69",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -210,10 +223,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592050200000,
-                  "availableFrom": 1589458200000
+                  "availableUntil": 1610802600000,
+                  "availableFrom": 1608210600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r7tc7",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl900fw7",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r54yd", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl900b43", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r54yd",
+              "id": "w172xphdl900b43",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -248,7 +265,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kgrkh",
+                  "versionId": "w1mshwkx3fzsbg5",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -258,10 +275,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591971000000,
-                  "availableFrom": 1589379000000
+                  "availableUntil": 1610799000000,
+                  "availableFrom": 1608207000000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r54yd",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl900b43",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r5168", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl8zxnq8", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r5168",
+              "id": "w172xphdl8zxnq8",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kgmtc",
+                  "versionId": "w1mshwkx3fzpp1b",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591967400000,
-                  "availableFrom": 1589375400000
+                  "availableUntil": 1610719800000,
+                  "availableFrom": 1608127800000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r5168",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl8zxnq8",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r4xg4", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl8zxjz4", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r4xg4",
+              "id": "w172xphdl8zxjz4",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kgj27",
+                  "versionId": "w1mshwkx3fzpk96",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591963800000,
-                  "availableFrom": 1589371800000
+                  "availableUntil": 1610716200000,
+                  "availableFrom": 1608124200000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r4xg4",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl8zxjz4",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r2819", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl8zxf70", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r2819",
+              "id": "w172xphdl8zxf70",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -392,7 +421,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kcvnd",
+                  "versionId": "w1mshwkx3fzpfk2",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -402,10 +431,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591884600000,
-                  "availableFrom": 1589292600000
+                  "availableUntil": 1610712600000,
+                  "availableFrom": 1608120600000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r2819",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl8zxf70",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "بی بی سی اردو نیوز بلیٹن" },
-            "locators": { "pid": "w172xjzxd3r2495", "brandPid": "p03413l5" },
+            "locators": { "pid": "w172xphdl8ztrt5", "brandPid": "p03413l5" },
             "media": {
-              "id": "w172xjzxd3r2495",
+              "id": "w172xphdl8ztrt5",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن",
                 "medium": "دن بھر کی اہم خبروں پر مشتمل دس منٹ دورانیے کے بی بی سی اردو کے نیوز بلیٹن"
@@ -440,7 +473,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpwzz7kcqx8",
+                  "versionId": "w1mshwkx3fzls47",
                   "types": ["Original"],
                   "duration": 600,
                   "durationISO8601": "PT10M",
@@ -450,10 +483,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591881000000,
-                  "availableFrom": 1589289000000
+                  "availableUntil": 1610633400000,
+                  "availableFrom": 1608041400000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p03413l5", "title": "بی بی سی اردو نیوز بلیٹن" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xjzxd3r2495",
+            "id": "urn:bbc:ares:ws_media:page:bbc_urdu_radio/w172xphdl8ztrt5",
             "type": "ws_radio"
           }
         ]

--- a/data/uzbek/bbc_uzbek_radio/w172x9f9qjcq3lm.json
+++ b/data/uzbek/bbc_uzbek_radio/w172x9f9qjcq3lm.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_uzbek_radio",
     "language": "uz",
-    "lastUpdated": 1589529753485,
+    "lastUpdated": 1608295797610,
     "firstPublished": 1583569000000,
     "lastPublished": 1583569000000,
     "timestamp": 1583569000000,
@@ -18,15 +18,15 @@
       "producer": "UZBEK"
     },
     "tags": {},
-    "version": "v1.3.0",
+    "version": "v1.3.11",
     "blockTypes": ["media"],
     "title": "Би-би-си Афғонистон учун",
-    "releaseDateTimeStamp": 1583539200000
+    "releaseDateTimeStamp": 1583539200000,
+    "atiAnalytics": {}
   },
   "content": {
     "blocks": [
       {
-        "availability": "notAvailable",
         "id": "w172x9f9qjcq3lm",
         "subType": "episode",
         "format": "Audio",
@@ -39,6 +39,8 @@
         "embedding": false,
         "advertising": false,
         "versions": [],
+        "availability": "notAvailable",
+        "smpKind": "radioProgramme",
         "type": "media"
       }
     ]
@@ -59,6 +61,8 @@
       "embedding": false,
       "advertising": false,
       "versions": [],
+      "availability": "notAvailable",
+      "smpKind": "radioProgramme",
       "type": "media"
     },
     "indexImage": {
@@ -72,6 +76,7 @@
       "copyrightHolder": null,
       "type": "image"
     },
+    "releaseDateTimestamp": 1583539200000,
     "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
     "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172x9f9qjcq3lm",
     "type": "ws_radio"
@@ -89,12 +94,12 @@
         "promos": [
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk0b3h1ln53", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3ddqt205m", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk0b3h1ln53",
+              "id": "w172xq3ddqt205m",
               "subType": "episode",
               "format": "Audio",
-              "title": "14/05/2020 GMT",
+              "title": "17/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -104,20 +109,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdplvx7s6",
+                  "versionId": "w1mshx5wxwsv0hp",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1592056770000,
-                  "availableFrom": 1589464770000
+                  "availableUntil": 1610805570000,
+                  "availableFrom": 1608213570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -131,18 +139,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608163200000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1ln53",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3ddqt205m",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk0b3h1hr80", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3ddqsz38j", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk0b3h1hr80",
+              "id": "w172xq3ddqsz38j",
               "subType": "episode",
               "format": "Audio",
-              "title": "13/05/2020 GMT",
+              "title": "16/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -152,20 +161,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdplvtbw3",
+                  "versionId": "w1mshx5wxwsr3ll",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591970370000,
-                  "availableFrom": 1589378370000
+                  "availableUntil": 1610719170000,
+                  "availableFrom": 1608127170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -179,18 +191,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1608076800000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1hr80",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3ddqsz38j",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk0b3h1dvbx", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3ddqsw6cf", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk0b3h1dvbx",
+              "id": "w172xq3ddqsw6cf",
               "subType": "episode",
               "format": "Audio",
-              "title": "12/05/2020 GMT",
+              "title": "15/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -200,20 +213,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdplvqfz0",
+                  "versionId": "w1mshx5wxwsn6ph",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591883970000,
-                  "availableFrom": 1589291970000
+                  "availableUntil": 1610632770000,
+                  "availableFrom": 1608040770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -227,18 +243,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607990400000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h1dvbx",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3ddqsw6cf",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk0b3h19yft", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3ddqss9gb", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk0b3h19yft",
+              "id": "w172xq3ddqss9gb",
               "subType": "episode",
               "format": "Audio",
-              "title": "11/05/2020 GMT",
+              "title": "14/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -248,20 +265,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdplvmk1x",
+                  "versionId": "w1mshx5wxwsk9sd",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591797570000,
-                  "availableFrom": 1589205570000
+                  "availableUntil": 1610546370000,
+                  "availableFrom": 1607954370000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -275,18 +295,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607904000000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk0b3h19yft",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3ddqss9gb",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk09r6r368k", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xqxbhttnck9", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk09r6r368k",
+              "id": "w172xqxbhttnck9",
               "subType": "episode",
               "format": "Audio",
-              "title": "10/05/2020 GMT",
+              "title": "13/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -296,7 +317,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdbbkdswn",
+                  "versionId": "w1mshy0jv1gw6p1",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -306,10 +327,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591711170000,
-                  "availableFrom": 1589119170000
+                  "availableUntil": 1610459970000,
+                  "availableFrom": 1607867970000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -323,18 +347,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607817600000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6r368k",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xqxbhttnck9",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk09r6r09cg", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xqxbhttkgn6", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk09r6r09cg",
+              "id": "w172xqxbhttkgn6",
               "subType": "episode",
               "format": "Audio",
-              "title": "09/05/2020 GMT",
+              "title": "12/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -344,7 +369,7 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdbbk9wzk",
+                  "versionId": "w1mshy0jv1gs9ry",
                   "types": ["Original"],
                   "duration": 1800,
                   "durationISO8601": "PT30M",
@@ -354,10 +379,13 @@
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591624770000,
-                  "availableFrom": 1589032770000
+                  "availableUntil": 1610373570000,
+                  "availableFrom": 1607781570000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -371,18 +399,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607731200000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6r09cg",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xqxbhttkgn6",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk09r6qxdgc", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3d1ghcrgw", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk09r6qxdgc",
+              "id": "w172xq3d1ghcrgw",
               "subType": "episode",
               "format": "Audio",
-              "title": "08/05/2020 GMT",
+              "title": "11/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -392,20 +421,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdbbk702g",
+                  "versionId": "w1mshx5wkmh4rsy",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591538370000,
-                  "availableFrom": 1588946370000
+                  "availableUntil": 1610287170000,
+                  "availableFrom": 1607695170000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -419,18 +451,19 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607644800000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6qxdgc",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3d1ghcrgw",
             "type": "ws_radio"
           },
           {
             "headlines": { "headline": "Би-би-си Афғонистон учун" },
-            "locators": { "pid": "w172xk09r6qthk8", "brandPid": "p03414fb" },
+            "locators": { "pid": "w172xq3d1gh8vks", "brandPid": "p03414fb" },
             "media": {
-              "id": "w172xk09r6qthk8",
+              "id": "w172xq3d1gh8vks",
               "subType": "episode",
               "format": "Audio",
-              "title": "07/05/2020 GMT",
+              "title": "10/12/2020 GMT",
               "synopses": {
                 "short": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари",
                 "medium": "Би-би-си ўзбек хизматининг Афғонистон учун янгиликлари ва хабарлари"
@@ -440,20 +473,23 @@
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "w1mshpxdbbk435c",
+                  "versionId": "w1mshx5wkmh1vwv",
                   "types": ["Original"],
-                  "duration": 1800,
-                  "durationISO8601": "PT30M",
+                  "duration": 870,
+                  "durationISO8601": "PT14M30S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": false,
                     "nonUk": false,
                     "world": true
                   },
-                  "availableUntil": 1591451970000,
-                  "availableFrom": 1588859970000
+                  "availableUntil": 1610200770000,
+                  "availableFrom": 1607608770000,
+                  "availabilityStatus": "available"
                 }
               ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
               "type": "media"
             },
             "indexImage": {
@@ -467,8 +503,9 @@
               "copyrightHolder": null,
               "type": "image"
             },
+            "releaseDateTimestamp": 1607558400000,
             "brand": { "pid": "p03414fb", "title": "Би-би-си Афғонистон учун" },
-            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xk09r6qthk8",
+            "id": "urn:bbc:ares:ws_media:page:bbc_uzbek_radio/w172xq3d1gh8vks",
             "type": "ws_radio"
           }
         ]

--- a/data/zhongwen/bbc_cantonese_radio/w172xf3r5x8hw4v.json
+++ b/data/zhongwen/bbc_cantonese_radio/w172xf3r5x8hw4v.json
@@ -5,7 +5,7 @@
     "type": "WSRADIO",
     "createdBy": "bbc_cantonese_radio",
     "language": "zh",
-    "lastUpdated": 1608208707519,
+    "lastUpdated": 1608296048166,
     "firstPublished": 1591488372000,
     "lastPublished": 1591488372000,
     "timestamp": 1591488372000,


### PR DESCRIPTION

**Overall change:**

Updated the On Demand Radio fixture data to include the recent episodes data, so local tests can run on the recent episodes component. Allowed the local tests to run on local.

The fixture data covers the three test scenarios:
Multiple episodes
One episode
No episodes

**Code changes:**

Updated fixture data.
Removed if clause that that stopped the recent episodes component tests running locally.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Passes all on local