### PR TITLE
Upgrade podcast promo with ie11 fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,14 +1740,40 @@
       }
     },
     "@bbc/psammead-podcast-promo": {
-      "version": "0.1.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/@bbc/psammead-podcast-promo/-/psammead-podcast-promo-0.1.0-alpha.12.tgz",
-      "integrity": "sha512-zQGB6paQRwfRn6nxH84YOcGzjObl2JXX+ZvgLlKiO+L+4uAf9WJ8j7RSOhbFnTAzYId0xC/ebomKCzj2PQ8yZg==",
+      "version": "0.1.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@bbc/psammead-podcast-promo/-/psammead-podcast-promo-0.1.0-alpha.23.tgz",
+      "integrity": "sha512-tc+e7RfX4AFJf4L/k603iMzK4kRVSdxrEefXyZ0ZQ2oE6quC5mxmNLpOLWGOnTExnk7G6R0aQW0Fhlxw4GgBvQ==",
       "requires": {
-        "@bbc/gel-foundations": "^6.0.0",
-        "@bbc/psammead-assets": "^3.1.2",
-        "@bbc/psammead-image-placeholder": "^3.0.8",
-        "@bbc/psammead-styles": "^7.0.2"
+        "@bbc/gel-foundations": "^6.1.0",
+        "@bbc/psammead-assets": "^3.1.3",
+        "@bbc/psammead-image-placeholder": "^3.0.13",
+        "@bbc/psammead-styles": "^7.2.0"
+      },
+      "dependencies": {
+        "@bbc/gel-foundations": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@bbc/gel-foundations/-/gel-foundations-6.1.0.tgz",
+          "integrity": "sha512-bWzYYMe4hrN/EUzr3rEr1psBXJsW3SAXceVVwegY48vOqdfKjwJejOd/Q6u+Ge3GOCR9ZSIailOQmi1174SUrQ=="
+        },
+        "@bbc/psammead-assets": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-assets/-/psammead-assets-3.1.4.tgz",
+          "integrity": "sha512-w7J7guvS1XR6Vcu6OjxE88WVQHF+VvdgLsA8ihXSwE5mhpTLOFz8wha0IOvWkD1FJ+nVnzHOiw4ENcO0OwC2Fw=="
+        },
+        "@bbc/psammead-image-placeholder": {
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-image-placeholder/-/psammead-image-placeholder-3.0.13.tgz",
+          "integrity": "sha512-od1wLpJ/YDXhy5vqhgJkZ6VAC8/kjzUGN/4dJF1UfZmw3OJL2RYzpTJZeLFnSU2nraqgRnvc1R7LkKwr7cgIvA==",
+          "requires": {
+            "@bbc/psammead-assets": "^3.1.3",
+            "@bbc/psammead-styles": "^7.2.0"
+          }
+        },
+        "@bbc/psammead-styles": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/@bbc/psammead-styles/-/psammead-styles-7.2.1.tgz",
+          "integrity": "sha512-I2wiCo8UFgAaGntW+AOrbeIx3t7RWmF1yLz6Kha2IemhJcPh5u60z+7a8oe+asYYmJdDFWMvrCNXWl4qCe8MMw=="
+        }
       }
     },
     "@bbc/psammead-radio-schedule": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@bbc/psammead-most-read": "^6.0.11",
     "@bbc/psammead-navigation": "^9.0.1",
     "@bbc/psammead-paragraph": "^4.0.5",
-    "@bbc/psammead-podcast-promo": "0.1.0-alpha.12",
+    "@bbc/psammead-podcast-promo": "0.1.0-alpha.23",
     "@bbc/psammead-radio-schedule": "^5.0.16",
     "@bbc/psammead-rich-text-transforms": "^2.0.2",
     "@bbc/psammead-script-link": "^3.0.6",

--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -5,5 +5,5 @@ module.exports = {
   // below the smallest value in the build output; this avoids the
   // need for frequent changes as bundle sizes fluctuate.
   MIN_SIZE: 574,
-  MAX_SIZE: 859,
+  MAX_SIZE: 877,
 };

