### PR TITLE
Group minor and patch updates for webpack and loadable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,19 @@
       "groupSlug": "all-minor-patch"
     },
     {
+      "packagePatterns": ["^@loadable"],
+      "updateTypes": ["minor", "patch"],
+      "groupName": "loadable non-major dependencies",
+      "groupSlug": "loadable-minor-patch"
+    },
+    {
+      "packagePatterns": ["^webpack"],
+      "excludePackagePatterns": ["^webpack"],
+      "updateTypes": ["minor", "patch"],
+      "groupName": "webpack non-major dependencies",
+      "groupSlug": "webpack-minor-patch"
+    },
+    {
       "packagePatterns": ["^@bbc"],
       "groupName": "all BBC non-major dependencies",
       "updateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,6 @@
     },
     {
       "packagePatterns": ["^webpack"],
-      "excludePackagePatterns": ["^webpack"],
       "updateTypes": ["minor", "patch"],
       "groupName": "webpack non-major dependencies",
       "groupSlug": "webpack-minor-patch"


### PR DESCRIPTION
**Overall change:**
Following removal of webpack and loadable from the main 3rd party grouped PR we still need config to group them together for minor and patch dependencies.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
