### PR TITLE
On Demand Audio E2Es - Added wait before reload to allow cache to warm for retry on fail

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
 /* eslint-disable consistent-return */
 import path from 'ramda/src/path';
 import {
@@ -52,7 +53,8 @@ export default ({ service, pageType, variant, isAmp }) => {
         },
         () => {
           it('should be displayed if the toggle is on, and shows the expected number of items', function test() {
-            // Reload for retry if data didn't update on page
+            // Reload for retry if data didn't update on page, after a wait for next load to have warmed cache
+            cy.wait(5000);
             cy.reload();
             let toggleName;
 

--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -53,8 +53,7 @@ export default ({ service, pageType, variant, isAmp }) => {
         },
         () => {
           it('should be displayed if the toggle is on, and shows the expected number of items', function test() {
-            // Reload for retry if data didn't update on page, after a wait for next load to have warmed cache
-            cy.wait(5000);
+            // Reload for retry if data didn't update on page
             cy.reload();
             let toggleName;
 
@@ -146,7 +145,18 @@ export default ({ service, pageType, variant, isAmp }) => {
                       /* eslint-enable no-console */
                     }
 
+                    // get length and wait if the assertion fails
+                    cy.get('[data-e2e=recent-episodes-list-item]')
+                      .its('length')
+                      .then(length => {
+                        if (length !== expectedNumberOfEpisodes) {
+                          cy.wait(5000);
+                        }
+                      });
+
                     // More than one episode expected
+                    // If this test fails the next retry should pass
+                    // as time has been allowed for the upstream cache to populate
                     if (expectedNumberOfEpisodes > 1) {
                       cy.get('[data-e2e=recent-episodes-list]').should('exist');
 


### PR DESCRIPTION
Our theory about the failing recent episodes component E2Es is that the Ares data is updated, but the page is still showing the cached episodes. This causes a mismatch in number of episodes expected and presented. The wait added is 1 second more than the 4 second time it should take for the page to then be updates on reload. The wait only occurs on the first run if the mismatch is there, then when it retries hopefully the cache will be updated.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

All pass