### PR TITLE
Unpin various dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18116,6 +18116,15 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -19377,17 +19386,6 @@
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
         "prismjs": "~1.23.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
-          "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        }
       }
     },
     "regenerate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11774,6 +11774,12 @@
       "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-3.3.1.tgz",
       "integrity": "sha512-afNs8egrYqUAxURPPPw3M1yBpKMDL8p4xOf0kPl6c7Wtzhf6MRcV7dk9sEKdYSRq8NL4RIgXV/4O4iK9e48Izg=="
     },
+    "highlight.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
+      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "dev": true
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -15370,14 +15376,6 @@
       "requires": {
         "fault": "^1.0.0",
         "highlight.js": "~10.5.0"
-      },
-      "dependencies": {
-        "highlight.js": {
-          "version": "10.4.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-          "dev": true
-        }
       }
     },
     "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./src/client.js",
   "resolutions": {
     "prismjs": "1.22.0",
-    "node-forge": "0.10.0",
     "axios": "0.21.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "prismjs": "1.22.0",
     "node-forge": "0.10.0",
     "ini": "1.3.7",
-    "highlight.js": "10.4.1",
     "axios": "0.21.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Simorgh",
   "main": "./src/client.js",
   "resolutions": {
-    "prismjs": "1.22.0",
     "axios": "0.21.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "resolutions": {
     "prismjs": "1.22.0",
     "node-forge": "0.10.0",
-    "ini": "1.3.7",
     "axios": "0.21.1"
   },
   "scripts": {


### PR DESCRIPTION
**Overall change:**
We often pin depenencies to resolve dependabot alerts, over time package maintainers will update their packages to use the latest secure version of dependencies. Now the dependencies have been updated all but axios can be unpinned allow `npm install`s default resolution behaviour to take over.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
