### PR TITLE
Add exposure scanning

### DIFF
--- a/.github/workflows/scan-exposures.yml
+++ b/.github/workflows/scan-exposures.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn install --frozen-lockfile
       
       - name: Scan Issue
+        shell: bash
         if: ${{ github.event_name == 'issues' }}
         env:
           ISSUE_NUMBER: ${{ github.issue.number }}
@@ -46,7 +47,7 @@ jobs:
         shell: bash
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' }}
         env:
-          PR_NUMBER: test123
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PATTERN: ${{ secrets.PATTERN }}
         run: yarn scan:exposures -pr "$PR_NUMBER" "$PATTERN"
 
@@ -72,6 +73,7 @@ jobs:
         run: yarn install --frozen-lockfile
       
       - name: Scan Issue
+        shell: bash
         # This step only runs on issue comments
         if: ${{ !github.event.issue.pull_request }}
         env:
@@ -81,6 +83,7 @@ jobs:
           yarn scan:exposures -issue "$ISSUE_NUMBER" "$PATTERN"
       
       - name: Scan PR
+        shell: bash
         # This step only runs on PR comments
         if: ${{ github.event.issue.pull_request }}
         env:

--- a/.github/workflows/scan-exposures.yml
+++ b/.github/workflows/scan-exposures.yml
@@ -43,6 +43,7 @@ jobs:
           yarn scan:exposures -issue "$ISSUE_NUMBER" "$PATTERN"
       
       - name: Scan PR
+        shell: bash
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' }}
         env:
           PR_NUMBER: test123

