### PR TITLE
Add base config as basis for our config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["config:base"],
   "packageRules": [
     {
       "packagePatterns": ["*"],


### PR DESCRIPTION
**Overall change:**
Use dependabots 'base config' as the base: https://docs.renovatebot.com/presets-config/#configbase

We override that with config to 
- combine all minor and patch updates
- combine all minor and patch psammmead updates
- the default config will ensure seperate PRs are created for each major update which is likely to be a breaking change and require manual intervention

The base config also add the following config preset to actually enable renovate, we have not included this so far: https://docs.renovatebot.com/presets-default/#enablerenovate

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
