### PR TITLE
Add spacing on article timestamp v2

### DIFF
--- a/src/app/components/Grid/index.jsx
+++ b/src/app/components/Grid/index.jsx
@@ -14,6 +14,7 @@ import {
 import {
   GEL_MARGIN_BELOW_400PX,
   GEL_MARGIN_ABOVE_400PX,
+  GEL_SPACING_DBL,
 } from '@bbc/gel-foundations/spacings';
 import { ServiceContext } from '#contexts/ServiceContext';
 
@@ -269,6 +270,7 @@ const PopOutAtGroup5 = styled(GridItemMedium)`
     @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
       max-height: 0; /* [1] */
       padding-top: 0.25rem;
+      margin: 0 ${GEL_SPACING_DBL};
     }
   }
 `;

--- a/src/app/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
@@ -106,6 +106,7 @@ exports[`ArticleTimestamp should render a 'created' Timestamp correctly 1`] = `
     .emotion-1 {
       max-height: 0;
       padding-top: 0.25rem;
+      margin: 0 1rem;
     }
   }
 }
@@ -260,6 +261,7 @@ exports[`ArticleTimestamp should render both a 'created' and an 'updated' Timest
     .emotion-1 {
       max-height: 0;
       padding-top: 0.25rem;
+      margin: 0 1rem;
     }
   }
 }
@@ -422,6 +424,7 @@ exports[`ArticleTimestamp should render with a prefix 1`] = `
     .emotion-1 {
       max-height: 0;
       padding-top: 0.25rem;
+      margin: 0 1rem;
     }
   }
 }
@@ -584,6 +587,7 @@ exports[`ArticleTimestamp should render with a suffix 1`] = `
     .emotion-1 {
       max-height: 0;
       padding-top: 0.25rem;
+      margin: 0 1rem;
     }
   }
 }
@@ -746,6 +750,7 @@ exports[`ArticleTimestamp should render with no suffix or prefix 1`] = `
     .emotion-1 {
       max-height: 0;
       padding-top: 0.25rem;
+      margin: 0 1rem;
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9148

**Overall change:**
This PR addresses an issue causing timestamps to touch the edge of the screen

**Before**
![image](https://user-images.githubusercontent.com/2413911/122058934-d12c7c80-cdf4-11eb-99a1-c73480239aa0.png)

**After**
![image](https://user-images.githubusercontent.com/2413911/122059281-24063400-cdf5-11eb-8625-d71dfb5ae057.png)

**Code changes:**
- Adds padding to the PopOut Grid component that houses the timestamp.
- Updates corresponding snapshots

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
