### PR TITLE
Tell google about the .co.uk URL for Sport AMP

### DIFF
--- a/src/app/containers/ArticleTimestamp/timeFormatTests/expectedFormats.json
+++ b/src/app/containers/ArticleTimestamp/timeFormatTests/expectedFormats.json
@@ -299,6 +299,16 @@
       "exact date and time with timezone": "12 July 2019, 13:55 BST"
     }
   },
+  "sport": {
+    "default": {
+      "one minute ago": "1 minute ago",
+      "five minutes ago": "5 minutes ago",
+      "one hour ago": "1 hour ago",
+      "five hours ago": "5 hours ago",
+      "exact date": "10 October 2018",
+      "exact date and time with timezone": "12 July 2019, 13:55 BST"
+    }
+  },
   "serbian": {
     "lat": {
       "one minute ago": "Pre 1 minuta",

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -12,7 +12,7 @@ import {
   renderAppleItunesApp,
 } from './utils';
 
-const ENGLISH_SERVICES = ['news'];
+const ENGLISH_SERVICES = ['news', 'sport'];
 const FACEBOOK_ADMIN_ID = 100004154058350;
 const FACEBOOK_APP_ID = 1609039196070050;
 const FACEBOOK_PAGES =

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -188,6 +188,10 @@ it.each`
         id="56427710"
         pageType={STORY_PAGE}
         pathname={pathName}
+        title="A story"
+        description="The story's description"
+        lang="en-GB"
+        openGraphType="article"
       />,
     );
 

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -143,7 +143,7 @@ it('should render the canonical link', async () => {
   });
 });
 
-it('should render the alternate links', async () => {
+it('should render the alternate links for article page', async () => {
   render(<CanonicalNewsInternationalOrigin />);
 
   const expected = [
@@ -172,6 +172,52 @@ it('should render the alternate links', async () => {
     expect(actual).toEqual(expected);
   });
 });
+
+it.each`
+  service    | pathName
+  ${'news'}  | ${'/news/56427710'}
+  ${'sport'} | ${'/sport/football/56427710'}
+`(
+  'should render the alternate links for $service story page',
+  async ({ service, pathName }) => {
+    render(
+      <MetadataWithContext
+        service={service}
+        bbcOrigin={dotComOrigin}
+        platform="canonical"
+        id="56427710"
+        pageType={STORY_PAGE}
+        pathname={pathName}
+      />,
+    );
+
+    const expected = [
+      {
+        href: `https://www.bbc.com${pathName}`,
+        hreflang: 'x-default',
+      },
+      {
+        href: `https://www.bbc.com${pathName}`,
+        hreflang: 'en',
+      },
+      {
+        href: `https://www.bbc.co.uk${pathName}`,
+        hreflang: 'en-gb',
+      },
+    ];
+
+    await waitFor(() => {
+      const actual = Array.from(
+        document.querySelectorAll('head > link[rel="alternate"]'),
+      ).map(tag => ({
+        href: tag.getAttribute('href'),
+        hreflang: tag.getAttribute('hreflang'),
+      }));
+
+      expect(actual).toEqual(expected);
+    });
+  },
+);
 
 it('should render the apple touch icons', async () => {
   render(<CanonicalNewsInternationalOrigin />);

--- a/src/server/utilities/serviceConfigs/index.js
+++ b/src/server/utilities/serviceConfigs/index.js
@@ -35,6 +35,7 @@ import { service as portuguese } from '../../../app/lib/config/services/portugue
 import { service as punjabi } from '../../../app/lib/config/services/punjabi';
 import { service as russian } from '../../../app/lib/config/services/russian';
 import { service as scotland } from '../../../app/lib/config/services/scotland';
+import { service as sport } from '../../../app/lib/config/services/sport';
 import { service as serbian } from '../../../app/lib/config/services/serbian';
 import { service as sinhala } from '../../../app/lib/config/services/sinhala';
 import { service as somali } from '../../../app/lib/config/services/somali';
@@ -82,6 +83,7 @@ export default {
   portuguese,
   punjabi,
   russian,
+  sport,
   scotland,
   serbian,
   sinhala,


### PR DESCRIPTION
Resolves #8988 

**Overall change:**
Adds link rel=alternate tags to the head of Sport AMP pages

**Code changes:**

- Adds Sport to the list of pages to show rel=alternate links in the head of, so that we expose the .co.uk URLs to google etc
- Adds a test to cover alterntative links for sport and news story pages
- Updates timestampContainer test to cover sport as a consquence of updating some out-of-date utilities for the alternative links test

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
