### PR TITLE
Radio schedule ordering

### DIFF
--- a/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -499,7 +499,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #6E6E73;
+  color: #222222;
   margin: 0;
 }
 
@@ -518,28 +518,43 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-39 {
-  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
-  color: #11708C;
-  display: inline-block;
-  margin-left: 0.5rem;
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
 }
 
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-39:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
 }
 
-@media (min-width: 37.5rem) {
-  .emotion-39 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-39:hover,
+.emotion-39:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-39:visited {
+  color: #6E6E73;
+}
+
+.emotion-39:hover .emotion-44 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-39:focus .emotion-44 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .emotion-41 {
@@ -554,7 +569,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-43 {
-  color: #6E6E73;
+  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -611,9 +626,9 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #FFFFFF;
+  background-color: #222222;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #FFFFFF;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -638,7 +653,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-49>svg {
-  color: #11708C;
+  color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -658,72 +673,57 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   padding-right: 0.5rem;
 }
 
-.emotion-76 {
+.emotion-154 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #222222;
+  color: #6E6E73;
   margin: 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-76 {
+  .emotion-154 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-76 {
+  .emotion-154 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-78 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
+.emotion-156 {
+  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.5rem;
+  color: #11708C;
+  display: inline-block;
+  margin-left: 0.5rem;
 }
 
-.emotion-78:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-156 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-78:hover,
-.emotion-78:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@media (min-width: 37.5rem) {
+  .emotion-156 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-78:visited {
+.emotion-160 {
   color: #6E6E73;
-}
-
-.emotion-78:hover .emotion-44 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-78:focus .emotion-44 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-82 {
-  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -735,54 +735,54 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-82 {
+  .emotion-160 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-82 {
+  .emotion-160 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-86 {
+.emotion-164 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #FFFFFF;
+  color: #11708C;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-86 {
+  .emotion-164 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-86 {
+  .emotion-164 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-86 {
+  .emotion-164 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-88>svg {
-  color: #FFFFFF;
+.emotion-166>svg {
+  color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -864,132 +864,6 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
       >
         <li
           class="emotion-18 emotion-19 emotion-17"
-          data-e2e="next"
-          dir="rtl"
-          role="listitem"
-        >
-          <div
-            class="emotion-21 emotion-22"
-          >
-            <div
-              class="emotion-23 emotion-24"
-            >
-              <span
-                class="emotion-25 emotion-26"
-                dir="rtl"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="emotion-27 emotion-28"
-                  focusable="false"
-                  height="13"
-                  viewBox="0 0 13 13"
-                  width="13"
-                >
-                  <path
-                    d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
-                  />
-                  <path
-                    d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
-                  />
-                </svg>
-              </span>
-              <span
-                aria-hidden="true"
-                class="emotion-29 emotion-30"
-                dir="rtl"
-              >
-                <time
-                  class="emotion-31 emotion-32"
-                  datetime="2030-01-01"
-                >
-                  09:00
-                </time>
-              </span>
-            </div>
-          </div>
-          <div
-            class="emotion-33 emotion-34"
-          >
-            <div
-              class="emotion-35 emotion-36"
-            >
-              <h3
-                class="emotion-37 emotion-38"
-              >
-                <span
-                  role="text"
-                >
-                  <span
-                    class="emotion-39 emotion-40"
-                    dir="rtl"
-                  >
-                    لاحق 
-                  </span>
-                  العالم هذا الصباح
-                  <span
-                    class="emotion-41 emotion-42"
-                  >
-                    , 
-                    09:00
-                    , 
-                  </span>
-                  <span
-                    class="emotion-43 emotion-44"
-                  >
-                    1 يناير/ كانون الثاني 2030
-                  </span>
-                </span>
-              </h3>
-              <p
-                class="emotion-45 emotion-46"
-              >
-                الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
-              </p>
-            </div>
-            <div
-              class="emotion-47 emotion-48"
-            >
-              <span
-                class="emotion-49 emotion-50"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="emotion-51 emotion-52"
-                  focusable="false"
-                  height="12px"
-                  viewBox="0 0 13 12"
-                  width="13px"
-                >
-                  <path
-                    d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-                  />
-                  <path
-                    d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-                  />
-                </svg>
-              </span>
-              <time
-                class="emotion-53 emotion-54"
-                datetime="PT1H30M30S"
-                dir="rtl"
-              >
-                <span
-                  class="emotion-41 emotion-42"
-                >
-                   المدة 1،30،30 
-                </span>
-                <span
-                  aria-hidden="true"
-                >
-                  1:30:30
-                </span>
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
@@ -1041,10 +915,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-76 emotion-38"
+                class="emotion-37 emotion-38"
               >
                 <a
-                  class="emotion-78 emotion-79"
+                  class="emotion-39 emotion-40"
                   href="/arabic/bbc_arabic_radio/w172x9qcpbyctzs"
                 >
                   <span
@@ -1059,7 +933,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-82 emotion-44"
+                      class="emotion-43 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -1073,10 +947,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-86 emotion-48"
+              class="emotion-47 emotion-48"
             >
               <span
-                class="emotion-88 emotion-50"
+                class="emotion-49 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1166,10 +1040,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-76 emotion-38"
+                class="emotion-37 emotion-38"
               >
                 <a
-                  class="emotion-78 emotion-79"
+                  class="emotion-39 emotion-40"
                   href="/arabic/bbc_arabic_radio/w172xbf7kbvtt4h"
                 >
                   <span
@@ -1184,7 +1058,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-82 emotion-44"
+                      class="emotion-43 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -1198,10 +1072,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-86 emotion-48"
+              class="emotion-47 emotion-48"
             >
               <span
-                class="emotion-88 emotion-50"
+                class="emotion-49 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1291,10 +1165,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-76 emotion-38"
+                class="emotion-37 emotion-38"
               >
                 <a
-                  class="emotion-78 emotion-79"
+                  class="emotion-39 emotion-40"
                   href="/arabic/bbc_arabic_radio/w172xbdf3m84fx2"
                 >
                   <span
@@ -1309,7 +1183,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-82 emotion-44"
+                      class="emotion-43 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -1323,10 +1197,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-86 emotion-48"
+              class="emotion-47 emotion-48"
             >
               <span
-                class="emotion-88 emotion-50"
+                class="emotion-49 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1358,6 +1232,132 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                   aria-hidden="true"
                 >
                   06:00
+                </span>
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-18 emotion-19 emotion-17"
+          data-e2e="next"
+          dir="rtl"
+          role="listitem"
+        >
+          <div
+            class="emotion-21 emotion-22"
+          >
+            <div
+              class="emotion-23 emotion-24"
+            >
+              <span
+                class="emotion-25 emotion-26"
+                dir="rtl"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-27 emotion-28"
+                  focusable="false"
+                  height="13"
+                  viewBox="0 0 13 13"
+                  width="13"
+                >
+                  <path
+                    d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+                  />
+                  <path
+                    d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+                  />
+                </svg>
+              </span>
+              <span
+                aria-hidden="true"
+                class="emotion-29 emotion-30"
+                dir="rtl"
+              >
+                <time
+                  class="emotion-31 emotion-32"
+                  datetime="2030-01-01"
+                >
+                  09:00
+                </time>
+              </span>
+            </div>
+          </div>
+          <div
+            class="emotion-33 emotion-34"
+          >
+            <div
+              class="emotion-35 emotion-36"
+            >
+              <h3
+                class="emotion-154 emotion-38"
+              >
+                <span
+                  role="text"
+                >
+                  <span
+                    class="emotion-156 emotion-157"
+                    dir="rtl"
+                  >
+                    لاحق 
+                  </span>
+                  العالم هذا الصباح
+                  <span
+                    class="emotion-41 emotion-42"
+                  >
+                    , 
+                    09:00
+                    , 
+                  </span>
+                  <span
+                    class="emotion-160 emotion-44"
+                  >
+                    1 يناير/ كانون الثاني 2030
+                  </span>
+                </span>
+              </h3>
+              <p
+                class="emotion-45 emotion-46"
+              >
+                الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
+              </p>
+            </div>
+            <div
+              class="emotion-164 emotion-48"
+            >
+              <span
+                class="emotion-166 emotion-50"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-51 emotion-52"
+                  focusable="false"
+                  height="12px"
+                  viewBox="0 0 13 12"
+                  width="13px"
+                >
+                  <path
+                    d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                  />
+                  <path
+                    d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                  />
+                </svg>
+              </span>
+              <time
+                class="emotion-53 emotion-54"
+                datetime="PT1H30M30S"
+                dir="rtl"
+              >
+                <span
+                  class="emotion-41 emotion-42"
+                >
+                   المدة 1،30،30 
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  1:30:30
                 </span>
               </time>
             </div>

--- a/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -499,7 +499,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #222222;
+  color: #6E6E73;
   margin: 0;
 }
 
@@ -518,43 +518,28 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-39 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
+  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.5rem;
+  color: #11708C;
+  display: inline-block;
+  margin-left: 0.5rem;
 }
 
-.emotion-39:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-39 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-39:hover,
-.emotion-39:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-39:visited {
-  color: #6E6E73;
-}
-
-.emotion-39:hover .emotion-44 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-39:focus .emotion-44 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@media (min-width: 37.5rem) {
+  .emotion-39 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
 .emotion-41 {
@@ -569,7 +554,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-43 {
-  color: #3F3F42;
+  color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -626,9 +611,9 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #FFFFFF;
+  color: #11708C;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -653,7 +638,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-49>svg {
-  color: #FFFFFF;
+  color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -673,57 +658,72 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   padding-right: 0.5rem;
 }
 
-.emotion-154 {
+.emotion-76 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #6E6E73;
+  color: #222222;
   margin: 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-154 {
+  .emotion-76 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-154 {
+  .emotion-76 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-156 {
-  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
-  color: #11708C;
-  display: inline-block;
-  margin-left: 0.5rem;
+.emotion-78 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
 }
 
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-156 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-78:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
 }
 
-@media (min-width: 37.5rem) {
-  .emotion-156 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-78:hover,
+.emotion-78:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.emotion-160 {
+.emotion-78:visited {
   color: #6E6E73;
+}
+
+.emotion-78:hover .emotion-44 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-78:focus .emotion-44 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-82 {
+  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -735,54 +735,54 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-160 {
+  .emotion-82 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-160 {
+  .emotion-82 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-164 {
+.emotion-86 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #FFFFFF;
+  background-color: #222222;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #FFFFFF;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-164 {
+  .emotion-86 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-164 {
+  .emotion-86 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-164 {
+  .emotion-86 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-166>svg {
-  color: #11708C;
+.emotion-88>svg {
+  color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -864,6 +864,132 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
       >
         <li
           class="emotion-18 emotion-19 emotion-17"
+          data-e2e="next"
+          dir="rtl"
+          role="listitem"
+        >
+          <div
+            class="emotion-21 emotion-22"
+          >
+            <div
+              class="emotion-23 emotion-24"
+            >
+              <span
+                class="emotion-25 emotion-26"
+                dir="rtl"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-27 emotion-28"
+                  focusable="false"
+                  height="13"
+                  viewBox="0 0 13 13"
+                  width="13"
+                >
+                  <path
+                    d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+                  />
+                  <path
+                    d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+                  />
+                </svg>
+              </span>
+              <span
+                aria-hidden="true"
+                class="emotion-29 emotion-30"
+                dir="rtl"
+              >
+                <time
+                  class="emotion-31 emotion-32"
+                  datetime="2030-01-01"
+                >
+                  09:00
+                </time>
+              </span>
+            </div>
+          </div>
+          <div
+            class="emotion-33 emotion-34"
+          >
+            <div
+              class="emotion-35 emotion-36"
+            >
+              <h3
+                class="emotion-37 emotion-38"
+              >
+                <span
+                  role="text"
+                >
+                  <span
+                    class="emotion-39 emotion-40"
+                    dir="rtl"
+                  >
+                    لاحق 
+                  </span>
+                  العالم هذا الصباح
+                  <span
+                    class="emotion-41 emotion-42"
+                  >
+                    , 
+                    09:00
+                    , 
+                  </span>
+                  <span
+                    class="emotion-43 emotion-44"
+                  >
+                    1 يناير/ كانون الثاني 2030
+                  </span>
+                </span>
+              </h3>
+              <p
+                class="emotion-45 emotion-46"
+              >
+                الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
+              </p>
+            </div>
+            <div
+              class="emotion-47 emotion-48"
+            >
+              <span
+                class="emotion-49 emotion-50"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="emotion-51 emotion-52"
+                  focusable="false"
+                  height="12px"
+                  viewBox="0 0 13 12"
+                  width="13px"
+                >
+                  <path
+                    d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                  />
+                  <path
+                    d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                  />
+                </svg>
+              </span>
+              <time
+                class="emotion-53 emotion-54"
+                datetime="PT1H30M30S"
+                dir="rtl"
+              >
+                <span
+                  class="emotion-41 emotion-42"
+                >
+                   المدة 1،30،30 
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  1:30:30
+                </span>
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
@@ -915,10 +1041,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-37 emotion-38"
+                class="emotion-76 emotion-38"
               >
                 <a
-                  class="emotion-39 emotion-40"
+                  class="emotion-78 emotion-79"
                   href="/arabic/bbc_arabic_radio/w172x9qcpbyctzs"
                 >
                   <span
@@ -933,7 +1059,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-43 emotion-44"
+                      class="emotion-82 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -947,10 +1073,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-86 emotion-48"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-88 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1040,10 +1166,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-37 emotion-38"
+                class="emotion-76 emotion-38"
               >
                 <a
-                  class="emotion-39 emotion-40"
+                  class="emotion-78 emotion-79"
                   href="/arabic/bbc_arabic_radio/w172xbf7kbvtt4h"
                 >
                   <span
@@ -1058,7 +1184,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-43 emotion-44"
+                      class="emotion-82 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -1072,10 +1198,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-86 emotion-48"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-88 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1165,10 +1291,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-37 emotion-38"
+                class="emotion-76 emotion-38"
               >
                 <a
-                  class="emotion-39 emotion-40"
+                  class="emotion-78 emotion-79"
                   href="/arabic/bbc_arabic_radio/w172xbdf3m84fx2"
                 >
                   <span
@@ -1183,7 +1309,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                       , 
                     </span>
                     <span
-                      class="emotion-43 emotion-44"
+                      class="emotion-82 emotion-44"
                     >
                       26 مارس/ آذار 2020
                     </span>
@@ -1197,10 +1323,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </p>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-86 emotion-48"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-88 emotion-50"
               >
                 <svg
                   aria-hidden="true"
@@ -1232,132 +1358,6 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                   aria-hidden="true"
                 >
                   06:00
-                </span>
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-19 emotion-17"
-          data-e2e="next"
-          dir="rtl"
-          role="listitem"
-        >
-          <div
-            class="emotion-21 emotion-22"
-          >
-            <div
-              class="emotion-23 emotion-24"
-            >
-              <span
-                class="emotion-25 emotion-26"
-                dir="rtl"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="emotion-27 emotion-28"
-                  focusable="false"
-                  height="13"
-                  viewBox="0 0 13 13"
-                  width="13"
-                >
-                  <path
-                    d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
-                  />
-                  <path
-                    d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
-                  />
-                </svg>
-              </span>
-              <span
-                aria-hidden="true"
-                class="emotion-29 emotion-30"
-                dir="rtl"
-              >
-                <time
-                  class="emotion-31 emotion-32"
-                  datetime="2030-01-01"
-                >
-                  09:00
-                </time>
-              </span>
-            </div>
-          </div>
-          <div
-            class="emotion-33 emotion-34"
-          >
-            <div
-              class="emotion-35 emotion-36"
-            >
-              <h3
-                class="emotion-154 emotion-38"
-              >
-                <span
-                  role="text"
-                >
-                  <span
-                    class="emotion-156 emotion-157"
-                    dir="rtl"
-                  >
-                    لاحق 
-                  </span>
-                  العالم هذا الصباح
-                  <span
-                    class="emotion-41 emotion-42"
-                  >
-                    , 
-                    09:00
-                    , 
-                  </span>
-                  <span
-                    class="emotion-160 emotion-44"
-                  >
-                    1 يناير/ كانون الثاني 2030
-                  </span>
-                </span>
-              </h3>
-              <p
-                class="emotion-45 emotion-46"
-              >
-                الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
-              </p>
-            </div>
-            <div
-              class="emotion-164 emotion-48"
-            >
-              <span
-                class="emotion-166 emotion-50"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="emotion-51 emotion-52"
-                  focusable="false"
-                  height="12px"
-                  viewBox="0 0 13 12"
-                  width="13px"
-                >
-                  <path
-                    d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-                  />
-                  <path
-                    d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-                  />
-                </svg>
-              </span>
-              <time
-                class="emotion-53 emotion-54"
-                datetime="PT1H30M30S"
-                dir="rtl"
-              >
-                <span
-                  class="emotion-41 emotion-42"
-                >
-                   المدة 1،30،30 
-                </span>
-                <span
-                  aria-hidden="true"
-                >
-                  1:30:30
                 </span>
               </time>
             </div>

--- a/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
+++ b/src/app/containers/RadioSchedule/utilities/processRadioSchedule.js
@@ -56,10 +56,10 @@ export default (data, service, currentTime) => {
   }
 
   const programsToShow = scheduleDataIsComplete && [
+    schedules[latestProgramIndex + 1],
     schedules[latestProgramIndex],
     schedules[latestProgramIndex - 1],
     schedules[latestProgramIndex - 2],
-    schedules[latestProgramIndex + 1],
   ];
 
   const processedSchedule =

--- a/src/app/containers/RadioSchedule/utilities/processRadioSchedule.test.js
+++ b/src/app/containers/RadioSchedule/utilities/processRadioSchedule.test.js
@@ -73,7 +73,7 @@ describe('processRadioSchedule', () => {
       expect(programs[0].startTime).toBeGreaterThan(programs[1].startTime);
       expect(programs[1].startTime).toBeGreaterThan(programs[2].startTime);
       // Checks that the next program is last item on the array
-      expect(programs[3].startTime).toBeGreaterThan(programs[0].startTime);
+      expect(programs[2].startTime).toBeGreaterThan(programs[3].startTime);
     });
 
     it('should return a program that has the right fields', () => {

--- a/src/app/containers/RadioSchedule/utilities/processRadioSchedule.test.js
+++ b/src/app/containers/RadioSchedule/utilities/processRadioSchedule.test.js
@@ -68,11 +68,9 @@ describe('processRadioSchedule', () => {
       expect(programs).toHaveLength(4);
     });
 
-    it('should return programs in the right order', () => {
-      // Checks the order of live and onDemand programs
+    it('should return the programs ordered by start time, newest first', () => {
       expect(programs[0].startTime).toBeGreaterThan(programs[1].startTime);
       expect(programs[1].startTime).toBeGreaterThan(programs[2].startTime);
-      // Checks that the next program is last item on the array
       expect(programs[2].startTime).toBeGreaterThan(programs[3].startTime);
     });
 

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -1542,7 +1542,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #222222;
+  color: #6E6E73;
   margin: 0;
 }
 
@@ -1561,47 +1561,32 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-274 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
+  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.5rem;
+  color: #11708C;
+  display: inline-block;
+  margin-left: 0.5rem;
 }
 
-.emotion-274:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-274 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-274:hover,
-.emotion-274:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-274:visited {
-  color: #6E6E73;
-}
-
-.emotion-274:hover .emotion-279 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-274:focus .emotion-279 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@media (min-width: 37.5rem) {
+  .emotion-274 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
 .emotion-278 {
-  color: #3F3F42;
+  color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -1658,9 +1643,9 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #FFFFFF;
+  color: #11708C;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1685,7 +1670,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-284>svg {
-  color: #FFFFFF;
+  color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -1705,57 +1690,72 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   padding-right: 0.5rem;
 }
 
-.emotion-389 {
+.emotion-311 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #6E6E73;
+  color: #222222;
   margin: 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-389 {
+  .emotion-311 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-389 {
+  .emotion-311 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-391 {
-  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
-  color: #11708C;
-  display: inline-block;
-  margin-left: 0.5rem;
+.emotion-313 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
 }
 
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-391 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-313:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
 }
 
-@media (min-width: 37.5rem) {
-  .emotion-391 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-313:hover,
+.emotion-313:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
-.emotion-395 {
+.emotion-313:visited {
   color: #6E6E73;
+}
+
+.emotion-313:hover .emotion-279 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-313:focus .emotion-279 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-317 {
+  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -1767,54 +1767,54 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-395 {
+  .emotion-317 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-395 {
+  .emotion-317 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-399 {
+.emotion-321 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #FFFFFF;
+  background-color: #222222;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #FFFFFF;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-399 {
+  .emotion-321 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-399 {
+  .emotion-321 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-399 {
+  .emotion-321 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-401>svg {
-  color: #11708C;
+.emotion-323>svg {
+  color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -3019,6 +3019,132 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           >
             <li
               class="emotion-253 emotion-254 emotion-56"
+              data-e2e="next"
+              dir="rtl"
+              role="listitem"
+            >
+              <div
+                class="emotion-256 emotion-257"
+              >
+                <div
+                  class="emotion-258 emotion-259"
+                >
+                  <span
+                    class="emotion-260 emotion-261"
+                    dir="rtl"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="emotion-262 emotion-263"
+                      focusable="false"
+                      height="13"
+                      viewBox="0 0 13 13"
+                      width="13"
+                    >
+                      <path
+                        d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+                      />
+                      <path
+                        d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="emotion-264 emotion-265"
+                    dir="rtl"
+                  >
+                    <time
+                      class="emotion-40 emotion-41"
+                      datetime="2030-01-01"
+                    >
+                      ۰۹:۰۰
+                    </time>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="emotion-268 emotion-269"
+              >
+                <div
+                  class="emotion-270 emotion-271"
+                >
+                  <h3
+                    class="emotion-272 emotion-273"
+                  >
+                    <span
+                      role="text"
+                    >
+                      <span
+                        class="emotion-274 emotion-275"
+                        dir="rtl"
+                      >
+                        بعدی 
+                      </span>
+                      چشم انداز بامدادی 1
+                      <span
+                        class="emotion-86 emotion-87"
+                      >
+                        , 
+                        ۰۹:۰۰
+                        , 
+                      </span>
+                      <span
+                        class="emotion-278 emotion-279"
+                      >
+                        ۱ ژانویه ۲۰۳۰
+                      </span>
+                    </span>
+                  </h3>
+                  <p
+                    class="emotion-280 emotion-281"
+                  >
+                    تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
+                  </p>
+                </div>
+                <div
+                  class="emotion-282 emotion-283"
+                >
+                  <span
+                    class="emotion-284 emotion-285"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="emotion-286 emotion-287"
+                      focusable="false"
+                      height="12px"
+                      viewBox="0 0 13 12"
+                      width="13px"
+                    >
+                      <path
+                        d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                      />
+                      <path
+                        d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                      />
+                    </svg>
+                  </span>
+                  <time
+                    class="emotion-288 emotion-289"
+                    datetime="PT26M30S"
+                    dir="rtl"
+                  >
+                    <span
+                      class="emotion-86 emotion-87"
+                    >
+                       ۲۶،۳۰ المدة الزمنية 
+                    </span>
+                    <span
+                      aria-hidden="true"
+                    >
+                      ۲۶:۳۰
+                    </span>
+                  </time>
+                </div>
+              </div>
+            </li>
+            <li
+              class="emotion-253 emotion-254 emotion-56"
               data-e2e="onDemand"
               dir="rtl"
               role="listitem"
@@ -3070,10 +3196,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-272 emotion-273"
+                    class="emotion-311 emotion-273"
                   >
                     <a
-                      class="emotion-274 emotion-275"
+                      class="emotion-313 emotion-314"
                       href="/persian/bbc_dari_radio/w172x1rwggbcdq8"
                     >
                       <span
@@ -3088,7 +3214,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-278 emotion-279"
+                          class="emotion-317 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3102,10 +3228,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-282 emotion-283"
+                  class="emotion-321 emotion-283"
                 >
                   <span
-                    class="emotion-284 emotion-285"
+                    class="emotion-323 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3195,10 +3321,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-272 emotion-273"
+                    class="emotion-311 emotion-273"
                   >
                     <a
-                      class="emotion-274 emotion-275"
+                      class="emotion-313 emotion-314"
                       href="/persian/bbc_dari_radio/w3csz8fk"
                     >
                       <span
@@ -3213,7 +3339,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-278 emotion-279"
+                          class="emotion-317 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3227,10 +3353,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-282 emotion-283"
+                  class="emotion-321 emotion-283"
                 >
                   <span
-                    class="emotion-284 emotion-285"
+                    class="emotion-323 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3320,10 +3446,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-272 emotion-273"
+                    class="emotion-311 emotion-273"
                   >
                     <a
-                      class="emotion-274 emotion-275"
+                      class="emotion-313 emotion-314"
                       href="/persian/bbc_dari_radio/w3csz7tn"
                     >
                       <span
@@ -3338,7 +3464,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-278 emotion-279"
+                          class="emotion-317 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3352,10 +3478,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-282 emotion-283"
+                  class="emotion-321 emotion-283"
                 >
                   <span
-                    class="emotion-284 emotion-285"
+                    class="emotion-323 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3387,132 +3513,6 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       aria-hidden="true"
                     >
                       ۲۹:۳۰
-                    </span>
-                  </time>
-                </div>
-              </div>
-            </li>
-            <li
-              class="emotion-253 emotion-254 emotion-56"
-              data-e2e="next"
-              dir="rtl"
-              role="listitem"
-            >
-              <div
-                class="emotion-256 emotion-257"
-              >
-                <div
-                  class="emotion-258 emotion-259"
-                >
-                  <span
-                    class="emotion-260 emotion-261"
-                    dir="rtl"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="emotion-262 emotion-263"
-                      focusable="false"
-                      height="13"
-                      viewBox="0 0 13 13"
-                      width="13"
-                    >
-                      <path
-                        d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
-                      />
-                      <path
-                        d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    class="emotion-264 emotion-265"
-                    dir="rtl"
-                  >
-                    <time
-                      class="emotion-40 emotion-41"
-                      datetime="2030-01-01"
-                    >
-                      ۰۹:۰۰
-                    </time>
-                  </span>
-                </div>
-              </div>
-              <div
-                class="emotion-268 emotion-269"
-              >
-                <div
-                  class="emotion-270 emotion-271"
-                >
-                  <h3
-                    class="emotion-389 emotion-273"
-                  >
-                    <span
-                      role="text"
-                    >
-                      <span
-                        class="emotion-391 emotion-392"
-                        dir="rtl"
-                      >
-                        بعدی 
-                      </span>
-                      چشم انداز بامدادی 1
-                      <span
-                        class="emotion-86 emotion-87"
-                      >
-                        , 
-                        ۰۹:۰۰
-                        , 
-                      </span>
-                      <span
-                        class="emotion-395 emotion-279"
-                      >
-                        ۱ ژانویه ۲۰۳۰
-                      </span>
-                    </span>
-                  </h3>
-                  <p
-                    class="emotion-280 emotion-281"
-                  >
-                    تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
-                  </p>
-                </div>
-                <div
-                  class="emotion-399 emotion-283"
-                >
-                  <span
-                    class="emotion-401 emotion-285"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="emotion-286 emotion-287"
-                      focusable="false"
-                      height="12px"
-                      viewBox="0 0 13 12"
-                      width="13px"
-                    >
-                      <path
-                        d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-                      />
-                      <path
-                        d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-                      />
-                    </svg>
-                  </span>
-                  <time
-                    class="emotion-288 emotion-289"
-                    datetime="PT26M30S"
-                    dir="rtl"
-                  >
-                    <span
-                      class="emotion-86 emotion-87"
-                    >
-                       ۲۶،۳۰ المدة الزمنية 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                    >
-                      ۲۶:۳۰
                     </span>
                   </time>
                 </div>

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -1542,7 +1542,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #6E6E73;
+  color: #222222;
   margin: 0;
 }
 
@@ -1561,32 +1561,47 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-274 {
-  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
-  color: #11708C;
-  display: inline-block;
-  margin-left: 0.5rem;
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
 }
 
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-274 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-274:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
 }
 
-@media (min-width: 37.5rem) {
-  .emotion-274 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+.emotion-274:hover,
+.emotion-274:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-274:visited {
+  color: #6E6E73;
+}
+
+.emotion-274:hover .emotion-279 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-274:focus .emotion-279 {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .emotion-278 {
-  color: #6E6E73;
+  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -1643,9 +1658,9 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #FFFFFF;
+  background-color: #222222;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #FFFFFF;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1670,7 +1685,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-284>svg {
-  color: #11708C;
+  color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -1690,72 +1705,57 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   padding-right: 0.5rem;
 }
 
-.emotion-311 {
+.emotion-389 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #222222;
+  color: #6E6E73;
   margin: 0;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-311 {
+  .emotion-389 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-311 {
+  .emotion-389 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-313 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
+.emotion-391 {
+  font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.5rem;
+  color: #11708C;
+  display: inline-block;
+  margin-left: 0.5rem;
 }
 
-.emotion-313:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-391 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-313:hover,
-.emotion-313:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+@media (min-width: 37.5rem) {
+  .emotion-391 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }
 
-.emotion-313:visited {
+.emotion-395 {
   color: #6E6E73;
-}
-
-.emotion-313:hover .emotion-279 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-313:focus .emotion-279 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-317 {
-  color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
   width: 100%;
@@ -1767,54 +1767,54 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-317 {
+  .emotion-395 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-317 {
+  .emotion-395 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-321 {
+.emotion-399 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #222222;
+  background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #FFFFFF;
+  color: #11708C;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-321 {
+  .emotion-399 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-321 {
+  .emotion-399 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-321 {
+  .emotion-399 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-323>svg {
-  color: #FFFFFF;
+.emotion-401>svg {
+  color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -3019,132 +3019,6 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           >
             <li
               class="emotion-253 emotion-254 emotion-56"
-              data-e2e="next"
-              dir="rtl"
-              role="listitem"
-            >
-              <div
-                class="emotion-256 emotion-257"
-              >
-                <div
-                  class="emotion-258 emotion-259"
-                >
-                  <span
-                    class="emotion-260 emotion-261"
-                    dir="rtl"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="emotion-262 emotion-263"
-                      focusable="false"
-                      height="13"
-                      viewBox="0 0 13 13"
-                      width="13"
-                    >
-                      <path
-                        d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
-                      />
-                      <path
-                        d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    aria-hidden="true"
-                    class="emotion-264 emotion-265"
-                    dir="rtl"
-                  >
-                    <time
-                      class="emotion-40 emotion-41"
-                      datetime="2030-01-01"
-                    >
-                      ۰۹:۰۰
-                    </time>
-                  </span>
-                </div>
-              </div>
-              <div
-                class="emotion-268 emotion-269"
-              >
-                <div
-                  class="emotion-270 emotion-271"
-                >
-                  <h3
-                    class="emotion-272 emotion-273"
-                  >
-                    <span
-                      role="text"
-                    >
-                      <span
-                        class="emotion-274 emotion-275"
-                        dir="rtl"
-                      >
-                        بعدی 
-                      </span>
-                      چشم انداز بامدادی 1
-                      <span
-                        class="emotion-86 emotion-87"
-                      >
-                        , 
-                        ۰۹:۰۰
-                        , 
-                      </span>
-                      <span
-                        class="emotion-278 emotion-279"
-                      >
-                        ۱ ژانویه ۲۰۳۰
-                      </span>
-                    </span>
-                  </h3>
-                  <p
-                    class="emotion-280 emotion-281"
-                  >
-                    تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
-                  </p>
-                </div>
-                <div
-                  class="emotion-282 emotion-283"
-                >
-                  <span
-                    class="emotion-284 emotion-285"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="emotion-286 emotion-287"
-                      focusable="false"
-                      height="12px"
-                      viewBox="0 0 13 12"
-                      width="13px"
-                    >
-                      <path
-                        d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
-                      />
-                      <path
-                        d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
-                      />
-                    </svg>
-                  </span>
-                  <time
-                    class="emotion-288 emotion-289"
-                    datetime="PT26M30S"
-                    dir="rtl"
-                  >
-                    <span
-                      class="emotion-86 emotion-87"
-                    >
-                       ۲۶،۳۰ المدة الزمنية 
-                    </span>
-                    <span
-                      aria-hidden="true"
-                    >
-                      ۲۶:۳۰
-                    </span>
-                  </time>
-                </div>
-              </div>
-            </li>
-            <li
-              class="emotion-253 emotion-254 emotion-56"
               data-e2e="onDemand"
               dir="rtl"
               role="listitem"
@@ -3196,10 +3070,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-311 emotion-273"
+                    class="emotion-272 emotion-273"
                   >
                     <a
-                      class="emotion-313 emotion-314"
+                      class="emotion-274 emotion-275"
                       href="/persian/bbc_dari_radio/w172x1rwggbcdq8"
                     >
                       <span
@@ -3214,7 +3088,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-317 emotion-279"
+                          class="emotion-278 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3228,10 +3102,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-321 emotion-283"
+                  class="emotion-282 emotion-283"
                 >
                   <span
-                    class="emotion-323 emotion-285"
+                    class="emotion-284 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3321,10 +3195,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-311 emotion-273"
+                    class="emotion-272 emotion-273"
                   >
                     <a
-                      class="emotion-313 emotion-314"
+                      class="emotion-274 emotion-275"
                       href="/persian/bbc_dari_radio/w3csz8fk"
                     >
                       <span
@@ -3339,7 +3213,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-317 emotion-279"
+                          class="emotion-278 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3353,10 +3227,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-321 emotion-283"
+                  class="emotion-282 emotion-283"
                 >
                   <span
-                    class="emotion-323 emotion-285"
+                    class="emotion-284 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3446,10 +3320,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-270 emotion-271"
                 >
                   <h3
-                    class="emotion-311 emotion-273"
+                    class="emotion-272 emotion-273"
                   >
                     <a
-                      class="emotion-313 emotion-314"
+                      class="emotion-274 emotion-275"
                       href="/persian/bbc_dari_radio/w3csz7tn"
                     >
                       <span
@@ -3464,7 +3338,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           , 
                         </span>
                         <span
-                          class="emotion-317 emotion-279"
+                          class="emotion-278 emotion-279"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
@@ -3478,10 +3352,10 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </p>
                 </div>
                 <div
-                  class="emotion-321 emotion-283"
+                  class="emotion-282 emotion-283"
                 >
                   <span
-                    class="emotion-323 emotion-285"
+                    class="emotion-284 emotion-285"
                   >
                     <svg
                       aria-hidden="true"
@@ -3513,6 +3387,132 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       aria-hidden="true"
                     >
                       ۲۹:۳۰
+                    </span>
+                  </time>
+                </div>
+              </div>
+            </li>
+            <li
+              class="emotion-253 emotion-254 emotion-56"
+              data-e2e="next"
+              dir="rtl"
+              role="listitem"
+            >
+              <div
+                class="emotion-256 emotion-257"
+              >
+                <div
+                  class="emotion-258 emotion-259"
+                >
+                  <span
+                    class="emotion-260 emotion-261"
+                    dir="rtl"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="emotion-262 emotion-263"
+                      focusable="false"
+                      height="13"
+                      viewBox="0 0 13 13"
+                      width="13"
+                    >
+                      <path
+                        d="M6.5 0A6.5 6.5 0 1013 6.5 6.5 6.5 0 006.5 0zm0 11.5a5 5 0 115-5 5 5 0 01-5 5z"
+                      />
+                      <path
+                        d="M7.34 2.9h-1v3.8L9.4 8.57l.41-.56-2.47-1.89V2.9z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="emotion-264 emotion-265"
+                    dir="rtl"
+                  >
+                    <time
+                      class="emotion-40 emotion-41"
+                      datetime="2030-01-01"
+                    >
+                      ۰۹:۰۰
+                    </time>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="emotion-268 emotion-269"
+              >
+                <div
+                  class="emotion-270 emotion-271"
+                >
+                  <h3
+                    class="emotion-389 emotion-273"
+                  >
+                    <span
+                      role="text"
+                    >
+                      <span
+                        class="emotion-391 emotion-392"
+                        dir="rtl"
+                      >
+                        بعدی 
+                      </span>
+                      چشم انداز بامدادی 1
+                      <span
+                        class="emotion-86 emotion-87"
+                      >
+                        , 
+                        ۰۹:۰۰
+                        , 
+                      </span>
+                      <span
+                        class="emotion-395 emotion-279"
+                      >
+                        ۱ ژانویه ۲۰۳۰
+                      </span>
+                    </span>
+                  </h3>
+                  <p
+                    class="emotion-280 emotion-281"
+                  >
+                    تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
+                  </p>
+                </div>
+                <div
+                  class="emotion-399 emotion-283"
+                >
+                  <span
+                    class="emotion-401 emotion-285"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="emotion-286 emotion-287"
+                      focusable="false"
+                      height="12px"
+                      viewBox="0 0 13 12"
+                      width="13px"
+                    >
+                      <path
+                        d="M9.021 1.811l-.525.525c.938.938 1.5 2.25 1.5 3.675s-.563 2.738-1.5 3.675l.525.525c1.05-1.087 1.725-2.55 1.725-4.2s-.675-3.112-1.725-4.2z"
+                      />
+                      <path
+                        d="M10.596.199l-.525.562c1.35 1.35 2.175 3.225 2.175 5.25s-.825 3.9-2.175 5.25l.525.525c1.5-1.462 2.4-3.525 2.4-5.775s-.9-4.312-2.4-5.812zM6.996 1.511l-2.25 2.25H.996v4.5h3.75l2.25 2.25z"
+                      />
+                    </svg>
+                  </span>
+                  <time
+                    class="emotion-288 emotion-289"
+                    datetime="PT26M30S"
+                    dir="rtl"
+                  >
+                    <span
+                      class="emotion-86 emotion-87"
+                    >
+                       ۲۶،۳۰ المدة الزمنية 
+                    </span>
+                    <span
+                      aria-hidden="true"
+                    >
+                      ۲۶:۳۰
                     </span>
                   </time>
                 </div>


### PR DESCRIPTION
Resolves #8897

**Overall change:**
Reordering the Radio Schedule component to have the future episode first, followed by live/most recent.

**Code changes:**

- Switched the future episode from the final position to the first position in the array
- Updated the unit test to reflect this change and updated the name for clarify
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
