### PR TITLE
Update cps asset regex

### DIFF
--- a/data/cymrufyw/cpsAssets/etholiad-2017-39407507.json
+++ b/data/cymrufyw/cpsAssets/etholiad-2017-39407507.json
@@ -1,0 +1,466 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares::asset:newyddion/etholiad-2017-39407507",
+    "locators": {
+      "assetUri": "/newyddion/etholiad-2017-39407507",
+      "cpsUrn": "urn:bbc:content:assetUri:newyddion/etholiad-2017-39407507",
+      "curie": "http://www.bbc.co.uk/asset/86d24cff-f55f-0b41-8318-afc98f4e42d0",
+      "assetId": "39407507"
+    },
+    "type": "STY",
+    "createdBy": "newyddion-v6",
+    "language": "cy",
+    "lastUpdated": 1606747255602,
+    "firstPublished": 1493388731000,
+    "lastPublished": 1493388731000,
+    "timestamp": 1493388731000,
+    "options": {
+      "isIgorSeoTagsEnabled": false,
+      "includeComments": false,
+      "allowRightHandSide": true,
+      "isFactCheck": false,
+      "allowDateStamp": true,
+      "suitableForSyndication": true,
+      "hasNewsTracker": false,
+      "allowRelatedStoriesBox": true,
+      "isKeyContent": false,
+      "allowHeadline": true,
+      "allowAdvertising": true,
+      "hasContentWarning": false,
+      "isBreakingNews": false,
+      "allowPrintingSharingLinks": false
+    },
+    "analyticsLabels": {
+      "cps_asset_type": "sty",
+      "counterName": "newyddion.etholiad.2017.story.39407507.page",
+      "cps_asset_id": "39407507"
+    },
+    "tags": {},
+    "version": "v1.3.11",
+    "blockTypes": [
+      "heading",
+      "paragraph",
+      "subheading"
+    ],
+    "includeComments": false,
+    "atiAnalytics": {
+      "producerName": "WALES",
+      "producerId": "100"
+    },
+    "readTime": 3,
+    "siteUri": "/newyddion"
+  },
+  "content": {
+    "blocks": [
+      {
+        "text": "Pa etholiadau fydd yn cael eu cynnal ym mis Mai 2017?",
+        "markupType": "plain_text",
+        "type": "heading"
+      },
+      {
+        "text": "Bydd etholiadau'n cael eu cynnal mewn 34 o gynghorau yn Lloegr, pob un o 32 o gynghorau Yr Alban a phob un o 22 o gynghorau Cymru ar 4 Mai 2017.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Yn ogystal, bydd chwe ardal yn Lloegr yn pleidleisio am rôl newydd y &quot;meiri awdurdod lleol cyfunol&quot;.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bydd y meiri yma'n gyfrifol am ddatblygiad economaidd yn eu hardaloedd, ond fe fydd gan rai bwerau dros drafnidiaeth a thai.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae Doncaster a Gogledd Tyneside hefyd yn ethol meiri awdurdod lleol, fydd yn arweinwyr eu cynghorau.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Dros bwy ydw i'n pleidleisio a beth maen nhw'n ei wneud?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Mewn etholiadau lleol, mae cynghorwyr yn cael eu hethol i redeg awdurdodau lleol.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae cyngor sir yn gyfrifol am reoli sir, fel Sir Ddinbych neu Sir Gaerfyrddin er enghraifft.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Maen nhw'n gyfrifol am ofalu am y gwasanaethau cyngor mwyaf drud gan gynnwys ysgolion, gwasanaethau cymdeithasol, llyfrgelloedd, priffyrdd, trafnidiaeth gyhoeddus, heddluoedd a gwasanaethau tân, gwastraff a chynllunio strategol.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Caiff rhai siroedd eu rhannu'n gynghorau ardal, sy'n gyfrifol am faterion lleol a gwasanaethau fel cynllunio, tai cyngor, ffyrdd llai, iechyd yr amgylchedd, marchnadoedd, casglu gwastraff ac ailgylchu, parciau a thwristiaeth.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mewn rhai llefydd, mae'r ddau fath o gyngor yn cael eu cyfuno i greu awdurdod unedol sy'n gyfrifol am yr holl wasanaethau.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Yn 2017, mae bron pob etholiad yn Lloegr ar gyfer cyngor sir, tra bod pob cyngor yng Nghymru a'r Alban yn awdurdodau unedol.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Beth am ethol meiri?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Bydd chwe maer newydd yn cael eu hethol i gynrychioli nifer o ardaloedd yn Lloegr.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae'r swyddi yma'n cael eu creu fel rhan o gynllun y llywodraeth i gynyddu pwerau lleol a datganoli mwy o bwerau i ardaloedd yn Lloegr.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bydd y meiri yn cynrychioli nifer o awdurdodau lleol ym mhob ardal.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae'r union bwerau yn amrywio yn ôl y gwahanol gytundebau rhwng awdurdodau a'r llywodraeth, ond yn gyffredinol yn ymwneud a strategaeth economaidd, trafnidiaeth a chynllunio.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Pam nad yw pob cyngor yn Lloegr yn cynnal etholiad?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Mae gwahanol fathau o gyngor ar draws y DU ac maen nhw'n cynnal etholiadau ar adegau gwahanol.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Nid yw pob cyngor yn cynnal etholiad bob blwyddyn.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Pryd mae disgwyl y canlyniadau?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Bydd rhai cynghorau yng Nghymru a Lloegr yn dechrau cyfri' pleidleisiau yn syth ar ôl i'r blychau gan am 22:00 ar 4 Mai.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bydd eraill yn dechrau cyfri' fore Gwener gyda'r canlyniadau'n cael eu cadarnhau yn ystod y dydd.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae cynghorau yn Yr Alban yn dechrau cyfri' fore Gwener, ac mae disgwyl y canlyniadau cyntaf tua 12:00.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bydd canlyniadau etholiadau meiri yn cael eu cyhoeddi ddydd Gwener.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sut mae cyfrifo rheolaeth cyngor?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Os oes gan blaid fwyafrif ar unrhyw gyngor, mae'n cael ei ystyried mewn rheolaeth o'r cyngor yna.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Os nad oes gan unrhyw blaid fwyafrif yna caiff ei ddisgrifio fel &quot;Dim Rheolaeth Lawn&quot;.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mae'r BBC, Press Association ac eraill yn diffinio rheolaeth cyngor cyn etholiad fel y blaid, os oes un o gwbl, sydd â mwyafrif ar y noson cyn y bleidlais.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Pe bai'r Ceidwadwyr wedi ennill cyngor yn 2012, ond yna drwy aelodau'n gadael y blaid a seddi wedi eu colli mewn isetholiadau mae'r cyngor yn troi'n un Dim Rheolaeth Lawn, yn 2017, pe bai'r Ceidwadwyr yn cael mwyafrif byddai'n cael ei ddisgrifio fel y Ceidwadwyr yn cipio'r cyngor.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sut mae cyfrifo newid mewn seddi?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "Mae newid mewn seddi yn ddibynnol ar faint o seddi wnaeth bob plaid eu hennill yn yr etholiad tebyg diwethaf.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Yn Lloegr, roedd yr etholiad diwethaf i bron bob un o'r seddi yn 2013* a bron pobman yng Nghymru yn 2012**.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Roedd etholiadau lleol diwethaf Yr Alban yn 2012.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mewn rhai cynghorau, mae newidiadau i ffiniau wrth ad-drefnu cynghorau ac mae'r nifer o seddi ar y cyngor yn newid.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Mewn achosion o'r fath, mae'r BBC yn defnyddio &quot;canlyniadau damcaniaethol&quot; i amcangyfrif beth fyddai'r canlyniad wedi bod petai'r ffiniau wedi newid yn yr etholiad diwethaf.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bydd cyfanswm y seddi i bob plaid ychydig yn wahanol i'r seddi wrth ddiddymu a'r rhai gafodd eu hennill yn 2012 a 2013.",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "<italic>* Roedd etholiad diwethaf tebyg Doncaster yn 2015</italic>",
+        "markupType": "candy_xml",
+        "type": "paragraph"
+      },
+      {
+        "text": "<italic>** Cafodd etholiad Ynys Môn ei ohirio am flwyddyn tan 2013.</italic>",
+        "markupType": "candy_xml",
+        "type": "paragraph"
+      },
+      {
+        "text": "Beth mae DRL a thalfyriadau eraill yn eu golygu?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "ANI - Annibynnol",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "CEID - Ceidwadwyr",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "DRL - Dim Rheolaeth Lawn",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "DRh - Democratiaid Rhyddfrydol",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "GRDD - Plaid Werdd",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "LLAF - Llafur",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "LLG - Llais Gwynedd",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "PC - Plaid Cymru",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "UKIP - Plaid Annibyniaeth y DU",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Pa gynghorau sy'n cynnal etholiad eleni?",
+        "markupType": "plain_text",
+        "type": "subheading"
+      },
+      {
+        "text": "<link><caption>Cliciwch yma am fanylion yr holl ymgeiswyr ar gyfer yr etholiadau lleol</caption><url href=\"http://www.bbc.co.uk/cymrufyw/etholiad-2017-39513723\" platform=\"highweb\"/></link>.",
+        "markupType": "candy_xml",
+        "aresUrl": "https://ares-api.api.bbci.co.uk/api/asset/newyddion/etholiad-2017-39513723",
+        "type": "paragraph"
+      },
+      {
+        "text": "Abertawe",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Blaenau Gwent",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Bro Morgannwg",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Caerdydd",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Caerffili",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Casnewydd",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Castell-nedd Port Talbot",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Ceredigion",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Conwy",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Gwynedd",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Merthyr Tudful",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Pen-y-bont ar Ogwr",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Powys",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Rhondda Cynon Taf",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sir Penfro",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sir Ddinbych",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sir Fynwy",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sir Gaerfyrddin",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Sir y Fflint",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Torfaen",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Wrecsam",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      },
+      {
+        "text": "Ynys Môn",
+        "markupType": "plain_text",
+        "type": "paragraph"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": {
+      "shortHeadline": "Sut fydd y BBC yn adrodd canlyniadau etholiadau lleol 2017?",
+      "headline": "Sut fydd y BBC yn adrodd canlyniadau etholiadau lleol 2017?"
+    },
+    "locators": {
+      "assetUri": "/newyddion/etholiad-2017-39407507",
+      "cpsUrn": "urn:bbc:content:assetUri:newyddion/etholiad-2017-39407507",
+      "curie": "http://www.bbc.co.uk/asset/86d24cff-f55f-0b41-8318-afc98f4e42d0",
+      "assetId": "39407507"
+    },
+    "summary": "Sut fydd y BBC yn adrodd canlyniadau etholiadau lleol 2017?",
+    "timestamp": 1493388731000,
+    "language": "cy",
+    "indexImage": {
+      "id": "95830301",
+      "subType": "index",
+      "href": "http://c.files.bbci.co.uk/283F/production/_95830301_mediaitem95830300.jpg",
+      "path": "/cpsprodpb/283F/production/_95830301_mediaitem95830300.jpg",
+      "height": 351,
+      "width": 624,
+      "altText": "etholiad",
+      "copyrightHolder": "BBC",
+      "type": "image"
+    },
+    "id": "urn:bbc:ares::asset:newyddion/etholiad-2017-39407507",
+    "type": "cps"
+  },
+  "relatedContent": {
+    "section": {
+      "subType": "index",
+      "name": "Etholiad 2017",
+      "uri": "/newyddion/etholiad/2017",
+      "type": "simple"
+    },
+    "site": {
+      "subType": "site",
+      "name": "Newyddion",
+      "uri": "/newyddion",
+      "type": "simple"
+    },
+    "groups": []
+  }
+}

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -394,6 +394,8 @@ describe('cpsAssetPagePath', () => {
     '/zhongwen/simp/test-12345678',
     '/zhongwen/trad/test-12345678',
     '/zhongwen/simp/test-12345678.amp',
+    '/cymrufyw/etholiad-2017-39407507',
+    '/cymrufyw/etholiad-2017-39407507.amp',
   ];
 
   shouldMatchValidRoutes(validRoutes, cpsAssetPagePath);

--- a/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`regex utils snapshots should create expected regex from getArticleRegex
 
 exports[`regex utils snapshots should create expected regex from getArticleSwRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|erthyglau|sgeulachdan)/sw.js"`;
 
