### PR TITLE
Enable AMP ad placeholder for Mundo

### DIFF
--- a/src/app/containers/Ad/index.test.jsx
+++ b/src/app/containers/Ad/index.test.jsx
@@ -59,7 +59,9 @@ describe('Ad Container', () => {
     describe('AMP', () => {
       shouldMatchSnapshot(
         'should correctly render a leaderboard ad',
-        <ServiceContextProvider service="mundo">
+        <ServiceContext.Provider
+          value={{ showAdPlaceholder: false, ...context }}
+        >
           <RequestContextProvider
             bbcOrigin="https://www.test.bbc.co.uk"
             id="c0000000000o"
@@ -74,12 +76,14 @@ describe('Ad Container', () => {
               <AdContainer slotType="leaderboard" />
             </ToggleContext.Provider>
           </RequestContextProvider>
-        </ServiceContextProvider>,
+        </ServiceContext.Provider>,
       );
 
       shouldMatchSnapshot(
         'should correctly render an mpu ad',
-        <ServiceContextProvider service="mundo">
+        <ServiceContext.Provider
+          value={{ showAdPlaceholder: false, ...context }}
+        >
           <RequestContextProvider
             bbcOrigin="https://www.test.bbc.co.uk"
             id="c0000000000o"
@@ -94,7 +98,7 @@ describe('Ad Container', () => {
               <AdContainer slotType="mpu" />
             </ToggleContext.Provider>
           </RequestContextProvider>
-        </ServiceContextProvider>,
+        </ServiceContext.Provider>,
       );
 
       shouldMatchSnapshot(

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -66,7 +66,7 @@ export const service = {
       brandHighlightColour: `${C_WHITE}`,
       brandBorderColour: `${C_POSTBOX_30}`,
     },
-    showAdPlaceholder: false,
+    showAdPlaceholder: true,
     translations: {
       ads: {
         advertisementLabel: 'Publicidad',


### PR DESCRIPTION
Resolves #9243

**Overall change:**
Enabling the AMP ad placeholder for Mundo

**Code changes:**

- Changed showAdPlaceholder to true
- Updated the existing tests to pass service context values

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
