### PR TITLE
Reconfigure dependabot to only allow security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,8 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "sunday"
-    time: "03:00"
-  open-pull-requests-limit: 100
-  labels:
-  - dependencies
-  milestone: 107
-  versioning-strategy: increase
-  ignore:
-  - dependency-name: "@bbc/psammead-story-promo-list"
-    versions:
-    - ">= 1.0.1.a"
-    - "< 1.0.2"
-  - dependency-name: react-amphtml
-    versions:
-    - "> 3.0.1"
-  - dependency-name: snyk
-    versions:
-    - ">= 1.185.5.a"
-    - "< 1.185.6"
-  - dependency-name: "@storybook/react"
-    versions:
-    - ">= 5.1.3.a"
-    - "< 5.1.4"
-  - dependency-name: uuid
-    versions:
-    - ">= 7.a"
-    - "< 8"
-  - dependency-name: uuid
-    versions:
-    - ">= 8.a"
-    - "< 9"
-  rebase-strategy: disabled
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'daily'
+    allowed_updates:
+      - match:
+          update_type: 'security'


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Only allow dependabot to raise security updates

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
