### PR TITLE
Disable tests for Scotland on test env

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -5905,7 +5905,7 @@ module.exports = () => ({
           },
           test: {
             paths: ['/scotland/articles/czwj5l0n210o'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/scotland/articles/czwj5l0n210o'],


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Disables the tests for /scotland as the GTM route has been removed
- 
**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
