### PR TITLE
Update Radio Schedule stories to follow CSF

### DIFF
--- a/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
+++ b/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
@@ -4,7 +4,7 @@ import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import { renderProgramCard as Component } from '../testHelpers/helper';
 
 export default {
-  title: 'Components/RadioSchedule/ProgramCard',
+  title: 'Components/Radio Schedule/Program Card',
   Component,
   decorators: [withKnobs, withServicesKnob()],
 };

--- a/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
+++ b/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
@@ -1,0 +1,16 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+// import ProgramCard from '.';
+import { renderProgramCard as Component } from '../testHelpers/helper';
+
+export default {
+  title: 'Components/RadioSchedule/ProgramCard',
+  Component,
+  decorators: [withKnobs, withServicesKnob()],
+};
+
+export const OnDemand = props => <Component {...props} state="onDemand" />;
+export const Live = props => <Component {...props} state="live" />;
+export const Next = props => <Component {...props} state="next" />;

--- a/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
+++ b/src/app/components/RadioSchedule/ProgramCard/index.stories.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
-// import ProgramCard from '.';
 import { renderProgramCard as Component } from '../testHelpers/helper';
 
 export default {

--- a/src/app/components/RadioSchedule/StartTime/index.stories.jsx
+++ b/src/app/components/RadioSchedule/StartTime/index.stories.jsx
@@ -20,7 +20,7 @@ const Component = ({ service, locale, script, dir, timezone }) => (
 );
 
 export default {
-  title: 'Components/RadioSchedule/StartTime',
+  title: 'Components/Radio Schedule/Start Time',
   Component,
   decorators: [withKnobs, withServicesKnob()],
 };

--- a/src/app/components/RadioSchedule/StartTime/index.stories.jsx
+++ b/src/app/components/RadioSchedule/StartTime/index.stories.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import StartTime from '.';
+
+const storiesUnixTimestamp = 1566914061212;
+
+// eslint-disable-next-line react/prop-types
+const Component = ({ service, locale, script, dir, timezone }) => {
+  return (
+    <ServiceContextProvider
+      service={service}
+      locale={locale}
+      script={script}
+      dir={dir}
+      timezone={timezone}
+    >
+      <StartTime timestamp={storiesUnixTimestamp} />
+    </ServiceContextProvider>
+  );
+};
+
+export default {
+  title: 'Components/RadioSchedule/StartTime',
+  Component,
+  decorators: [withKnobs, withServicesKnob()],
+};
+
+export const Default = props => <Component {...props} />;

--- a/src/app/components/RadioSchedule/StartTime/index.stories.jsx
+++ b/src/app/components/RadioSchedule/StartTime/index.stories.jsx
@@ -7,19 +7,17 @@ import StartTime from '.';
 const storiesUnixTimestamp = 1566914061212;
 
 // eslint-disable-next-line react/prop-types
-const Component = ({ service, locale, script, dir, timezone }) => {
-  return (
-    <ServiceContextProvider
-      service={service}
-      locale={locale}
-      script={script}
-      dir={dir}
-      timezone={timezone}
-    >
-      <StartTime timestamp={storiesUnixTimestamp} />
-    </ServiceContextProvider>
-  );
-};
+const Component = ({ service, locale, script, dir, timezone }) => (
+  <ServiceContextProvider
+    service={service}
+    locale={locale}
+    script={script}
+    dir={dir}
+    timezone={timezone}
+  >
+    <StartTime timestamp={storiesUnixTimestamp} />
+  </ServiceContextProvider>
+);
 
 export default {
   title: 'Components/RadioSchedule/StartTime',

--- a/src/app/components/RadioSchedule/index.stories.jsx
+++ b/src/app/components/RadioSchedule/index.stories.jsx
@@ -4,7 +4,7 @@ import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import { renderRadioSchedule as Component } from './testHelpers/helper';
 
 export default {
-  title: 'Components/RadioSchedule',
+  title: 'Components/Radio Schedule',
   Component,
   decorators: [withKnobs, withServicesKnob()],
 };

--- a/src/app/components/RadioSchedule/index.stories.jsx
+++ b/src/app/components/RadioSchedule/index.stories.jsx
@@ -1,78 +1,16 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
-import {
-  withServicesKnob,
-  buildRTLSubstories,
-} from '@bbc/psammead-storybook-helpers';
-import {
-  renderProgramCard,
-  renderRadioSchedule,
-  uniqueStates,
-} from './testHelpers/helper';
-import { ServiceContextProvider } from '#contexts/ServiceContext';
-import notes from '../README.md';
-import StartTime from './StartTime';
+import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
+import { renderRadioSchedule as Component } from './testHelpers/helper';
 
-const storiesUnixTimestamp = 1566914061212;
+export default {
+  title: 'Components/RadioSchedule',
+  Component,
+  decorators: [withKnobs, withServicesKnob()],
+};
 
-const RADIO_SCHEDULE_STORIES = 'Components/RadioSchedule';
-const radioScheduleStories = storiesOf(RADIO_SCHEDULE_STORIES, module)
-  .addDecorator(withKnobs)
-  .addDecorator(withServicesKnob());
+export const RadioSchedule = props => <Component {...props} />;
 
-radioScheduleStories.add('default', props => renderRadioSchedule(props), {
-  notes,
-});
-
-radioScheduleStories.add(
-  'Schedule with different heights',
-  props => renderRadioSchedule({ ...props, withLongSummary: true }),
-  { notes },
+export const ScheduleDifferentHeights = props => (
+  <Component {...props} withLongSummary />
 );
-
-buildRTLSubstories(RADIO_SCHEDULE_STORIES, {
-  include: ['default'],
-});
-
-const PROGRAM_CARD_STORIES = 'Components/RadioSchedule/ProgramCard';
-const programCardStories = storiesOf(PROGRAM_CARD_STORIES, module).addDecorator(
-  withKnobs,
-);
-
-uniqueStates.forEach(state => {
-  programCardStories.add(
-    `${state}`,
-    ({ service }) =>
-      renderProgramCard({
-        service,
-        state,
-      }),
-    { notes },
-  );
-});
-
-buildRTLSubstories(PROGRAM_CARD_STORIES, {
-  include: [...uniqueStates],
-});
-
-storiesOf('Components/RadioSchedule/StartTime', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withServicesKnob())
-  .add(
-    'default',
-    ({ locale, script, service, dir, timezone = 'GMT' }) => {
-      return (
-        <ServiceContextProvider
-          service={service}
-          locale={locale}
-          script={script}
-          dir={dir}
-          timezone={timezone}
-        >
-          <StartTime timestamp={storiesUnixTimestamp} />
-        </ServiceContextProvider>
-      );
-    },
-    { notes },
-  );

--- a/src/app/components/RadioSchedule/index.stories.jsx
+++ b/src/app/components/RadioSchedule/index.stories.jsx
@@ -9,7 +9,7 @@ export default {
   decorators: [withKnobs, withServicesKnob()],
 };
 
-export const RadioSchedule = props => <Component {...props} />;
+export const RadioSchedule = Component;
 
 export const ScheduleDifferentHeights = props => (
   <Component {...props} withLongSummary />


### PR DESCRIPTION
Resolves #9242

**Overall change:**
Rewrite the stories for components/RadioSchedule

**Code changes:**

- Rewrite RadioSchedule, ProgramCard, and StartTime stories to remove use of `storiesOf`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
