### PR TITLE
Send Click/View to ATI

### DIFF
--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -24,6 +24,7 @@ const ARTICLE_PHOTO_GALLERY = 'article-photo-gallery';
 const ARTICLE_CORRESPONDENT_PIECE = 'article-correspondent';
 
 const pageTypeUrlBuilders = {
+  STY: buildArticleATIUrl,
   article: buildArticleATIUrl,
   frontPage: buildIndexPageATIUrl,
   media: buildTvRadioATIUrl,
@@ -83,6 +84,7 @@ const pageTypeParamBuilders = {
 
 const createBuilderFactory = (requestContext, pageTypeHandlers) => {
   const { pageType } = requestContext;
+  console.log(pageType);
 
   return pageTypeHandlers[pageType];
 };

--- a/src/app/containers/ATIAnalytics/params/index.js
+++ b/src/app/containers/ATIAnalytics/params/index.js
@@ -24,7 +24,8 @@ const ARTICLE_PHOTO_GALLERY = 'article-photo-gallery';
 const ARTICLE_CORRESPONDENT_PIECE = 'article-correspondent';
 
 const pageTypeUrlBuilders = {
-  STY: buildArticleATIUrl,
+  STY: (data, requestContext, serviceContext) =>
+    buildCpsAssetPageATIUrl(data, requestContext, serviceContext, 'article'),
   article: buildArticleATIUrl,
   frontPage: buildIndexPageATIUrl,
   media: buildTvRadioATIUrl,
@@ -80,11 +81,12 @@ const pageTypeParamBuilders = {
       serviceContext,
       ARTICLE_CORRESPONDENT_PIECE,
     ),
+  STY: (data, requestContext, serviceContext) =>
+    buildCpsAssetPageATIParams(data, requestContext, serviceContext, 'article'),
 };
 
 const createBuilderFactory = (requestContext, pageTypeHandlers) => {
   const { pageType } = requestContext;
-  console.log(pageType);
 
   return pageTypeHandlers[pageType];
 };

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -51,8 +51,8 @@ import AdContainer from '#containers/Ad';
 import CanonicalAdBootstrapJs from '#containers/Ad/Canonical/CanonicalAdBootstrapJs';
 import { RequestContext } from '#contexts/RequestContext';
 import useToggle from '#hooks/useToggle';
-import sendEventBeacon from '#containers/ATIAnalytics/beacon/index';
-import buildATIClickParams from '#containers/ATIAnalytics/params';
+import { sendEventBeacon } from '#containers/ATIAnalytics/beacon/index';
+import { buildATIClickParams } from '#containers/ATIAnalytics/params';
 import { getComponentInfo } from '#app/lib/analyticsUtils/index';
 
 const MpuContainer = styled(AdContainer)`
@@ -73,14 +73,14 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
 
   useEffect(async () => {
     const eventTrackingProps = buildATIClickParams(
-      {},
+      pageData,
       requestContext,
       serviceContext,
     );
 
     const componentInfo = getComponentInfo({
       result: 'https://www.bbc.com/mundo/something',
-      name: 'mostRead',
+      componentName: 'mostRead',
       componentData: {
         actionLabel: 'most-read-navigate',
         child: 'link',
@@ -89,6 +89,7 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
 
     await sendEventBeacon({
       type: 'click',
+      componentName: 'mostRead',
       service,
       componentInfo,
       ...eventTrackingProps,


### PR DESCRIPTION
**Overall change:**
This PR presents a working click event despatch to ATI. It modifies our Story pages to send a click event immediately on page load; click and view tracking mechanisms are out of scope for this investigation PR and are covered by other PRs. We have intentionally used the existing `sendEventBeacon` component documented [here](https://github.com/bbc/simorgh/blob/be9497217bb82e2b1c80e7b7f7d962f5ba901a0a/src/app/containers/ATIAnalytics/README.md#how-to-set-up-tracking-for-a-component) as it looks suitable to be integrated into the new click/view tracking approaches investigated on other PRs. The current solution dispatches _both_ a view and click event simultaneously when called, these show `TYPE` `onSiteAds`:
![image](https://user-images.githubusercontent.com/9645462/115841269-886bcf00-a414-11eb-9ff4-4ef9f5147279.png)

The solution we currently have meets some requirements we have identified for event despatch:
- The events sent are interpreted correctly by the tag inspector as `onSiteAds` ati hits
- They include a sensible set of data with the hit based on what was a agreed at the time `sendEventBeacon` was written, we can easily change this if we agree to send different data:
![image](https://user-images.githubusercontent.com/9645462/115841742-03cd8080-a415-11eb-9919-a91341b352b1.png)

Next steps to prepare `sendEventBeacon` for production:
- Agree what data should be sent with click and view events, @JonBeeb informs me that what is currently sent does not meet our current requirements
- The current implementation sends a view event with every click, this should be changed to just send a click event or view event respectively. The click tracking/view tracking mechanisms should decide which events to send.
- Integrate `sendEventBeacon` into the click/view tracking solutions

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
