### PR TITLE
Explicitly use lang and className props instead of spreading

### DIFF
--- a/src/app/containers/ConsentBanner/Banner/cookie.amp.jsx
+++ b/src/app/containers/ConsentBanner/Banner/cookie.amp.jsx
@@ -168,12 +168,13 @@ const ManageSettingsButton = styled.button`
  * the Manage Cookie Settings banner.
  */
 // eslint-disable-next-line react/prop-types
-export const AmpCookieSettingsButton = ({ children, ...rest }) => (
+export const AmpCookieSettingsButton = ({ children, lang, className }) => (
   <button
     on="tap:consent.prompt, privacy.hide, cookie.show, AMP.setState({ isManagingSettings: true })"
     type="button"
     data-testid="amp-cookie-settings-button"
-    {...rest}
+    lang={lang}
+    className={className}
   >
     {children}
   </button>


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
- Replaces the use of the spread operator and explicitly adds both lang and className attributes to the amp cookie consent button

The spread operator meant that the service prop was being added as an attribute on the button and this failed AMP validation.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
