### PR TITLE
force lazy images to load in chromatic

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,12 @@
 /* eslint-disable import/prefer-default-export */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { addDecorator } from '@storybook/react';
 import { create } from '@storybook/theming';
 import * as fontFaces from '@bbc/psammead-styles/fonts';
 import GlobalStyles from '@bbc/psammead-styles/global-styles';
+import isChromatic from 'chromatic/isChromatic';
+import { forceVisible } from 'react-lazyload';
 
 const fontPathMap = [
   { prefix: 'F_ISKOOLA_POTA_BBC', path: 'fonts/IskoolaPota/' },
@@ -18,21 +20,29 @@ const fontPathMap = [
   { prefix: 'F_SHONAR_BANGLA', path: 'fonts/ShonarBangla/' },
 ];
 
-addDecorator(story => (
-  /* eslint-disable react/jsx-filename-extension */
-  <>
-    <GlobalStyles
-      fonts={Object.values(fontFaces).map(fontFace => {
-        const fontMap =
-          fontPathMap.find(map => fontFace.name.startsWith(map.prefix)) ||
-          fontPathMap[0];
-        return fontFace(fontMap.path);
-      })}
-    />
-    {story()}
-  </>
-  /* eslint-enable react/jsx-filename-extension */
-));
+addDecorator(story => {
+  useEffect(() => {
+    if (isChromatic()) {
+      forceVisible();
+    }
+  }, []);
+
+  return (
+    /* eslint-disable react/jsx-filename-extension */
+    <>
+      <GlobalStyles
+        fonts={Object.values(fontFaces).map(fontFace => {
+          const fontMap =
+            fontPathMap.find(map => fontFace.name.startsWith(map.prefix)) ||
+            fontPathMap[0];
+          return fontFace(fontMap.path);
+        })}
+      />
+      {story()}
+    </>
+    /* eslint-enable react/jsx-filename-extension */
+  );
+});
 
 const theme = create({
   base: 'light',


### PR DESCRIPTION
**Overall change:**
Force load all lazy images when Chromatic is running.

This will reduce the amount of flakey diffs per PR.

**Code changes:**

- Calls utility function provided by react-lazyload that force loads all images on the page. This function is only called in Chromatic.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
