### PR TITLE
Add useClickTracking custom hook and use in caption component

### DIFF
--- a/src/app/containers/Caption/index.jsx
+++ b/src/app/containers/Caption/index.jsx
@@ -8,6 +8,7 @@ import Blocks from '../Blocks';
 import Fragment from '../Fragment';
 import InlineLink from '../InlineLink';
 import Inline from '../InlineContainer';
+import useClickTracking from '#app/hooks/useClickTracking';
 
 const componentsToRender = {
   fragment: Fragment,
@@ -47,8 +48,9 @@ const renderCaption = (
   script,
   service,
   dir,
+  clickRef,
 ) => (
-  <Caption script={script} service={service} dir={dir}>
+  <Caption ref={clickRef} script={script} service={service} dir={dir}>
     {offscreenText && <VisuallyHiddenText>{offscreenText}</VisuallyHiddenText>}
     {paragraphBlocks.map(block => renderParagraph(block))}
   </Caption>
@@ -64,6 +66,9 @@ const CaptionContainer = ({ block, type }) => {
     audioCaptionOffscreenText,
     dir,
   } = useContext(ServiceContext);
+
+  const clickRef = useClickTracking();
+
   const offscreenText = chooseOffscreenText(
     type,
     videoCaptionOffscreenText,
@@ -78,7 +83,14 @@ const CaptionContainer = ({ block, type }) => {
     block,
   );
 
-  return renderCaption(paragraphBlocks, offscreenText, script, service, dir);
+  return renderCaption(
+    paragraphBlocks,
+    offscreenText,
+    script,
+    service,
+    dir,
+    clickRef,
+  );
 };
 
 CaptionContainer.propTypes = {

--- a/src/app/hooks/useClickTracking/index.jsx
+++ b/src/app/hooks/useClickTracking/index.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+const useClickTracking = () => {
+  const clickRef = useRef(null);
+
+  const handleClick = () => {
+    // eslint-disable-next-line no-console
+    console.log('Clicked!');
+  };
+
+  useEffect(() => {
+    const trackedComponent = clickRef.current;
+
+    trackedComponent?.addEventListener('click', handleClick);
+    return () => trackedComponent?.removeEventListener('click', handleClick);
+  }, []);
+
+  return clickRef;
+};
+
+export default useClickTracking;


### PR DESCRIPTION
**Overall change:**
This PR consists of the creation of a new custom hook, `useClickTracking`, that returns a reference. This reference can then be given as a prop to a component to track clicks on that component. On this PR this hook has been integrated into the caption component, as an example of its use.

**Notes:**
This current hook logs clicks for a component after it has already been clicked, but this can easily be remedied in a future solution, making use of react state. It's also likely that a future solution will have to delay any navigation until it can be sure an ATI request has been sent, this will probably need a timeout as a fallback to prevent navigation being delayed significantly.
More discussion needs to be had around the connection between the view and click tracking. My understanding is that there is no case where click tracking is used and view tracking isn't; for ATI, a click is essentially a view and a click. Potential solutions include writing a new hook that is composed of both the click and view/impression custom tracking hooks, or simply turning them into one hook. Checks may also have to be made as to the type of click, e.g. cmd + click, middle click, etc. This can be done relatively easily.

