### PR TITLE
remove schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,12 @@
       "packagePatterns": ["*"],
       "updateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "schedule": ["hourly"]
+      "groupSlug": "all-minor-patch"
     },
     {
       "packagePatterns": ["^@psammead/"],
       "updateTypes": ["minor", "patch"],
-      "groupName": "psammead",
-      "schedule": ["hourly"]
+      "groupName": "psammead"
     }
   ]
 }


### PR DESCRIPTION
**Overall change:**
Looks like hourly might not be a valid schedule, looking at the docs, at least initially not having a schedule will mean renovate will run 'around the clock' which will be fine for early testing: https://docs.renovatebot.com/configuration-options/#schedule

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
