### PR TITLE
Add utility function to check if most read is enabled for the service

### DIFF
--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -3,6 +3,7 @@ import { STORY_PAGE, MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import getAssetType from './getAssetType';
 import getAssetUri from './getAssetUri';
 import hasRecommendations from './hasRecommendations';
+import hasMostRead from './hasMostRead';
 import fetchPageData from '../../utils/fetchPageData';
 import { getMostReadEndpoint } from '#lib/utilities/getUrlHelpers/getMostReadUrls';
 import getMostWatchedEndpoint from '#lib/utilities/getUrlHelpers/getMostWatchedUrl';
@@ -23,13 +24,18 @@ const pageTypeUrls = async (
   switch (assetType) {
     case STORY_PAGE:
       return [
-        {
-          name: 'mostRead',
-          path: getMostReadEndpoint({ service, variant }).replace('.json', ''),
-          assetUri,
-          api: 'mostread',
-          apiContext: 'secondary_data',
-        },
+        (await hasMostRead(service, variant))
+          ? {
+              name: 'mostRead',
+              path: getMostReadEndpoint({ service, variant }).replace(
+                '.json',
+                '',
+              ),
+              assetUri,
+              api: 'mostread',
+              apiContext: 'secondary_data',
+            }
+          : null,
         {
           name: 'secondaryColumn',
           path: getSecondaryColumnUrl({ service, variant }),

--- a/src/app/routes/cpsAsset/utils/hasMostRead.js
+++ b/src/app/routes/cpsAsset/utils/hasMostRead.js
@@ -4,8 +4,8 @@ import getConfig from '#app/routes/utils/getConfig';
 const hasMostRead = async (service, variant) => {
   const config = await getConfig(service, variant);
 
-  const serviceHashasMostRead = path(['mostRead', 'hasMostRead'], config);
-  return serviceHashasMostRead;
+  const serviceHasMostRead = path(['mostRead', 'hasMostRead'], config);
+  return serviceHasMostRead;
 };
 
 export default hasMostRead;

--- a/src/app/routes/cpsAsset/utils/hasMostRead.js
+++ b/src/app/routes/cpsAsset/utils/hasMostRead.js
@@ -4,8 +4,7 @@ import getConfig from '#app/routes/utils/getConfig';
 const hasMostRead = async (service, variant) => {
   const config = await getConfig(service, variant);
 
-  const serviceHasMostRead = path(['mostRead', 'hasMostRead'], config);
-  return serviceHasMostRead;
+  return path(['mostRead', 'hasMostRead'], config);
 };
 
 export default hasMostRead;

--- a/src/app/routes/cpsAsset/utils/hasMostRead.js
+++ b/src/app/routes/cpsAsset/utils/hasMostRead.js
@@ -1,0 +1,11 @@
+import path from 'ramda/src/path';
+import getConfig from '#app/routes/utils/getConfig';
+
+const hasMostRead = async (service, variant) => {
+  const config = await getConfig(service, variant);
+
+  const serviceHashasMostRead = path(['mostRead', 'hasMostRead'], config);
+  return serviceHashasMostRead;
+};
+
+export default hasMostRead;

--- a/src/app/routes/cpsAsset/utils/hasMostRead.test.js
+++ b/src/app/routes/cpsAsset/utils/hasMostRead.test.js
@@ -1,0 +1,27 @@
+// components to test
+import hasMostRead from './hasMostRead';
+import getConfig from '../../utils/getConfig';
+
+jest.mock('../../utils/getConfig', () => jest.fn());
+
+describe('hasMostRead', () => {
+  it('returns true if service has most read component enabled', async () => {
+    getConfig.mockImplementationOnce(() => ({
+      mostRead: {
+        hasMostRead: true,
+      },
+    }));
+
+    expect(await hasMostRead('mock-service', null)).toBeTruthy();
+  });
+
+  it('returns false if service has most read component disabled', async () => {
+    getConfig.mockImplementationOnce(() => ({
+      mostRead: {
+        hasMostRead: false,
+      },
+    }));
+
+    expect(await hasMostRead('mock-service', null)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Resolves #1411

**Overall change:**
We are attempting to fetch most read data for services that do not have the most read component enabled. Issue identified through logging.

**Code changes:**

- Added a function to check the service's hasMostRead config value to prevent unnecessary data fetch.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
