### PR TITLE
experiment to check include has been initialised with shadow dom

### DIFF
--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -3,7 +3,7 @@ import runCanonicalAdsTests from '../../../support/helpers/adsTests/testsForCano
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.
-export const testsThatAlwaysRunForCanonicalOnly = ({ service }) => {
+export const testsThatAlwaysRunForCanonicalOnly = () => {
   describe(`Include initialisation only on Mundo on specific page`, () => {
     // This test ensures that inline scripts used in includes execute successfully and
     // progressively enhance the include. These scripts can be supressed by the browser
@@ -12,14 +12,16 @@ export const testsThatAlwaysRunForCanonicalOnly = ({ service }) => {
     // following progressive enhancement by the include's inline scripts.
     // This test specifically is targeted at this test asset: '/mundo/23263889'
     it('should load the eclipse VJ include successfully', () => {
-      if (service === 'mundo') {
-        cy.get('.bbc-news-vj-shadow-dom', { includeShadowDom: true }).should(
-          'exist',
-        );
-        cy.get(
-          '#responsive-embed-vjamericas-176-eclipse-lookup-app-core-content',
-        ).should('not.exist');
-      }
+      cy.window().then(win => {
+        if (win.location.pathname.includes('/mundo/23263889')) {
+          cy.get('.bbc-news-vj-shadow-dom', { includeShadowDom: true }).should(
+            'exist',
+          );
+          cy.get(
+            '#responsive-embed-vjamericas-176-eclipse-lookup-app-core-content',
+          ).should('not.exist');
+        }
+      });
     });
   });
 };

--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -11,8 +11,11 @@ export const testsThatAlwaysRunForCanonicalOnly = ({ service }) => {
     // our story pages should not do this. The test checks the core content has been removed
     // following progressive enhancement by the include's inline scripts.
     // This test specifically is targeted at this test asset: '/mundo/23263889'
-    it('should load the eclipse VJ include successfully', () => {
+    it.only('should load the eclipse VJ include successfully', () => {
       if (service === 'mundo') {
+        cy.get('.bbc-news-vj-shadow-dom', { includeShadowDom: true }).should(
+          'exist',
+        );
         cy.get(
           '#responsive-embed-vjamericas-176-eclipse-lookup-app-core-content',
         ).should('not.exist');

--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -11,7 +11,7 @@ export const testsThatAlwaysRunForCanonicalOnly = ({ service }) => {
     // our story pages should not do this. The test checks the core content has been removed
     // following progressive enhancement by the include's inline scripts.
     // This test specifically is targeted at this test asset: '/mundo/23263889'
-    it.only('should load the eclipse VJ include successfully', () => {
+    it('should load the eclipse VJ include successfully', () => {
       if (service === 'mundo') {
         cy.get('.bbc-news-vj-shadow-dom', { includeShadowDom: true }).should(
           'exist',


### PR DESCRIPTION
**Overall change:**
Tests a theory the include tests may fail in certain environments because includes are choosing to use an iframe integration rather than shadow dom.

**Code changes:**
- Adds an assertion to check for a selector that should be present when an includes integrate using the shadow dom: 
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/9645462/105871403-2c4e0600-5ff1-11eb-8d17-48b051224112.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
