### PR TITLE
Add Ukrainian external links to podcast page

### DIFF
--- a/data/ukrainian/podcasts/p09jsy3h.json
+++ b/data/ukrainian/podcasts/p09jsy3h.json
@@ -1,0 +1,260 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:brand:bbc_ukrainian_audio/p09jsy3h",
+    "locators": {
+      "pid": "p09lm42b",
+      "brandPid": "p09jsy3h"
+    },
+    "type": "WSRADIO",
+    "createdBy": "bbc_ukrainian_audio",
+    "language": "uk",
+    "lastUpdated": 1625646740334,
+    "firstPublished": 1625501515000,
+    "lastPublished": 1625501515000,
+    "timestamp": 1625501515000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "Що це було - BBC News Україна",
+      "pageIdentifier": "ukrainian.bbc_ukrainian_audio.podcasts.programmes.p09jsy3h.page",
+      "producerId": "94",
+      "contentType": "player-episode",
+      "producer": "UKRAINIAN"
+    },
+    "tags": {},
+    "version": "v1.3.13",
+    "blockTypes": ["media"],
+    "title": "Що це було",
+    "releaseDateTimeStamp": 1623801600000
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p09lm42b",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "У цьому випуску говоримо про те, хто живе на держдачах і коли чиновники з’їдуть з них.",
+          "long": "Колишніх чиновників часів президентства Віктора Януковича виселяють з держдач у Кончі-Заспі та Пущі-Водиці. У цьому випуску говоримо про те, хто там живе і коли посадовці з’їдуть з тих дач. Що відбувається і чи виконує Володимир Зеленський обіцянки віддати майно під дитячі табори – розбирались кореспонденти ВВС News Україна Світлана Дорош і Олесь Христюк."
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+        "embedding": false,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p09lm2k9",
+            "types": ["Podcast"],
+            "duration": 1110,
+            "durationISO8601": "PT18M30S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableFrom": 1623830640000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "Державні дачі та обіцянки Зеленського",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": {
+      "headline": "Що це було"
+    },
+    "locators": {
+      "pid": "p09lm42b",
+      "brandPid": "p09jsy3h"
+    },
+    "media": {
+      "id": "p09lm42b",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "У цьому випуску говоримо про те, хто живе на держдачах і коли чиновники з’їдуть з них.",
+        "long": "Колишніх чиновників часів президентства Віктора Януковича виселяють з держдач у Кончі-Заспі та Пущі-Водиці. У цьому випуску говоримо про те, хто там живе і коли посадовці з’їдуть з тих дач. Що відбувається і чи виконує Володимир Зеленський обіцянки віддати майно під дитячі табори – розбирались кореспонденти ВВС News Україна Світлана Дорош і Олесь Христюк."
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+      "embedding": false,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p09lm2k9",
+          "types": ["Podcast"],
+          "duration": 1110,
+          "durationISO8601": "PT18M30S",
+          "warnings": {},
+          "availableTerritories": {
+            "uk": true,
+            "nonUk": true,
+            "world": false
+          },
+          "availableFrom": 1623830640000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "Державні дачі та обіцянки Зеленського",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1623801600000,
+    "brand": {
+      "pid": "p09jsy3h",
+      "title": "Що це було"
+    },
+    "id": "urn:bbc:ares:ws_media:page:bbc_ukrainian_audio/p09lm42b",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Ukrainian",
+      "uri": "/ukrainian",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": {
+              "headline": "Що це було"
+            },
+            "locators": {
+              "pid": "p09l876v",
+              "brandPid": "p09jsy3h"
+            },
+            "media": {
+              "id": "p09l876v",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Головна історія тижня, яку пояснює ВВС News Україна. На цей раз - футбол і політика.",
+                "long": "У цьому випуску - про політику і футбол. Збірна України стартує на Євро 2020 – у новій формі, яка обурила багатьох росіян. У тому, як розгортався скандал і чого очікувати від чемпіонату загалом, розбиралися кореспонденти ВВС Святослав Хоменко та Олесь Христюк."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09l864g",
+                  "types": ["Podcast"],
+                  "duration": 1785,
+                  "durationISO8601": "PT29M45S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1623440340000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Форма збірної України і старт Євро 2020",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1623369600000,
+            "brand": {
+              "pid": "p09jsy3h",
+              "title": "Що це було"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_ukrainian_audio/p09l876v",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Що це було"
+            },
+            "locators": {
+              "pid": "p09jt0g9",
+              "brandPid": "p09jsy3h"
+            },
+            "media": {
+              "id": "p09jt0g9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Головна історія, яку пояснюють журналісти ВВС News Україна."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09jrrzy",
+                  "types": ["Podcast"],
+                  "duration": 60,
+                  "durationISO8601": "PT1M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1622127960000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Що це було",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09jrsxv.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1622073600000,
+            "brand": {
+              "pid": "p09jsy3h",
+              "title": "Що це було"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_ukrainian_audio/p09jt0g9",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.js
@@ -18,6 +18,7 @@ const podcastExternalLinks = {
   persian: () => import('./persian.js'),
   portuguese: () => import('./portuguese.js'),
   russian: () => import('./russian.js'),
+  ukrainian: () => import('./ukrainian.js'),
   zhongwen: () => import('./zhongwen.js'),
 };
 

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/ukrainian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/ukrainian.js
@@ -1,0 +1,17 @@
+const externalLinks = {
+  default: {
+    p09jsy3h: [
+      {
+        linkText: 'Spotify',
+        linkUrl: 'https://open.spotify.com/show/3q7550hSqicRIJSFsQ5BVr',
+      },
+      {
+        linkText: 'Apple',
+        linkUrl:
+          'https://podcasts.apple.com/gb/podcast/%D1%89%D0%BE-%D1%86%D0%B5-%D0%B1%D1%83%D0%BB%D0%BE/id1569801762',
+      },
+    ],
+  },
+};
+
+export default externalLinks;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Adding external links for the new Ukrainian podcast page

**Code changes:**

- Added fixture data for Ukrainian podcast
- Added external links

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
