### PR TITLE
add 'podcasts' to page identifier for ATI

### DIFF
--- a/src/app/routes/podcast/getInitialData/index.js
+++ b/src/app/routes/podcast/getInitialData/index.js
@@ -23,6 +23,11 @@ const getRecentEpisodesToggle = pathOr(DEFAULT_TOGGLE_VALUE, [
   'recentPodcastEpisodes',
 ]);
 
+const getPodcastPageIdentifier = pageIdentifier => {
+  const [service, masterbrand, ...rest] = pageIdentifier.split('.');
+  return [service, masterbrand, 'podcasts', ...rest].join('.');
+};
+
 export default async ({ path: pathname, pageType, service, toggles }) => {
   try {
     const podcastDataPath = overrideRendererOnTest(pathname);
@@ -63,6 +68,13 @@ export default async ({ path: pathname, pageType, service, toggles }) => {
         })
       : [];
 
+    const pageIdentifier = get([
+      'metadata',
+      'analyticsLabels',
+      'pageIdentifier',
+    ]);
+    const podcastPageIdentifier = getPodcastPageIdentifier(pageIdentifier);
+
     return {
       status,
       pageData: {
@@ -89,7 +101,7 @@ export default async ({ path: pathname, pageType, service, toggles }) => {
           LOG_LEVELS.WARN,
         ),
         pageTitle: get(['metadata', 'analyticsLabels', 'pageTitle']),
-        pageIdentifier: get(['metadata', 'analyticsLabels', 'pageIdentifier']),
+        pageIdentifier: podcastPageIdentifier,
         imageUrl: get(['content', 'blocks', 0, 'imageUrl'], LOG_LEVELS.INFO),
         promoBrandTitle: get(['promo', 'brand', 'title']),
         durationISO8601: get(

--- a/src/app/routes/podcast/getInitialData/index.test.js
+++ b/src/app/routes/podcast/getInitialData/index.test.js
@@ -68,6 +68,20 @@ describe('Get initial data for podcasts', () => {
     );
   });
 
+  it('should return the correct page identifier used for analytics', async () => {
+    const { pageData } = await getInitialData({
+      path: 'mock-podcast-path',
+      pageType: MEDIA_PAGE,
+      toggles: {
+        recentPodcastEpisodes: { enabled: false, value: 4 },
+      },
+    });
+
+    expect(pageData.pageIdentifier).toEqual(
+      'arabic.bbc_arabic_radio.podcasts.p08wtg4d.page',
+    );
+  });
+
   it('should return recent episode data when recentEpisode toggle is enabled', async () => {
     const { pageData } = await getInitialData({
       path: 'mock-podcast-path',


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8756

**Overall change:**
Creates the correct page identifier used for distinguishing podcast pages in Analytics.

<img width="729" alt="Screenshot 2021-02-02 at 08 55 27" src="https://user-images.githubusercontent.com/4798332/106575911-7de81a80-6534-11eb-8678-9028a1c6d6fe.png">

**Code changes:**

- Adds a function that accepts page identifier from Ares and returns a podcast specific page identifier

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [x] This PR requires manual testing
