### PR TITLE
Silence error from include test

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -11,18 +11,17 @@ Cypress.on(`window:before:load`, win => {
   });
 });
 
-// Workaround for AMP Analytics bug - there is a pending fix here: https://github.com/ampproject/amphtml/pull/28448
-// Can be removed when this is resolved.
+// Catches an unexplained error experienced while running the following test:
+// https://github.com/bbc/simorgh/blob/49e5b72db84df57144a92963734bcd080938e45b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js#L14
+// We decided we could not invest any more time in the unexplained error as the test
+// successfully functioned with this specific error caught and discarded.
 // eslint-disable-next-line consistent-return
-Cypress.on('uncaught:exception', () => {
+Cypress.on('uncaught:exception', err => {
   // returning false here prevents Cypress from failing the test
-  // if (
-  //   err.message &&
-  //   err.message.includes(
-  //     'Inline or remote config should not overwrite vendor transport settings',
-  //   )
-  // ) {
-  //   return false;
-  // }
-  return false;
+  if (
+    err.message &&
+    err.message.includes("Cannot read property 'postMessage' of undefined")
+  ) {
+    return false;
+  }
 });


### PR DESCRIPTION
**Overall change:**
After spending around a day investigating the following error during cypress tests we reluctantly propose to suppress it and re-enable console error failures from any other cause:
`Cannot read property 'postMessage' of undefined`

This PR also includes removal of error catching for a now resolved amp anlaytics bug: https://github.com/ampproject/amphtml/pull/28448 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
