### PR TITLE
Add topics path exception for cymrufyw

### DIFF
--- a/src/app/containers/RelatedTopics/index.jsx
+++ b/src/app/containers/RelatedTopics/index.jsx
@@ -36,13 +36,12 @@ const RelatedTopics = ({ topics }) => {
   const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
   const viewRef = useViewTracker(eventTrackingData);
   const heading = pathOr('Related Topics', ['relatedTopics'], translations);
+  const topicsPath = pathOr('topics', ['topicsPath'], translations);
 
   const getTopicPageUrl = id => {
-    const wordForTopics = service === 'cymrufyw' ? 'pynciau' : 'topics';
-
     return variant
-      ? `${process?.env?.SIMORGH_BASE_URL}/${service}/${variant}/${wordForTopics}/${id}`
-      : `${process?.env?.SIMORGH_BASE_URL}/${service}/${wordForTopics}/${id}`;
+      ? `${process?.env?.SIMORGH_BASE_URL}/${service}/${variant}/${topicsPath}/${id}`
+      : `${process?.env?.SIMORGH_BASE_URL}/${service}/${topicsPath}/${id}`;
   };
 
   return (

--- a/src/app/containers/RelatedTopics/index.jsx
+++ b/src/app/containers/RelatedTopics/index.jsx
@@ -38,9 +38,11 @@ const RelatedTopics = ({ topics }) => {
   const heading = pathOr('Related Topics', ['relatedTopics'], translations);
 
   const getTopicPageUrl = id => {
+    const wordForTopics = service === 'cymrufyw' ? 'pynciau' : 'topics';
+
     return variant
-      ? `${process?.env?.SIMORGH_BASE_URL}/${service}/${variant}/topics/${id}`
-      : `${process?.env?.SIMORGH_BASE_URL}/${service}/topics/${id}`;
+      ? `${process?.env?.SIMORGH_BASE_URL}/${service}/${variant}/${wordForTopics}/${id}`
+      : `${process?.env?.SIMORGH_BASE_URL}/${service}/${wordForTopics}/${id}`;
   };
 
   return (

--- a/src/app/containers/RelatedTopics/index.test.jsx
+++ b/src/app/containers/RelatedTopics/index.test.jsx
@@ -101,6 +101,24 @@ describe('Expected use', () => {
     );
   });
 
+  it('should construct the correct topics href given a topic id when service=cymrufyw', () => {
+    const topic = {
+      topicName: 'foo',
+      topicId: 'bar',
+    };
+
+    const { getByText } = render(
+      <WithContexts service="cymrufyw">
+        <RelatedTopics topics={[topic]} />
+      </WithContexts>,
+    );
+
+    expect(getByText(topic.topicName)).toHaveAttribute(
+      'href',
+      `https://bbc.com/cymrufyw/pynciau/${topic.topicId}`,
+    );
+  });
+
   it('should construct the correct topics href given a topic id and a variant', () => {
     const topic = {
       topicName: 'foo',

--- a/src/app/lib/config/services/cymrufyw.js
+++ b/src/app/lib/config/services/cymrufyw.js
@@ -71,6 +71,7 @@ export const service = {
       currentPage: 'Y dudalen bresennol',
       skipLinkText: `Neidio i'r cynnwys`,
       relatedContent: 'Cynnwys perthnasol',
+      topicsPath: 'pynciau',
       relatedTopics: 'Pynciau Cysylltiedig',
       navMenuText: 'Adrannau',
       mediaAssetPage: {


### PR DESCRIPTION
Resolves #9247 

**Overall change:**
Ensures that the correct link is constructed for the related topics on cymrufyw (uses `/pynciau` instead of `/topics`).

**Code changes:**

- Adds an attribute to the cymrufyw config: `topicsPath`, with the value of `pynciau`.
- Determines if the `topicsPath` attribute exists in the service config, and if so uses it for the hrefs. If the attribute doesn't exist, the href will use `/topics`. 

Test asset: http://localhost:7080/cymrufyw/53403042

---

- [X] I have assigned myself to this PR and the corresponding issues
- [X] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [X] I have assigned this PR to the Simorgh project
- [X] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [X] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
