### PR TITLE
cache node_modules in github actions

### DIFF
--- a/.github/workflows/simorgh-deploy-storybook.yml
+++ b/.github/workflows/simorgh-deploy-storybook.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache Node Modules
-        id: cache-node-modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: node_modules

--- a/.github/workflows/simorgh-deploy-storybook.yml
+++ b/.github/workflows/simorgh-deploy-storybook.yml
@@ -16,9 +16,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install and Build
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build Storybook
         run: |
-          npm ci
           npm run build:storybook
           git config --global user.name "simorgh-bbc"
           git config --global user.email "DENewsSimorghDev@bbc.co.uk"

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -21,11 +21,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
       - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+
       - name: Integration Tests
         run: npm run test:integration -- --ci

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
-        id: cache-node-modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: node_modules

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
-        id: cache-node-modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: node_modules

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -26,10 +26,19 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install & Build Simorgh
-        run: |
-          npm ci
-          npm run build:local
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build Simorgh
+        run: npm run build:local
 
       - name: Start Simorgh Server
         run: nohup node build/server.js > /dev/null 2>&1 &

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
-        id: cache-node-modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: node_modules

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -28,7 +28,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
       - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Chromatic UI Tests

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
 
       - name: Cache Node Modules
-        id: cache-node-modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: node_modules

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -64,7 +64,6 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Unit Tests
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm run test:unit
 
       - name: Report Code Climate Test Coverage

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -38,10 +38,20 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "GIT_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
 
-      - name: Install & Build Simorgh
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build Simorgh
         run: |
           echo ${GITHUB_REF##*/}
-          npm ci
           npm run build
 
       - name: Setup Code Climate Test Coverage
@@ -54,6 +64,7 @@ jobs:
           ./cc-test-reporter before-build
 
       - name: Unit Tests
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm run test:unit
 
       - name: Report Code Climate Test Coverage


### PR DESCRIPTION
**Overall change:**
Speeds up GitHub action build times by caching node_modules using [`cache` action from GitHub](https://github.com/actions/cache)

A guide on implementation - https://www.jonathan-wilkinson.com/github-actions-cache-everything

**Code changes:**

- Adds a new step in GitHub action workflows called `Cache Node Modules` that will automatically cache node_modules at the end of a successful workflow
- skips installing node modules if the cache has been hit

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
