### PR TITLE
Pin Consent Banner to bottom of viewport

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`defaultPageWrapper should render default page wrapper with children 1`] = `
-.emotion-206 {
+.emotion-208 {
   min-height: 100vh;
   display: -webkit-box;
   display: -webkit-flex;
@@ -17,7 +17,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   background-color: #FDFDFD;
 }
 
-.emotion-24 {
+.emotion-26 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -26,13 +26,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:25rem) {
-  .emotion-24 {
+  .emotion-26 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-24 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -54,12 +54,12 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-22 {
+  .emotion-24 {
     display: block;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: inline-block;
   width: 100%;
   max-width: 10.496849999999998rem;
@@ -71,12 +71,12 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   box-sizing: content-box;
   color: #FFFFFF;
   fill: currentColor;
@@ -93,34 +93,34 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:25rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1rem;
     padding-bottom: 0.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1.25rem;
     padding-bottom: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active),print {
-  .emotion-14 {
+  .emotion-16 {
     fill: windowText;
   }
 }
 
-.emotion-19:hover .emotion-14,
-.emotion-19:focus .emotion-14 {
+.emotion-21:hover .emotion-16,
+.emotion-21:focus .emotion-16 {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.25rem solid #FFFFFF;
   margin-bottom: -0.25rem;
 }
 
-.emotion-16 {
+.emotion-18 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -132,7 +132,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -155,20 +155,20 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-20:focus {
+.emotion-22:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
@@ -180,38 +180,38 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:25rem) {
-  .emotion-20:focus {
+  .emotion-22:focus {
     top: 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     padding: 0.5rem;
   }
 }
 
-.emotion-132 {
+.emotion-134 {
   position: relative;
   background-color: #B80000;
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.emotion-132 .emotion-35::after {
+.emotion-134 .emotion-37::after {
   left: 0;
 }
 
-.emotion-130 {
+.emotion-132 {
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.emotion-80 {
+.emotion-82 {
   position: relative;
 }
 
-.emotion-30 {
+.emotion-32 {
   position: relative;
   padding: 0;
   margin: 0;
@@ -222,14 +222,14 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   width: 2.75rem;
 }
 
-.emotion-30:hover,
-.emotion-30:focus {
+.emotion-32:hover,
+.emotion-32:focus {
   cursor: pointer;
   box-shadow: inset 0 0 0 0.25rem #FFFFFF;
 }
 
-.emotion-30:hover::after,
-.emotion-30:focus::after {
+.emotion-32:hover::after,
+.emotion-32:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -240,30 +240,30 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:37.5rem) {
-  .emotion-30 {
+  .emotion-32 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) {
-  .emotion-30 {
+  .emotion-32 {
     height: 2.75rem;
     width: 2.75rem;
   }
 }
 
-.emotion-30 svg {
+.emotion-32 svg {
   vertical-align: middle;
 }
 
-.emotion-26 {
+.emotion-28 {
   color: #fff;
   fill: currentColor;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-78 {
+  .emotion-80 {
     white-space: nowrap;
     overflow-x: scroll;
     -webkit-scroll-behavior: auto;
@@ -278,11 +278,11 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
     -ms-overflow-style: none;
   }
 
-  .emotion-78::-webkit-scrollbar {
+  .emotion-80::-webkit-scrollbar {
     display: none;
   }
 
-  .emotion-78:after {
+  .emotion-80:after {
     content: ' ';
     height: 100%;
     width: 3rem;
@@ -296,13 +296,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   }
 
 @media (min-width:25rem) {
-    .emotion-78:after {
+    .emotion-80:after {
       width: 6rem;
     }
 }
 }
 
-.emotion-76 {
+.emotion-78 {
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -310,25 +310,25 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:37.5rem) {
-  .emotion-76 {
+  .emotion-78 {
     overflow: hidden;
   }
 }
 
-.emotion-34 {
+.emotion-36 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-34:last-child {
+  .emotion-36:last-child {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-34::after {
+  .emotion-36::after {
     content: '';
     position: absolute;
     bottom: -1px;
@@ -338,7 +338,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   }
 }
 
-.emotion-32 {
+.emotion-34 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -353,26 +353,26 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     padding: 0.75rem 0.5rem;
   }
 }
 
-.emotion-32:hover::after {
+.emotion-34:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -381,7 +381,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.emotion-32:focus::after {
+.emotion-34:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -392,7 +392,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   border: 0.25rem solid #FFFFFF;
 }
 
-.emotion-128 {
+.emotion-130 {
   background-color: #222222;
   clear: both;
   overflow: hidden;
@@ -405,37 +405,37 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:37.5rem) {
-  .emotion-128 {
+  .emotion-130 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (prefers-reduced-motion:reduce) {
-  .emotion-128 {
+  .emotion-130 {
     -webkit-transition: none;
     transition: none;
   }
 }
 
-.emotion-126 {
+.emotion-128 {
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
   border-bottom: 0.125rem solid #3F3F42;
 }
 
-.emotion-84 {
+.emotion-86 {
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #3F3F42;
 }
 
-.emotion-84:last-child {
+.emotion-86:last-child {
   padding-bottom: 1rem;
   border: 0;
 }
 
-.emotion-82 {
+.emotion-84 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -447,33 +447,33 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-82 {
+  .emotion-84 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-82 {
+  .emotion-84 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-82:hover,
-.emotion-82:focus {
+.emotion-84:hover,
+.emotion-84:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-134 {
+.emotion-136 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.emotion-144 {
+.emotion-146 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -482,13 +482,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:25rem) {
-  .emotion-144 {
+  .emotion-146 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
-.emotion-204 {
+.emotion-206 {
   background-color: #222222;
   font-size: 0.875rem;
   line-height: 1rem;
@@ -498,36 +498,36 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (max-width:25rem) {
-  .emotion-204 {
+  .emotion-206 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width:25rem) {
-  .emotion-204 {
+  .emotion-206 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-204 {
+  .emotion-206 {
     line-height: 1.125rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-204 {
+  .emotion-206 {
     font-size: 0.8125rem;
   }
 }
 
-.emotion-202 {
+.emotion-204 {
   max-width: 80rem;
   margin: 0 auto;
   padding-top: 0.5rem);
 }
 
-.emotion-194 {
+.emotion-196 {
   border-bottom: 0.0625rem solid #3F3F42;
   list-style-type: none;
   margin: 0;
@@ -537,14 +537,14 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @supports (grid-template-columns:fit-content(200px)) {
-  .emotion-194 {
+  .emotion-196 {
     display: grid;
     grid-auto-flow: column;
   }
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-194 {
+  .emotion-196 {
     grid-auto-flow: row;
     -webkit-column-count: 1;
     column-count: 1;
@@ -552,7 +552,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:15rem) and (max-width:37.4375rem) {
-  .emotion-194 {
+  .emotion-196 {
     grid-column-gap: 0.5rem;
     grid-template-columns: repeat(2,1fr);
     grid-template-rows: repeat( 5,auto );
@@ -562,7 +562,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:37.5rem) and (max-width:62.9375rem) {
-  .emotion-194 {
+  .emotion-196 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(3,1fr);
     grid-template-rows: repeat( 4,auto );
@@ -572,7 +572,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:63rem) and (max-width:79.9375rem) {
-  .emotion-194 {
+  .emotion-196 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(4,1fr);
     grid-template-rows: repeat( 3,auto );
@@ -582,7 +582,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 @media (min-width:80rem) {
-  .emotion-194 {
+  .emotion-196 {
     grid-column-gap: 1rem;
     grid-template-columns: repeat(5,1fr);
     grid-template-rows: repeat( 3,auto );
@@ -591,7 +591,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   }
 }
 
-.emotion-194 > li:first-of-type {
+.emotion-196 > li:first-of-type {
   border-bottom: 0.0625rem solid #3F3F42;
   padding: 0.5rem 0;
   margin-bottom: 0.5rem;
@@ -601,7 +601,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   column-span: all;
 }
 
-.emotion-150 {
+.emotion-152 {
   min-width: 50%;
   -webkit-column-gap: 1rem;
   column-gap: 1rem;
@@ -609,7 +609,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   break-inside: avoid-column;
 }
 
-.emotion-148 {
+.emotion-150 {
   padding: 0.5rem 0 0.5rem;
   color: #FFFFFF;
   font-weight: 700;
@@ -618,25 +618,33 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   display: block;
 }
 
-.emotion-149:hover .emotion-146,
-.emotion-149:focus .emotion-146 {
+.emotion-151:hover .emotion-148,
+.emotion-151:focus .emotion-148 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-200 {
+.emotion-202 {
   color: #FFFFFF;
   margin: 0;
   padding: 1rem 0;
 }
 
-.emotion-198 {
+.emotion-200 {
   padding: 0.5rem 0 0.5rem;
   color: #FFFFFF;
   font-weight: 700;
   -webkit-text-decoration: none;
   text-decoration: none;
   display: inline;
+}
+
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
 }
 
 .emotion-12 {
@@ -822,72 +830,76 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
     I am the ServiceWorker component
   </p>
   <div
-    class="emotion-206 emotion-207"
+    class="emotion-208 emotion-209"
     id="main-wrapper"
   >
     <header
       role="banner"
     >
       <div
-        class="emotion-12 emotion-13"
-        dir="ltr"
+        class="emotion-14 emotion-15"
       >
         <div
-          class="emotion-10 emotion-11"
+          class="emotion-12 emotion-13"
           dir="ltr"
         >
-          <h2
-            class="emotion-0 emotion-1"
+          <div
+            class="emotion-10 emotion-11"
             dir="ltr"
           >
-            We've updated our Privacy and Cookies Policy
-          </h2>
-          <p
-            class="emotion-2 emotion-3"
-            dir="ltr"
-          >
-            We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
-          </p>
-          <ul
-            class="emotion-8 emotion-9"
-            dir="ltr"
-          >
-            <li
-              class="emotion-4 emotion-5"
+            <h2
+              class="emotion-0 emotion-1"
               dir="ltr"
             >
-              <button
-                type="button"
-              >
-                OK
-              </button>
-            </li>
-            <li
-              class="emotion-4 emotion-5"
+              We've updated our Privacy and Cookies Policy
+            </h2>
+            <p
+              class="emotion-2 emotion-3"
               dir="ltr"
             >
-              <a
-                href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+              We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
+            </p>
+            <ul
+              class="emotion-8 emotion-9"
+              dir="ltr"
+            >
+              <li
+                class="emotion-4 emotion-5"
+                dir="ltr"
               >
-                Find out what's changed
-              </a>
-            </li>
-          </ul>
+                <button
+                  type="button"
+                >
+                  OK
+                </button>
+              </li>
+              <li
+                class="emotion-4 emotion-5"
+                dir="ltr"
+              >
+                <a
+                  href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+                >
+                  Find out what's changed
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
       <div
-        class="emotion-24 emotion-25"
+        class="emotion-26 emotion-27"
       >
         <div
-          class="emotion-22 emotion-23"
+          class="emotion-24 emotion-25"
         >
           <a
-            class="emotion-18 emotion-19"
+            class="emotion-20 emotion-21"
             href="/news"
           >
             <svg
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               focusable="false"
               height="24"
               viewBox="0 0 167.95 24"
@@ -911,13 +923,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
               </g>
             </svg>
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-18 emotion-19"
             >
               BBC News
             </span>
           </a>
           <a
-            class="emotion-20 emotion-21"
+            class="emotion-22 emotion-23"
             dir="ltr"
             href="#content"
           >
@@ -926,25 +938,25 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
         </div>
       </div>
       <nav
-        class="emotion-132 emotion-133"
+        class="emotion-134 emotion-135"
         dir="ltr"
         role="navigation"
       >
         <div
-          class="emotion-130 emotion-131"
+          class="emotion-132 emotion-133"
         >
           <div
-            class="emotion-80 emotion-81"
+            class="emotion-82 emotion-83"
           >
             <button
               aria-expanded="false"
-              class="emotion-30 emotion-31"
+              class="emotion-32 emotion-33"
               dir="ltr"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="emotion-26 emotion-27"
+                class="emotion-28 emotion-29"
                 focusable="false"
                 height="2.75rem"
                 viewBox="0 0 44 44"
@@ -955,146 +967,146 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
                 />
               </svg>
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-18 emotion-19"
               >
                 Sections
               </span>
             </button>
             <div
-              class="emotion-78 emotion-79"
+              class="emotion-80 emotion-81"
               dir="ltr"
             >
               <ul
-                class="emotion-76 emotion-77"
+                class="emotion-78 emotion-79"
                 role="list"
               >
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news"
                   >
                     Home
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/uk"
                   >
                     UK
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/world"
                   >
                     World
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/business"
                   >
                     Business
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/politics"
                   >
                     Politics
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/technology"
                   >
                     Tech
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/science_and_environment"
                   >
                     Science
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/health"
                   >
                     Health
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/education"
                   >
                     Family & Education
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/entertainment_and_arts"
                   >
                     Entertainment & Arts
                   </a>
                 </li>
                 <li
-                  class="emotion-34 emotion-35"
+                  class="emotion-36 emotion-37"
                   dir="ltr"
                   role="listitem"
                 >
                   <a
-                    class="emotion-32 emotion-33"
+                    class="emotion-34 emotion-35"
                     href="/news/stories"
                   >
                     Stories
@@ -1104,129 +1116,129 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
             </div>
           </div>
           <div
-            class="emotion-128 emotion-129"
+            class="emotion-130 emotion-131"
             height="0"
           >
             <ul
-              class="emotion-126 emotion-127"
+              class="emotion-128 emotion-129"
               role="list"
             >
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news"
                 >
                   Home
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/uk"
                 >
                   UK
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/world"
                 >
                   World
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/business"
                 >
                   Business
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/politics"
                 >
                   Politics
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/technology"
                 >
                   Tech
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/science_and_environment"
                 >
                   Science
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/health"
                 >
                   Health
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/education"
                 >
                   Family & Education
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/entertainment_and_arts"
                 >
                   Entertainment & Arts
                 </a>
               </li>
               <li
-                class="emotion-84 emotion-85"
+                class="emotion-86 emotion-87"
                 role="listitem"
               >
                 <a
-                  class="emotion-82 emotion-83"
+                  class="emotion-84 emotion-85"
                   href="/news/stories"
                 >
                   Stories
@@ -1238,7 +1250,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
       </nav>
     </header>
     <div
-      class="emotion-134 emotion-135"
+      class="emotion-136 emotion-137"
     >
       <h2>
         Child element
@@ -1248,18 +1260,18 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
       role="contentinfo"
     >
       <div
-        class="emotion-144 emotion-25"
+        class="emotion-146 emotion-27"
       >
         <div
-          class="emotion-22 emotion-23"
+          class="emotion-24 emotion-25"
         >
           <a
-            class="emotion-18 emotion-19"
+            class="emotion-20 emotion-21"
             href="/news"
           >
             <svg
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-16 emotion-17"
               focusable="false"
               height="24"
               viewBox="0 0 167.95 24"
@@ -1283,7 +1295,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
               </g>
             </svg>
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-18 emotion-19"
             >
               BBC News
             </span>
@@ -1291,131 +1303,131 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
         </div>
       </div>
       <div
-        class="emotion-204 emotion-205"
+        class="emotion-206 emotion-207"
       >
         <div
-          class="emotion-202 emotion-203"
+          class="emotion-204 emotion-205"
         >
           <ul
-            class="emotion-194 emotion-195"
+            class="emotion-196 emotion-197"
             role="list"
           >
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/news/help-41670342"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Why you can trust the BBC
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/terms"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Terms of Use
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.co.uk/aboutthebbc/"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   About the BBC
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/privacy/"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Privacy Policy
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/usingthebbc/cookies/"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Cookies
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/accessibility/"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Accessibility Help
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/contact/"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   Contact the BBC
                 </span>
               </a>
             </li>
             <li
-              class="emotion-150 emotion-151"
+              class="emotion-152 emotion-153"
               role="listitem"
             >
               <a
-                class="emotion-148 emotion-149"
+                class="emotion-150 emotion-151"
                 href="https://www.bbc.com/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
                 lang="en-GB"
               >
                 <span
-                  class="emotion-146 emotion-147"
+                  class="emotion-148 emotion-149"
                 >
                   AdChoices / Do Not Sell My Info
                 </span>
@@ -1423,7 +1435,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
             </li>
           </ul>
           <p
-            class="emotion-200 emotion-201"
+            class="emotion-202 emotion-203"
           >
             <span
               lang="en-GB"
@@ -1434,11 +1446,11 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
             2021 BBC. The BBC is not responsible for the content of external sites.
              
             <a
-              class="emotion-198 emotion-149"
+              class="emotion-200 emotion-151"
               href="https://www.bbc.co.uk/help/web/links/"
             >
               <span
-                class="emotion-146 emotion-147"
+                class="emotion-148 emotion-149"
               >
                 Read about our approach to external linking.
               </span>

--- a/src/app/containers/ConsentBanner/Banner/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/containers/ConsentBanner/Banner/__snapshots__/index.canonical.test.jsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Canonical Consent Banner Container should correctly render cookie banner - LTR layout 1`] = `
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+}
+
 .emotion-12 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -178,64 +186,76 @@ exports[`Canonical Consent Banner Container should correctly render cookie banne
 
 <div>
   <div
