### PR TITLE
remove cookie and localstorage deletion between snapshots

### DIFF
--- a/.storybook/helpers/clearAppStorage.js
+++ b/.storybook/helpers/clearAppStorage.js
@@ -1,6 +1,0 @@
-import Cookies from 'js-cookie';
-
-export default () => {
-  ['ckns_policy', 'ckns_explicit', 'ckns_privacy'].forEach(Cookies.remove);
-  window.localStorage.removeItem(`amp-store:${window.location.origin}`);
-};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,13 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { addDecorator } from '@storybook/react';
-import isChromatic from 'chromatic/isChromatic';
 import { create } from '@storybook/theming';
 import * as fontFaces from '@bbc/psammead-styles/fonts';
 import GlobalStyles from '@bbc/psammead-styles/global-styles';
-
-import clearAppStorage from './helpers/clearAppStorage';
 
 const fontPathMap = [
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
@@ -21,30 +18,21 @@ const fontPathMap = [
   { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
 ];
 
-addDecorator(story => {
-  useEffect(() => {
-    if (isChromatic()) {
-      // prevent the consent banner introducing inconsistent Chromatic snapshots
-      clearAppStorage();
-    }
-  }, []);
-
-  return (
-    /* eslint-disable react/jsx-filename-extension */
-    <>
-      <GlobalStyles
-        fonts={Object.values(fontFaces).map(fontFace => {
-          const fontMap =
-            fontPathMap.find(map => fontFace.name.startsWith(map.prefix)) ||
-            fontPathMap[0];
-          return fontFace(fontMap.path);
-        })}
-      />
-      {story()}
-    </>
-    /* eslint-enable react/jsx-filename-extension */
-  );
-});
+addDecorator(story => (
+  /* eslint-disable react/jsx-filename-extension */
+  <>
+    <GlobalStyles
+      fonts={Object.values(fontFaces).map(fontFace => {
+        const fontMap =
+          fontPathMap.find(map => fontFace.name.startsWith(map.prefix)) ||
+          fontPathMap[0];
+        return fontFace(fontMap.path);
+      })}
+    />
+    {story()}
+  </>
+  /* eslint-enable react/jsx-filename-extension */
+));
 
 const theme = create({
   base: 'light',


### PR DESCRIPTION
**Overall change:**
Fixes IE11 snapshots breaking and failing CI checks.

This error pointed to the string of characters causing the issue. It was the deletion of localStorage items. By removing this code the snapshots should work in IE11 again.

The deletion of localStorage and cookies between snapshots was an attempt to fix the flakey consent banner snapshot diffs. This did not end up working but did not cause these errors until a week later.

**Code changes:**

- Remove use of `clearAppStorage` function in `./storybook/preview.js`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
