### PR TITLE
Add google safeframe to connectSrc in csp

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -24,6 +24,7 @@ const advertisingDirectives = {
     'https://secure-dcr-cert.imrworldwide.com',
     'https://pixel.adsafeprotected.com',
     'https://cdn.adsafeprotected.com',
+    'https://*.safeframe.googlesyndication.com',
   ],
   frameSrc: [
     'https://*.g.doubleclick.net',

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -48,6 +48,7 @@ describe('cspHeader', () => {
         'https://secure-dcr-cert.imrworldwide.com',
         'https://pixel.adsafeprotected.com',
         'https://cdn.adsafeprotected.com',
+        'https://*.safeframe.googlesyndication.com',
         "'self'",
       ],
       defaultSrcExpectation: [
@@ -131,6 +132,7 @@ describe('cspHeader', () => {
         'https://secure-dcr-cert.imrworldwide.com',
         'https://pixel.adsafeprotected.com',
         'https://cdn.adsafeprotected.com',
+        'https://*.safeframe.googlesyndication.com',
         "'self'",
       ],
       defaultSrcExpectation: [
@@ -254,6 +256,7 @@ describe('cspHeader', () => {
         'https://secure-dcr-cert.imrworldwide.com',
         'https://pixel.adsafeprotected.com',
         'https://cdn.adsafeprotected.com',
+        'https://*.safeframe.googlesyndication.com',
         "'self'",
       ],
       defaultSrcExpectation: [
@@ -340,6 +343,7 @@ describe('cspHeader', () => {
         'https://secure-dcr-cert.imrworldwide.com',
         'https://pixel.adsafeprotected.com',
         'https://cdn.adsafeprotected.com',
+        'https://*.safeframe.googlesyndication.com',
         "'self'",
       ],
       defaultSrcExpectation: [


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9023

**Overall change:**
Adds `'https://*.safeframe.googlesyndication.com'` to the `connectSrc` directive in the csp.

The bug only occurs on amp and appears to be because amp preconnects to the download the 'google safeframe container' to display ads.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
