### PR TITLE
Do not run manifest and service worker tests for Amp only PS services

### DIFF
--- a/cypress/integration/application/index.js
+++ b/cypress/integration/application/index.js
@@ -1,6 +1,7 @@
 import config from '../../support/config/services';
 import appConfig from '../../../src/server/utilities/serviceConfigs';
 import serviceHasPageType from '../../support/helpers/serviceHasPageType';
+import ampOnlyServices from '../../support/helpers/ampOnlyServices';
 
 const servicesUsingArticlePaths = ['news', 'scotland'];
 
@@ -13,26 +14,27 @@ describe('Application', () => {
     )
     .forEach(service => {
       const usesArticlePath = servicesUsingArticlePaths.includes(service);
-
-      it(`should return a 200 status code for ${service}'s service worker`, () => {
-        cy.testResponseCodeAndType({
-          path: usesArticlePath
-            ? `/${config[service].name}/articles/sw.js`
-            : `/${config[service].name}/sw.js`,
-          responseCode: 200,
-          type: 'application/javascript',
+      if (!ampOnlyServices.includes(service)) {
+        it(`should return a 200 status code for ${service}'s service worker`, () => {
+          cy.testResponseCodeAndType({
+            path: usesArticlePath
+              ? `/${config[service].name}/articles/sw.js`
+              : `/${config[service].name}/sw.js`,
+            responseCode: 200,
+            type: 'application/javascript',
+          });
         });
-      });
 
-      it(`should return a 200 status code for ${service} manifest file`, () => {
-        cy.testResponseCodeAndType({
-          path: usesArticlePath
-            ? `/${config[service].name}/articles/manifest.json`
-            : `/${config[service].name}/manifest.json`,
-          responseCode: 200,
-          type: 'application/json',
+        it(`should return a 200 status code for ${service} manifest file`, () => {
+          cy.testResponseCodeAndType({
+            path: usesArticlePath
+              ? `/${config[service].name}/articles/manifest.json`
+              : `/${config[service].name}/manifest.json`,
+            responseCode: 200,
+            type: 'application/json',
+          });
         });
-      });
+      }
     });
 });
 

--- a/cypress/support/helpers/ampOnlyServices.js
+++ b/cypress/support/helpers/ampOnlyServices.js
@@ -1,0 +1,2 @@
+const ampOnlyServices = ['news', 'sport', 'newsround'];
+export { ampOnlyServices as default };

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -18,6 +18,7 @@ import {
 
 import getPaths from './getPaths';
 import serviceHasPageType from './serviceHasPageType';
+import ampOnlyServices from './ampOnlyServices';
 import visitPage from './visitPage';
 import getAmpUrl from './getAmpUrl';
 
@@ -55,8 +56,6 @@ const runTestsForPage = ({
             pageType,
             variant: config[service].variant,
           };
-
-          const ampOnlyServices = ['news', 'sport', 'newsround'];
 
           if (!ampOnlyServices.includes(service)) {
             // Enables overriding of the smoke test values in the config/settings.js file


### PR DESCRIPTION

**Overall change:**

Tests were failign that were running the manifest and service worker 200 status checks on sport and newsround. This PR adds a condition clause so that only services that are not in the ampOnlyServices list run these tests.

**Code changes:**

Services to only run on the AMP tests, inlcuding not the manifest or service worker tests, are in the file ampOnlyServices.js.

Conditionals in cypress/integration/application/index.js and cypress/support/helpers/runTestsForPage.js

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

tests pass against live