-    class="emotion-12 emotion-13"
-    dir="ltr"
+    class="emotion-14 emotion-15"
   >
     <div
-      class="emotion-10 emotion-11"
+      class="emotion-12 emotion-13"
       dir="ltr"
     >
-      <h2
-        class="emotion-0 emotion-1"
+      <div
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
-        Let us know you agree to cookies
-      </h2>
-      <p
-        class="emotion-2 emotion-3"
-        dir="ltr"
-      >
-        We and our partners use technologies, such as 
-        <a
-          href="https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/"
-        >
-          cookies
-        </a>
-        , and collect browsing data to give you the best online experience and to personalise the content and advertising shown to you. Please let us know if you agree.
-      </p>
-      <ul
-        class="emotion-8 emotion-9"
-        dir="ltr"
-      >
-        <li
-          class="emotion-4 emotion-5"
+        <h2
+          class="emotion-0 emotion-1"
           dir="ltr"
         >
-          <button
-            data-cookie-banner="accept"
-            type="button"
-          >
-            Yes, I agree
-          </button>
-        </li>
-        <li
-          class="emotion-4 emotion-5"
+          Let us know you agree to cookies
+        </h2>
+        <p
+          class="emotion-2 emotion-3"
           dir="ltr"
         >
+          We and our partners use technologies, such as 
           <a
