### PR TITLE
Add Olympic index to Japanese nav

### DIFF
--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -310,6 +310,10 @@ export const service = {
         url: '/japanese/52137815',
       },
       {
+        title: '東京五輪・パラ',
+        url: '/japanese/57464837',
+      },
+      {
         title: '日本',
         url: '/japanese/topics/cyx5k201n3qt',
       },


### PR DESCRIPTION
Resolves #9186

**Overall change:**
Adding Olympic index link to Japanese navigation banner

**Code changes:**

- Added title and index to Japanese config

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
