### PR TITLE
Add Marathi and Portuguese podcast URLs to E2Es all environments

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -3843,7 +3843,31 @@ module.exports = () => ({
         smoke: false,
       },
       liveRadio: { environments: undefined, smoke: false },
-      onDemandAudio: { environments: undefined, smoke: false },
+      onDemandAudio: {
+        environments: {
+          live: {
+            paths: [
+              '/marathi/podcasts/p09431p4', // Podcast Brand
+              '/marathi/podcasts/p09431p4/p09bplch', // Podcast Episode
+            ],
+            enabled: true,
+          },
+          test: {
+            paths: [
+              '/marathi/podcasts/p09431p4', // Podcast Brand
+              '/marathi/podcasts/p09431p4/p09bplch', // Podcast Episode
+            ],
+            enabled: true,
+          },
+          local: {
+            paths: [
+              '/marathi/podcasts/p09431p4', // Podcast Brand
+              '/marathi/podcasts/p09431p4/p09bplch', // Podcast Episode
+            ],
+            enabled: true,
+          },
+        },
+      },
       onDemandTV: {
         environments: {
           live: {
@@ -5550,7 +5574,32 @@ module.exports = () => ({
         smoke: false,
       },
       liveRadio: { environments: undefined, smoke: false },
-      onDemandAudio: { environments: undefined, smoke: false },
+      onDemandAudio: {
+        environments: {
+          live: {
+            paths: [
+              '/portuguese/podcasts/p07r3r3t', // Podcast Brand
+              '/portuguese/podcasts/p07r3r3t/p083x9gr', // Podcast Episode
+            ],
+            enabled: true,
+          },
+          test: {
+            paths: [
+              '/portuguese/podcasts/p07r3r3t', // Podcast Brand
+              '/portuguese/podcasts/p07r3r3t/p083x9gr', // Podcast Episode
+            ],
+            enabled: true,
+          },
+          local: {
+            paths: [
+              '/portuguese/podcasts/p07r3r3t', // Podcast Brand
+              '/portuguese/podcasts/p07r3r3t/p083x9gr', // Podcast Episode
+            ],
+            enabled: true,
+          },
+        },
+        smoke: false,
+      },
       onDemandTV: { environments: undefined, smoke: false },
       mediaAssetPage: {
         environments: {

--- a/data/marathi/podcasts/p09431p4.json
+++ b/data/marathi/podcasts/p09431p4.json
@@ -1,0 +1,444 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:brand:bbc_marathi_audio/p09431p4",
+    "locators": { "pid": "p09bplch", "brandPid": "p09431p4" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_marathi_audio",
+    "language": "mr",
+    "lastUpdated": 1616672993649,
+    "firstPublished": 1616601119000,
+    "lastPublished": 1616601119000,
+    "timestamp": 1616601119000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "तीन गोष्टी - BBC News मराठी",
+      "pageIdentifier": "marathi.bbc_marathi_audio.programmes.p09431p4.page",
+      "producerId": "59",
+      "contentType": "player-episode",
+      "producer": "MARATHI"
+    },
+    "tags": {},
+    "version": "v1.3.11",
+    "blockTypes": ["media"],
+    "title": "तीन गोष्टी",
+    "releaseDateTimeStamp": 1616544000000,
+    "atiAnalytics": {}
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p09bplch",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "24 तासांत एकट्या मुंबईत पाच हजार रुग्ण सापडलेत",
+          "long": "राज्यात गेल्या 24 तासांत 31 हजारांवर रुग्ण सापडलेत तर एकट्या मुंबईत हा आकडा पाच हजारापार गेलेला पाहायला मिळाला. तज्ज्ञ म्हणतात की लॉकडाऊनशिवाय पर्याय नाही. पण प्रशासन काय निर्णय घेणार?\nमहाराष्ट्रात कोरोनाचं दुहेरी म्युटेशन पाहायला मिळतंय. याचा अर्थ काय होतो? यामुळे महाराष्ट्रात रुग्णसंख्या खूप वाढत आहे का?\nमुख्यमंत्री उद्धव ठाकरे आणि गृहमंत्री अनिल देशमुख यांच्या अडचणींमध्ये वाढ होतोना दिसतेय. विरोधक आक्रमक होतायत, महाविकास आघाडी अशावेळी काय पवित्रा घेतेय? \nऐका या सगळ्याबद्दल आजच्या तीन गोष्टींमध्ये."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+        "embedding": false,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p09bphm6",
+            "types": ["Podcast"],
+            "duration": 1889,
+            "durationISO8601": "PT31M29S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableUntil": 1617202020000,
+            "availableFrom": 1616600820000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "कोरोना लॉकडाऊन मुंबई, महाराष्ट्रात लागेल? | राज्यात दुहेरी म्युटेशन | उद्धव ठाकरेंच्या अडचणी वाढल्या (BBC News Marathi)",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "तीन गोष्टी" },
+    "locators": { "pid": "p09bplch", "brandPid": "p09431p4" },
+    "media": {
+      "id": "p09bplch",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "24 तासांत एकट्या मुंबईत पाच हजार रुग्ण सापडलेत",
+        "long": "राज्यात गेल्या 24 तासांत 31 हजारांवर रुग्ण सापडलेत तर एकट्या मुंबईत हा आकडा पाच हजारापार गेलेला पाहायला मिळाला. तज्ज्ञ म्हणतात की लॉकडाऊनशिवाय पर्याय नाही. पण प्रशासन काय निर्णय घेणार?\nमहाराष्ट्रात कोरोनाचं दुहेरी म्युटेशन पाहायला मिळतंय. याचा अर्थ काय होतो? यामुळे महाराष्ट्रात रुग्णसंख्या खूप वाढत आहे का?\nमुख्यमंत्री उद्धव ठाकरे आणि गृहमंत्री अनिल देशमुख यांच्या अडचणींमध्ये वाढ होतोना दिसतेय. विरोधक आक्रमक होतायत, महाविकास आघाडी अशावेळी काय पवित्रा घेतेय? \nऐका या सगळ्याबद्दल आजच्या तीन गोष्टींमध्ये."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "embedding": false,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p09bphm6",
+          "types": ["Podcast"],
+          "duration": 1889,
+          "durationISO8601": "PT31M29S",
+          "warnings": {},
+          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
+          "availableUntil": 1617202020000,
+          "availableFrom": 1616600820000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "कोरोना लॉकडाऊन मुंबई, महाराष्ट्रात लागेल? | राज्यात दुहेरी म्युटेशन | उद्धव ठाकरेंच्या अडचणी वाढल्या (BBC News Marathi)",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1616544000000,
+    "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bplch",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Marathi",
+      "uri": "/marathi",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bld3r", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bld3r",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "मुंबई, पुणे यांसह अनेक शहरांमध्ये नियम कठोर केले गेले आहेत.",
+                "long": "होळी आणि धुळवडीच्या पार्श्वभूमीवर मुंबईत नियम कडक करण्यात आले आहेत. \n1 एप्रिलपासून 45 वर्षांवरील सर्व व्यक्तींना मिळणार कोरोनाची लस.\nदेवेंद्र फडणवीस दिल्लीत गृहसचिवांच्या भेटीला. राज्य सरकारवर गंभीर आरोप.\n\nऐका हे सर्व आजच्या तीन गोष्टींमध्ये."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09blcr6",
+                  "types": ["Podcast"],
+                  "duration": 1882,
+                  "durationISO8601": "PT31M22S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1617118320000,
+                  "availableFrom": 1616517120000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना महाराष्ट्र लॉकडाऊन: होळीसाठी कडक नियम | लसीकरण 1 एप्रिलपासून 45 वर्षांवरील सर्वांना (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616457600000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bld3r",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bh5fl", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bh5fl",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "कोव्हिशील्ड लशीचा दुसरा डोस आता 6-8 आठवड्यांनी का देणार?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09bh4tq",
+                  "types": ["Podcast"],
+                  "duration": 1753,
+                  "durationISO8601": "PT29M13S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1617030060000,
+                  "availableFrom": 1616428860000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना लस कोव्हिशील्ड दुसरा डोस | लॉकडाऊन निर्णय, नरेंद्र मोदी | अनिल देशमुख राजीनाम्याचा शरद पवारांवर दबाव?",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616371200000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bh5fl",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bbxjg", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bbxjg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात का वाढत आहेत कोरोनाचे आकडे? अनिल देशमुख यांच्या राजीनाम्याची मागणी का होतेय?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09bbx14",
+                  "types": ["Podcast"],
+                  "duration": 1871,
+                  "durationISO8601": "PT31M11S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1616860260000,
+                  "availableFrom": 1616255460000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "महाराष्ट्रात कोरोनावरची लस मुंबईत बोलणार? | अनिल देशमुख यांच्यावर परमबीर सिंह यांचा लेटरबाँब (3 गोष्टी पॉडकास्ट)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616198400000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bbxjg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09b85l4", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09b85l4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात नेमक्या कोणत्या जिल्ह्यांमध्ये आकडे वाढले? मुख्यमंत्र्यांचे लॉकडाऊनचे संकेत?",
+                "medium": "महाराष्ट्रात नेमक्या कोणत्या जिल्ह्यांमध्ये आकडे वाढले? मुख्यमंत्र्यांचे पुन्हा लॉकडाऊनचे संकेत?",
+                "long": "महाराष्ट्रात कोरोनाच्या दुसऱ्या लाटेत नेमक्या कोणत्या शहरांमध्ये किती आकडे वाढत आहेत? पाहा बीबीसी मराठीचं सखोल विश्लेषण.\nआणि महाराष्ट्र खरंच लॉकडाऊनच्या दिशेने वाटचाल करतोय का? उद्धव ठाकरे लॉकडाऊनवर काय म्हणाले?\nउत्तराखंडचे नवे मुख्यमंत्री तीरथ सिंह रावत यांच्या जीन्सच्या वक्तव्यावर कोण काय म्हणालं? \nऐकू या हे सगळं आजच्या तीन गोष्टींमध्ये"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09b8490",
+                  "types": ["Podcast"],
+                  "duration": 1919,
+                  "durationISO8601": "PT31M59S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1618757400000,
+                  "availableFrom": 1616169000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "महाराष्ट्रात कोरोना रुग्ण कुठे आणि कसे वाढले? | उद्धव ठाकरे लॉकडाऊनवर काय म्हणाले? (3 गोष्टी पॉडकास्ट) (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616112000000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09b85l4",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09b3hqh", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09b3hqh",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात कोरोनाच्या आकड्यांमध्ये विक्रमी वाढ का होतेय?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09b3hbs",
+                  "types": ["Podcast"],
+                  "duration": 1828,
+                  "durationISO8601": "PT30M28S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1616687340000,
+                  "availableFrom": 1616082540000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना महाराष्ट्र: पुणे, नागपूर नवे हॉटस्पॉट? | लशीचे दोन डोस का? | सचिन वाझे प्रकरण (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616025600000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09b3hqh",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p094nsrm", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p094nsrm",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "दिवसभरातल्या कोरोना आणि इतर घडामोडींचा आढावा",
+                "medium": "दिवसभरातल्या कोरोना आणि इतर सर्व महत्त्वाच्या घडामोडींचा आढावा घेणारं मराठीतलं पहिलं पॉडकास्ट."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p094nsgq",
+                  "types": ["Podcast"],
+                  "duration": 60,
+                  "durationISO8601": "PT1M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1611227580000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Welcome",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1611187200000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p094nsrm",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/marathi/podcasts/p09431p4/p09bplch.json
+++ b/data/marathi/podcasts/p09431p4/p09bplch.json
@@ -1,0 +1,444 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bplch",
+    "locators": { "pid": "p09bplch", "brandPid": "p09431p4" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_marathi_audio",
+    "language": "mr",
+    "lastUpdated": 1616674396776,
+    "firstPublished": 1616601119000,
+    "lastPublished": 1616601119000,
+    "timestamp": 1616601119000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "तीन गोष्टी - BBC News मराठी",
+      "pageIdentifier": "marathi.bbc_marathi_audio.p09bplch.page",
+      "producerId": "59",
+      "contentType": "player-episode",
+      "producer": "MARATHI"
+    },
+    "tags": {},
+    "version": "v1.3.11",
+    "blockTypes": ["media"],
+    "title": "तीन गोष्टी",
+    "releaseDateTimeStamp": 1616544000000,
+    "atiAnalytics": {}
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p09bplch",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "24 तासांत एकट्या मुंबईत पाच हजार रुग्ण सापडलेत",
+          "long": "राज्यात गेल्या 24 तासांत 31 हजारांवर रुग्ण सापडलेत तर एकट्या मुंबईत हा आकडा पाच हजारापार गेलेला पाहायला मिळाला. तज्ज्ञ म्हणतात की लॉकडाऊनशिवाय पर्याय नाही. पण प्रशासन काय निर्णय घेणार?\nमहाराष्ट्रात कोरोनाचं दुहेरी म्युटेशन पाहायला मिळतंय. याचा अर्थ काय होतो? यामुळे महाराष्ट्रात रुग्णसंख्या खूप वाढत आहे का?\nमुख्यमंत्री उद्धव ठाकरे आणि गृहमंत्री अनिल देशमुख यांच्या अडचणींमध्ये वाढ होतोना दिसतेय. विरोधक आक्रमक होतायत, महाविकास आघाडी अशावेळी काय पवित्रा घेतेय? \nऐका या सगळ्याबद्दल आजच्या तीन गोष्टींमध्ये."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+        "embedding": true,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p09bphm6",
+            "types": ["Podcast"],
+            "duration": 1889,
+            "durationISO8601": "PT31M29S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableUntil": 1617202020000,
+            "availableFrom": 1616600820000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "कोरोना लॉकडाऊन मुंबई, महाराष्ट्रात लागेल? | राज्यात दुहेरी म्युटेशन | उद्धव ठाकरेंच्या अडचणी वाढल्या (BBC News Marathi)",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "तीन गोष्टी" },
+    "locators": { "pid": "p09bplch", "brandPid": "p09431p4" },
+    "media": {
+      "id": "p09bplch",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "24 तासांत एकट्या मुंबईत पाच हजार रुग्ण सापडलेत",
+        "long": "राज्यात गेल्या 24 तासांत 31 हजारांवर रुग्ण सापडलेत तर एकट्या मुंबईत हा आकडा पाच हजारापार गेलेला पाहायला मिळाला. तज्ज्ञ म्हणतात की लॉकडाऊनशिवाय पर्याय नाही. पण प्रशासन काय निर्णय घेणार?\nमहाराष्ट्रात कोरोनाचं दुहेरी म्युटेशन पाहायला मिळतंय. याचा अर्थ काय होतो? यामुळे महाराष्ट्रात रुग्णसंख्या खूप वाढत आहे का?\nमुख्यमंत्री उद्धव ठाकरे आणि गृहमंत्री अनिल देशमुख यांच्या अडचणींमध्ये वाढ होतोना दिसतेय. विरोधक आक्रमक होतायत, महाविकास आघाडी अशावेळी काय पवित्रा घेतेय? \nऐका या सगळ्याबद्दल आजच्या तीन गोष्टींमध्ये."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "embedding": true,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p09bphm6",
+          "types": ["Podcast"],
+          "duration": 1889,
+          "durationISO8601": "PT31M29S",
+          "warnings": {},
+          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
+          "availableUntil": 1617202020000,
+          "availableFrom": 1616600820000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "कोरोना लॉकडाऊन मुंबई, महाराष्ट्रात लागेल? | राज्यात दुहेरी म्युटेशन | उद्धव ठाकरेंच्या अडचणी वाढल्या (BBC News Marathi)",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bplkg.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1616544000000,
+    "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bplch",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Marathi",
+      "uri": "/marathi",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bld3r", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bld3r",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "मुंबई, पुणे यांसह अनेक शहरांमध्ये नियम कठोर केले गेले आहेत.",
+                "long": "होळी आणि धुळवडीच्या पार्श्वभूमीवर मुंबईत नियम कडक करण्यात आले आहेत. \n1 एप्रिलपासून 45 वर्षांवरील सर्व व्यक्तींना मिळणार कोरोनाची लस.\nदेवेंद्र फडणवीस दिल्लीत गृहसचिवांच्या भेटीला. राज्य सरकारवर गंभीर आरोप.\n\nऐका हे सर्व आजच्या तीन गोष्टींमध्ये."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09blcr6",
+                  "types": ["Podcast"],
+                  "duration": 1882,
+                  "durationISO8601": "PT31M22S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1617118320000,
+                  "availableFrom": 1616517120000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना महाराष्ट्र लॉकडाऊन: होळीसाठी कडक नियम | लसीकरण 1 एप्रिलपासून 45 वर्षांवरील सर्वांना (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bld48.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616457600000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bld3r",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bh5fl", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bh5fl",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "कोव्हिशील्ड लशीचा दुसरा डोस आता 6-8 आठवड्यांनी का देणार?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09bh4tq",
+                  "types": ["Podcast"],
+                  "duration": 1753,
+                  "durationISO8601": "PT29M13S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1617030060000,
+                  "availableFrom": 1616428860000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना लस कोव्हिशील्ड दुसरा डोस | लॉकडाऊन निर्णय, नरेंद्र मोदी | अनिल देशमुख राजीनाम्याचा शरद पवारांवर दबाव?",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09bh5gq.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616371200000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bh5fl",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09bbxjg", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09bbxjg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात का वाढत आहेत कोरोनाचे आकडे? अनिल देशमुख यांच्या राजीनाम्याची मागणी का होतेय?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09bbx14",
+                  "types": ["Podcast"],
+                  "duration": 1871,
+                  "durationISO8601": "PT31M11S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1616860260000,
+                  "availableFrom": 1616255460000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "महाराष्ट्रात कोरोनावरची लस मुंबईत बोलणार? | अनिल देशमुख यांच्यावर परमबीर सिंह यांचा लेटरबाँब (3 गोष्टी पॉडकास्ट)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616198400000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09bbxjg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09b85l4", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09b85l4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात नेमक्या कोणत्या जिल्ह्यांमध्ये आकडे वाढले? मुख्यमंत्र्यांचे लॉकडाऊनचे संकेत?",
+                "medium": "महाराष्ट्रात नेमक्या कोणत्या जिल्ह्यांमध्ये आकडे वाढले? मुख्यमंत्र्यांचे पुन्हा लॉकडाऊनचे संकेत?",
+                "long": "महाराष्ट्रात कोरोनाच्या दुसऱ्या लाटेत नेमक्या कोणत्या शहरांमध्ये किती आकडे वाढत आहेत? पाहा बीबीसी मराठीचं सखोल विश्लेषण.\nआणि महाराष्ट्र खरंच लॉकडाऊनच्या दिशेने वाटचाल करतोय का? उद्धव ठाकरे लॉकडाऊनवर काय म्हणाले?\nउत्तराखंडचे नवे मुख्यमंत्री तीरथ सिंह रावत यांच्या जीन्सच्या वक्तव्यावर कोण काय म्हणालं? \nऐकू या हे सगळं आजच्या तीन गोष्टींमध्ये"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09b8490",
+                  "types": ["Podcast"],
+                  "duration": 1919,
+                  "durationISO8601": "PT31M59S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1618757400000,
+                  "availableFrom": 1616169000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "महाराष्ट्रात कोरोना रुग्ण कुठे आणि कसे वाढले? | उद्धव ठाकरे लॉकडाऊनवर काय म्हणाले? (3 गोष्टी पॉडकास्ट) (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09b85m9.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616112000000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09b85l4",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p09b3hqh", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p09b3hqh",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "महाराष्ट्रात कोरोनाच्या आकड्यांमध्ये विक्रमी वाढ का होतेय?"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09b3hbs",
+                  "types": ["Podcast"],
+                  "duration": 1828,
+                  "durationISO8601": "PT30M28S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1616687340000,
+                  "availableFrom": 1616082540000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "कोरोना महाराष्ट्र: पुणे, नागपूर नवे हॉटस्पॉट? | लशीचे दोन डोस का? | सचिन वाझे प्रकरण (BBC News Marathi)",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1616025600000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p09b3hqh",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "तीन गोष्टी" },
+            "locators": { "pid": "p094nsrm", "brandPid": "p09431p4" },
+            "media": {
+              "id": "p094nsrm",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "दिवसभरातल्या कोरोना आणि इतर घडामोडींचा आढावा",
+                "medium": "दिवसभरातल्या कोरोना आणि इतर सर्व महत्त्वाच्या घडामोडींचा आढावा घेणारं मराठीतलं पहिलं पॉडकास्ट."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p094nsgq",
+                  "types": ["Podcast"],
+                  "duration": 60,
+                  "durationISO8601": "PT1M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1611227580000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Welcome",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0940n97.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1611187200000,
+            "brand": { "pid": "p09431p4", "title": "तीन गोष्टी" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_marathi_audio/p094nsrm",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/portuguese/podcasts/p07r3r3t.json
+++ b/data/portuguese/podcasts/p07r3r3t.json
@@ -1,0 +1,543 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:brand:bbc_brasil/p07r3r3t",
+    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_brasil",
+    "language": "pt-br",
+    "lastUpdated": 1616672972760,
+    "firstPublished": 1582557642000,
+    "lastPublished": 1582557642000,
+    "timestamp": 1582557642000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "Que História! - BBC News Brasil",
+      "pageIdentifier": "portuguese.bbc_brasil.programmes.p07r3r3t.page",
+      "producerId": "33",
+      "contentType": "player-episode",
+      "producer": "PORTUGUESE"
+    },
+    "tags": {},
+    "version": "v1.3.11",
+    "blockTypes": ["media"],
+    "title": "Que História!",
+    "releaseDateTimeStamp": 1584057600000,
+    "atiAnalytics": {}
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p083x9gr",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
+          "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+        "embedding": false,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p083x8gs",
+            "types": ["Podcast"],
+            "duration": 982,
+            "durationISO8601": "PT16M22S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableFrom": 1584090000000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "Que História!" },
+    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "media": {
+      "id": "p083x9gr",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
+        "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "embedding": false,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p083x8gs",
+          "types": ["Podcast"],
+          "duration": 982,
+          "durationISO8601": "PT16M22S",
+          "warnings": {},
+          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
+          "availableFrom": 1584090000000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1584057600000,
+    "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x9gr",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Portuguese",
+      "uri": "/portuguese",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p083x87j", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p083x87j",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Moradores de ilha entraram em frenesi por causa de carga de navio naufragado na costa.",
+                "medium": "Em 1941, cargueiro carregado de uísque bateu nas rochas de ilha escocesa; moradores fizeram jogo de gato e rato com polícia para esconder carga que tinham 'resgatado' do navio."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p083x2k6",
+                  "types": ["Podcast"],
+                  "duration": 548,
+                  "durationISO8601": "PT9M8S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1583485200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'Uísque ao mar!': a curiosa história do 'verão da lata' escocês em plena 2ª Guerra",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1583452800000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x87j",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p083wkq9", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p083wkq9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Adolescente não sabe que a pessoa que acredita ser seu pai é ator contratado pela mãe.",
+                "medium": "Ator fundou empresa no Japão que 'aluga' amigos e familiares para atender à uma crescente demanda em país por relações postiças."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p083wjsg",
+                  "types": ["Podcast"],
+                  "duration": 725,
+                  "durationISO8601": "PT12M5S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1582880400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "As famílias 'alugadas' no Japão",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1582848000000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083wkq9",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p0837nfw", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p0837nfw",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Sobreviventes passaram quatro dias boiando em águas infestadas por tubarões.",
+                "medium": "Em junho de 1945, torpedos japoneses afundaram cruzador americano, deixando centenas de marinheiros boiando no Oceano Pacífico, lutando contra desidratação, fome e tubarões."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0837lxk",
+                  "types": ["Podcast"],
+                  "duration": 703,
+                  "durationISO8601": "PT11M43S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1582275600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O naufrágio de navio militar na 2ª Guerra que inspirou filme 'Tubarão'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1582243200000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p0837nfw",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p082wrwc", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p082wrwc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Aos 17 anos, Miché Solomon conheceu menina que era 'sua cara' — e viu seu mundo ruir.",
+                "medium": "Em 1997, mulher vestida de enfermeira deixou hospital com bebê, enquanto a mãe dormia; por causa de uma selfie, tirada 17 anos depois, que criança roubada descobriu a verdade."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0830923",
+                  "types": ["Podcast"],
+                  "duration": 1033,
+                  "durationISO8601": "PT17M13S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1581670800000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'Graças a uma selfie, descobri que minha mãe me roubou quando era bebê'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1581638400000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p082wrwc",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p081mcd8", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p081mcd8",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Os raros relatos de brasileiros que enfrentaram as bombas e o racionamento em Londres.",
+                "medium": "Podcast conta como foi vida de pequeno grupo de jornalistas, intelectuais e diplomatas que permaneceu na Grã-Bretanha quando país declarou guerra à Alemanha em 1939."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p082hrjj",
+                  "types": ["Podcast"],
+                  "duration": 1084,
+                  "durationISO8601": "PT18M4S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1581066000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Os Brasileiros da Blitz",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1581033600000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081mcd8",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p081jh7q", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p081jh7q",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Músico chileno foi até a Síria para achar seus netos e trazê-los para casa.",
+                "medium": "Após receber notícia da morte da filha e do genro na Síria, Patrício Galvez partiu para zona de guerra em busca de seus sete netos."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p081tv30",
+                  "types": ["Podcast"],
+                  "duration": 815,
+                  "durationISO8601": "PT13M35S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1580461200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "A saga do avô em busca dos netos órfãos do Estado Islâmico",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1580428800000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081jh7q",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p08129g5", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p08129g5",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Megaexplosão de vulcão em 1883 causou destruição e mexeu com ar, luz e cores do planeta.",
+                "medium": "Explosão de vulcão foi tão barulhenta que pôde ser ouvida as 5 mil km de distância; ouça relato de uma testemunha do bombástico evento."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p081259q",
+                  "types": ["Podcast"],
+                  "duration": 667,
+                  "durationISO8601": "PT11M7S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1579856400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Krakatoa: a erupção que o mundo inteiro sentiu",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1579824000000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p08129g5",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p080j23n", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p080j23n",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "O calvário enfrentado por mulher nos EUA após ser descrita como adúltera em post falso.",
+                "medium": "Caso de Monika Glennon ilustra perigos da internet e os estragos que alguém com um teclado e um ressentimento podem causar."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p080j1f8",
+                  "types": ["Podcast"],
+                  "duration": 832,
+                  "durationISO8601": "PT13M52S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1579251600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'O post criado para arruinar minha vida'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1579219200000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p080j23n",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/portuguese/podcasts/p07r3r3t/p083x9gr.json
+++ b/data/portuguese/podcasts/p07r3r3t/p083x9gr.json
@@ -1,0 +1,543 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x9gr",
+    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_brasil",
+    "language": "pt-br",
+    "lastUpdated": 1616674866493,
+    "firstPublished": 1582557642000,
+    "lastPublished": 1582557642000,
+    "timestamp": 1582557642000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "Que História! - BBC News Brasil",
+      "pageIdentifier": "portuguese.bbc_brasil.p083x9gr.page",
+      "producerId": "33",
+      "contentType": "player-episode",
+      "producer": "PORTUGUESE"
+    },
+    "tags": {},
+    "version": "v1.3.11",
+    "blockTypes": ["media"],
+    "title": "Que História!",
+    "releaseDateTimeStamp": 1584057600000,
+    "atiAnalytics": {}
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p083x9gr",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
+          "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+        "embedding": true,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p083x8gs",
+            "types": ["Podcast"],
+            "duration": 982,
+            "durationISO8601": "PT16M22S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableFrom": 1584090000000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "Que História!" },
+    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "media": {
+      "id": "p083x9gr",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
+        "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "embedding": true,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p083x8gs",
+          "types": ["Podcast"],
+          "duration": 982,
+          "durationISO8601": "PT16M22S",
+          "warnings": {},
+          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
+          "availableFrom": 1584090000000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1584057600000,
+    "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+    "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x9gr",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Portuguese",
+      "uri": "/portuguese",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p083x87j", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p083x87j",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Moradores de ilha entraram em frenesi por causa de carga de navio naufragado na costa.",
+                "medium": "Em 1941, cargueiro carregado de uísque bateu nas rochas de ilha escocesa; moradores fizeram jogo de gato e rato com polícia para esconder carga que tinham 'resgatado' do navio."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p083x2k6",
+                  "types": ["Podcast"],
+                  "duration": 548,
+                  "durationISO8601": "PT9M8S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1583485200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'Uísque ao mar!': a curiosa história do 'verão da lata' escocês em plena 2ª Guerra",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x88b.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1583452800000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x87j",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p083wkq9", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p083wkq9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Adolescente não sabe que a pessoa que acredita ser seu pai é ator contratado pela mãe.",
+                "medium": "Ator fundou empresa no Japão que 'aluga' amigos e familiares para atender à uma crescente demanda em país por relações postiças."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p083wjsg",
+                  "types": ["Podcast"],
+                  "duration": 725,
+                  "durationISO8601": "PT12M5S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1582880400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "As famílias 'alugadas' no Japão",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p083wkqx.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1582848000000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083wkq9",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p0837nfw", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p0837nfw",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Sobreviventes passaram quatro dias boiando em águas infestadas por tubarões.",
+                "medium": "Em junho de 1945, torpedos japoneses afundaram cruzador americano, deixando centenas de marinheiros boiando no Oceano Pacífico, lutando contra desidratação, fome e tubarões."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0837lxk",
+                  "types": ["Podcast"],
+                  "duration": 703,
+                  "durationISO8601": "PT11M43S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1582275600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O naufrágio de navio militar na 2ª Guerra que inspirou filme 'Tubarão'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1582243200000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p0837nfw",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p082wrwc", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p082wrwc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Aos 17 anos, Miché Solomon conheceu menina que era 'sua cara' — e viu seu mundo ruir.",
+                "medium": "Em 1997, mulher vestida de enfermeira deixou hospital com bebê, enquanto a mãe dormia; por causa de uma selfie, tirada 17 anos depois, que criança roubada descobriu a verdade."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0830923",
+                  "types": ["Podcast"],
+                  "duration": 1033,
+                  "durationISO8601": "PT17M13S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1581670800000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'Graças a uma selfie, descobri que minha mãe me roubou quando era bebê'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p082wrxj.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1581638400000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p082wrwc",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p081mcd8", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p081mcd8",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Os raros relatos de brasileiros que enfrentaram as bombas e o racionamento em Londres.",
+                "medium": "Podcast conta como foi vida de pequeno grupo de jornalistas, intelectuais e diplomatas que permaneceu na Grã-Bretanha quando país declarou guerra à Alemanha em 1939."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p082hrjj",
+                  "types": ["Podcast"],
+                  "duration": 1084,
+                  "durationISO8601": "PT18M4S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1581066000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Os Brasileiros da Blitz",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p081mcdz.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1581033600000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081mcd8",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p081jh7q", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p081jh7q",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Músico chileno foi até a Síria para achar seus netos e trazê-los para casa.",
+                "medium": "Após receber notícia da morte da filha e do genro na Síria, Patrício Galvez partiu para zona de guerra em busca de seus sete netos."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p081tv30",
+                  "types": ["Podcast"],
+                  "duration": 815,
+                  "durationISO8601": "PT13M35S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1580461200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "A saga do avô em busca dos netos órfãos do Estado Islâmico",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p081jh88.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1580428800000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081jh7q",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p08129g5", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p08129g5",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Megaexplosão de vulcão em 1883 causou destruição e mexeu com ar, luz e cores do planeta.",
+                "medium": "Explosão de vulcão foi tão barulhenta que pôde ser ouvida as 5 mil km de distância; ouça relato de uma testemunha do bombástico evento."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p081259q",
+                  "types": ["Podcast"],
+                  "duration": 667,
+                  "durationISO8601": "PT11M7S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1579856400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Krakatoa: a erupção que o mundo inteiro sentiu",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p08129k3.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1579824000000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p08129g5",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": { "headline": "Que História!" },
+            "locators": { "pid": "p080j23n", "brandPid": "p07r3r3t" },
+            "media": {
+              "id": "p080j23n",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "O calvário enfrentado por mulher nos EUA após ser descrita como adúltera em post falso.",
+                "medium": "Caso de Monika Glennon ilustra perigos da internet e os estragos que alguém com um teclado e um ressentimento podem causar."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p080j1f8",
+                  "types": ["Podcast"],
+                  "duration": 832,
+                  "durationISO8601": "PT13M52S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1579251600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'O post criado para arruinar minha vida'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p080j247.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1579219200000,
+            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p080j23n",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
All environments now will run an E2E on the batch 2 of podcasts - Marathi and Portuguese
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Tests pass
