### PR TITLE
fixes event tracking in top stories that have only 1 item

### DIFF
--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -1187,30 +1187,32 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
       <div
         class="emotion-19 emotion-20"
       >
-        <div
-          class="emotion-21 emotion-22"
-          data-e2e="story-promo"
-        >
+        <div>
           <div
-            class="emotion-23 emotion-24"
-            dir="ltr"
+            class="emotion-21 emotion-22"
+            data-e2e="story-promo"
           >
-            <h3
-              class="emotion-25 emotion-26"
+            <div
+              class="emotion-23 emotion-24"
+              dir="ltr"
             >
-              <a
-                class="emotion-27 emotion-28"
-                href="/mundo/noticias-internacional-51939501"
+              <h3
+                class="emotion-25 emotion-26"
               >
-                China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
-              </a>
-            </h3>
-            <time
-              class="emotion-29 emotion-30"
-              datetime="2020-02-03"
-            >
-              3rd February 2020
-            </time>
+                <a
+                  class="emotion-27 emotion-28"
+                  href="/mundo/noticias-internacional-51939501"
+                >
+                  China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
+                </a>
+              </h3>
+              <time
+                class="emotion-29 emotion-30"
+                datetime="2020-02-03"
+              >
+                3rd February 2020
+              </time>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/containers/CpsTopStories/index.jsx
+++ b/src/app/containers/CpsTopStories/index.jsx
@@ -15,15 +15,19 @@ const EVENT_TRACKING_DATA = {
 
 const PromoComponent = ({ promo, dir }) => {
   const { serviceDatetimeLocale } = useContext(ServiceContext);
+  const viewRef = useViewTracker(EVENT_TRACKING_DATA);
 
   return (
-    <StoryPromo
-      item={promo}
-      dir={dir}
-      displayImage={false}
-      displaySummary={false}
-      serviceDatetimeLocale={serviceDatetimeLocale}
-    />
+    <div ref={viewRef}>
+      <StoryPromo
+        item={promo}
+        dir={dir}
+        displayImage={false}
+        displaySummary={false}
+        serviceDatetimeLocale={serviceDatetimeLocale}
+        eventTrackingData={EVENT_TRACKING_DATA}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
**Overall change:**
Fixes event tracking not working when top stories has only 1 item as demonstrated here https://www.test.bbc.com/afrique/23222399

**Code changes:**

- Adds event tracking to single item top stories component

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
