### PR TITLE
Remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: 'javascript'
-    directory: '/'
-    update_schedule: 'daily'
-    allowed_updates:
-      - match:
-          update_type: 'security'


### PR DESCRIPTION
**Overall change:**
Removes dependabot config as security updates are no longer managed by it anymore: https://stackoverflow.com/questions/64047526/how-to-get-dependabot-to-trigger-for-security-updates-only 

We are moving to renovate to manage our dependency updates.

This should unblock current issues blocking merges

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
