### PR TITLE
add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "packageRules": [
+    {
+      "packagePatterns": ["*"],
+      "updateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "schedule": ["every weekend"]
+    },
+    {
+      "packagePatterns": ["^@psammead/"],
+      "updateTypes": ["minor", "patch"],
+      "groupName": "psammead",
+      "schedule": ["before 2am"]
+    }
+  ]
+}

--- a/src/integration/common/renovate.json
+++ b/src/integration/common/renovate.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["config:base", ":pinAllExceptPeerDependencies"],
-  "packageRules": [
-    {
-      "packagePatterns": ["^@psammead/"]
-    }
-  ]
-}

--- a/src/integration/common/renovate.json
+++ b/src/integration/common/renovate.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["config:base", ":pinAllExceptPeerDependencies"],
+  "packageRules": [
+    {
+      "packagePatterns": ["^@psammead/"]
+    }
+  ]
+}


### PR DESCRIPTION
**Overall change:**
Adds Renovate config

~More info on chosen config here https://github.com/bbc/simorgh/pull/8701#discussion_r556366041~
@andrewscfc @chris-hinds @joshcoventry put together this config on a call, it:
- Groups all minor and patch dependencies for psammead
- Groups all minor and patch dependencies for all other dependencies
- Creates seperate PRs for all major dependencies

We will test this config and follow-up with an update to the repo readme to explain these choices.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
