### PR TITLE
Use processRecentEpisodes function for OD Audio & TV recent episodes E2Es

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -8,6 +8,7 @@ import {
 } from '../../../support/helpers/onDemandRadioTv';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import getDataUrl from '../../../support/helpers/getDataUrl';
+import processRecentEpisodes from '../../../../src/app/routes/utils/processRecentEpisodes';
 
 export default ({ service, pageType, variant, isAmp }) => {
   describe(`Tests for ${service} ${pageType}`, () => {
@@ -80,10 +81,12 @@ export default ({ service, pageType, variant, isAmp }) => {
                     : `${currentPath}`;
 
                 cy.request(getDataUrl(url)).then(({ body }) => {
-                  // Count the number of episodes that are available and so will show (there can be unavailable episodes in the list)
-                  const expectedNumberOfEpisodes = body.relatedContent.groups[0].promos
-                    .filter(({ media }) => media.versions.length)
-                    .slice(0, recentEpisodesMaxNumber).length;
+                  const episodeId = path(['content', 'blocks', 0, 'id'], body);
+
+                  const expectedNumberOfEpisodes = processRecentEpisodes(body, {
+                    exclude: episodeId,
+                    recentEpisodesLimit: recentEpisodesMaxNumber,
+                  }).length;
 
                   cy.log(
                     `Number of available episodes? ${expectedNumberOfEpisodes}`,

--- a/cypress/integration/pages/onDemandTV/tests.js
+++ b/cypress/integration/pages/onDemandTV/tests.js
@@ -8,6 +8,7 @@ import {
 } from '../../../support/helpers/onDemandRadioTv';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import getDataUrl from '../../../support/helpers/getDataUrl';
+import processRecentEpisodes from '../../../../src/app/routes/utils/processRecentEpisodes';
 
 export default ({ service, pageType, variant, isAmp }) => {
   describe(`Tests for ${service} ${pageType}`, () => {
@@ -68,10 +69,12 @@ export default ({ service, pageType, variant, isAmp }) => {
                   : `${currentPath}`;
 
               cy.request(getDataUrl(url)).then(({ body }) => {
-                // Count the number of episodes that are available and so will show (there can be unavailable episodes in the list)
-                const expectedNumberOfEpisodes = body.relatedContent.groups[0].promos
-                  .filter(({ media }) => media.versions.length)
-                  .slice(0, recentEpisodesMaxNumber).length;
+                const episodeId = path(['content', 'blocks', 0, 'id'], body);
+
+                const expectedNumberOfEpisodes = processRecentEpisodes(body, {
+                  exclude: episodeId,
+                  recentEpisodesLimit: recentEpisodesMaxNumber,
+                }).length;
 
                 cy.log(
                   `Number of available episodes? ${expectedNumberOfEpisodes}`,

--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -11,14 +11,10 @@ const validateEpisode = episode => {
       is(String, episode.brand.title),
       episode.media,
       is(String, episode.media.id),
-      is(Array, episode.media.versions),
       episode.media.versions[0],
       is(String, episode.media.versions[0].durationISO8601),
       is(Number, episode.releaseDateTimestamp),
     ];
-    console.log(episode.media.versions, '- versions');
-    console.log(checks, '- checks');
-
     return checks.every(Boolean);
   } catch {
     return false;

--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -15,6 +15,7 @@ const validateEpisode = episode => {
       is(String, episode.media.versions[0].durationISO8601),
       is(Number, episode.releaseDateTimestamp),
     ];
+
     return checks.every(Boolean);
   } catch {
     return false;

--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -16,6 +16,8 @@ const validateEpisode = episode => {
       is(String, episode.media.versions[0].durationISO8601),
       is(Number, episode.releaseDateTimestamp),
     ];
+    console.log(episode.media.versions, '- versions');
+    console.log(checks, '- checks');
 
     return checks.every(Boolean);
   } catch {
@@ -39,11 +41,14 @@ const excludeEpisode = idToExclude => episode =>
 const processRecentEpisodes = (
   pageData,
   { recentEpisodesLimit = 4, exclude = null } = {},
-) =>
-  path(['relatedContent', 'groups', 0, 'promos'], pageData)
+) => {
+  // const wat = path(['relatedContent', 'groups', 0, 'promos'], pageData);
+
+  return path(['relatedContent', 'groups', 0, 'promos'], pageData)
     .filter(validateEpisode)
     .filter(excludeEpisode(exclude))
     .map(formatEpisode)
     .slice(0, recentEpisodesLimit);
+};
 
 export default processRecentEpisodes;

--- a/src/app/routes/utils/processRecentEpisodes/index.jsx
+++ b/src/app/routes/utils/processRecentEpisodes/index.jsx
@@ -41,14 +41,11 @@ const excludeEpisode = idToExclude => episode =>
 const processRecentEpisodes = (
   pageData,
   { recentEpisodesLimit = 4, exclude = null } = {},
-) => {
-  // const wat = path(['relatedContent', 'groups', 0, 'promos'], pageData);
-
-  return path(['relatedContent', 'groups', 0, 'promos'], pageData)
+) =>
+  path(['relatedContent', 'groups', 0, 'promos'], pageData)
     .filter(validateEpisode)
     .filter(excludeEpisode(exclude))
     .map(formatEpisode)
     .slice(0, recentEpisodesLimit);
-};
 
 export default processRecentEpisodes;


### PR DESCRIPTION
**Overall change:**
We are having flakes in our TEST env E2Es for recent episodes on podcasts/OD-radio pages. We noticed that the recent episode data validation being done in the tests doesn't match the data validation being done within the page's `getInitialData` function. The goal of this PR is to make the Recent Episodes E2Es process the JSON response in the same ways as the pages.

**Code changes:**
- Make OnDemand Audio & OnDemandTV tests use the `processRecentEpisodes` util, rather than having their own episode filtering logic.
- Remove `is(Array, versions)` check from `validateEpisode` checks in `processRecentEpisodes`, as Cypress was returning false with the `instanceof Array` function, even when versions was an array. We think the `versions[0]` check is sufficient.

See this comment for details of the issue with implementing this using the `is(Array, versions)` check: https://github.com/bbc/simorgh/pull/8939#discussion_r587320288
