### PR TITLE
Dont render topic tags on sport

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -82,7 +82,7 @@ const ArticlePageMostReadSection = styled(MostReadSection)`
 `;
 
 const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
-  const { articleAuthor } = useContext(ServiceContext);
+  const { service, articleAuthor } = useContext(ServiceContext);
   const { state } = useLocation();
   const hash = state?.hash;
   const headline = getHeadline(pageData);
@@ -91,6 +91,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const lastPublished = getLastPublished(pageData);
   const aboutTags = getAboutTags(pageData);
   const topics = path(['metadata', 'topics'], pageData);
+  const isSport = service === 'sport';
 
   useEffect(() => {
     if (hash) {
@@ -185,7 +186,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
         </ArticlePageGrid>
       </main>
 
-      {topics && (
+      {!isSport && topics && (
         <ArticlePageGrid>
           <GridItemLarge>
             <RelatedTopics topics={topics} />

--- a/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
+++ b/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
@@ -36,6 +36,7 @@ import {
   getLastPublished,
   getAboutTags,
 } from '#lib/utilities/parseAssetData';
+import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#contexts/RequestContext';
 import { GelPageGrid, GridItemLarge } from '#app/components/Grid';
 import RelatedTopics from '#containers/RelatedTopics';
@@ -72,6 +73,7 @@ MediaAssetPageGrid.propTypes = {
 };
 
 const MediaAssetPage = ({ pageData }) => {
+  const { service } = useContext(ServiceContext);
   const { canonicalLink, isAmp } = useContext(RequestContext);
   const isLegacyMediaAssetPage = () => canonicalLink.split('/').length > 7;
 
@@ -88,6 +90,7 @@ const MediaAssetPage = ({ pageData }) => {
     pageData,
   );
   const topics = path(['metadata', 'topics'], pageData);
+  const isSport = service === 'sport';
 
   const getIndexImageLocator = () => {
     const indexImagePath = pathOr(
@@ -201,7 +204,7 @@ const MediaAssetPage = ({ pageData }) => {
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
       </StyledMediaAssetPageGrid>
 
-      {topics && (
+      {!isSport && topics && (
         <MediaAssetPageGrid>
           <GridItemLarge>
             <RelatedTopics topics={topics} />

--- a/src/app/pages/PhotoGalleryPage/PhotoGalleryPage.jsx
+++ b/src/app/pages/PhotoGalleryPage/PhotoGalleryPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import {
   GEL_SPACING_DBL,
@@ -35,6 +35,7 @@ import {
   getLastPublished,
 } from '#lib/utilities/parseAssetData';
 import RelatedTopics from '#containers/RelatedTopics';
+import { ServiceContext } from '#contexts/ServiceContext';
 
 const PhotoGalleryPageGrid = ({ children, ...props }) => (
   <GelPageGrid
@@ -58,6 +59,7 @@ PhotoGalleryPageGrid.propTypes = {
 };
 
 const PhotoGalleryPage = ({ pageData }) => {
+  const { service } = useContext(ServiceContext);
   const title = path(['promo', 'headlines', 'headline'], pageData);
   const shortHeadline = path(['promo', 'headlines', 'shortHeadline'], pageData);
   const summary = path(['promo', 'summary'], pageData);
@@ -79,6 +81,7 @@ const PhotoGalleryPage = ({ pageData }) => {
   const firstPublished = getFirstPublished(pageData);
   const lastPublished = getLastPublished(pageData);
   const aboutTags = getAboutTags(pageData);
+  const isSport = service === 'sport';
 
   const componentsToRender = {
     fauxHeadline,
@@ -145,7 +148,7 @@ const PhotoGalleryPage = ({ pageData }) => {
         <Blocks blocks={blocks} componentsToRender={componentsToRender} />
       </StyledPhotoGalleryPageGrid>
 
-      {topics && (
+      {!isSport && topics && (
         <PhotoGalleryPageGrid>
           <GridItemLarge>
             <RelatedTopics topics={topics} />

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -99,6 +99,7 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
   const featuresInitialData = path(['secondaryColumn', 'features'], pageData);
   const recommendationsInitialData = path(['recommendations'], pageData);
   const topics = path(['metadata', 'topics'], pageData);
+  const isSport = service === 'sport';
 
   const gridColumns = {
     group0: 8,
@@ -320,7 +321,7 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
             <Blocks blocks={blocks} componentsToRender={componentsToRender} />
           </main>
 
-          {topics && (
+          {!isSport && topics && (
             <GridItemLarge>
               <RelatedTopics topics={topics} />
             </GridItemLarge>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9244

**Overall change:**
Stops rendering of topic tags on sport pages.

**Code changes:**

- Conditionally render on service not equal to sport for all articles, stories, PGLs and MAPs.

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project
- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
