### PR TITLE
Remove added query 'site=test' from front page amp

### DIFF
--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -89,12 +89,7 @@ const runTestsForPage = ({
         describe(`${pageType} - ${currentPath} - AMP`, () => {
           before(() => {
             Cypress.env('currentPath', currentPath);
-            // If the page type is front page we use this query to get test ads which are more reliable
-            // This was implemented due to a repeating application error on Arabic AMP front page when ads were present
-            if (pageType === 'frontPage') {
-              // eslint-disable-next-line no-param-reassign
-              currentPath += '?site=test';
-            }
+
             visitPage(getAmpUrl(currentPath), pageType);
           });
 


### PR DESCRIPTION
To fix the failure in the builds at the moment

**Overall change:**

We added a query onto the url for front page amp tests to try to fix the problems we had with ads. It didn't fix the problem, but I didn't remove the code (it didn't cause problems). Now it is causing a failure in the topic tags test because the way I construct the URL to fetch the data to see if topic tags are present doesn't take into account the added query on the URL

This code removes the added query

**Code changes:**

Removes the code added before
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

I don't know why it didn't fail on the smoke tests on the PR before. It failed in the pipeline build tests on the smoke tests. Now when I run the smoke tests on front page it doesn't fail.
