### PR TITLE
Log OD Audio Recent Episodes front-end/JSON E2E differences 

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -108,25 +108,39 @@ export default ({ service, pageType, variant, isAmp }) => {
                       episode => episode.innerText,
                     );
 
-                    const jsonResWithHumanReadableDates = processedEpisodesData.map(
-                      episodeData => ({
-                        ...episodeData,
-                        timestamp: new Date(
-                          episodeData.timestamp,
-                        ).toLocaleString(),
-                      }),
+                    const convertTimestampsToLocaleString = recentEpisodesArray => {
+                      return recentEpisodesArray.map(episode => ({
+                        ...episode,
+                        timestamp: new Date(episode.timestamp).toLocaleString(),
+                      }));
+                    };
+
+                    const cypressJsonResWithLocaleStringTimestamp = convertTimestampsToLocaleString(
+                      processedEpisodesData,
                     );
+
+                    const simorghJsonResWithLocaleStringTimestamp =
+                      !isAmp &&
+                      convertTimestampsToLocaleString(
+                        win.SIMORGH_DATA.pageData.recentEpisodes,
+                      );
 
                     if (
                       renderedEpisodesArray.length !==
-                      jsonResWithHumanReadableDates.length
+                      cypressJsonResWithLocaleStringTimestamp.length
                     ) {
                       /* eslint-disable no-console */
                       console.log(
-                        'From json response - ',
-                        jsonResWithHumanReadableDates,
+                        'Cypress json response - ',
+                        cypressJsonResWithLocaleStringTimestamp,
                       );
-                      console.log('On page - ', renderedEpisodesInnerText);
+                      console.log('HTML on page - ', renderedEpisodesInnerText);
+                      if (!isAmp) {
+                        console.log(
+                          'Simorgh json response - ',
+                          simorghJsonResWithLocaleStringTimestamp,
+                        );
+                      }
                       /* eslint-enable no-console */
                     }
 

--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -55,6 +55,7 @@ export default ({ service, pageType, variant, isAmp }) => {
             // Reload for retry if data didn't update on page
             cy.reload();
             let toggleName;
+
             if (Cypress.env('currentPath').includes('podcasts')) {
               toggleName = 'recentPodcastEpisodes';
             } else {
@@ -83,40 +84,79 @@ export default ({ service, pageType, variant, isAmp }) => {
                 cy.request(getDataUrl(url)).then(({ body }) => {
                   const episodeId = path(['content', 'blocks', 0, 'id'], body);
 
-                  const expectedNumberOfEpisodes = processRecentEpisodes(body, {
+                  const processedEpisodesData = processRecentEpisodes(body, {
                     exclude: episodeId,
                     recentEpisodesLimit: recentEpisodesMaxNumber,
-                  }).length;
+                  });
+
+                  const expectedNumberOfEpisodes = processedEpisodesData.length;
 
                   cy.log(
                     `Number of available episodes? ${expectedNumberOfEpisodes}`,
                   );
-                  // More than one episode expected
-                  if (expectedNumberOfEpisodes > 1) {
-                    cy.get('[data-e2e=recent-episodes-list]').should('exist');
 
-                    cy.get('[data-e2e=recent-episodes-list]').within(() => {
-                      cy.get('[data-e2e=recent-episodes-list-item]')
-                        .its('length')
-                        .should('eq', expectedNumberOfEpisodes);
-                    });
-                  }
-                  // If there is only one item, it is not in a list
-                  else if (expectedNumberOfEpisodes === 1) {
-                    cy.get('aside[aria-labelledby=recent-episodes]').within(
-                      () => {
-                        cy.get('div[class*="Wrapper"]').should('exist');
-                      },
-                    );
-                  }
-                  // No items expected
-                  else {
-                    cy.get('aside[aria-labelledby=recent-episodes]').should(
-                      'not.exist',
+                  cy.window().then(win => {
+                    const renderedEpisodes = win.document.querySelectorAll(
+                      '[data-e2e=recent-episodes-list-item]',
                     );
 
-                    cy.log('No episodes present or available');
-                  }
+                    const renderedEpisodesArray = Array.prototype.slice.call(
+                      renderedEpisodes,
+                    );
+
+                    const renderedEpisodesInnerText = renderedEpisodesArray.map(
+                      episode => episode.innerText,
+                    );
+
+                    const jsonResWithHumanReadableDates = processedEpisodesData.map(
+                      episodeData => ({
+                        ...episodeData,
+                        timestamp: new Date(
+                          episodeData.timestamp,
+                        ).toLocaleString(),
+                      }),
+                    );
+
+                    if (
+                      renderedEpisodesArray.length !==
+                      jsonResWithHumanReadableDates.length
+                    ) {
+                      /* eslint-disable no-console */
+                      console.log(
+                        'From json response - ',
+                        jsonResWithHumanReadableDates,
+                      );
+                      console.log('On page - ', renderedEpisodesInnerText);
+                      /* eslint-enable no-console */
+                    }
+
+                    // More than one episode expected
+                    if (expectedNumberOfEpisodes > 1) {
+                      cy.get('[data-e2e=recent-episodes-list]').should('exist');
+
+                      cy.get('[data-e2e=recent-episodes-list]').within(() => {
+                        cy.get('[data-e2e=recent-episodes-list-item]')
+                          .its('length')
+                          .should('eq', expectedNumberOfEpisodes);
+                      });
+                    }
+                    // If there is only one item, it is not in a list
+                    else if (expectedNumberOfEpisodes === 1) {
+                      cy.get('aside[aria-labelledby=recent-episodes]').within(
+                        () => {
+                          cy.get('div[class*="Wrapper"]').should('exist');
+                        },
+                      );
+                    }
+                    // No items expected
+                    else {
+                      cy.get('aside[aria-labelledby=recent-episodes]').should(
+                        'not.exist',
+                      );
+
+                      cy.log('No episodes present or available');
+                    }
+                  });
                 });
               }
               // Not toggled on for this service


### PR DESCRIPTION
**Problem**
- Recent Episodes tests on OD-Audio sporadically flake. Two recent examples: [Mar 10, 2021 4:46 AM](https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/657504540040/testReports/reports/live-simorgh-e2e-scheduled-JunitReportsTest/live-simorgh-e2e-scheduled-JunitReportsTest%3A2109c2ca-544b-413a-85f5-80519a0393ae?region=eu-west-1&test-reports-meta=eyJmIjp7InRleHQiOiIifSwicyI6eyJkaXJlY3Rpb24iOjEsInByb3BlcnR5Ijoic3RhdHVzIn0sIm4iOjIwLCJpIjowfQ), [Mar 9, 2021 10:53 PM](https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/657504540040/testReports/reports/live-simorgh-e2e-scheduled-JunitReportsTest/live-simorgh-e2e-scheduled-JunitReportsTest%3Af980cbd7-88f3-478d-b127-821398612a86?region=eu-west-1&test-reports-meta=eyJmIjp7InRleHQiOiIifSwicyI6eyJkaXJlY3Rpb24iOjEsInByb3BlcnR5Ijoic3RhdHVzIn0sIm4iOjIwLCJpIjowfQ)

```
1572 | 1) onDemandAudio - /indonesia/podcasts/p02pc9v6.amp
1573 | --
1574 | Tests for indonesia onDemandAudio
1575 | Tests for indonesia onDemandAudio default with toggle use
1576 | Recent Episodes component
1577 | should be displayed if the toggle is on, and shows the expected number of items:
1578 |  
1579 | Timed out retrying
1580 | + expected - actual
1581 |  
1582 | -4
1583 | +3
1586 |  
1587 | 2) onDemandAudio - /indonesia/podcasts/p02pc9v6/p096mj9z.amp
1588 | Tests for indonesia onDemandAudio
1589 | Tests for indonesia onDemandAudio default with toggle use
1590 | Recent Episodes component
1591 | should be displayed if the toggle is on, and shows the expected number of items:
1592 |  
1593 | Timed out retrying
1594 | + expected - actual
1595 |  
1596 | -5
1597 | +4
```

- The fails mean that there is a difference in the number of recent episodes being returned in the `.json` request that Cypress directly makes, versus the number of recent episodes rendered on the page that Cypress visits.
- We think these fails relate to the data responses changing - newer episodes being returned, and a cacheing difference between when the page is visited, versus when the data is requested.

**Overall change:**
- We have very little visibility as to which episodes are being rendered versus which are being returned in the json. This PR logs those two things out (console.log does appear to output to codebuild) **when the html episode count does not match the json episode count** so that we can get an understanding of which episodes are/are not being returned.
- This won't fix the flakes, it's just to help debugging.

**Code changes:**

- Log the json data response.
- Log the rendered html episode list items' inner text


