### PR TITLE
Remove Sinhala OD-radio and live radio tests from cypress settings

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -6404,16 +6404,16 @@ module.exports = () => ({
       liveRadio: {
         environments: {
           live: {
-            paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
+            paths: [],
             enabled: false,
           },
           test: {
-            paths: ['/sinhala/bbc_sinhala_radio/liveradio?renderer_env=live'],
+            paths: [],
             enabled: false,
           },
           local: {
-            paths: ['/sinhala/bbc_sinhala_radio/liveradio'],
-            enabled: true,
+            paths: [],
+            enabled: false,
           },
         },
         smoke: false,
@@ -6421,22 +6421,16 @@ module.exports = () => ({
       onDemandAudio: {
         environments: {
           live: {
-            paths: [
-              '/sinhala/bbc_sinhala_radio/programmes/w13xtv4q', // On Demand Brand
-              '/sinhala/bbc_sinhala_radio/w3ct1c7d', // On Demand Episode
-            ],
-            enabled: true,
+            paths: [],
+            enabled: false,
           },
           test: {
-            paths: [
-              '/sinhala/bbc_sinhala_radio/programmes/w13xtv4q', // On Demand Brand
-              '/sinhala/bbc_sinhala_radio/w3ct1c7d', // On Demand Episode
-            ],
-            enabled: true,
+            paths: [],
+            enabled: false,
           },
           local: {
-            paths: ['/sinhala/bbc_sinhala_radio/w172x8zn8th1lwb'],
-            enabled: true,
+            paths: [],
+            enabled: false,
           },
         },
         smoke: false,

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -6401,40 +6401,8 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      liveRadio: {
-        environments: {
-          live: {
-            paths: [],
-            enabled: false,
-          },
-          test: {
-            paths: [],
-            enabled: false,
-          },
-          local: {
-            paths: [],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
-      onDemandAudio: {
-        environments: {
-          live: {
-            paths: [],
-            enabled: false,
-          },
-          test: {
-            paths: [],
-            enabled: false,
-          },
-          local: {
-            paths: [],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      liveRadio: { environments: undefined, smoke: false },
+      onDemandAudio: { environments: undefined, smoke: false },
       onDemandTV: { environments: undefined, smoke: false },
       mediaAssetPage: {
         environments: {


### PR DESCRIPTION
Resolves failing e2es on TEST

**Overall change:**
- Remove recently decommissioned Sinhala on-demand radio & live radio tests from Cypress

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
