### PR TITLE
Podcast external links

### DIFF
--- a/src/app/containers/PodcastExternalLinks/PodcastLink.jsx
+++ b/src/app/containers/PodcastExternalLinks/PodcastLink.jsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import { oneOf, string } from 'prop-types';
+import { C_CLOUD_LIGHT, C_EBON, C_METAL } from '@bbc/psammead-styles/colours';
+import { getSansBold } from '@bbc/psammead-styles/font-styles';
+import { getLongPrimer } from '@bbc/gel-foundations/typography';
+
+const PodcastLink = styled.a`
+  ${({ script }) => script && getLongPrimer(script)};
+  ${({ service }) => getSansBold(service)}
+  ${({ dir }) =>
+    dir === 'rtl' ? 'padding-left: 1rem' : 'padding-right: 1rem'};
+  color: ${C_EBON};
+  text-decoration: none;
+  display: inline-block;
+
+  &:visited {
+    color: ${C_METAL};
+  }
+
+  &:focus,
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:not(:first-child) {
+    ${({ dir }) =>
+      dir === 'rtl'
+        ? `
+      padding-right: 1rem;
+      border-left: 1px ${C_CLOUD_LIGHT} solid;`
+        : `
+      padding-left: 1rem;
+      border-left: 1px ${C_CLOUD_LIGHT} solid;
+      `}
+  }
+`;
+
+PodcastLink.propTypes = {
+  script: string.isRequired,
+  dir: oneOf(['rtl', 'ltr']).isRequired,
+  service: string.isRequired,
+};
+
+export default PodcastLink;

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -1,0 +1,59 @@
+import React, { useContext } from 'react';
+import { arrayOf, shape, string } from 'prop-types';
+import pathOr from 'ramda/src/pathOr';
+import styled from '@emotion/styled';
+import { C_CLOUD_LIGHT, C_EBON } from '@bbc/psammead-styles/colours';
+import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+import { getGreatPrimer } from '@bbc/gel-foundations/typography';
+
+import { ServiceContext } from '#contexts/ServiceContext';
+import Link from './PodcastLink';
+
+const Wrapper = styled.div`
+  border-top: 1px ${C_CLOUD_LIGHT} solid;
+  border-bottom: 1px ${C_CLOUD_LIGHT} solid;
+  margin: 0;
+  padding: 0 0 1rem 0;
+`;
+
+const Title = styled.h2`
+  ${({ service }) => getSansRegular(service)}
+  ${({ script }) => getGreatPrimer(script)};
+  color: ${C_EBON};
+`;
+
+const PodcastExternalLinks = ({ links }) => {
+  const { translations, service, script } = useContext(ServiceContext);
+  const defaultTranslation = 'Our podcast is also available on';
+  const title = pathOr(
+    defaultTranslation,
+    ['media', 'podcastExternalLinks'],
+    translations,
+  );
+
+  return (
+    <Wrapper>
+      <Title script={script} service={service}>
+        {title}
+      </Title>
+      <div>
+        {links.map(({ linkText, linkUrl }) => (
+          <Link href={linkUrl} key={linkText} service={service} script={script}>
+            {linkText}
+          </Link>
+        ))}
+      </div>
+    </Wrapper>
+  );
+};
+
+PodcastExternalLinks.propTypes = {
+  links: arrayOf(
+    shape({
+      linkText: string.isRequired,
+      linkUrl: string.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default PodcastExternalLinks;

--- a/src/app/containers/PodcastExternalLinks/index.stories.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.stories.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { withKnobs } from '@storybook/addon-knobs';
+import PodcastExternalLinks from '.';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+
+const links = [
+  {
+    linkUrl: 'https://bbc.com',
+    linkText: 'Apple',
+  },
+  {
+    linkUrl: 'https://bbc.com',
+    linkText: 'Google',
+  },
+  {
+    linkUrl: 'https://bbc.com',
+    linkText: 'Spotify',
+  },
+  {
+    linkUrl: 'https://bbc.com',
+    linkText: 'RSS',
+  },
+];
+
+storiesOf('Containers/Podcast', module)
+  .addParameters({ chromatic: { disable: true } })
+  .addDecorator(withKnobs)
+  .addDecorator(withServicesKnob())
+  .add(`default`, ({ service, variant }) => (
+    <ServiceContextProvider service={service} variant={variant}>
+      <PodcastExternalLinks links={links} />
+    </ServiceContextProvider>
+  ));


### PR DESCRIPTION
Resolves #8862

**Overall change:**
Create podcast external links component

**Code changes:**
- Create PodcastExternalLinks container
- Add container to OnDemandAudio page when it is a Podcast
- Get external links from AReS getInitialData
- Add component to storybook

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false npm run test:e2e:interactive`)
- [ ] This PR requires manual testing
