### PR TITLE
License exception added (TV4)

### DIFF
--- a/license-exceptions.json
+++ b/license-exceptions.json
@@ -51,6 +51,9 @@
     "type-fest@*": {
       "reason": "Dual-licensed under MIT or CC0-1.0; https://github.com/sindresorhus/type-fest#license"
     },
+    "tv4@*": {
+      "reason": "Licensed under MIT; https://github.com/geraintluff/tv4/blob/master/LICENSE.txt"
+    },
     "ua-parser-js@*": {
       "reason": "Dual license under GPL or MIT; https://github.com/faisalman/ua-parser-js#license"
     },


### PR DESCRIPTION
Allows #9087 to work
**Overall change:**

BBC license checker doesn’t recognise the string “Public Domain,MIT” as valid, but it is. It is put in the license exceptions file so that it does not cause a problem with PRs.

The license added was 

tv4@1.3.0
    License:     Public Domain,MIT
    Repository:  https://github.com/geraintluff/tv4
    Publisher:   Geraint Luff
    Url:         undefined


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project


