### PR TITLE
fix chromatic consent banner snapshots

### DIFF
--- a/.storybook/helpers/clearAppStorage.js
+++ b/.storybook/helpers/clearAppStorage.js
@@ -1,0 +1,6 @@
+import Cookies from 'js-cookie';
+
+export default () => {
+  ['ckns_policy', 'ckns_explicit', 'ckns_privacy'].forEach(Cookies.remove);
+  window.localStorage.removeItem(`amp-store:${window.location.origin}`);
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,13 @@
 /* eslint-disable import/prefer-default-export */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { addDecorator } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
 import { create } from '@storybook/theming';
 import * as fontFaces from '@bbc/psammead-styles/fonts';
 import GlobalStyles from '@bbc/psammead-styles/global-styles';
-import Cookies from 'js-cookie';
+
+import clearAppStorage from './helpers/clearAppStorage';
 
 const fontPathMap = [
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
@@ -19,15 +21,13 @@ const fontPathMap = [
   { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
 ];
 
-const clearBrowserStorage = () => {
-  Cookies.remove('ckns_policy');
-  Cookies.remove('ckns_explicit');
-  Cookies.remove('ckns_privacy');
-  window.localStorage.removeItem(`amp-store:${window.location.origin}`);
-};
-
 addDecorator(story => {
-  clearBrowserStorage();
+  useEffect(() => {
+    if (isChromatic()) {
+      // prevent the consent banner introducing inconsistent Chromatic snapshots
+      clearAppStorage();
+    }
+  }, []);
 
   return (
     /* eslint-disable react/jsx-filename-extension */

--- a/src/app/components/MediaPlayer/index.stories.jsx
+++ b/src/app/components/MediaPlayer/index.stories.jsx
@@ -23,6 +23,7 @@ const StyledMessageContainer = styled.div`
 
 storiesOf('Components/Media Player', module)
   .addDecorator(withKnobs)
+  .addParameters({ chromatic: { diffThreshold: 0.2 } })
   .add(
     'Articles Canonical',
     () => (
@@ -148,6 +149,7 @@ storiesOf('Components/Media Player', module)
 
 storiesOf('Components/Media Player', module)
   .addDecorator(ampDecorator)
+  .addParameters({ chromatic: { diffThreshold: 0.2 } })
   .add(
     'AMP',
     () => (

--- a/src/app/pages/LiveRadioPage/index.stories.jsx
+++ b/src/app/pages/LiveRadioPage/index.stories.jsx
@@ -44,6 +44,7 @@ storiesOf('Pages/Radio Page', module)
       services: Object.keys(liveRadioFixtures),
     }),
   )
+  .addParameters({ chromatic: { diffThreshold: 0.2 } })
   .add('default', ({ service }) => (
     <BrowserRouter>
       <LiveRadioPage

--- a/src/app/pages/OnDemandAudioPage/index.stories.jsx
+++ b/src/app/pages/OnDemandAudioPage/index.stories.jsx
@@ -35,6 +35,7 @@ storiesOf('Pages/OnDemand Radio Page', module)
       services: Object.keys(onDemandRadioFixtures),
     }),
   )
+  .addParameters({ chromatic: { diffThreshold: 0.2 } })
   .add('default', ({ service }) => (
     <BrowserRouter>
       <OnDemandAudioPage


### PR DESCRIPTION
**Overall change:**
Fixes (potentially) Chromatic introducing inconsistent snapshots.

**Code changes:**

- Clear cookies and local storage after the component mounts or is viewed by Chromatic. This ensure the next snapshot has no cookies or local storage.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
