### PR TITLE
role="text" for broken text using assistive tech

### DIFF
--- a/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -248,7 +248,9 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
           dir="ltr"
           href="https://bbc.com"
         >
-          <span>
+          <span
+            role="text"
+          >
             Apple
             <span
               class="emotion-19 emotion-20"
@@ -267,7 +269,9 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
           dir="ltr"
           href="https://bbc.com"
         >
-          <span>
+          <span
+            role="text"
+          >
             Spotify
             <span
               class="emotion-19 emotion-20"
@@ -286,7 +290,9 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
           dir="ltr"
           href="https://bbc.com"
         >
-          <span>
+          <span
+            role="text"
+          >
             RSS
             <span
               class="emotion-19 emotion-20"

--- a/src/app/containers/PodcastExternalLinks/index.jsx
+++ b/src/app/containers/PodcastExternalLinks/index.jsx
@@ -93,7 +93,7 @@ const PodcastExternalLinks = ({ brandTitle, links }) => {
           {links.map(({ linkText, linkUrl }) => (
             <StyledListItem dir={dir} key={linkText}>
               <Link href={linkUrl} service={service} script={script} dir={dir}>
-                <span>
+                <span role="text">
                   {linkText}
                   <VisuallyHiddenText>{`, ${brandTitle}`}</VisuallyHiddenText>
                 </span>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8970

**Overall change:**
Fixes assistive tech splitting text on podcast links.

**Code changes:**

- Adds `role="text"` to the wrapping span containing the text that is read out for the link

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
