### PR TITLE
Reserve additional 16px to prevent advert content shift

### DIFF
--- a/src/app/containers/Ad/Amp/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/Amp/__snapshots__/index.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`AMP Ads Snapshots should correctly render an AMP leaderboard ad 1`] = `
 
 @media (min-width: 63rem) {
   .emotion-4 {
-    min-height: 17.6875rem;
+    min-height: 18.6875rem;
   }
 }
 

--- a/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/Canonical/__snapshots__/index.test.jsx.snap
@@ -100,7 +100,7 @@ exports[`CanonicalAds Ads Snapshots should correctly render an Canonical leaderb
 
 @media (min-width: 58.75rem) {
   .emotion-0 {
-    min-height: 17.6875rem;
+    min-height: 18.6875rem;
     padding: 0.5rem 1rem;
   }
 }

--- a/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Ad/__snapshots__/index.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`Ad Container Snapshots AMP should correctly render a leaderboard ad 1`]
 
 @media (min-width: 63rem) {
   .emotion-4 {
-    min-height: 17.6875rem;
+    min-height: 18.6875rem;
   }
 }
 
@@ -310,7 +310,7 @@ exports[`Ad Container Snapshots Canonical should correctly render a leaderboard 
 
 @media (min-width: 58.75rem) {
   .emotion-0 {
-    min-height: 17.6875rem;
+    min-height: 18.6875rem;
     padding: 0.5rem 1rem;
   }
 }

--- a/src/app/containers/Ad/utilities/adSlotStyles.js
+++ b/src/app/containers/Ad/utilities/adSlotStyles.js
@@ -49,7 +49,7 @@ const LEADERBOARD_HEIGHTS = {
   GROUP_3: `${5.625 + AD_UNIT_MARGIN}rem`,
   // 90px + AD_UNIT_MARGIN = 115px
   LARGE: `${16.625 + AD_UNIT_MARGIN}rem`,
-  // 250px + AD_UNIT_MARGIN = 275px
+  // 266px + AD_UNIT_MARGIN = 291px
 };
 
 /*

--- a/src/app/containers/Ad/utilities/adSlotStyles.js
+++ b/src/app/containers/Ad/utilities/adSlotStyles.js
@@ -48,7 +48,7 @@ const LEADERBOARD_HEIGHTS = {
   // 60px + AD_UNIT_MARGIN = 85px
   GROUP_3: `${5.625 + AD_UNIT_MARGIN}rem`,
   // 90px + AD_UNIT_MARGIN = 115px
-  LARGE: `${15.625 + AD_UNIT_MARGIN}rem`,
+  LARGE: `${16.625 + AD_UNIT_MARGIN}rem`,
   // 250px + AD_UNIT_MARGIN = 275px
 };
 


### PR DESCRIPTION
Resolves #7803

**Overall change:**
On both canonical and AMP pages, we are seeing a slight layout shift when the advert loads in, due to the reserved space not being quite large enough. Reserving an additional 16px of vertical space on both AMP and canonical to prevent this shift.

**Code changes:**

- Increased placeholder vertical height by 16px for both canonical and AMP ad slots. 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
