### PR TITLE
[Experiment] Removed retries on amp banner tests

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForAMPOnly.js
@@ -11,103 +11,93 @@ import {
 import visitPage from '../../../support/helpers/visitPage';
 
 export default ({ service, variant, pageType, path }) => {
-  describe(
-    'AMP consent banner',
-    {
-      retries: 3,
-    },
-    () => {
-      it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
-        getPrivacyBanner(service, variant).should('be.visible');
+  describe('AMP consent banner', () => {
+    it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
+      getPrivacyBanner(service, variant).should('be.visible');
 
-        getCookieBannerAmp(service, variant).should('not.be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
 
-        getPrivacyBannerAccept(service, variant).click();
+      getPrivacyBannerAccept(service, variant).click();
 
-        getCookieBannerAmp(service, variant).should('be.visible');
-        getPrivacyBanner(service, variant).should('not.be.visible');
+      getCookieBannerAmp(service, variant).should('be.visible');
+      getPrivacyBanner(service, variant).should('not.be.visible');
 
-        getCookieBannerAcceptAmp(service, variant).click();
+      getCookieBannerAcceptAmp(service, variant).click();
 
-        getCookieBannerAmp(service, variant).should('not.be.visible');
-        getPrivacyBanner(service, variant).should('not.be.visible');
-      });
+      getCookieBannerAmp(service, variant).should('not.be.visible');
+      getPrivacyBanner(service, variant).should('not.be.visible');
+    });
 
-      it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
-        getPrivacyBannerAccept(service, variant).click();
+    it('should show privacy banner if cookie banner isnt accepted, on reload', () => {
+      getPrivacyBannerAccept(service, variant).click();
 
-        visitPage(path, pageType);
+      visitPage(path, pageType);
 
-        getPrivacyBanner(service, variant).should('be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
-      });
+      getPrivacyBanner(service, variant).should('be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
+    });
 
-      it('should not show privacy & cookie banners once both accepted, on reload', () => {
-        getPrivacyBannerAccept(service, variant).click();
-        getCookieBannerAcceptAmp(service, variant).click();
+    it('should not show privacy & cookie banners once both accepted, on reload', () => {
+      getPrivacyBannerAccept(service, variant).click();
+      getCookieBannerAcceptAmp(service, variant).click();
 
-        visitPage(path, pageType);
+      visitPage(path, pageType);
 
-        getPrivacyBanner(service, variant).should('not.be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
-      });
+      getPrivacyBanner(service, variant).should('not.be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
+    });
 
-      it('should go to manage settings banner once manage settings button is clicked, and when accept button is clicked the banners no longer show', () => {
-        getPrivacyBanner(service, variant).should('be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
+    it('should go to manage settings banner once manage settings button is clicked, and when accept button is clicked the banners no longer show', () => {
+      getPrivacyBanner(service, variant).should('be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
 
-        getPrivacyBannerAccept(service, variant).click();
-        getCookieBannerManageSettingsButton(service, variant).click();
-        getCookieBannerAcceptInManageSettings(service, variant).click();
-        getCookieBannerManageSettings(service, variant).should(
-          'not.be.visible',
-        );
+      getPrivacyBannerAccept(service, variant).click();
+      getCookieBannerManageSettingsButton(service, variant).click();
+      getCookieBannerAcceptInManageSettings(service, variant).click();
+      getCookieBannerManageSettings(service, variant).should('not.be.visible');
 
-        cy.reload();
+      cy.reload();
 
-        getPrivacyBanner(service, variant).should('not.be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
-      });
+      getPrivacyBanner(service, variant).should('not.be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
+    });
 
-      it('should go to manage settings banner once manage settings button is clicked, and when reject button is clicked the banners no longer show', () => {
-        getPrivacyBanner(service, variant).should('be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
+    it('should go to manage settings banner once manage settings button is clicked, and when reject button is clicked the banners no longer show', () => {
+      getPrivacyBanner(service, variant).should('be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
 
-        getPrivacyBannerAccept(service, variant).click();
-        getCookieBannerManageSettingsButton(service, variant).click();
-        getCookieBannerRejectInManageSettings(service, variant).click();
-        getCookieBannerManageSettings(service, variant).should(
-          'not.be.visible',
-        );
+      getPrivacyBannerAccept(service, variant).click();
+      getCookieBannerManageSettingsButton(service, variant).click();
+      getCookieBannerRejectInManageSettings(service, variant).click();
+      getCookieBannerManageSettings(service, variant).should('not.be.visible');
 
-        cy.reload();
+      cy.reload();
 
-        getPrivacyBanner(service, variant).should('not.be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
-      });
+      getPrivacyBanner(service, variant).should('not.be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
+    });
 
-      it('should show privacy banner once you reload the page on the Manage settings expanded view without clicking Accept or Reject buttons', () => {
-        getPrivacyBanner(service, variant).should('be.visible');
-        getCookieBannerAmp(service, variant).should('not.be.visible');
+    it('should show privacy banner once you reload the page on the Manage settings expanded view without clicking Accept or Reject buttons', () => {
+      getPrivacyBanner(service, variant).should('be.visible');
+      getCookieBannerAmp(service, variant).should('not.be.visible');
 
-        getPrivacyBannerAccept(service, variant).click();
-        getCookieBannerManageSettingsButton(service, variant).click();
-        getCookieBannerManageSettings().should('be.visible');
+      getPrivacyBannerAccept(service, variant).click();
+      getCookieBannerManageSettingsButton(service, variant).click();
+      getCookieBannerManageSettings().should('be.visible');
 
-        cy.reload();
+      cy.reload();
 
-        getPrivacyBanner(service, variant).should('be.visible');
-      });
+      getPrivacyBanner(service, variant).should('be.visible');
+    });
 
-      it('should show the manage cookie settings banner when the cookie settings button in the footer is clicked', () => {
-        getPrivacyBannerAccept(service, variant).click();
-        getCookieBannerAcceptAmp(service, variant).click();
+    it('should show the manage cookie settings banner when the cookie settings button in the footer is clicked', () => {
+      getPrivacyBannerAccept(service, variant).click();
+      getCookieBannerAcceptAmp(service, variant).click();
 
-        cy.get('[data-testid="amp-cookie-settings-button"]')
-          .click()
-          .get('[data-testid="amp-cookie-banner-manage-settings"]')
-          .should('be.visible');
-      });
-    },
-  );
+      cy.get('[data-testid="amp-cookie-settings-button"]')
+        .click()
+        .get('[data-testid="amp-cookie-banner-manage-settings"]')
+        .should('be.visible');
+    });
+  });
 };


### PR DESCRIPTION
**Overall change:**

Removed retries on the amp banner tests that were put in to help them pass because they were very flakey. It could be that the flakes were due to the test run struggling with lack of resources/memory. With these increased we can see if the flakes were caused by them and the retries not needed. There is a concern the retries are causing memory leaks and if we don't need them it is better not to have them.

**Code changes:**

Removed the retries

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

When I run the amp consent banner tests I now see the failures again due to lack of retries on flake.
