### PR TITLE
force immer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,14 +1910,20 @@
       "integrity": "sha512-QvO1J9drc7K2SeBrHuO5/8nQ1QTks/OOG+vwva4lM7T28pPgf556snMpPE/3KE6uD2UJky8I4A5dNRNbqAXiDw==",
       "dev": true,
       "requires": {
-        "axios": "0.21.1",
+        "axios": "0.19.0",
         "debug": "^3.0.1",
         "openurl": "^1.1.1",
         "yargs": "^13.3.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.1"
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
         },
         "debug": {
           "version": "3.2.7",
@@ -1927,6 +1933,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.3",
@@ -4785,22 +4797,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
       "dev": true
-    },
-    "axios": {
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-          "dev": true
-        }
-      },
-      "version": "0.21.1"
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -12309,12 +12305,6 @@
         "which-pm-runs": "^1.0.0"
       }
     },
-    "immer": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
-      "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
-      "dev": true
-    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -18762,6 +18752,12 @@
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
           "dev": true
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+          "dev": true
+        },
         "inquirer": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
@@ -23140,7 +23136,7 @@
       "integrity": "sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==",
       "dev": true,
       "requires": {
-        "axios": "0.21.1",
+        "axios": "^0.21.1",
         "joi": "^17.3.0",
         "lodash": "^4.17.20",
         "minimist": "^1.2.5",
@@ -23148,7 +23144,13 @@
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.1"
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
         },
         "follow-redirects": {
           "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simorgh",
   "main": "./src/client.js",
   "resolutions": {
-    "axios": "0.21.1"
+    "axios": "0.21.1",
+    "immer": "8.0.1"
   },
   "scripts": {
     "preinstall": "[ \"$npm_config_refer\" != \"ci\" ] && npx npm-force-resolutions || exit 0",


### PR DESCRIPTION
Force version of `immer` dependency to resolve security vulnerability

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