-exports[`regex utils snapshots should create expected regex from getCpsAssetRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/:assetUri([a-z-_]{0,}[0-9]{8,}):amp(.amp)?"`;
+exports[`regex utils snapshots should create expected regex from getCpsAssetRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/:assetUri([a-z0-9-_]{0,}[0-9]{8,}):amp(.amp)?"`;
 
 exports[`regex utils snapshots should create expected regex from getErrorPageRegex 1`] = `"/:service(news|persian|igbo)/:errorCode(404|500):variant(/simp|/trad|/cyr|/lat)?"`;
 
@@ -38,7 +38,7 @@ exports[`regex utils snapshots should create expected regex from getPodcastBrand
 
 exports[`regex utils snapshots should create expected regex from getPodcastEpisodeRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/podcasts/:brandId([a-z0-9]+)/:mediaId([a-z0-9]+):amp(.amp)?"`;
 
-exports[`regex utils snapshots should create expected regex from getRecommendationsDataRegex 1`] = `"/:service(news|persian|igbo)/:assetUri([a-z-_]{0,}[0-9]{8,})/recommendations:variant(/simp|/trad|/cyr|/lat)?.json"`;
+exports[`regex utils snapshots should create expected regex from getRecommendationsDataRegex 1`] = `"/:service(news|persian|igbo)/:assetUri([a-z0-9-_]{0,}[0-9]{8,})/recommendations:variant(/simp|/trad|/cyr|/lat)?.json"`;
 
 exports[`regex utils snapshots should create expected regex from getSecondaryColumnDataRegex 1`] = `"/:service(news|persian|igbo)/sty-secondary-column:variant(/simp|/trad|/cyr|/lat)?.json"`;
 

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -1,6 +1,6 @@
 const idRegex = 'c[a-zA-Z0-9]{10}o';
 const ampRegex = '.amp';
-const assetUriRegex = '[a-z-_]{0,}[0-9]{8,}';
+const assetUriRegex = '[a-z0-9-_]{0,}[0-9]{8,}';
 const legacyAssetUriRegex = '[a-z0-9-_]{1,}/[a-z0-9-_/]{1,}';
 const variantRegex = '/simp|/trad|/cyr|/lat';
 const articleLocalRegex = 'articles|erthyglau|sgeulachdan';


### PR DESCRIPTION
Resolves N/A

**Overall change:**
- Expand cpsAsset regex to cater for numbers before the asset id
- Update tests
- Add new asset fixture data

Without this change this url does not render: http://localhost:7080/cymrufyw/etholiad-2017-39407507

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
