### PR TITLE
Correct ATI url on .com AMP pages

### DIFF
--- a/src/app/contexts/RequestContext/index.jsx
+++ b/src/app/contexts/RequestContext/index.jsx
@@ -41,7 +41,7 @@ export const RequestContextProvider = ({
   const env = getEnv(origin);
   const platform = isAmp ? 'amp' : 'canonical';
   const statsDestination = getStatsDestination({
-    isUK,
+    isUk: platform === 'amp' ? true : isUK,
     env,
     service,
   });

--- a/src/app/contexts/RequestContext/index.jsx
+++ b/src/app/contexts/RequestContext/index.jsx
@@ -41,7 +41,7 @@ export const RequestContextProvider = ({
   const env = getEnv(origin);
   const platform = isAmp ? 'amp' : 'canonical';
   const statsDestination = getStatsDestination({
-    isUk: platform === 'amp' ? true : isUK,
+    isUK: platform === 'amp' ? true : isUK, // getDestination requires that statsDestination is a PS variant on AMP
     env,
     service,
   });

--- a/src/app/contexts/RequestContext/index.test.jsx
+++ b/src/app/contexts/RequestContext/index.test.jsx
@@ -138,5 +138,23 @@ describe('RequestContext', () => {
         platform: 'canonical',
       });
     });
+
+    it('should return a PS statsDestination when isAmp is true and outside the UK', () => {
+      getOriginContext.default.mockReturnValue({
+        isUK: false,
+        origin: 'origin',
+      });
+      render(
+        <RequestContextProvider {...input}>
+          <Component />
+        </RequestContextProvider>,
+      );
+
+      expect(getStatsDestination.default).toHaveBeenCalledWith({
+        env: 'getEnv',
+        isUK: true,
+        service: 'service',
+      });
+    });
   });
 });