-            data-cookie-banner="reject"
-            href="https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+            href="https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/"
           >
-            No, take me to settings
+            cookies
           </a>
-        </li>
-      </ul>
+          , and collect browsing data to give you the best online experience and to personalise the content and advertising shown to you. Please let us know if you agree.
+        </p>
+        <ul
+          class="emotion-8 emotion-9"
+          dir="ltr"
+        >
+          <li
+            class="emotion-4 emotion-5"
+            dir="ltr"
+          >
+            <button
+              data-cookie-banner="accept"
+              type="button"
+            >
+              Yes, I agree
+            </button>
+          </li>
+          <li
+            class="emotion-4 emotion-5"
+            dir="ltr"
+          >
+            <a
+              data-cookie-banner="reject"
+              href="https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+            >
+              No, take me to settings
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Canonical Consent Banner Container should correctly render cookie banner - RTL layout 1`] = `
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+}
+
 .emotion-10 {
   max-width: 80rem;
   margin: 0 auto;
@@ -413,64 +433,76 @@ exports[`Canonical Consent Banner Container should correctly render cookie banne
 
 <div>
   <div
-    class="emotion-12 emotion-13"
-    dir="rtl"
+    class="emotion-14 emotion-15"
   >
     <div
-      class="emotion-10 emotion-11"
+      class="emotion-12 emotion-13"
       dir="rtl"
     >
-      <h2
-        class="emotion-0 emotion-1"
+      <div
+        class="emotion-10 emotion-11"
         dir="rtl"
       >
-        أخبرنا عما إذا كنت توافق على تحميل الكوكيز
-      </h2>
-      <p
-        class="emotion-2 emotion-3"
-        dir="rtl"
-      >
-        نستخدم نحن وشركاؤنا تقنيات مثل 
-        <a
-          href="https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/"
-        >
-          ملفات الارتباط
-        </a>
-        ، كما نقوم بجمع معلومات خاصة بالتصفح من أجل توفير أفضل خدمة رقمية ولجعل المحتوى والاعلانات، الموجهة إليك، شخصية. الرجاء إعلامنا إذا كنت موافقا على ذلك.
-      </p>
-      <ul
-        class="emotion-8 emotion-9"
-        dir="rtl"
-      >
-        <li
-          class="emotion-4 emotion-5"
+        <h2
+          class="emotion-0 emotion-1"
           dir="rtl"
         >
-          <button
-            data-cookie-banner="accept"
-            type="button"
-          >
-            نعم، موافق
-          </button>
-        </li>
-        <li
-          class="emotion-4 emotion-5"
+          أخبرنا عما إذا كنت توافق على تحميل الكوكيز
+        </h2>
+        <p
+          class="emotion-2 emotion-3"
           dir="rtl"
         >
+          نستخدم نحن وشركاؤنا تقنيات مثل 
           <a
-            data-cookie-banner="reject"
-            href="https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+            href="https://www.bbc.co.uk/usingthebbc/cookies/what-do-i-need-to-know-about-cookies/"
           >
-            كلا، أعدني إلى الإعدادات
+            ملفات الارتباط
           </a>
-        </li>
-      </ul>
+          ، كما نقوم بجمع معلومات خاصة بالتصفح من أجل توفير أفضل خدمة رقمية ولجعل المحتوى والاعلانات، الموجهة إليك، شخصية. الرجاء إعلامنا إذا كنت موافقا على ذلك.
+        </p>
+        <ul
+          class="emotion-8 emotion-9"
+          dir="rtl"
+        >
+          <li
+            class="emotion-4 emotion-5"
+            dir="rtl"
+          >
+            <button
+              data-cookie-banner="accept"
+              type="button"
+            >
+              نعم، موافق
+            </button>
+          </li>
+          <li
+            class="emotion-4 emotion-5"
+            dir="rtl"
+          >
+            <a
+              data-cookie-banner="reject"
+              href="https://www.bbc.co.uk/usingthebbc/cookies/how-can-i-change-my-bbc-cookie-settings/"
+            >
+              كلا، أعدني إلى الإعدادات
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Canonical Consent Banner Container should correctly render privacy banner - LTR layout 1`] = `
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+}
+
 .emotion-12 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -648,56 +680,68 @@ exports[`Canonical Consent Banner Container should correctly render privacy bann
 
 <div>
   <div
-    class="emotion-12 emotion-13"
-    dir="ltr"
+    class="emotion-14 emotion-15"
   >
     <div
-      class="emotion-10 emotion-11"
+      class="emotion-12 emotion-13"
       dir="ltr"
     >
-      <h2
-        class="emotion-0 emotion-1"
+      <div
+        class="emotion-10 emotion-11"
         dir="ltr"
       >
-        We've updated our Privacy and Cookies Policy
-      </h2>
-      <p
-        class="emotion-2 emotion-3"
-        dir="ltr"
-      >
-        We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
-      </p>
-      <ul
-        class="emotion-8 emotion-9"
-        dir="ltr"
-      >
-        <li
-          class="emotion-4 emotion-5"
+        <h2
+          class="emotion-0 emotion-1"
           dir="ltr"
         >
-          <button
-            type="button"
-          >
-            OK
-          </button>
-        </li>
-        <li
-          class="emotion-4 emotion-5"
+          We've updated our Privacy and Cookies Policy
+        </h2>
+        <p
+          class="emotion-2 emotion-3"
           dir="ltr"
         >
-          <a
-            href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+          We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.
+        </p>
+        <ul
+          class="emotion-8 emotion-9"
+          dir="ltr"
+        >
+          <li
+            class="emotion-4 emotion-5"
+            dir="ltr"
           >
-            Find out what's changed
-          </a>
-        </li>
-      </ul>
+            <button
+              type="button"
+            >
+              OK
+            </button>
+          </li>
+          <li
+            class="emotion-4 emotion-5"
+            dir="ltr"
+          >
+            <a
+              href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+            >
+              Find out what's changed
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Canonical Consent Banner Container should correctly render privacy banner - RTL layout 1`] = `
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+}
+
 .emotion-10 {
   max-width: 80rem;
   margin: 0 auto;
@@ -875,50 +919,54 @@ exports[`Canonical Consent Banner Container should correctly render privacy bann
 
 <div>
   <div
-    class="emotion-12 emotion-13"
-    dir="rtl"
+    class="emotion-14 emotion-15"
   >
     <div
-      class="emotion-10 emotion-11"
+      class="emotion-12 emotion-13"
       dir="rtl"
     >
-      <h2
-        class="emotion-0 emotion-1"
+      <div
+        class="emotion-10 emotion-11"
         dir="rtl"
       >
-        لقد حدّثنا سياستنا المتعلقة بالخصوصية وبالشروط الخاصة بملفات الارتباط Cookies
-      </h2>
-      <p
-        class="emotion-2 emotion-3"
-        dir="rtl"
-      >
-        لقد أدخلنا تغييرات مهمة على سياستنا المتعلقة بالخصوصية وعلى الشروط الخاصة بملفات الارتباط Cookies، ويهمنا أن تكونوا ملمين بما قد تعني هذه التغييرات بالنسبة لكم ولبياناتكم
-      </p>
-      <ul
-        class="emotion-8 emotion-9"
-        dir="rtl"
-      >
-        <li
-          class="emotion-4 emotion-5"
+        <h2
+          class="emotion-0 emotion-1"
           dir="rtl"
         >
-          <button
-            type="button"
-          >
-            موافق
-          </button>
-        </li>
-        <li
-          class="emotion-4 emotion-5"
+          لقد حدّثنا سياستنا المتعلقة بالخصوصية وبالشروط الخاصة بملفات الارتباط Cookies
+        </h2>
+        <p
+          class="emotion-2 emotion-3"
           dir="rtl"
         >
-          <a
-            href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+          لقد أدخلنا تغييرات مهمة على سياستنا المتعلقة بالخصوصية وعلى الشروط الخاصة بملفات الارتباط Cookies، ويهمنا أن تكونوا ملمين بما قد تعني هذه التغييرات بالنسبة لكم ولبياناتكم
+        </p>
+        <ul
+          class="emotion-8 emotion-9"
+          dir="rtl"
+        >
+          <li
+            class="emotion-4 emotion-5"
+            dir="rtl"
           >
-            إطلع على التغييرات
-          </a>
-        </li>
-      </ul>
+            <button
+              type="button"
+            >
+              موافق
+            </button>
+          </li>
+          <li
+            class="emotion-4 emotion-5"
+            dir="rtl"
+          >
+            <a
+              href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+            >
+              إطلع على التغييرات
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/containers/ConsentBanner/Banner/index.canonical.jsx
+++ b/src/app/containers/ConsentBanner/Banner/index.canonical.jsx
@@ -1,9 +1,22 @@
 import React, { useContext } from 'react';
+import styled from '@emotion/styled';
 import { func, string } from 'prop-types';
 import { ConsentBanner } from '@bbc/psammead-consent-banner';
 import { ServiceContext } from '#contexts/ServiceContext';
 import BannerText from './Text';
 import getDataAttribute from './getDataAttribute';
+
+// Styles to pin the consent banner to the bottom of the view port
+// The z-index ensures the banner is always at the front, the value of 20
+// was chosen to be higher than other absolute positioned elements such as
+// the SkipLink component: https://github.com/bbc/psammead/blob/latest/packages/components/psammead-social-embed/src/SkipLinkWrapper/index.jsx#L34
+const ConsentBannerWrapper = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
+`;
 
 const Accept = (message, onClick, dataAttribute) => {
   return (
@@ -28,24 +41,26 @@ const CanonicalConsentBannerContainer = ({ type, onReject, onAccept }) => {
   const dataAttribute = getDataAttribute(type);
 
   return (
-    <ConsentBanner
-      dir={dir}
-      title={consentBannerConfig.title}
-      text={BannerText(consentBannerConfig.description)}
-      accept={Accept(
-        consentBannerConfig.accept,
-        onAccept,
-        dataAttribute('accept'),
-      )}
-      reject={Reject(
-        consentBannerConfig.reject,
-        consentBannerConfig.rejectUrl,
-        onReject,
-        dataAttribute('reject'),
-      )}
-      script={script}
-      service={service}
-    />
+    <ConsentBannerWrapper>
+      <ConsentBanner
+        dir={dir}
+        title={consentBannerConfig.title}
+        text={BannerText(consentBannerConfig.description)}
+        accept={Accept(
+          consentBannerConfig.accept,
+          onAccept,
+          dataAttribute('accept'),
+        )}
+        reject={Reject(
+          consentBannerConfig.reject,
+          consentBannerConfig.rejectUrl,
+          onReject,
+          dataAttribute('reject'),
+        )}
+        script={script}
+        service={service}
+      />
+    </ConsentBannerWrapper>
   );
 };
 

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
-.emotion-22 {
+.emotion-24 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -23,12 +23,12 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-22 {
+  .emotion-24 {
     display: block;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: inline-block;
   width: 100%;
   max-width: 14.880600000000001rem;
@@ -40,12 +40,12 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   box-sizing: content-box;
   color: #FFFFFF;
   fill: currentColor;
@@ -62,34 +62,34 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1rem;
     padding-bottom: 0.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1.25rem;
     padding-bottom: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active),print {
-  .emotion-14 {
+  .emotion-16 {
     fill: windowText;
   }
 }
 
-.emotion-19:hover .emotion-14,
-.emotion-19:focus .emotion-14 {
+.emotion-21:hover .emotion-16,
+.emotion-21:focus .emotion-16 {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.25rem solid #FFFFFF;
   margin-bottom: -0.25rem;
 }
 
-.emotion-16 {
+.emotion-18 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -101,7 +101,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -124,20 +124,20 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-20:focus {
+.emotion-22:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
@@ -149,38 +149,38 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-20:focus {
+  .emotion-22:focus {
     top: 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     padding: 0.5rem;
   }
 }
 
-.emotion-108 {
+.emotion-110 {
   position: relative;
   background-color: #B80000;
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.emotion-108 .emotion-35::after {
+.emotion-110 .emotion-37::after {
   left: 0;
 }
 
-.emotion-106 {
+.emotion-108 {
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.emotion-68 {
+.emotion-70 {
   position: relative;
 }
 
-.emotion-30 {
+.emotion-32 {
   position: relative;
   padding: 0;
   margin: 0;
@@ -191,14 +191,14 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   width: 2.75rem;
 }
 
-.emotion-30:hover,
-.emotion-30:focus {
+.emotion-32:hover,
+.emotion-32:focus {
   cursor: pointer;
   box-shadow: inset 0 0 0 0.25rem #FFFFFF;
 }
 
-.emotion-30:hover::after,
-.emotion-30:focus::after {
+.emotion-32:hover::after,
+.emotion-32:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -209,30 +209,30 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-30 {
+  .emotion-32 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) {
-  .emotion-30 {
+  .emotion-32 {
     height: 2.75rem;
     width: 2.75rem;
   }
 }
 
-.emotion-30 svg {
+.emotion-32 svg {
   vertical-align: middle;
 }
 
-.emotion-26 {
+.emotion-28 {
   color: #fff;
   fill: currentColor;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-66 {
+  .emotion-68 {
     white-space: nowrap;
     overflow-x: scroll;
     -webkit-scroll-behavior: auto;
@@ -247,11 +247,11 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
     -ms-overflow-style: none;
   }
 
-  .emotion-66::-webkit-scrollbar {
+  .emotion-68::-webkit-scrollbar {
     display: none;
   }
 
-  .emotion-66:after {
+  .emotion-68:after {
     content: ' ';
     height: 100%;
     width: 3rem;
@@ -265,13 +265,13 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   }
 
 @media (min-width:25rem) {
-    .emotion-66:after {
+    .emotion-68:after {
       width: 6rem;
     }
 }
 }
 
-.emotion-64 {
+.emotion-66 {
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -279,25 +279,25 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-64 {
+  .emotion-66 {
     overflow: hidden;
   }
 }
 
-.emotion-34 {
+.emotion-36 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-34:last-child {
+  .emotion-36:last-child {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-34::after {
+  .emotion-36::after {
     content: '';
     position: absolute;
     bottom: -1px;
@@ -307,7 +307,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   }
 }
 
-.emotion-32 {
+.emotion-34 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -322,26 +322,26 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     padding: 0.75rem 0.5rem;
   }
 }
 
-.emotion-32:hover::after {
+.emotion-34:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -350,7 +350,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.emotion-32:focus::after {
+.emotion-34:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -361,7 +361,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
-.emotion-104 {
+.emotion-106 {
   background-color: #222222;
   clear: both;
   overflow: hidden;
@@ -374,37 +374,37 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-104 {
+  .emotion-106 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (prefers-reduced-motion:reduce) {
-  .emotion-104 {
+  .emotion-106 {
     -webkit-transition: none;
     transition: none;
   }
 }
 
-.emotion-102 {
+.emotion-104 {
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
   border-bottom: 0.125rem solid #3F3F42;
 }
 
-.emotion-72 {
+.emotion-74 {
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #3F3F42;
 }
 
-.emotion-72:last-child {
+.emotion-74:last-child {
   padding-bottom: 1rem;
   border: 0;
 }
 
-.emotion-70 {
+.emotion-72 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -416,23 +416,31 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-70:hover,
-.emotion-70:focus {
+.emotion-72:hover,
+.emotion-72:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
 }
 
 .emotion-12 {
@@ -610,7 +618,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   color: #FFFFFF;
 }
 
-.emotion-24 {
+.emotion-26 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -618,7 +626,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-24 {
+  .emotion-26 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
@@ -629,65 +637,69 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
     role="banner"
   >
     <div
-      class="emotion-12 emotion-13"
-      dir="ltr"
+      class="emotion-14 emotion-15"
     >
       <div
-        class="emotion-10 emotion-11"
+        class="emotion-12 emotion-13"
         dir="ltr"
       >
-        <h2
-          class="emotion-0 emotion-1"
+        <div
+          class="emotion-10 emotion-11"
           dir="ltr"
         >
-          We don update our Privacy and Cookies Policy
-        </h2>
-        <p
-          class="emotion-2 emotion-3"
-          dir="ltr"
-        >
-          We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
-        </p>
-        <ul
-          class="emotion-8 emotion-9"
-          dir="ltr"
-        >
-          <li
-            class="emotion-4 emotion-5"
+          <h2
+            class="emotion-0 emotion-1"
             dir="ltr"
           >
-            <button
-              type="button"
-            >
-              OK
-            </button>
-          </li>
-          <li
-            class="emotion-4 emotion-5"
+            We don update our Privacy and Cookies Policy
+          </h2>
+          <p
+            class="emotion-2 emotion-3"
             dir="ltr"
           >
-            <a
-              href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+            We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
+          </p>
+          <ul
+            class="emotion-8 emotion-9"
+            dir="ltr"
+          >
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
             >
-              Find out wetin don change
-            </a>
-          </li>
-        </ul>
+              <button
+                type="button"
+              >
+                OK
+              </button>
+            </li>
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
+            >
+              <a
+                href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+              >
+                Find out wetin don change
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div
-      class="emotion-24 emotion-25"
+      class="emotion-26 emotion-27"
     >
       <div
-        class="emotion-22 emotion-23"
+        class="emotion-24 emotion-25"
       >
         <a
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           href="/pidgin"
         >
           <svg
             aria-hidden="true"
-            class="emotion-14 emotion-15"
+            class="emotion-16 emotion-17"
             focusable="false"
             height="24"
             viewBox="0 0 238 24"
@@ -715,7 +727,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
             </g>
           </svg>
           <span
-            class="emotion-16 emotion-17"
+            class="emotion-18 emotion-19"
             role="text"
           >
             <span
@@ -728,7 +740,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
           </span>
         </a>
         <a
-          class="emotion-20 emotion-21"
+          class="emotion-22 emotion-23"
           dir="ltr"
           href="#content"
         >
@@ -737,25 +749,25 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
       </div>
     </div>
     <nav
-      class="emotion-108 emotion-109"
+      class="emotion-110 emotion-111"
       dir="ltr"
       role="navigation"
     >
       <div
-        class="emotion-106 emotion-107"
+        class="emotion-108 emotion-109"
       >
         <div
-          class="emotion-68 emotion-69"
+          class="emotion-70 emotion-71"
         >
           <button
             aria-expanded="false"
-            class="emotion-30 emotion-31"
+            class="emotion-32 emotion-33"
             dir="ltr"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="emotion-26 emotion-27"
+              class="emotion-28 emotion-29"
               focusable="false"
               height="2.75rem"
               viewBox="0 0 44 44"
@@ -766,110 +778,110 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
               />
             </svg>
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-18 emotion-19"
             >
               Plenti seshon
             </span>
           </button>
           <div
-            class="emotion-66 emotion-67"
+            class="emotion-68 emotion-69"
             dir="ltr"
           >
             <ul
-              class="emotion-64 emotion-65"
+              class="emotion-66 emotion-67"
               role="list"
             >
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin"
                 >
                   Home
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c2dwqd1zr92t"
                 >
                   Nigeria
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c404v061z85t"
                 >
                   Africa
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c0823e52dd0t"
                 >
                   World
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/media/video"
                 >
                   Video
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cjgn7gv77vrt"
                 >
                   Sport
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cqywjyzk2vyt"
                 >
                   Entertainment
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/popular/read"
                 >
                   Most popular
@@ -879,96 +891,96 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
           </div>
         </div>
         <div
-          class="emotion-104 emotion-105"
+          class="emotion-106 emotion-107"
           height="0"
         >
           <ul
-            class="emotion-102 emotion-103"
+            class="emotion-104 emotion-105"
             role="list"
           >
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin"
               >
                 Home
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c2dwqd1zr92t"
               >
                 Nigeria
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c404v061z85t"
               >
                 Africa
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c0823e52dd0t"
               >
                 World
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/media/video"
               >
                 Video
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cjgn7gv77vrt"
               >
                 Sport
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cqywjyzk2vyt"
               >
                 Entertainment
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/popular/read"
               >
                 Most popular
@@ -983,7 +995,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 `;
 
 exports[`Header Snapshots should render correctly for WS radio page 1`] = `
-.emotion-24 {
+.emotion-26 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -992,13 +1004,13 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-24 {
+  .emotion-26 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-24 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1020,12 +1032,12 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-22 {
+  .emotion-24 {
     display: block;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: inline-block;
   width: 100%;
   max-width: 14.880600000000001rem;
@@ -1037,12 +1049,12 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   box-sizing: content-box;
   color: #FFFFFF;
   fill: currentColor;
@@ -1059,34 +1071,34 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1rem;
     padding-bottom: 0.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1.25rem;
     padding-bottom: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active),print {
-  .emotion-14 {
+  .emotion-16 {
     fill: windowText;
   }
 }
 
-.emotion-19:hover .emotion-14,
-.emotion-19:focus .emotion-14 {
+.emotion-21:hover .emotion-16,
+.emotion-21:focus .emotion-16 {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.25rem solid #FFFFFF;
   margin-bottom: -0.25rem;
 }
 
-.emotion-16 {
+.emotion-18 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -1098,7 +1110,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -1121,20 +1133,20 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-20:focus {
+.emotion-22:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
@@ -1146,38 +1158,38 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-20:focus {
+  .emotion-22:focus {
     top: 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     padding: 0.5rem;
   }
 }
 
-.emotion-108 {
+.emotion-110 {
   position: relative;
   background-color: #B80000;
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.emotion-108 .emotion-35::after {
+.emotion-110 .emotion-37::after {
   left: 0;
 }
 
-.emotion-106 {
+.emotion-108 {
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.emotion-68 {
+.emotion-70 {
   position: relative;
 }
 
-.emotion-30 {
+.emotion-32 {
   position: relative;
   padding: 0;
   margin: 0;
@@ -1188,14 +1200,14 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   width: 2.75rem;
 }
 
-.emotion-30:hover,
-.emotion-30:focus {
+.emotion-32:hover,
+.emotion-32:focus {
   cursor: pointer;
   box-shadow: inset 0 0 0 0.25rem #FFFFFF;
 }
 
-.emotion-30:hover::after,
-.emotion-30:focus::after {
+.emotion-32:hover::after,
+.emotion-32:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1206,30 +1218,30 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-30 {
+  .emotion-32 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) {
-  .emotion-30 {
+  .emotion-32 {
     height: 2.75rem;
     width: 2.75rem;
   }
 }
 
-.emotion-30 svg {
+.emotion-32 svg {
   vertical-align: middle;
 }
 
-.emotion-26 {
+.emotion-28 {
   color: #fff;
   fill: currentColor;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-66 {
+  .emotion-68 {
     white-space: nowrap;
     overflow-x: scroll;
     -webkit-scroll-behavior: auto;
@@ -1244,11 +1256,11 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
     -ms-overflow-style: none;
   }
 
-  .emotion-66::-webkit-scrollbar {
+  .emotion-68::-webkit-scrollbar {
     display: none;
   }
 
-  .emotion-66:after {
+  .emotion-68:after {
     content: ' ';
     height: 100%;
     width: 3rem;
@@ -1262,13 +1274,13 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   }
 
 @media (min-width:25rem) {
-    .emotion-66:after {
+    .emotion-68:after {
       width: 6rem;
     }
 }
 }
 
-.emotion-64 {
+.emotion-66 {
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -1276,25 +1288,25 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-64 {
+  .emotion-66 {
     overflow: hidden;
   }
 }
 
-.emotion-34 {
+.emotion-36 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-34:last-child {
+  .emotion-36:last-child {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-34::after {
+  .emotion-36::after {
     content: '';
     position: absolute;
     bottom: -1px;
@@ -1304,7 +1316,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   }
 }
 
-.emotion-32 {
+.emotion-34 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1319,26 +1331,26 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     padding: 0.75rem 0.5rem;
   }
 }
 
-.emotion-32:hover::after {
+.emotion-34:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1347,7 +1359,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.emotion-32:focus::after {
+.emotion-34:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1358,7 +1370,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
-.emotion-104 {
+.emotion-106 {
   background-color: #222222;
   clear: both;
   overflow: hidden;
@@ -1371,37 +1383,37 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-104 {
+  .emotion-106 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (prefers-reduced-motion:reduce) {
-  .emotion-104 {
+  .emotion-106 {
     -webkit-transition: none;
     transition: none;
   }
 }
 
-.emotion-102 {
+.emotion-104 {
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
   border-bottom: 0.125rem solid #3F3F42;
 }
 
-.emotion-72 {
+.emotion-74 {
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #3F3F42;
 }
 
-.emotion-72:last-child {
+.emotion-74:last-child {
   padding-bottom: 1rem;
   border: 0;
 }
 
-.emotion-70 {
+.emotion-72 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1413,23 +1425,31 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-70:hover,
-.emotion-70:focus {
+.emotion-72:hover,
+.emotion-72:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
 }
 
 .emotion-12 {
@@ -1612,65 +1632,69 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
     role="banner"
   >
     <div
-      class="emotion-12 emotion-13"
-      dir="ltr"
+      class="emotion-14 emotion-15"
     >
       <div
-        class="emotion-10 emotion-11"
+        class="emotion-12 emotion-13"
         dir="ltr"
       >
-        <h2
-          class="emotion-0 emotion-1"
+        <div
+          class="emotion-10 emotion-11"
           dir="ltr"
         >
-          We don update our Privacy and Cookies Policy
-        </h2>
-        <p
-          class="emotion-2 emotion-3"
-          dir="ltr"
-        >
-          We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
-        </p>
-        <ul
-          class="emotion-8 emotion-9"
-          dir="ltr"
-        >
-          <li
-            class="emotion-4 emotion-5"
+          <h2
+            class="emotion-0 emotion-1"
             dir="ltr"
           >
-            <button
-              type="button"
-            >
-              OK
-            </button>
-          </li>
-          <li
-            class="emotion-4 emotion-5"
+            We don update our Privacy and Cookies Policy
+          </h2>
+          <p
+            class="emotion-2 emotion-3"
             dir="ltr"
           >
-            <a
-              href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+            We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
+          </p>
+          <ul
+            class="emotion-8 emotion-9"
+            dir="ltr"
+          >
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
             >
-              Find out wetin don change
-            </a>
-          </li>
-        </ul>
+              <button
+                type="button"
+              >
+                OK
+              </button>
+            </li>
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
+            >
+              <a
+                href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+              >
+                Find out wetin don change
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div
-      class="emotion-24 emotion-25"
+      class="emotion-26 emotion-27"
     >
       <div
-        class="emotion-22 emotion-23"
+        class="emotion-24 emotion-25"
       >
         <a
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           href="/pidgin"
         >
           <svg
             aria-hidden="true"
-            class="emotion-14 emotion-15"
+            class="emotion-16 emotion-17"
             focusable="false"
             height="24"
             viewBox="0 0 238 24"
@@ -1698,7 +1722,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
             </g>
           </svg>
           <span
-            class="emotion-16 emotion-17"
+            class="emotion-18 emotion-19"
             role="text"
           >
             <span
@@ -1711,7 +1735,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
           </span>
         </a>
         <a
-          class="emotion-20 emotion-21"
+          class="emotion-22 emotion-23"
           dir="ltr"
           href="#content"
         >
@@ -1720,25 +1744,25 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
       </div>
     </div>
     <nav
-      class="emotion-108 emotion-109"
+      class="emotion-110 emotion-111"
       dir="ltr"
       role="navigation"
     >
       <div
-        class="emotion-106 emotion-107"
+        class="emotion-108 emotion-109"
       >
         <div
-          class="emotion-68 emotion-69"
+          class="emotion-70 emotion-71"
         >
           <button
             aria-expanded="false"
-            class="emotion-30 emotion-31"
+            class="emotion-32 emotion-33"
             dir="ltr"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="emotion-26 emotion-27"
+              class="emotion-28 emotion-29"
               focusable="false"
               height="2.75rem"
               viewBox="0 0 44 44"
@@ -1749,110 +1773,110 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
               />
             </svg>
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-18 emotion-19"
             >
               Plenti seshon
             </span>
           </button>
           <div
-            class="emotion-66 emotion-67"
+            class="emotion-68 emotion-69"
             dir="ltr"
           >
             <ul
-              class="emotion-64 emotion-65"
+              class="emotion-66 emotion-67"
               role="list"
             >
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin"
                 >
                   Home
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c2dwqd1zr92t"
                 >
                   Nigeria
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c404v061z85t"
                 >
                   Africa
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c0823e52dd0t"
                 >
                   World
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/media/video"
                 >
                   Video
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cjgn7gv77vrt"
                 >
                   Sport
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cqywjyzk2vyt"
                 >
                   Entertainment
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/popular/read"
                 >
                   Most popular
@@ -1862,96 +1886,96 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
           </div>
         </div>
         <div
-          class="emotion-104 emotion-105"
+          class="emotion-106 emotion-107"
           height="0"
         >
           <ul
-            class="emotion-102 emotion-103"
+            class="emotion-104 emotion-105"
             role="list"
           >
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin"
               >
                 Home
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c2dwqd1zr92t"
               >
                 Nigeria
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c404v061z85t"
               >
                 Africa
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c0823e52dd0t"
               >
                 World
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/media/video"
               >
                 Video
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cjgn7gv77vrt"
               >
                 Sport
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cqywjyzk2vyt"
               >
                 Entertainment
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/popular/read"
               >
                 Most popular
@@ -1966,7 +1990,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 `;
 
 exports[`Header Snapshots should render correctly for news article 1`] = `
-.emotion-24 {
+.emotion-26 {
   background-color: #B80000;
   min-height: 2.5rem;
   width: 100%;
@@ -1975,13 +1999,13 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-24 {
+  .emotion-26 {
     min-height: 3.25rem;
     padding: 0 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-24 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2003,12 +2027,12 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-22 {
+  .emotion-24 {
     display: block;
   }
 }
 
-.emotion-18 {
+.emotion-20 {
   display: inline-block;
   width: 100%;
   max-width: 14.880600000000001rem;
@@ -2020,12 +2044,12 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (max-width:14.9375rem) {
-  .emotion-18 {
+  .emotion-20 {
     display: block;
   }
 }
 
-.emotion-14 {
+.emotion-16 {
   box-sizing: content-box;
   color: #FFFFFF;
   fill: currentColor;
@@ -2042,34 +2066,34 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1rem;
     padding-bottom: 0.75rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-14 {
+  .emotion-16 {
     padding-top: 1.25rem;
     padding-bottom: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast:active),print {
-  .emotion-14 {
+  .emotion-16 {
     fill: windowText;
   }
 }
 
-.emotion-19:hover .emotion-14,
-.emotion-19:focus .emotion-14 {
+.emotion-21:hover .emotion-16,
+.emotion-21:focus .emotion-16 {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-bottom: 0.25rem solid #FFFFFF;
   margin-bottom: -0.25rem;
 }
 
-.emotion-16 {
+.emotion-18 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   -webkit-clip: rect(1px,1px,1px,1px);
@@ -2081,7 +2105,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   margin: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   position: absolute;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -2104,20 +2128,20 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-20 {
+  .emotion-22 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-20:focus {
+.emotion-22:focus {
   -webkit-clip-path: none;
   clip-path: none;
   -webkit-clip: auto;
@@ -2129,38 +2153,38 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:25rem) {
-  .emotion-20:focus {
+  .emotion-22:focus {
     top: 0.5rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-20 {
+  .emotion-22 {
     padding: 0.5rem;
   }
 }
 
-.emotion-108 {
+.emotion-110 {
   position: relative;
   background-color: #B80000;
   border-top: 0.0625rem solid #FFFFFF;
 }
 
-.emotion-108 .emotion-35::after {
+.emotion-110 .emotion-37::after {
   left: 0;
 }
 
-.emotion-106 {
+.emotion-108 {
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
 }
 
-.emotion-68 {
+.emotion-70 {
   position: relative;
 }
 
-.emotion-30 {
+.emotion-32 {
   position: relative;
   padding: 0;
   margin: 0;
@@ -2171,14 +2195,14 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   width: 2.75rem;
 }
 
-.emotion-30:hover,
-.emotion-30:focus {
+.emotion-32:hover,
+.emotion-32:focus {
   cursor: pointer;
   box-shadow: inset 0 0 0 0.25rem #FFFFFF;
 }
 
-.emotion-30:hover::after,
-.emotion-30:focus::after {
+.emotion-32:hover::after,
+.emotion-32:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2189,30 +2213,30 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-30 {
+  .emotion-32 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width:20rem) {
-  .emotion-30 {
+  .emotion-32 {
     height: 2.75rem;
     width: 2.75rem;
   }
 }
 
-.emotion-30 svg {
+.emotion-32 svg {
   vertical-align: middle;
 }
 
-.emotion-26 {
+.emotion-28 {
   color: #fff;
   fill: currentColor;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-66 {
+  .emotion-68 {
     white-space: nowrap;
     overflow-x: scroll;
     -webkit-scroll-behavior: auto;
@@ -2227,11 +2251,11 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
     -ms-overflow-style: none;
   }
 
-  .emotion-66::-webkit-scrollbar {
+  .emotion-68::-webkit-scrollbar {
     display: none;
   }
 
-  .emotion-66:after {
+  .emotion-68:after {
     content: ' ';
     height: 100%;
     width: 3rem;
@@ -2245,13 +2269,13 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   }
 
 @media (min-width:25rem) {
-    .emotion-66:after {
+    .emotion-68:after {
       width: 6rem;
     }
 }
 }
 
-.emotion-64 {
+.emotion-66 {
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -2259,25 +2283,25 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-64 {
+  .emotion-66 {
     overflow: hidden;
   }
 }
 
-.emotion-34 {
+.emotion-36 {
   display: inline-block;
   position: relative;
   z-index: 2;
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-34:last-child {
+  .emotion-36:last-child {
     margin-right: 3rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-34::after {
+  .emotion-36::after {
     content: '';
     position: absolute;
     bottom: -1px;
@@ -2287,7 +2311,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   }
 }
 
-.emotion-32 {
+.emotion-34 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -2302,26 +2326,26 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-32 {
+  .emotion-34 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width:37.4375rem) {
-  .emotion-32 {
+  .emotion-34 {
     padding: 0.75rem 0.5rem;
   }
 }
 
-.emotion-32:hover::after {
+.emotion-34:hover::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2330,7 +2354,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   border-bottom: 0.25rem solid #FFFFFF;
 }
 
-.emotion-32:focus::after {
+.emotion-34:focus::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2341,7 +2365,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   border: 0.25rem solid #FFFFFF;
 }
 
-.emotion-104 {
+.emotion-106 {
   background-color: #222222;
   clear: both;
   overflow: hidden;
@@ -2354,37 +2378,37 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:37.5rem) {
-  .emotion-104 {
+  .emotion-106 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (prefers-reduced-motion:reduce) {
-  .emotion-104 {
+  .emotion-106 {
     -webkit-transition: none;
     transition: none;
   }
 }
 
-.emotion-102 {
+.emotion-104 {
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
   border-bottom: 0.125rem solid #3F3F42;
 }
 
-.emotion-72 {
+.emotion-74 {
   padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #3F3F42;
 }
 
-.emotion-72:last-child {
+.emotion-74:last-child {
   padding-bottom: 1rem;
   border: 0;
 }
 
-.emotion-70 {
+.emotion-72 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -2396,23 +2420,31 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 @media (min-width:20rem) and (max-width:37.4375rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:37.5rem) {
-  .emotion-70 {
+  .emotion-72 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-70:hover,
-.emotion-70:focus {
+.emotion-72:hover,
+.emotion-72:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.emotion-14 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 20;
 }
 
 .emotion-12 {
@@ -2595,65 +2627,69 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
     role="banner"
   >
     <div
-      class="emotion-12 emotion-13"
-      dir="ltr"
+      class="emotion-14 emotion-15"
     >
       <div
-        class="emotion-10 emotion-11"
+        class="emotion-12 emotion-13"
         dir="ltr"
       >
-        <h2
-          class="emotion-0 emotion-1"
+        <div
+          class="emotion-10 emotion-11"
           dir="ltr"
         >
-          We don update our Privacy and Cookies Policy
-        </h2>
-        <p
-          class="emotion-2 emotion-3"
-          dir="ltr"
-        >
-          We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
-        </p>
-        <ul
-          class="emotion-8 emotion-9"
-          dir="ltr"
-        >
-          <li
-            class="emotion-4 emotion-5"
+          <h2
+            class="emotion-0 emotion-1"
             dir="ltr"
           >
-            <button
-              type="button"
-            >
-              OK
-            </button>
-          </li>
-          <li
-            class="emotion-4 emotion-5"
+            We don update our Privacy and Cookies Policy
+          </h2>
+          <p
+            class="emotion-2 emotion-3"
             dir="ltr"
           >
-            <a
-              href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+            We don make some important changes to our Privacy and Cookies Policy and we wan make you know wetin dis one mean for you and your personal infomation.
+          </p>
+          <ul
+            class="emotion-8 emotion-9"
+            dir="ltr"
+          >
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
             >
-              Find out wetin don change
-            </a>
-          </li>
-        </ul>
+              <button
+                type="button"
+              >
+                OK
+              </button>
+            </li>
+            <li
+              class="emotion-4 emotion-5"
+              dir="ltr"
+            >
+              <a
+                href="https://www.bbc.co.uk/usingthebbc/your-data-matters"
+              >
+                Find out wetin don change
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div
-      class="emotion-24 emotion-25"
+      class="emotion-26 emotion-27"
     >
       <div
-        class="emotion-22 emotion-23"
+        class="emotion-24 emotion-25"
       >
         <a
-          class="emotion-18 emotion-19"
+          class="emotion-20 emotion-21"
           href="/pidgin"
         >
           <svg
             aria-hidden="true"
-            class="emotion-14 emotion-15"
+            class="emotion-16 emotion-17"
             focusable="false"
             height="24"
             viewBox="0 0 238 24"
@@ -2681,7 +2717,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
             </g>
           </svg>
           <span
-            class="emotion-16 emotion-17"
+            class="emotion-18 emotion-19"
             role="text"
           >
             <span
@@ -2694,7 +2730,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
           </span>
         </a>
         <a
-          class="emotion-20 emotion-21"
+          class="emotion-22 emotion-23"
           dir="ltr"
           href="#content"
         >
@@ -2703,25 +2739,25 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
       </div>
     </div>
     <nav
-      class="emotion-108 emotion-109"
+      class="emotion-110 emotion-111"
       dir="ltr"
       role="navigation"
     >
       <div
-        class="emotion-106 emotion-107"
+        class="emotion-108 emotion-109"
       >
         <div
-          class="emotion-68 emotion-69"
+          class="emotion-70 emotion-71"
         >
           <button
             aria-expanded="false"
-            class="emotion-30 emotion-31"
+            class="emotion-32 emotion-33"
             dir="ltr"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="emotion-26 emotion-27"
+              class="emotion-28 emotion-29"
               focusable="false"
               height="2.75rem"
               viewBox="0 0 44 44"
@@ -2732,110 +2768,110 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
               />
             </svg>
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-18 emotion-19"
             >
               Plenti seshon
             </span>
           </button>
           <div
-            class="emotion-66 emotion-67"
+            class="emotion-68 emotion-69"
             dir="ltr"
           >
             <ul
-              class="emotion-64 emotion-65"
+              class="emotion-66 emotion-67"
               role="list"
             >
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin"
                 >
                   Home
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c2dwqd1zr92t"
                 >
                   Nigeria
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c404v061z85t"
                 >
                   Africa
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/c0823e52dd0t"
                 >
                   World
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/media/video"
                 >
                   Video
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cjgn7gv77vrt"
                 >
                   Sport
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/topics/cqywjyzk2vyt"
                 >
                   Entertainment
                 </a>
               </li>
               <li
-                class="emotion-34 emotion-35"
+                class="emotion-36 emotion-37"
                 dir="ltr"
                 role="listitem"
               >
                 <a
-                  class="emotion-32 emotion-33"
+                  class="emotion-34 emotion-35"
                   href="/pidgin/popular/read"
                 >
                   Most popular
@@ -2845,96 +2881,96 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
           </div>
         </div>
         <div
-          class="emotion-104 emotion-105"
+          class="emotion-106 emotion-107"
           height="0"
         >
           <ul
-            class="emotion-102 emotion-103"
+            class="emotion-104 emotion-105"
             role="list"
           >
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin"
               >
                 Home
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c2dwqd1zr92t"
               >
                 Nigeria
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c404v061z85t"
               >
                 Africa
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/c0823e52dd0t"
               >
                 World
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/media/video"
               >
                 Video
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cjgn7gv77vrt"
               >
                 Sport
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/topics/cqywjyzk2vyt"
               >
                 Entertainment
               </a>
             </li>
             <li
-              class="emotion-72 emotion-73"
+              class="emotion-74 emotion-75"
               role="listitem"
             >
               <a
-                class="emotion-70 emotion-71"
+                class="emotion-72 emotion-73"
                 href="/pidgin/popular/read"
               >
                 Most popular


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8696

**Overall change:**
Pins the consent banner to the bottom of the viewport

**Code changes:**
- Apply a reduced set of the styles used by Google to pin consent banners to the bottom of the view port: 
![image](https://user-images.githubusercontent.com/9645462/104346898-d9a42280-54f7-11eb-800f-aec3a7a5447d.png)
  - We have removed some excessive defensive styles (use of important and 'int max' z-index) and default background colour
- Updated snapshots 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
