### PR TITLE
Added +/- 1 tolerance in E2Es for Recent Episodes component

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -46,158 +46,142 @@ export default ({ service, pageType, variant, isAmp }) => {
       before(() => {
         cy.getToggles(service);
       });
-      describe(
-        'Recent Episodes component',
-        {
-          retries: 3,
-        },
-        () => {
-          it('should be displayed if the toggle is on, and shows the expected number of items', function test() {
-            // Reload for retry if data didn't update on page
-            cy.reload();
-            let toggleName;
+      describe('Recent Episodes component', () => {
+        it('should be displayed if the toggle is on, and shows the expected number of items', function test() {
+          let toggleName;
 
-            if (Cypress.env('currentPath').includes('podcasts')) {
-              toggleName = 'recentPodcastEpisodes';
-            } else {
-              toggleName = 'recentAudioEpisodes';
-            }
-            cy.fixture(`toggles/${service}.json`).then(toggles => {
-              const recentEpisodesEnabled = path(
-                [toggleName, 'enabled'],
+          if (Cypress.env('currentPath').includes('podcasts')) {
+            toggleName = 'recentPodcastEpisodes';
+          } else {
+            toggleName = 'recentAudioEpisodes';
+          }
+          cy.fixture(`toggles/${service}.json`).then(toggles => {
+            const recentEpisodesEnabled = path(
+              [toggleName, 'enabled'],
+              toggles,
+            );
+            cy.log(
+              `Recent Episodes component enabled? ${recentEpisodesEnabled}`,
+            );
+            // There cannot be more episodes shown than the max allowed
+            if (recentEpisodesEnabled) {
+              const recentEpisodesMaxNumber = path(
+                [toggleName, 'value'],
                 toggles,
               );
-              cy.log(
-                `Recent Episodes component enabled? ${recentEpisodesEnabled}`,
-              );
-              // There cannot be more episodes shown than the max allowed
-              if (recentEpisodesEnabled) {
-                const recentEpisodesMaxNumber = path(
-                  [toggleName, 'value'],
-                  toggles,
+              const currentPath = Cypress.env('currentPath');
+              const url =
+                Cypress.env('APP_ENV') === 'test'
+                  ? `${currentPath}?renderer_env=live`
+                  : `${currentPath}`;
+
+              cy.request(getDataUrl(url)).then(({ body }) => {
+                const episodeId = path(['content', 'blocks', 0, 'id'], body);
+
+                const processedEpisodesData = processRecentEpisodes(body, {
+                  exclude: episodeId,
+                  recentEpisodesLimit: recentEpisodesMaxNumber,
+                });
+
+                const expectedNumberOfEpisodes = processedEpisodesData.length;
+
+                cy.log(
+                  `Number of available episodes? ${expectedNumberOfEpisodes}`,
                 );
-                const currentPath = Cypress.env('currentPath');
-                const url =
-                  Cypress.env('APP_ENV') === 'test'
-                    ? `${currentPath}?renderer_env=live`
-                    : `${currentPath}`;
 
-                cy.request(getDataUrl(url)).then(({ body }) => {
-                  const episodeId = path(['content', 'blocks', 0, 'id'], body);
-
-                  const processedEpisodesData = processRecentEpisodes(body, {
-                    exclude: episodeId,
-                    recentEpisodesLimit: recentEpisodesMaxNumber,
-                  });
-
-                  const expectedNumberOfEpisodes = processedEpisodesData.length;
-
-                  cy.log(
-                    `Number of available episodes? ${expectedNumberOfEpisodes}`,
+                cy.window().then(win => {
+                  const renderedEpisodes = win.document.querySelectorAll(
+                    '[data-e2e=recent-episodes-list-item]',
                   );
 
-                  cy.window().then(win => {
-                    const renderedEpisodes = win.document.querySelectorAll(
-                      '[data-e2e=recent-episodes-list-item]',
+                  const renderedEpisodesArray = Array.prototype.slice.call(
+                    renderedEpisodes,
+                  );
+
+                  const renderedEpisodesInnerText = renderedEpisodesArray.map(
+                    episode => episode.innerText,
+                  );
+
+                  const convertTimestampsToLocaleString = recentEpisodesArray => {
+                    return recentEpisodesArray.map(episode => ({
+                      ...episode,
+                      timestamp: new Date(episode.timestamp).toLocaleString(),
+                    }));
+                  };
+
+                  const cypressJsonResWithLocaleStringTimestamp = convertTimestampsToLocaleString(
+                    processedEpisodesData,
+                  );
+
+                  const simorghJsonResWithLocaleStringTimestamp =
+                    !isAmp &&
+                    convertTimestampsToLocaleString(
+                      win.SIMORGH_DATA.pageData.recentEpisodes,
                     );
 
-                    const renderedEpisodesArray = Array.prototype.slice.call(
-                      renderedEpisodes,
+                  if (
+                    renderedEpisodesArray.length !==
+                    cypressJsonResWithLocaleStringTimestamp.length
+                  ) {
+                    /* eslint-disable no-console */
+                    cy.log(
+                      'Cypress json response - ',
+                      JSON.stringify(cypressJsonResWithLocaleStringTimestamp),
                     );
-
-                    const renderedEpisodesInnerText = renderedEpisodesArray.map(
-                      episode => episode.innerText,
-                    );
-
-                    const convertTimestampsToLocaleString = recentEpisodesArray => {
-                      return recentEpisodesArray.map(episode => ({
-                        ...episode,
-                        timestamp: new Date(episode.timestamp).toLocaleString(),
-                      }));
-                    };
-
-                    const cypressJsonResWithLocaleStringTimestamp = convertTimestampsToLocaleString(
-                      processedEpisodesData,
-                    );
-
-                    const simorghJsonResWithLocaleStringTimestamp =
-                      !isAmp &&
-                      convertTimestampsToLocaleString(
-                        win.SIMORGH_DATA.pageData.recentEpisodes,
-                      );
-
-                    if (
-                      renderedEpisodesArray.length !==
-                      cypressJsonResWithLocaleStringTimestamp.length
-                    ) {
-                      /* eslint-disable no-console */
+                    cy.log('HTML on page - ', renderedEpisodesInnerText);
+                    if (!isAmp) {
                       cy.log(
-                        'Cypress json response - ',
-                        JSON.stringify(cypressJsonResWithLocaleStringTimestamp),
+                        'Simorgh json response - ',
+                        JSON.stringify(simorghJsonResWithLocaleStringTimestamp),
                       );
-                      cy.log('HTML on page - ', renderedEpisodesInnerText);
-                      if (!isAmp) {
-                        cy.log(
-                          'Simorgh json response - ',
-                          JSON.stringify(
-                            simorghJsonResWithLocaleStringTimestamp,
-                          ),
-                        );
-                      }
-                      /* eslint-enable no-console */
                     }
+                    /* eslint-enable no-console */
+                  }
 
-                    // get length and wait if the assertion fails
-                    cy.get('[data-e2e=recent-episodes-list-item]')
-                      .its('length')
-                      .then(length => {
-                        if (length !== expectedNumberOfEpisodes) {
-                          cy.wait(5000);
-                        }
-                      });
+                  // More than one episode expected
+                  if (expectedNumberOfEpisodes > 1) {
+                    cy.get('[data-e2e=recent-episodes-list]').should('exist');
 
-                    // More than one episode expected
-                    // If this test fails the next retry should pass
-                    // as time has been allowed for the upstream cache to populate
-                    if (expectedNumberOfEpisodes > 1) {
-                      cy.get('[data-e2e=recent-episodes-list]').should('exist');
-
-                      cy.get('[data-e2e=recent-episodes-list]').within(() => {
-                        cy.get('[data-e2e=recent-episodes-list-item]')
-                          .its('length')
-                          .should('eq', expectedNumberOfEpisodes);
-                      });
-                    }
-                    // If there is only one item, it is not in a list
-                    else if (expectedNumberOfEpisodes === 1) {
-                      cy.get('aside[aria-labelledby=recent-episodes]').within(
-                        () => {
-                          cy.get('[data-e2e="recent-episodes-list"]').should(
-                            'not.exist',
+                    cy.get('[data-e2e=recent-episodes-list]').within(() => {
+                      cy.get('[data-e2e=recent-episodes-list-item]')
+                        .its('length')
+                        .should(length => {
+                          expect(length).to.be.closeTo(
+                            expectedNumberOfEpisodes,
+                            1,
                           );
-                        },
-                      );
-                    }
-                    // No items expected
-                    else {
-                      cy.get('aside[aria-labelledby=recent-episodes]').should(
-                        'not.exist',
-                      );
+                        });
+                    });
+                  }
+                  // If there is only one item, it is not in a list
+                  else if (expectedNumberOfEpisodes === 1) {
+                    cy.get('aside[aria-labelledby=recent-episodes]').within(
+                      () => {
+                        cy.get('[data-e2e="recent-episodes-list"]').should(
+                          'not.exist',
+                        );
+                      },
+                    );
+                  }
+                  // No items expected
+                  else {
+                    cy.get('aside[aria-labelledby=recent-episodes]').should(
+                      'not.exist',
+                    );
 
-                      cy.log('No episodes present or available');
-                    }
-                  });
+                    cy.log('No episodes present or available');
+                  }
                 });
-              }
-              // Not toggled on for this service
-              else {
-                cy.get('[data-e2e=recent-episodes-list]').should('not.exist');
-                cy.log('Recent episodes is not toggled on for this service');
-              }
-            });
+              });
+            }
+            // Not toggled on for this service
+            else {
+              cy.get('[data-e2e=recent-episodes-list]').should('not.exist');
+              cy.log('Recent episodes is not toggled on for this service');
+            }
           });
-        },
-      );
+        });
+      });
     });
   });
 };


### PR DESCRIPTION
Resolves #9105 

**Overall change:**

I use closeTo with a +/- 1 to allow tolerance of one episode more or less either way

**Code changes:**

closeTo

Also removed the wait, reload and retries as this did not help stop the tests failing but does slow down the tests.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Tests pass
