### PR TITLE
Enable AV for cymrufyw

### DIFF
--- a/src/app/containers/CpsAssetMediaPlayer/index.jsx
+++ b/src/app/containers/CpsAssetMediaPlayer/index.jsx
@@ -22,6 +22,7 @@ import {
   emptyBlockArrayDefaultProps,
 } from '#models/propTypes';
 import filterForBlockType from '#lib/utilities/blockHandlers';
+import getAssetUri from './utils/getAssetUri';
 
 const Wrapper = styled(GridItemLargeNoMargin)`
   margin-top: ${GEL_SPACING};
@@ -72,12 +73,11 @@ const CpsAssetMediaPlayer = ({
   );
 
   const available = path(['model', 'available'], metadataBlock);
-
   return (
     <Wrapper hasBottomPadding={hasBottomPadding} dir={dir}>
       <MediaPlayerContainer
         blocks={blocks}
-        assetId={assetUri.substr(1)}
+        assetId={getAssetUri(assetUri.substr(1))}
         assetType={isLegacyMedia ? 'legacy' : 'cps'}
         showPlaceholder={false}
         available={available}

--- a/src/app/containers/CpsAssetMediaPlayer/utils/getAssetUri/index.js
+++ b/src/app/containers/CpsAssetMediaPlayer/utils/getAssetUri/index.js
@@ -1,0 +1,9 @@
+const getAssetUri = assetUri => {
+  if (assetUri.includes('newyddion')) {
+    return assetUri.replace('newyddion', 'cymrufyw');
+  }
+
+  return assetUri;
+};
+
+export default getAssetUri;

--- a/src/app/containers/CpsAssetMediaPlayer/utils/getAssetUri/index.test.js
+++ b/src/app/containers/CpsAssetMediaPlayer/utils/getAssetUri/index.test.js
@@ -1,0 +1,15 @@
+import getAssetUri from '.';
+
+describe('getAssetUri', () => {
+  it('returns the correct assetUri for russian', () => {
+    const input = '/russian/multimedia/2016/05/160505_v_diving_record';
+    expect(getAssetUri(input)).toEqual(input);
+  });
+
+  it('returns the correct assetUri for cymrufyw/newyddion', () => {
+    const input = '/newyddion/55802579/p0953xf8/cy';
+    const output = '/cymrufyw/55802579/p0953xf8/cy';
+
+    expect(getAssetUri(input)).toEqual(output);
+  });
+});


### PR DESCRIPTION
Resolves N/A

**Overall change:**
- replaces `newyddion` with `cymrufyw` in the av-embed url builder.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [X] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [X] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
