### PR TITLE
Fix PS Story Page tests

### DIFF
--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -14,13 +14,33 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
         const descriptionBlock = body.content.blocks.find(
           block => block.role === 'introduction',
         );
-        const descriptionHtml = pathOr({}, ['text'], descriptionBlock);
+        // Condition added because introduction is non-mandatory
+        if (descriptionBlock) {
+          const descriptionHtml = pathOr({}, ['text'], descriptionBlock);
+          // strip html from the description, so we get description as plain text
+          const elem = document.createElement('div');
+          elem.innerHTML = descriptionHtml;
+          const description = elem.innerText;
+          cy.get('main p').should('contain', description);
+        }
+      });
+    });
 
-        // strip html from the description, so we get description as plain text
-        const elem = document.createElement('div');
-        elem.innerHTML = descriptionHtml;
-        const description = elem.innerText;
-        cy.get('main p').should('contain', description);
+    it('should render paragraph text for the page', () => {
+      cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
+        const paragraphBlock = body.content.blocks.find(
+          block => block.type === 'paragraph',
+        );
+        // Conditional because in test assets the data model structure is sometimes variable and unusual
+        // so cannot be accessed in the same way across assets
+        if (paragraphBlock) {
+          const descriptionHtml = pathOr({}, ['text'], paragraphBlock);
+          // strip html from the description, so we get description as plain text
+          const elem = document.createElement('div');
+          elem.innerHTML = descriptionHtml;
+          const paragraph = elem.innerText;
+          cy.get('main p').should('contain', paragraph);
+        }
       });
     });
   });

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4575,7 +4575,7 @@ module.exports = () => ({
             enabled: true,
           },
           test: {
-            paths: ['/news/uk-56342465', '/news/technology-56294493'],
+            paths: ['/news/23393110'],
             enabled: true,
           },
           local: {


### PR DESCRIPTION
There some failing tests on story pages on Public Services like news and sport. This PR fixes those failing tests by replacing test asset URLs that don't work, and only checking the introduction text if it exists.

My more in detail comment before on the reasons for this failure is the following:
I think these ‘description’ tests are failing because the assets https://www.test.bbc.com/sport/formula1/23355387 and https://www.test.bbc.com/newsround/23212028 do not have the introduction block role in their json.
The test does this
const descriptionBlock = body.content.blocks.find(
          block => block.role === ‘introduction’,
        );
But this does not work as there is no block.role = introduction.
In the passing tests there is role	“introduction” in a content block

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

Tests pass with these URLs