### PR TITLE
External Links for Russian Podcast

### DIFF
--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
@@ -73,6 +73,22 @@ const externalLinks = {
           'https://castbox.fm/channel/id3130703?utm_campaign=i_share_ch&utm_medium=dlink&utm_source=i_share&country=us',
       },
     ],
+    p09nx6zm: [
+      {
+        linkText: 'Apple',
+        linkUrl:
+          'https://podcasts.apple.com/ru/podcast/%D0%BF%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%B9%D0%BE%D0%BC%D0%B5%D0%B9-%D0%BC%D0%B0%D1%80%D1%83/id1575896140',
+      },
+      {
+        linkText: 'Yandex',
+        linkUrl: 'https://music.yandex.com/album/16801020',
+      },
+      {
+        linkText: 'CastBox',
+        linkUrl:
+          'https://castbox.fm/channel/%D0%9F%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%99%D0%BE%D0%BC%D0%B5%D0%B9-%D0%9C%D0%B0%D1%80%D1%83-id4407848',
+      },
+    ],
     p082h9l8: [
       {
         linkText: 'Spotify',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Adding links for Apple, Yandex, and CastBox.

**Code changes:**

- Added links and link text for podcast p09nx6zm.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
