### PR TITLE
Fix promo image on IE11

### DIFF
--- a/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
+++ b/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
@@ -183,7 +183,12 @@ const OnDemandAudioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
             columns={getGroups(6, 6, 6, 6, 6, 6)}
             enableGelGutters
           >
-            <StyledGridItemParagraph item columns={getGroups(6, 6, 4, 4, 4, 4)}>
+            <StyledGridItemParagraph
+              item
+              columns={getGroups(6, 6, 4, 4, 4, 4)}
+              parentColumns={getGroups(6, 6, 6, 6, 6, 6)}
+              parentEnableGelGutters
+            >
               <StyledRadioHeadingContainer
                 idAttr={idAttr}
                 brandTitle={brandTitle}
@@ -195,7 +200,12 @@ const OnDemandAudioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
                 <FooterTimestamp releaseDateTimeStamp={releaseDateTimeStamp} />
               )}
             </StyledGridItemParagraph>
-            <StyledGridItemImage item columns={getGroups(0, 0, 2, 2, 2, 2)}>
+            <StyledGridItemImage
+              item
+              columns={getGroups(0, 0, 2, 2, 2, 2)}
+              parentColumns={getGroups(6, 6, 6, 6, 6, 6)}
+              parentEnableGelGutters
+            >
               <EpisodeImage imageUrl={imageUrl} alt={imageAltText} />
             </StyledGridItemImage>
           </StyledGelWrapperGrid>

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
@@ -266,6 +266,60 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   }
 }
 
+@media (max-width: 14.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 0.5rem) + 3 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
 @supports (display: grid) {
   .emotion-9 {
     display: block;
@@ -462,6 +516,60 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
 @media (max-width: 62.9375rem) {
   .emotion-20 {
     padding-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 0.5rem) + 1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
   }
 }
 
@@ -1067,6 +1175,60 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   }
 }
 
+@media (max-width: 14.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 0.5rem) + 3 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
 @supports (display: grid) {
   .emotion-9 {
     display: block;
@@ -1263,6 +1425,60 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
 @media (max-width: 62.9375rem) {
   .emotion-20 {
     padding-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 0.5rem) + 1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
   }
 }
 
@@ -1846,6 +2062,60 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   }
 }
 
+@media (max-width: 14.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 0.5rem) + 3 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
 @supports (display: grid) {
   .emotion-9 {
     display: block;
@@ -2042,6 +2312,60 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
 @media (max-width: 62.9375rem) {
   .emotion-20 {
     padding-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 0.5rem) + 1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
   }
 }
 
@@ -2567,6 +2891,60 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   }
 }
 
+@media (max-width: 14.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-9 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 0.5rem) + 3 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-9 {
+    width: calc(4/6*(100% - 6 * 1rem) + 3 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
 @supports (display: grid) {
   .emotion-9 {
     display: block;
@@ -2763,6 +3141,60 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
 @media (max-width: 62.9375rem) {
   .emotion-20 {
     padding-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-23 {
+    width: calc(0/6*(100% - 6 * 0.5rem) + -1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 0.5rem) + 1 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-23 {
+    width: calc(2/6*(100% - 6 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/8964

**Overall change:**
Updates the `OnDemandAudioPage` component to add grid support for Internet Explorer 11.

**Code changes:**
- Adds `parentColumns` and `parentEnableGelGutters` properties. These are used when adding fall back support for unsupported browsers.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