--- a/src/app/lib/analyticsUtils/index.js
+++ b/src/app/lib/analyticsUtils/index.js
@@ -37,62 +37,34 @@ export const getDestination = (platform, statsDestination) => {
   };
 
   const geoVariants = {
-    NEWS: {
+    NEWS_PS: {
       PS: destinationIDs.NEWS_PS,
       GNL: destinationIDs.NEWS_GNL,
     },
-    NEWS_TEST: {
+    NEWS_PS_TEST: {
       PS: destinationIDs.NEWS_PS_TEST,
       GNL: destinationIDs.NEWS_GNL_TEST,
     },
-    SPORT: {
+    SPORT_PS: {
       PS: destinationIDs.SPORT_PS,
       GNL: destinationIDs.SPORT_GNL,
     },
-    SPORT_TEST: {
+    SPORT_PS_TEST: {
       PS: destinationIDs.SPORT_PS_TEST,
       GNL: destinationIDs.SPORT_GNL_TEST,
     },
-    NEWS_LANGUAGES: {
+    NEWS_LANGUAGES_PS: {
       PS: destinationIDs.NEWS_LANGUAGES_PS,
       GNL: destinationIDs.NEWS_LANGUAGES_GNL,
     },
-    NEWS_LANGUAGES_TEST: {
+    NEWS_LANGUAGES_PS_TEST: {
       PS: destinationIDs.NEWS_LANGUAGES_PS_TEST,
       GNL: destinationIDs.NEWS_LANGUAGES_GNL_TEST,
     },
   };
 
-  if (platform === 'amp') {
-    switch (statsDestination) {
-      case 'NEWS_PS':
-      case 'NEWS_GNL': {
-        return getAmpDestination(geoVariants.NEWS);
-      }
-      case 'NEWS_PS_TEST':
-      case 'NEWS_GNL_TEST': {
-        return getAmpDestination(geoVariants.NEWS_TEST);
-      }
-      case 'SPORT_PS':
-      case 'SPORT_GNL': {
-        return getAmpDestination(geoVariants.SPORT);
-      }
-      case 'SPORT_PS_TEST':
-      case 'SPORT_GNL_TEST': {
-        return getAmpDestination(geoVariants.SPORT_TEST);
-      }
-      case 'NEWS_LANGUAGES_PS':
-      case 'NEWS_LANGUAGES_GNL': {
-        return getAmpDestination(geoVariants.NEWS_LANGUAGES);
-      }
-      case 'NEWS_LANGUAGES_PS_TEST':
-      case 'NEWS_LANGUAGES_GNL_TEST': {
-        return getAmpDestination(geoVariants.NEWS_LANGUAGES_TEST);
-      }
-      default: {
-        return destinationIDs[statsDestination] || destinationIDs.NEWS_PS;
-      }
-    }
+  if (platform === 'amp' && geoVariants[statsDestination]) {
+    return getAmpDestination(geoVariants[statsDestination]);
   }
 
   return destinationIDs[statsDestination] || destinationIDs.NEWS_PS;

--- a/src/app/lib/analyticsUtils/index.js
+++ b/src/app/lib/analyticsUtils/index.js
@@ -37,27 +37,27 @@ export const getDestination = (platform, statsDestination) => {
   };
 
   const geoVariants = {
-    NEWS_PS: {
+    NEWS: {
       PS: destinationIDs.NEWS_PS,
       GNL: destinationIDs.NEWS_GNL,
     },
-    NEWS_PS_TEST: {
+    NEWS_TEST: {
       PS: destinationIDs.NEWS_PS_TEST,
       GNL: destinationIDs.NEWS_GNL_TEST,
     },
-    SPORT_PS: {
+    SPORT: {
       PS: destinationIDs.SPORT_PS,
       GNL: destinationIDs.SPORT_GNL,
     },
-    SPORT_PS_TEST: {
+    SPORT_TEST: {
       PS: destinationIDs.SPORT_PS_TEST,
       GNL: destinationIDs.SPORT_GNL_TEST,
     },
-    NEWS_LANGUAGES_PS: {
+    NEWS_LANGUAGES: {
       PS: destinationIDs.NEWS_LANGUAGES_PS,
       GNL: destinationIDs.NEWS_LANGUAGES_GNL,
     },
-    NEWS_LANGUAGES_PS_TEST: {
+    NEWS_LANGUAGES_TEST: {
       PS: destinationIDs.NEWS_LANGUAGES_PS_TEST,
       GNL: destinationIDs.NEWS_LANGUAGES_GNL_TEST,
     },

--- a/src/app/lib/analyticsUtils/index.js
+++ b/src/app/lib/analyticsUtils/index.js
@@ -63,8 +63,36 @@ export const getDestination = (platform, statsDestination) => {
     },
   };
 
-  if (platform === 'amp' && geoVariants[statsDestination]) {
-    return getAmpDestination(geoVariants[statsDestination]);
+  if (platform === 'amp') {
+    switch (statsDestination) {
+      case 'NEWS_PS':
+      case 'NEWS_GNL': {
+        return getAmpDestination(geoVariants.NEWS);
+      }
+      case 'NEWS_PS_TEST':
+      case 'NEWS_GNL_TEST': {
+        return getAmpDestination(geoVariants.NEWS_TEST);
+      }
+      case 'SPORT_PS':
+      case 'SPORT_GNL': {
+        return getAmpDestination(geoVariants.SPORT);
+      }
+      case 'SPORT_PS_TEST':
+      case 'SPORT_GNL_TEST': {
+        return getAmpDestination(geoVariants.SPORT_TEST);
+      }
+      case 'NEWS_LANGUAGES_PS':
+      case 'NEWS_LANGUAGES_GNL': {
+        return getAmpDestination(geoVariants.NEWS_LANGUAGES);
+      }
+      case 'NEWS_LANGUAGES_PS_TEST':
+      case 'NEWS_LANGUAGES_GNL_TEST': {
+        return getAmpDestination(geoVariants.NEWS_LANGUAGES_TEST);
+      }
+      default: {
+        return destinationIDs[statsDestination] || destinationIDs.NEWS_PS;
+      }
+    }
   }
 
   return destinationIDs[statsDestination] || destinationIDs.NEWS_PS;


### PR DESCRIPTION
Resolves #9041

**Overall change:**
Ensures that if a .com page is visited then amp-geo is used to determine location before building the analytics url on amp.

**Code changes:**

- `statsDestination` is a GNL variant if a .com page is visited, and so a switch statement is used to ensure that `getAmpDestination` is called with the correct parameters if `statsDestination` is a GNL variant and the user is on an amp page.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [X] This PR requires manual testing
