### PR TITLE
Disable newsround tests on test and live

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4620,11 +4620,11 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/newsround/56331357'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/newsround/23212028'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/newsround/56331357'],


### PR DESCRIPTION
**Overall change:**
Currently our E2E tests are failing because of various newsround tests:
![image](https://user-images.githubusercontent.com/9645462/111593037-6d78c000-87c1-11eb-87d9-7443ae9ff017.png)

This is because they are enabled on test but we do not support canonical pages for newsround on Simorgh: https://www.test.bbc.co.uk/newsround/23212028

This PR disables E2E tests for newsround on test and live as we have no concept of only testing amp for a given service.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