--- a/.github/workflows/scan-exposures.yml
+++ b/.github/workflows/scan-exposures.yml
@@ -1,0 +1,88 @@
+name: "Scan Exposures"
+
+on:
+  pull_request:
+    branches: [latest]
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  
+  
+jobs:
+
+  scan_prs:
+    name: Scan PR Exposures
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      
+      - name: Scan Issue
+        if: ${{ github.event_name == 'issues' }}
+        env:
+          ISSUE_NUMBER: ${{ github.issue.number }}
+          PATTERN: ${{ secrets.PATTERN }}
+        run: |
+          yarn scan -issue "$ISSUE_NUMBER" "$PATTERN"
+      
+      - name: Scan PR
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' }}
+        env:
+          PR_NUMBER: ${{ github.pull_request.number }}
+          PATTERN: ${{ secrets.PATTERN }}
+        run: yarn scan -pr "$PR_NUMBER" "$PATTERN"
+
+  scan_comments:
+    name: Scan Comment Exposures
+    runs-on: ubuntu-latest
+    # The issue_comment event is triggered by comments on issues and PRs.
+    if: ${{ github.event_name == 'issue_comment' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Node Modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Node Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      
+      - name: Scan Issue
+        # This step only runs on issue comments
+        if: ${{ !github.event.issue.pull_request }}
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PATTERN: ${{ secrets.PATTERN }}
+        run: |
+          yarn scan -issue "$ISSUE_NUMBER" "$PATTERN"
+      
+      - name: Scan PR
+        # This step only runs on PR comments
+        if: ${{ github.event.issue.pull_request }}
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PATTERN: ${{ secrets.PATTERN }}
+        run: yarn scan -pr "$PR_NUMBER" "$PATTERN"

--- a/.github/workflows/scan-exposures.yml
+++ b/.github/workflows/scan-exposures.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Scan PR
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' }}
         env:
-          PR_NUMBER: ${{ github.pull_request.number }}
+          PR_NUMBER: test123
           PATTERN: ${{ secrets.PATTERN }}
         run: yarn scan:exposures -pr "$PR_NUMBER" "$PATTERN"
 

--- a/.github/workflows/scan-exposures.yml
+++ b/.github/workflows/scan-exposures.yml
@@ -40,14 +40,14 @@ jobs:
           ISSUE_NUMBER: ${{ github.issue.number }}
           PATTERN: ${{ secrets.PATTERN }}
         run: |
-          yarn scan -issue "$ISSUE_NUMBER" "$PATTERN"
+          yarn scan:exposures -issue "$ISSUE_NUMBER" "$PATTERN"
       
       - name: Scan PR
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' }}
         env:
           PR_NUMBER: ${{ github.pull_request.number }}
           PATTERN: ${{ secrets.PATTERN }}
-        run: yarn scan -pr "$PR_NUMBER" "$PATTERN"
+        run: yarn scan:exposures -pr "$PR_NUMBER" "$PATTERN"
 
   scan_comments:
     name: Scan Comment Exposures
@@ -77,7 +77,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PATTERN: ${{ secrets.PATTERN }}
         run: |
-          yarn scan -issue "$ISSUE_NUMBER" "$PATTERN"
+          yarn scan:exposures -issue "$ISSUE_NUMBER" "$PATTERN"
       
       - name: Scan PR
         # This step only runs on PR comments
@@ -85,4 +85,4 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           PATTERN: ${{ secrets.PATTERN }}
-        run: yarn scan -pr "$PR_NUMBER" "$PATTERN"
+        run: yarn scan:exposures -pr "$PR_NUMBER" "$PATTERN"

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@emotion/styled": "11.3.0",
     "@loadable/component": "5.15.0",
     "@loadable/server": "5.15.0",
+    "@octokit/rest": "^18.6.7",
     "@testing-library/user-event": "13.1.9",
     "aws-embedded-metrics": "2.0.4",
     "compression": "1.7.4",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postshrinkwrap": "test -z $CI && ./scripts/packagelockHttps.sh; git update-index --assume-unchanged .env",
     "prepare": "husky install",
     "preinstall": "node scripts/check-package-manager.js",
+    "scan:exposures": "node scripts/scan-exposures.js",
     "start": "NODE_ENV=production node build/server.js",
     "stop": "./scripts/killApp.sh",
     "storybook": "node .storybook/buildFontPreloads && start-storybook -p 9001 -s .storybook/static -c .storybook",

--- a/scripts/scan-exposures.js
+++ b/scripts/scan-exposures.js
@@ -69,9 +69,7 @@ const scanPr = async pullNumber => {
 
     corpus = [title, body, ...prComments, ...prReviewComments];
   } catch (error) {
-    throw new Error(
-      `Error when attempting to get PR #${pullNumber}: \n${error}`,
-    );
+    throw new Error(`Error when attempting to get PR #${pullNumber}`);
   }
 
   return scanCorpus(corpus, regex);
@@ -104,10 +102,7 @@ const scanIssue = async issueNumber => {
 
     corpus = [title, body, ...issueComments];
   } catch (error) {
-    console.error(error);
-    throw new Error(
-      `Error when attempting to get issue #${issueNumber}: \n${error}`,
-    );
+    throw new Error(`Error when attempting to get issue #${issueNumber}`);
   }
 
   return scanCorpus(corpus, regex);

--- a/scripts/scan-exposures.js
+++ b/scripts/scan-exposures.js
@@ -1,0 +1,119 @@
+/* eslint-disable no-console */
+const { Octokit } = require('@octokit/rest');
+
+if (process.argv.length !== 5) {
+  throw new Error(
+    'Error: Incorrect number of args.\nUsage: node scan-simorgh.js <-pr/-issue> <id> <regex>',
+  );
+}
+
+const flag = process.argv[2];
+const id = process.argv[3];
+const regex = new RegExp(process.argv[4], 'i');
+
+const errorMsg =
+  '\n\nFound potential exposure in GitHub PR/Issue. Please follow internal instructions to remove this.\n\n';
+
+const octokit = new Octokit();
+
+const scanCorpus = corpus => {
+  let matches;
+  corpus.forEach(text => {
+    try {
+      matches = text.match(regex);
+    } catch (error) {
+      throw new Error('Error encountered when attempting to match regex.');
+    }
+    if (matches) {
+      process.exitCode = 1;
+      throw new Error(errorMsg);
+    }
+  });
+
+  console.log('\n\nFound no regex matches\n\n');
+
+  return true;
+};
+
+const scanPr = async pullNumber => {
+  let corpus = [];
+  const requestBody = {
+    owner: 'bbc',
+    repo: 'simorgh',
+    pullNumber,
+  };
+
+  try {
+    // Get PR itself
+    const pr = await octokit.request(
+      'GET /repos/{owner}/{repo}/pulls/{pullNumber}',
+      requestBody,
+    );
+    const { title, body } = pr.data;
+
+    // Get PR Comments
+    const prCommentsRequest = await octokit.request(
+      'GET /repos/{owner}/{repo}/issues/{pullNumber}/comments',
+      requestBody,
+    );
+    const prComments = prCommentsRequest.data.map(comment => comment.body);
+
+    // Get PR Review Comments
+    const prReviewCommentsRequest = await octokit.request(
+      'GET /repos/{owner}/{repo}/pulls/{pullNumber}/comments',
+      requestBody,
+    );
+    const prReviewComments = prReviewCommentsRequest.data.map(
+      comment => comment.body,
+    );
+
+    corpus = [title, body, ...prComments, ...prReviewComments];
+  } catch (error) {
+    throw new Error(
+      `Error when attempting to get PR #${pullNumber}: \n${error}`,
+    );
+  }
+
+  return scanCorpus(corpus, regex);
+};
+
+const scanIssue = async issueNumber => {
+  let corpus = [];
+  const requestBody = {
+    owner: 'bbc',
+    repo: 'simorgh',
+    issueNumber,
+  };
+
+  try {
+    // Get issue itself
+    const issue = await octokit.request(
+      'GET /repos/{owner}/{repo}/issues/{issueNumber}',
+      requestBody,
+    );
+    const { title, body } = issue.data;
+
+    // Get issue comments
+    const issueCommentsRequest = await octokit.request(
+      'GET /repos/{owner}/{repo}/issues/{issueNumber}/comments',
+      requestBody,
+    );
+    const issueComments = issueCommentsRequest.data.map(
+      comment => comment.body,
+    );
+
+    corpus = [title, body, ...issueComments];
+  } catch (error) {
+    console.error(error);
+    throw new Error(
+      `Error when attempting to get issue #${issueNumber}: \n${error}`,
+    );
+  }
+
+  return scanCorpus(corpus, regex);
+};
+
+({
+  '-pr': scanPr,
+  '-issue': scanIssue,
+}[flag](id));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,19 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/core@^3.5.0":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^6.0.1":
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
@@ -2112,12 +2125,37 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.2.1.tgz#3ba1abe8906863edd403e185bc12e2bf79b3e240"
   integrity sha512-IHQJpLciwzwDvciLxiFj3IEV5VYn7lSVcj5cu0jbTwMfK4IG6/g8SPrVp3Le1VRzIiYSRcBzm1dA7vgWelYP3Q==
 
+"@octokit/openapi-types@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-8.2.1.tgz#102e752a7378ff8d21057c70fd16f1c83856d8c5"
+  integrity sha512-BJz6kWuL3n+y+qM8Pv+UGbSxH6wxKf/SBs5yzGufMHwDefsa+Iq7ZGy1BINMD2z9SkXlIzk1qiu988rMuGXEMg==
+
 "@octokit/plugin-paginate-rest@^2.2.3":
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
   integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
   dependencies:
     "@octokit/types" "^6.11.0"
+
+"@octokit/plugin-paginate-rest@^2.6.2":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz#f469cb4a908792fb44679c5973d8bba820c88b0f"
+  integrity sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==
+  dependencies:
+    "@octokit/types" "^6.18.0"
+
+"@octokit/plugin-request-log@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.1.tgz#540ec90bb753dcaa682ee9f2cd6efdde9132fa90"
+  integrity sha512-Nx0g7I5ayAYghsLJP4Q1Ch2W9jYYM0FlWWWZocUro8rNxVwuZXGfFd7Rcqi9XDWepSXjg1WByiNJnZza2hIOvQ==
+  dependencies:
+    "@octokit/types" "^6.18.1"
+    deprecation "^2.3.1"
 
 "@octokit/plugin-rest-endpoint-methods@^4.0.0":
   version "4.15.1"
@@ -2136,6 +2174,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
   version "5.4.15"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
@@ -2148,12 +2195,41 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
+"@octokit/request@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.0.tgz#6084861b6e4fa21dc40c8e2a739ec5eff597e672"
+  integrity sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.6.7":
+  version "18.6.7"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.6.7.tgz#89b8ecd13edd9603f00453640d1fb0b4175d4b31"
+  integrity sha512-Kn6WrI2ZvmAztdx+HEaf88RuJn+LK72S8g6OpciE4kbZddAN84fu4fiPGxcEu052WmqKVnA/cnQsbNlrYC6rqQ==
+  dependencies:
+    "@octokit/core" "^3.5.0"
+    "@octokit/plugin-paginate-rest" "^2.6.2"
+    "@octokit/plugin-request-log" "^1.0.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.4.1"
+
 "@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.16.0.tgz#15f71e391ca74e91a21b70e3a1b033c89625dca4"
   integrity sha512-EktqSNq8EKXE82a7Vw33ozOEhFXIRik+rZHJTHAgVZRm/p2K5r5ecn5fVpRkLCm3CAVFwchRvt3yvtmfbt2LCQ==
   dependencies:
     "@octokit/openapi-types" "^7.2.0"
+
+"@octokit/types@^6.16.1", "@octokit/types@^6.18.0", "@octokit/types@^6.18.1":
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.18.1.tgz#a6db178536e649fd5d67a7b747754bcc43940be4"
+  integrity sha512-5YsddjO1U+xC8ZYKV8yZYebW55PCc7qiEEeZ+wZRr6qyclynzfyD65KZ5FdtIeP0/cANyFaD7hV69qElf1nMsQ==
+  dependencies:
+    "@octokit/openapi-types" "^8.2.1"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
**Overall change:**
Adds exposure scanning.

**Code changes:**
- Adds a script that scans PRs and Issues.
- Adds GitHub action, which runs the scan script on the relevant events.
- Adds Octokit as a dependency.


---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project
- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
