### PR TITLE
Configure renovate to pin dependencies

### DIFF
--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -11,6 +11,9 @@ https://github.com/bbc/simorgh/blob/bf3961e69a98f42410a80622bd9e9855f1145ed1/ren
 
 We also choose to [only enable renovate](https://github.com/bbc/simorgh/blob/bf3961e69a98f42410a80622bd9e9855f1145ed1/renovate.json#L3) for npm packages, it supports many dependency types include github actions and nvm to keep our version of node up-to-date but at this stage we chose to stick to npm packages and do other dependencies manually.
 
+## Pinning Dependencies
+We have configured renovate to [pin dependencies](https://github.com/bbc/simorgh/blob/09dbe8614cb6931765f2ddc61299d1fa2bbb6564/renovate.json#L2) based on their guidance on the subject [here](https://docs.renovatebot.com/dependency-pinning/#so-whats-best).
+
 ## Group All 3rd Party Non-Major Deps
 https://github.com/bbc/simorgh/blob/bf3961e69a98f42410a80622bd9e9855f1145ed1/renovate.json#L6..L10
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":pinVersions"],
   "enabledManagers": ["npm"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":pinVersions"],
+  "extends": ["config:base", ":pinDependencies"],
   "enabledManagers": ["npm"],
   "packageRules": [
     {


### PR DESCRIPTION
**Overall change:**
We originally were prompted to pin our dependencies during the initial setup of renovate and did so in this PR: https://github.com/bbc/simorgh/pull/8723. Since then, this config appears to have been lost and the pinning lost too, this PR reinstates the config to pin dependencies.

This merging of this PR will prompt renovate to pin dependencies in a seperate PR; I tested this on my fork of simorgh, creating a PR here: https://github.com/andrewscfc/simorgh/pull/11

**Code changes:**
- Adds config to pin dependencies: https://docs.renovatebot.com/presets-default/#pindependencies
- Updates renovate doc to explain the choice
- Renames the renovate file to use all caps match md conventions

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
