### PR TITLE
Reinstate Cypress CI script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:storybook": "build-storybook -s .storybook/static -c .storybook -o storybook_dist",
     "build:test": "cp envConfig/test.env .env && NODE_ENV=production webpack",
     "build:test:debug": "rm -rf build && awk '{sub(/LOG_DIR=.+/,\"LOG_DIR='log'\")}1' envConfig/test.env > .env && NODE_ENV=production webpack",
+    "cypress:ci": "rm -rf cypress/results; xvfb-run -a cypress run --reporter cypress-multi-reporters --reporter-options configFile=cypress/reporter-config.json",
     "cypress": "cypress run",
     "cypress:interactive": "cypress open",
     "cypress:3rdParty": "npm run cypress -- --project ./3rdPartyCypress/.",


### PR DESCRIPTION
**Overall change:**
Following the merge of https://github.com/bbc/simorgh/pull/8567 it was found that our scheduled E2Es rely on the `cypress:ci` script to run: https://github.com/bbc/simorgh/blob/latest/codebuild/e2e_buildspec.yml#L17

This PR reinstates that command temporarily to get scheduled E2Es working again; I will follow-up with a solution consistent with how our smoke E2Es run in our CD pipeline

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