--- a/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
@@ -65,9 +65,7 @@ exports[`PodcastPromo Should render correctly 1`] = `
 
 @media (min-width:63rem) {
   .emotion-22 {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
+    display: block;
   }
 }
 
@@ -83,30 +81,36 @@ exports[`PodcastPromo Should render correctly 1`] = `
 
 @media (min-width:20rem) {
   .emotion-8 {
-    display: unset;
+    display: block;
   }
 }
 
 @media (min-width:25rem) {
   .emotion-8 {
-    -webkit-flex: 0 0 6.8125rem;
-    -ms-flex: 0 0 6.8125rem;
-    flex: 0 0 6.8125rem;
+    -webkit-box-flex: 0;
+    -webkit-flex-grow: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    -webkit-flex-basis: 6.8125rem;
+    -ms-flex-preferred-size: 6.8125rem;
+    flex-basis: 6.8125rem;
   }
 }
 
 @media (min-width:37.5rem) {
   .emotion-8 {
-    -webkit-flex: 0 0 11.125rem;
-    -ms-flex: 0 0 11.125rem;
-    flex: 0 0 11.125rem;
+    -webkit-flex-basis: 11.125rem;
+    -ms-flex-preferred-size: 11.125rem;
+    flex-basis: 11.125rem;
     margin: 0;
   }
 }
 
 @media (min-width:63rem) {
   .emotion-8 {
-    width: 100%;
     margin: 0;
   }
 }

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -150,18 +150,6 @@ Object {
 }
 `;
 
-exports[`Canonical Most Watched Page I can see the list items 1`] = `"0:16Vidéo, Test asset, Durée 0,1626 avril 2017"`;
-
-exports[`Canonical Most Watched Page I can see the list items 2`] = `"Ecoutez, Gelila, miraculée des eaux 217 juin 2016"`;
-
-exports[`Canonical Most Watched Page I can see the list items 3`] = `"Ecoutez, Gelila, miraculée des eaux17 juin 2016"`;
-
-exports[`Canonical Most Watched Page I can see the list items 4`] = `"0:16Vidéo, Test asset, Durée 0,1626 avril 2017"`;
-
-exports[`Canonical Most Watched Page I can see the list items 5`] = `"Vidéo, Test 2 - Magari yasiyotumia mafuta yaanza kazi Kenya9 août 2016"`;
-
-exports[`Canonical Most Watched Page I can see the list items 6`] = `"Ecoutez, L’invité BBC Afrique 21/06/2016 : Ibrahim Maïga short24 juin 2016"`;
-
 exports[`Canonical Most Watched Page Main heading should match text 1`] = `"Les plus vus"`;
 
 exports[`Canonical Most Watched Page Main heading should match text 2`] = `"Les plus vus"`;

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -150,6 +150,18 @@ Object {
 }
 `;
 
+exports[`Canonical Most Watched Page I can see the list items 1`] = `"0:16Vidéo, Test asset, Durée 0,1626 avril 2017"`;
+
+exports[`Canonical Most Watched Page I can see the list items 2`] = `"Ecoutez, Gelila, miraculée des eaux 217 juin 2016"`;
+
+exports[`Canonical Most Watched Page I can see the list items 3`] = `"Ecoutez, Gelila, miraculée des eaux17 juin 2016"`;
+
+exports[`Canonical Most Watched Page I can see the list items 4`] = `"0:16Vidéo, Test asset, Durée 0,1626 avril 2017"`;
+
+exports[`Canonical Most Watched Page I can see the list items 5`] = `"Vidéo, Test 2 - Magari yasiyotumia mafuta yaanza kazi Kenya9 août 2016"`;
+
+exports[`Canonical Most Watched Page I can see the list items 6`] = `"Ecoutez, L’invité BBC Afrique 21/06/2016 : Ibrahim Maïga short24 juin 2016"`;
+
 exports[`Canonical Most Watched Page Main heading should match text 1`] = `"Les plus vus"`;
 
 exports[`Canonical Most Watched Page Main heading should match text 2`] = `"Les plus vus"`;


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8783

**Overall change:**
Fixes IE11 bug on the podcast promo by bring in these changes from the psammead package https://github.com/bbc/psammead/pull/4289

**Code changes:**

- upgrades dependency
- updates bundle size config

# How to test
- change directory to your local simorgh repo
- checkout this branch `upgrade-podcast-promo-with-ie11-fix`
- run `npm install` to install the upgraded dependency
- go to http://localhost:7080/russian/news-55041160 in IE11
- observe fixed UI

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
