### PR TITLE
Exclude webpack and @loadable from group dependency prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "packagePatterns": ["*"],
-      "excludePackagePatterns": ["^@bbc"],
+      "excludePackagePatterns": ["^@bbc", "^@loadable", "webpack"],
       "updateTypes": ["minor", "patch"],
       "groupName": "all 3rd party non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
**Overall change:**
While attempting to merge https://github.com/bbc/simorgh/pull/8724 to bring in all our minor and patch 3rd party dependencies, we found issues with the upgrade to `@loadable/` packages: https://github.com/bbc/simorgh/pull/8724#issuecomment-762780095

This change proposes excluding two core dependencies from grouping PRs as they need additional scruitiny before merging:
- loadable
  - This enables dynamic loading of bundles for individual services and page types, this is crucial to the site and it seems a minor upgrade caused a regression (not confirmed) so it is probably not safe group this in future
- webpack
  - Bundles our site and any regression could cause non-obvious but potentially major bugs

**Code changes:**
- Exclude webpack and loadable for 3rd party dependency grouped PR

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
