### PR TITLE
Use view tracker multi element fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0",
-    "react-intersection-observer": "8.32.0",
     "react-lazyload": "3.2.0",
     "react-router": "5.2.0",
     "react-router-config": "5.1.1",

--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -4,6 +4,6 @@ module.exports = {
   // Keep the MAX_SIZE +5 above the largest value and MIN_SIZE -5
   // below the smallest value in the build output; this avoids the
   // need for frequent changes as bundle sizes fluctuate.
-  MIN_SIZE: 612,
-  MAX_SIZE: 894,
+  MIN_SIZE: 614,
+  MAX_SIZE: 884,
 };

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -61,7 +61,6 @@ const useViewTracker = (props = {}) => {
         const shouldSendEvent = [
           hasRequiredProps,
           trackingIsEnabled,
-          isInView,
           !eventSent,
         ].every(Boolean);
 

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -10,7 +10,7 @@ const EVENT_TYPE = 'view';
 const VIEWED_DURATION_MS = 1000;
 const MIN_VIEWED_PERCENT = 0.5;
 
-const useViewTracker = props => {
+const useViewTracker = (props = {}) => {
   const observer = useRef();
   const timer = useRef(null);
   const [isInView, setIsInView] = useState();
@@ -103,7 +103,7 @@ const useViewTracker = props => {
   ]);
 
   return async element => {
-    if (!trackingIsEnabled || eventSent) {
+    if (!element || !trackingIsEnabled || eventSent) {
       return;
     }
     if (!observer.current) {

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState, useRef } from 'react';
 import path from 'ramda/src/path';
+import prop from 'ramda/src/prop';
 
 import { sendEventBeacon } from '#containers/ATIAnalytics/beacon';
 import { EventTrackingContext } from '#app/contexts/EventTrackingContext';
@@ -33,9 +34,9 @@ const useViewTracker = (props = {}) => {
       await import('intersection-observer');
     }
     const callback = changes => {
-      changes.forEach(({ isIntersecting }) => {
-        setIsInView(isIntersecting);
-      });
+      const someElementsAreInView = changes.some(prop('isIntersecting'));
+
+      setIsInView(someElementsAreInView);
     };
     const options = {
       threshold: [MIN_VIEWED_PERCENT],

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -48,9 +48,6 @@ const useViewTracker = (props = {}) => {
   useEffect(() => {
     if (isInView && !timer.current) {
       timer.current = setTimeout(() => {
-        const shouldSendEvent = [trackingIsEnabled, isInView, !eventSent].every(
-          Boolean,
-        );
         const hasRequiredProps = [
           campaignID,
           componentName,
@@ -61,7 +58,14 @@ const useViewTracker = (props = {}) => {
           statsDestination,
         ].every(Boolean);
 
-        if (shouldSendEvent && hasRequiredProps) {
+        const shouldSendEvent = [
+          hasRequiredProps,
+          trackingIsEnabled,
+          isInView,
+          !eventSent,
+        ].every(Boolean);
+
+        if (shouldSendEvent) {
           sendEventBeacon({
             campaignID,
             componentName,

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -10,7 +10,7 @@ const EVENT_TYPE = 'view';
 const VIEWED_DURATION_MS = 1000;
 const MIN_VIEWED_PERCENT = 0.5;
 
-const useViewTracker = (props = {}) => {
+const useViewTracker = props => {
   const observer = useRef();
   const timer = useRef(null);
   const [isInView, setIsInView] = useState();
@@ -32,17 +32,16 @@ const useViewTracker = (props = {}) => {
       // Polyfill IntersectionObserver, e.g. for IE11
       await import('intersection-observer');
     }
+    const callback = changes => {
+      changes.forEach(({ isIntersecting }) => {
+        setIsInView(isIntersecting);
+      });
+    };
+    const options = {
+      threshold: [MIN_VIEWED_PERCENT],
+    };
 
-    observer.current = new IntersectionObserver(
-      function observerCallback(changes) {
-        changes.forEach(({ isIntersecting }) => {
-          setIsInView(isIntersecting);
-        });
-      },
-      {
-        threshold: [MIN_VIEWED_PERCENT],
-      },
-    );
+    observer.current = new IntersectionObserver(callback, options);
   };
 
   useEffect(() => {

--- a/src/app/hooks/useViewTracker/index.test.jsx
+++ b/src/app/hooks/useViewTracker/index.test.jsx
@@ -220,13 +220,11 @@ describe('Expected use', () => {
     });
 
     const [[, options]] = global.IntersectionObserver.mock.calls;
+    const [[viewEventUrl]] = global.fetch.mock.calls;
 
     expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
     expect(options).toEqual({ threshold: [0.5] });
     expect(global.fetch).toHaveBeenCalledTimes(1);
-
-    const [[viewEventUrl]] = global.fetch.mock.calls;
-
     expect(urlToObject(viewEventUrl)).toEqual({
       origin: 'https://logws1363.ati-host.net',
       pathname: '/',
@@ -434,8 +432,6 @@ describe('Error handling', () => {
 
     await result.current(element);
 
-    act(() => jest.advanceTimersByTime(1100));
-
     expect(result.error).toBeUndefined();
     expect(typeof global.IntersectionObserver).toEqual('function');
   });
@@ -453,8 +449,6 @@ describe('Error handling', () => {
     const element = document.createElement('div');
 
     await result.current(element);
-
-    act(() => jest.advanceTimersByTime(1100));
 
     expect(result.error).toBeUndefined();
     expect(global.fetch).not.toHaveBeenCalled();

--- a/src/app/hooks/useViewTracker/index.test.jsx
+++ b/src/app/hooks/useViewTracker/index.test.jsx
@@ -516,4 +516,27 @@ describe('Error handling', () => {
     expect(result.error).toBeUndefined();
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it('should not throw error and not send event to ATI when no element is passed into hook ref callback function', async () => {
+    const trackingData = {
+      componentName: 'most-read',
+      format: 'CHD=promo::2',
+      url: 'http://www.bbc.com/pidgin/tori-51745682',
+    };
+
+    const { result } = renderHook(() => useViewTracker(trackingData), {
+      wrapper,
+      initialProps: {
+        pageData: fixtureData,
+      },
+    });
+
+    const element = null;
+
+    await result.current(element);
+
+    expect(result.error).toBeUndefined();
+    expect(global.IntersectionObserver).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/hooks/useViewTracker/index.test.jsx
+++ b/src/app/hooks/useViewTracker/index.test.jsx
@@ -48,10 +48,10 @@ const getObserverInstance = element => {
   }
 };
 
-const triggerIntersection = ({ isIntersecting, observer }) => {
+const triggerIntersection = ({ changes, observer }) => {
   const item = observers.get(observer);
 
-  item.callback([{ isIntersecting }]);
+  item.callback(changes);
 };
 
 const { error } = console;
@@ -139,7 +139,7 @@ describe('Expected use', () => {
 
     act(() => {
       triggerIntersection({
-        isIntersecting: false,
+        changes: [{ isIntersecting: false }],
         observer: observerInstance,
       });
     });
@@ -212,7 +212,10 @@ describe('Expected use', () => {
     const observerInstance = getObserverInstance(element);
 
     act(() => {
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {
@@ -262,12 +265,39 @@ describe('Expected use', () => {
 
     act(() => {
       triggerIntersection({
-        isIntersecting: true,
+        changes: [{ isIntersecting: true }],
         observer: observerInstanceA,
       });
       triggerIntersection({
-        isIntersecting: true,
+        changes: [{ isIntersecting: true }],
         observer: observerInstanceB,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should send one view event for multiple observed elements when at least one of them is in view', async () => {
+    const { result } = renderHook(() => useViewTracker(trackingData), {
+      wrapper,
+      initialProps: {
+        pageData: fixtureData,
+      },
+    });
+    const element = document.createElement('div');
+
+    await result.current(element);
+
+    const observerInstanceA = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: true }, { isIntersecting: false }],
+        observer: observerInstanceA,
       });
     });
 
@@ -294,7 +324,10 @@ describe('Expected use', () => {
     const { disconnect } = observerInstance;
 
     act(() => {
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {
@@ -319,7 +352,10 @@ describe('Expected use', () => {
     const { disconnect } = observerInstance;
 
     act(() => {
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {
@@ -345,7 +381,10 @@ describe('Expected use', () => {
 
     act(() => {
       // scroll element into view
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {
@@ -355,7 +394,7 @@ describe('Expected use', () => {
     act(() => {
       // scroll element out of view
       triggerIntersection({
-        isIntersecting: false,
+        changes: [{ isIntersecting: false }],
         observer: observerInstance,
       });
     });
@@ -382,7 +421,10 @@ describe('Expected use', () => {
 
     act(() => {
       // scroll element into view
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {
@@ -392,14 +434,17 @@ describe('Expected use', () => {
     act(() => {
       // scroll element out of view
       triggerIntersection({
-        isIntersecting: false,
+        changes: [{ isIntersecting: false }],
         observer: observerInstance,
       });
     });
 
     act(() => {
       // scroll element into view again
-      triggerIntersection({ isIntersecting: true, observer: observerInstance });
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
     });
 
     act(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12471,11 +12471,6 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-intersection-observer@8.32.0:
-  version "8.32.0"
-  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.0.tgz#47249332e12e8bb99ed35a10bb7dd10446445a7b"
-  integrity sha512-RlC6FvS3MFShxTn4FHAy904bVjX5Nn4/eTjUkurW0fHK+M/fyQdXuyCy9+L7yjA+YMGogzzSJNc7M4UtfSKvtw==
-
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
**Overall change:**
Fixes view event tracking for top stories - only the last item in the top stories component was being tracked for view events.

**Reason for bug**
Only the last element from a ref callback function was being tracked meaning example 2 from the [useViewTracker README](https://github.com/bbc/simorgh/blob/latest/src/app/hooks/useViewTracker/README.md) did not work as expected.

**Example of fix:**
_Event sent when scrolling top of component into view_

![from-top](https://user-images.githubusercontent.com/4798332/120442845-f7c2d000-c37d-11eb-98b6-1c24d460880e.gif)

_Event sent when scrolling bottom of component into view_

![from-bottom](https://user-images.githubusercontent.com/4798332/120442897-03ae9200-c37e-11eb-8f2e-6a9a9ac54d97.gif)

**Code changes:**

- Replaced `react-intersection-observer` hook with low-level IntersectionObserver API use so that we have full control of observed elements.
- Removed `react-intersection-observer` library from packages as we have no use for it now
- `useViewTracker` dynamically imports the IntersectionObserver polyfill when it detects that there is no browser support.
- updates unit tests with IntersectionObserver mock
- updates bundle sizes config because bundle sizes have decreased with removal of `react-intersection-observer` and the code-splitting of IntersectionObserver polyfill.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
This PR will need extensive browser testing.

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
