### PR TITLE
Improve a11y compliance for podcast external links

### DIFF
--- a/src/app/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -353,7 +353,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   <aside
     aria-labelledby="recent-episodes"
     class="emotion-0 emotion-1"
-    role="complimentary"
+    role="complementary"
   >
     <div
       class="emotion-2 emotion-3 emotion-4"

--- a/src/app/containers/EpisodeList/RecentAudioEpisodes/index.jsx
+++ b/src/app/containers/EpisodeList/RecentAudioEpisodes/index.jsx
@@ -90,7 +90,7 @@ const RecentAudioEpisodes = ({ masterBrand, episodes, brandId, pageType }) => {
   const liProps = { 'data-e2e': 'recent-episodes-list-item' };
 
   return (
-    <Spacer role="complimentary" aria-labelledby="recent-episodes">
+    <Spacer role="complementary" aria-labelledby="recent-episodes">
       <StyledSectionLabel
         script={script}
         service={service}

--- a/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -457,7 +457,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 <div>
   <aside
     aria-labelledby="recent-episodes"
-    role="complimentary"
+    role="complementary"
   >
     <div
       class="emotion-0 emotion-1 emotion-2"

--- a/src/app/containers/EpisodeList/RecentVideoEpisodes/index.jsx
+++ b/src/app/containers/EpisodeList/RecentVideoEpisodes/index.jsx
@@ -77,7 +77,7 @@ const RecentVideoEpisodes = ({ masterBrand, episodes }) => {
   const liProps = { 'data-e2e': 'recent-episodes-list-item' };
 
   return (
-    <aside role="complimentary" aria-labelledby="recent-episodes">
+    <aside role="complementary" aria-labelledby="recent-episodes">
       <StyledSectionLabel
         script={script}
         service={service}

--- a/src/app/containers/PodcastExternalLinks/Link.jsx
+++ b/src/app/containers/PodcastExternalLinks/Link.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { oneOf, string, shape } from 'prop-types';
-import { C_CLOUD_LIGHT, C_EBON, C_METAL } from '@bbc/psammead-styles/colours';
+import { C_EBON, C_METAL } from '@bbc/psammead-styles/colours';
 import { getSansBold } from '@bbc/psammead-styles/font-styles';
 import { getLongPrimer } from '@bbc/gel-foundations/typography';
 import { scriptPropType } from '@bbc/gel-foundations/prop-types';
@@ -14,30 +14,18 @@ const Link = styled.a`
   text-decoration: none;
   display: inline-block;
 
-  &:visited {
-    color: ${C_METAL};
-  }
-
-  &:focus,
-  &:hover {
-    text-decoration: underline;
-  }
-
   > span {
     margin: 0.8125rem 0;
     display: inline-block;
   }
 
-  &:not(:first-of-type) > span {
-    ${({ dir }) =>
-      dir === 'rtl'
-        ? `
-      padding-right: 1rem;
-      border-right: 1px ${C_CLOUD_LIGHT} solid;`
-        : `
-      padding-left: 1rem;
-      border-left: 1px ${C_CLOUD_LIGHT} solid;
-      `}
+  &:visited {
+    color: ${C_METAL};
+  }
+
+  &:focus,
+  &:hover > span {
+    text-decoration: underline;
   }
 `;
 

--- a/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -6,6 +6,13 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   border-bottom: 0.0625rem #BABABA solid;
   margin: 0;
   padding: 0;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1rem;
+  }
 }
 
 .emotion-3 {
@@ -14,6 +21,7 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   color: #3F3F42;
   margin-top: 2rem;
   margin: 0;
+  margin-top: 1rem;
 }
 
 @media (min-width: 37.5rem) {
@@ -30,12 +38,14 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
 
 @media (min-width: 25rem) {
   .emotion-3 {
+    margin-top: 1rem;
     margin-bottom: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
   .emotion-3 {
+    margin-top: 1rem;
     margin-bottom: 0;
   }
 }

--- a/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`PodcastExternalLinks Should render external links 1`] = `
 .emotion-0 {
-  border-top: 1px #BABABA solid;
-  border-bottom: 1px #BABABA solid;
+  border-top: 0.0625rem #BABABA solid;
+  border-bottom: 0.0625rem #BABABA solid;
   margin: 0;
   padding: 0;
 }

--- a/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -5,33 +5,145 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   border-top: 1px #BABABA solid;
   border-bottom: 1px #BABABA solid;
   margin: 0;
-  padding: 0 0 1rem 0;
+  padding: 0;
 }
 
-.emotion-2 {
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  color: #222222;
+.emotion-3 {
+  position: relative;
+  z-index: 0;
+  color: #3F3F42;
+  margin-top: 2rem;
+  margin: 0;
 }
 
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-2 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+@media (min-width: 37.5rem) {
+  .emotion-3 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-3 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+@media (min-width: 25rem) {
+  .emotion-3 {
+    margin-bottom: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-2 {
+  .emotion-3 {
+    margin-bottom: 0;
+  }
+}
+
+.emotion-5 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-9 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-11 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-4 {
+@media (min-width: 37.5rem) {
+  .emotion-11 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-11 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-11 {
+    padding-right: 1rem;
+  }
+}
+
+.emotion-13 {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.emotion-15 {
+  display: inline-block;
+}
+
+.emotion-15:not(:first-of-type)>a>span {
+  padding-left: 1rem;
+  border-left: 0.0625rem #BABABA solid;
+}
+
+.emotion-17 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -45,77 +157,136 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
+  .emotion-17 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-4 {
+  .emotion-17 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-4:visited {
+.emotion-17:visited {
   color: #6E6E73;
 }
 
-.emotion-4:focus,
-.emotion-4:hover {
+.emotion-17:focus,
+.emotion-17:hover>span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-4>span {
+.emotion-17>span {
   margin: 0.8125rem 0;
   display: inline-block;
 }
 
-.emotion-4:not(:first-of-type)>span {
-  padding-left: 1rem;
-  border-left: 1px #BABABA solid;
+.emotion-19 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
 }
 
 <div>
-  <div
+  <aside
+    aria-labelledby="third-party-links"
     class="emotion-0 emotion-1"
+    role="complementary"
   >
-    <h2
-      class="emotion-2 emotion-3"
+    <div
+      class="emotion-2 emotion-3 emotion-4"
     >
-      Этот подкаст доступен на
-    </h2>
-    <div>
-      <a
-        class="emotion-4 emotion-5"
-        dir="ltr"
-        href="https://bbc.com"
+      <h2
+        class="emotion-5 emotion-6"
       >
-        <span>
-          Apple
+        <span
+          class="emotion-7 emotion-8"
+        >
+          <span
+            class="emotion-9 emotion-10"
+          >
+            <span
+              class="emotion-11 emotion-12"
+              dir="ltr"
+              id="third-party-links"
+            >
+              Этот подкаст доступен на
+            </span>
+          </span>
         </span>
-      </a>
-      <a
-        class="emotion-4 emotion-5"
-        dir="ltr"
-        href="https://bbc.com"
-      >
-        <span>
-          Spotify
-        </span>
-      </a>
-      <a
-        class="emotion-4 emotion-5"
-        dir="ltr"
-        href="https://bbc.com"
-      >
-        <span>
-          RSS
-        </span>
-      </a>
+      </h2>
     </div>
-  </div>
+    <ul
+      class="emotion-13 emotion-14"
+      role="list"
+    >
+      <li
+        class="emotion-15 emotion-16"
+        dir="ltr"
+      >
+        <a
+          class="emotion-17 emotion-18"
+          dir="ltr"
+          href="https://bbc.com"
+        >
+          <span>
+            Apple
+            <span
+              class="emotion-19 emotion-20"
+            >
+              , A brand podcast
+            </span>
+          </span>
+        </a>
+      </li>
+      <li
+        class="emotion-15 emotion-16"
+        dir="ltr"
+      >
+        <a
+          class="emotion-17 emotion-18"
+          dir="ltr"
+          href="https://bbc.com"
+        >
+          <span>
+            Spotify
+            <span
+              class="emotion-19 emotion-20"
+            >
+              , A brand podcast
+            </span>
+          </span>
+        </a>
+      </li>
+      <li
+        class="emotion-15 emotion-16"
+        dir="ltr"
+      >
+        <a
+          class="emotion-17 emotion-18"
+          dir="ltr"
+          href="https://bbc.com"
+        >
+          <span>
+            RSS
+            <span
+              class="emotion-19 emotion-20"
+            >
+              , A brand podcast
+            </span>
+          </span>
+        </a>
+      </li>
+    </ul>
+  </aside>
 </div>
 `;

--- a/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -170,6 +170,11 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   }
 }
 
+.emotion-17>span {
+  margin: 0.8125rem 0;
+  display: inline-block;
+}
+
 .emotion-17:visited {
   color: #6E6E73;
 }
@@ -178,11 +183,6 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
 .emotion-17:hover>span {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.emotion-17>span {
-  margin: 0.8125rem 0;
-  display: inline-block;
 }
 
 .emotion-19 {

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -64,7 +64,7 @@ const PodcastExternalLinks = ({ brandTitle, links }) => {
     ['media', 'podcastExternalLinks'],
     translations,
   );
-  const moreThanOneLink = links.length > 1;
+  const hasMultipleLinks = links.length > 1;
   const firstLink = links[0];
 
   return (
@@ -78,7 +78,7 @@ const PodcastExternalLinks = ({ brandTitle, links }) => {
       >
         {title}
       </StyledSectionLabel>
-      {moreThanOneLink ? (
+      {hasMultipleLinks ? (
         <StyledList role="list">
           {links.map(({ linkText, linkUrl }) => (
             <StyledListItem dir={dir} key={linkText}>

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -15,8 +15,8 @@ import { ServiceContext } from '#contexts/ServiceContext';
 import Link from './Link';
 
 const Wrapper = styled.aside`
-  border-top: 1px ${C_CLOUD_LIGHT} solid;
-  border-bottom: 1px ${C_CLOUD_LIGHT} solid;
+  border-top: 0.0625rem ${C_CLOUD_LIGHT} solid;
+  border-bottom: 0.0625rem ${C_CLOUD_LIGHT} solid;
   margin: 0;
   padding: 0;
 `;

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -9,7 +9,9 @@ import SectionLabel from '@bbc/psammead-section-label';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
+  GEL_GROUP_4_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
+import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 
 import { ServiceContext } from '#contexts/ServiceContext';
 import Link from './Link';
@@ -19,14 +21,22 @@ const Wrapper = styled.aside`
   border-bottom: 0.0625rem ${C_CLOUD_LIGHT} solid;
   margin: 0;
   padding: 0;
+  margin-bottom: ${GEL_SPACING};
+
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    margin-bottom: ${GEL_SPACING_DBL};
+  }
 `;
 
 const StyledSectionLabel = styled(SectionLabel)`
   margin: 0;
+  margin-top: 1rem;
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    margin-top: 1rem;
     margin-bottom: 0;
   }
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    margin-top: 1rem;
     margin-bottom: 0;
   }
 `;

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -1,28 +1,59 @@
+/* eslint-disable jsx-a11y/aria-role */
 import React, { useContext } from 'react';
 import { arrayOf, shape, string } from 'prop-types';
 import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
-import { C_CLOUD_LIGHT, C_EBON } from '@bbc/psammead-styles/colours';
-import { getSansRegular } from '@bbc/psammead-styles/font-styles';
-import { getGreatPrimer } from '@bbc/gel-foundations/typography';
+import { C_CLOUD_LIGHT } from '@bbc/psammead-styles/colours';
+import VisuallyHiddenText from '@bbc/psammead-visually-hidden-text';
+import SectionLabel from '@bbc/psammead-section-label';
+import {
+  GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
+} from '@bbc/gel-foundations/breakpoints';
 
 import { ServiceContext } from '#contexts/ServiceContext';
 import Link from './Link';
 
-const Wrapper = styled.div`
+const Wrapper = styled.aside`
   border-top: 1px ${C_CLOUD_LIGHT} solid;
   border-bottom: 1px ${C_CLOUD_LIGHT} solid;
   margin: 0;
-  padding: 0 0 1rem 0;
+  padding: 0;
 `;
 
-const Title = styled.h2`
-  ${({ service }) => getSansRegular(service)}
-  ${({ script }) => getGreatPrimer(script)}
-  color: ${C_EBON};
+const StyledSectionLabel = styled(SectionLabel)`
+  margin: 0;
+  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
+    margin-bottom: 0;
+  }
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
+    margin-bottom: 0;
+  }
 `;
 
-const PodcastExternalLinks = ({ links }) => {
+const StyledList = styled.ul`
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const StyledListItem = styled.li`
+  display: inline-block;
+
+  &:not(:first-of-type) > a > span {
+    ${({ dir }) =>
+      dir === 'rtl'
+        ? `
+      padding-right: 1rem;
+      border-right: 0.0625rem ${C_CLOUD_LIGHT} solid;`
+        : `
+      padding-left: 1rem;
+      border-left: 0.0625rem ${C_CLOUD_LIGHT} solid;
+      `}
+  }
+`;
+
+const PodcastExternalLinks = ({ brandTitle, links }) => {
   const { translations, service, script, dir } = useContext(ServiceContext);
 
   if (!links.length) return null;
@@ -33,30 +64,53 @@ const PodcastExternalLinks = ({ links }) => {
     ['media', 'podcastExternalLinks'],
     translations,
   );
+  const moreThanOneLink = links.length > 1;
+  const firstLink = links[0];
 
   return (
-    <Wrapper>
-      <Title script={script} service={service}>
+    <Wrapper role="complementary" aria-labelledby="third-party-links">
+      <StyledSectionLabel
+        script={script}
+        service={service}
+        labelId="third-party-links"
+        bar={false}
+        dir={dir}
+      >
         {title}
-      </Title>
-      <div>
-        {links.map(({ linkText, linkUrl }) => (
-          <Link
-            href={linkUrl}
-            key={linkText}
-            service={service}
-            script={script}
-            dir={dir}
-          >
-            <span>{linkText}</span>
-          </Link>
-        ))}
-      </div>
+      </StyledSectionLabel>
+      {moreThanOneLink ? (
+        <StyledList role="list">
+          {links.map(({ linkText, linkUrl }) => (
+            <StyledListItem dir={dir} key={linkText}>
+              <Link href={linkUrl} service={service} script={script} dir={dir}>
+                <span>
+                  {linkText}
+                  <VisuallyHiddenText>{`, ${brandTitle}`}</VisuallyHiddenText>
+                </span>
+              </Link>
+            </StyledListItem>
+          ))}
+        </StyledList>
+      ) : (
+        <Link
+          href={firstLink.linkUrl}
+          key={firstLink.linkText}
+          service={service}
+          script={script}
+          dir={dir}
+        >
+          <span>
+            {firstLink.linkText}
+            <VisuallyHiddenText>{`, ${brandTitle}`}</VisuallyHiddenText>
+          </span>
+        </Link>
+      )}
     </Wrapper>
   );
 };
 
 PodcastExternalLinks.propTypes = {
+  brandTitle: string.isRequired,
   links: arrayOf(
     shape({
       linkText: string.isRequired,

--- a/src/app/containers/PodcastExternalLinks/index.test.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.test.jsx
@@ -8,7 +8,7 @@ import PodcastExternalLinks from '.';
 /* eslint-disable react/prop-types */
 const Component = ({ links, service = 'russian', variant = null }) => (
   <ServiceContextProvider service={service} variant={variant}>
-    <PodcastExternalLinks links={links} />
+    <PodcastExternalLinks links={links} brandTitle="A brand podcast" />
   </ServiceContextProvider>
 );
 
@@ -34,12 +34,24 @@ describe('PodcastExternalLinks', () => {
   );
 
   it('should render the right amount of items', () => {
-    const { container } = render(<Component links={links} />);
+    const { container, getByRole } = render(<Component links={links} />);
     const elements = container.getElementsByTagName('a');
+    const listElements = container.getElementsByTagName('li');
+    const list = getByRole('list');
+
     expect(elements.length).toBe(3);
+    expect(listElements.length).toBe(3);
+    expect(list).toBeInTheDocument();
 
     const { container: emptyContainer } = render(<Component links={[]} />);
     expect(emptyContainer.getElementsByTagName('a').length).toEqual(0);
+  });
+
+  it('should not render a list for only one item', () => {
+    const { container, queryByRole } = render(<Component links={[links[0]]} />);
+    const elements = container.getElementsByTagName('a');
+    expect(elements.length).toBe(1);
+    expect(queryByRole('list')).not.toBeInTheDocument();
   });
 
   it('should use default translations when translations are unavailable', () => {
@@ -52,5 +64,18 @@ describe('PodcastExternalLinks', () => {
     );
     const afriqueTitle = afriqueGetByText('This podcast is also available on');
     expect(afriqueTitle).toBeInTheDocument();
+  });
+
+  it('should render component in an aside', () => {
+    const { getByRole } = render(<Component links={links} />);
+    const aside = getByRole('complementary');
+    expect(aside.tagName).toEqual('ASIDE');
+    expect(aside.getAttribute('aria-labelledBy')).toEqual('third-party-links');
+  });
+
+  it('should render hidden text in the links', () => {
+    const { getAllByText } = render(<Component links={links} />);
+    const visuallyHiddenText = getAllByText(', A brand podcast');
+    expect(visuallyHiddenText.length).toEqual(3);
   });
 });

--- a/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
+++ b/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import path from 'ramda/src/path';
 import is from 'ramda/src/is';
 import styled from '@emotion/styled';
-import { shape, string, number, bool, func } from 'prop-types';
+import { shape, string, number, bool, func, node } from 'prop-types';
 import { GEL_SPACING_TRPL } from '@bbc/gel-foundations/spacings';
 import {
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
@@ -64,6 +64,23 @@ const StyledGridItemImage = styled(Grid)`
     grid-column-end: span 2;
   }
 `;
+
+const PageGrid = ({ children }) => (
+  <GelPageGrid columns={getGroups(6, 6, 6, 6, 8, 20)} enableGelGutters>
+    <Grid
+      item
+      startOffset={getGroups(1, 1, 1, 1, 2, 5)}
+      columns={getGroups(6, 6, 6, 6, 6, 12)}
+      margins={getGroups(true, true, true, true, false, false)}
+    >
+      {children}
+    </Grid>
+  </GelPageGrid>
+);
+
+PageGrid.propTypes = {
+  children: node.isRequired,
+};
 
 const OnDemandAudioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
   const idAttr = SKIP_LINK_ANCHOR_ID;
@@ -215,25 +232,22 @@ const OnDemandAudioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
                 : []
             }
           />
-          {isPodcast && <PodcastExternalLinks links={externalLinks} />}
         </Grid>
       </GelPageGrid>
+      {isPodcast && (
+        <PageGrid>
+          <PodcastExternalLinks links={externalLinks} brandTitle={brandTitle} />
+        </PageGrid>
+      )}
       {hasRecentEpisodes && (
-        <GelPageGrid columns={getGroups(6, 6, 6, 6, 8, 20)} enableGelGutters>
-          <Grid
-            item
-            startOffset={getGroups(1, 1, 1, 1, 2, 5)}
-            columns={getGroups(6, 6, 6, 6, 6, 12)}
-            margins={getGroups(true, true, true, true, false, false)}
-          >
-            <RecentAudioEpisodes
-              masterBrand={masterBrand}
-              episodes={recentEpisodes}
-              brandId={brandId}
-              pageType={pageType}
-            />
-          </Grid>
-        </GelPageGrid>
+        <PageGrid>
+          <RecentAudioEpisodes
+            masterBrand={masterBrand}
+            episodes={recentEpisodes}
+            brandId={brandId}
+            pageType={pageType}
+          />
+        </PageGrid>
       )}
       {radioScheduleData && (
         <RadioScheduleContainer initialData={radioScheduleData} />


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Make podcast external links a11y compliant

**Code changes:**
- Replace all 1px values with 0.0625rem.
- Move component to a labelled aside landmark (not within main landmark).
- Use an unordered list for the links (if more than 1 link).
- Announce brand title as part of the link text (with VH comma).
- Check hover and focus styling works
- Update h2 to use Section label

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
