### PR TITLE
Fixed amp cookie banner test problem, added Mundo URLS on live and test

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -82,7 +82,7 @@ export default ({ service, variant, pageType, path }) => {
 
     getPrivacyBannerAccept(service, variant).click();
     getCookieBannerManageSettingsButton(service, variant).click();
-    getCookieBannerManageSettings(service, variant).should('be.visible');
+    getCookieBannerManageSettings().should('be.visible');
 
     cy.reload();
 

--- a/cypress/integration/specialFeatures/utilities/cookiePrivacyBanner/index.js
+++ b/cypress/integration/specialFeatures/utilities/cookiePrivacyBanner/index.js
@@ -76,11 +76,8 @@ export const getCookieBannerManageSettingsButton = (service, variant) =>
         .amp.initial.manage,
     );
 
-export const getCookieBannerManageSettings = (service, variant) =>
-  cy.contains(
-    appConfig[config[service].name][variant].translations.consentBanner.cookie
-      .amp.manage.description.heading3,
-  );
+export const getCookieBannerManageSettings = () =>
+  cy.get('[data-testid=amp-cookie-banner-manage-settings]');
 
 export const getCookieBannerAcceptInManageSettings = (service, variant) =>
   cy

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4173,12 +4173,24 @@ module.exports = () => ({
       cookieBanner: {
         environments: {
           live: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/mundo/articles/cdwrpl7qwqqo',
+              '/mundo',
+              '/mundo/noticias-internacional-53826365',
+              '/mundo/popular/read',
+              '/mundo/media-52123665',
+            ],
+            enabled: true,
           },
           test: {
-            paths: [],
-            enabled: false,
+            paths: [
+              '/mundo/articles/ce42wzqr2mko',
+              '/mundo',
+              '/mundo/noticias-internacional-23055705',
+              '/mundo/popular/read',
+              '/mundo/media-23283126',
+            ],
+            enabled: true,
           },
           local: {
             paths: [


### PR DESCRIPTION

The check for if the manage settings banner has expanded is done by looking for '[data-testid=amp-cookie-banner-manage-settings]', an id, rather than through what element contains the target string.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

tests now pass on local, test and live