### PR TITLE
Fix font size, fix padding for 600+

### DIFF
--- a/src/app/containers/Gist/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Gist/__snapshots__/index.test.jsx.snap
@@ -5,8 +5,8 @@ exports[`Gist should render the gist with multiple list items 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   color: #6E6E73;
   border-top: 0.25rem solid #B80000;
   background-color: #FFFFFF;
@@ -17,15 +17,15 @@ exports[`Gist should render the gist with multiple list items 1`] = `
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-0 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
@@ -44,16 +44,18 @@ exports[`Gist should render the gist with multiple list items 1`] = `
   }
 }
 
-@media (min-width: 63rem) {
+@media (min-width: 37.5rem) {
   .emotion-0 {
     padding-left: 2rem;
   }
 
-  .emotion-0 ul {
+  .emotion-0 ul>li {
     padding-left: 1rem;
   }
+}
 
-  .emotion-0 ul>li {
+@media (min-width: 63rem) {
+  .emotion-0 ul {
     padding-left: 1rem;
   }
 }
@@ -70,15 +72,15 @@ exports[`Gist should render the gist with multiple list items 1`] = `
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-2 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
   }
 }
 
@@ -357,8 +359,8 @@ exports[`Gist should render the gist with one list item 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   color: #6E6E73;
   border-top: 0.25rem solid #B80000;
   background-color: #FFFFFF;
@@ -369,15 +371,15 @@ exports[`Gist should render the gist with one list item 1`] = `
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-0 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
   .emotion-0 {
-    font-size: 1rem;
-    line-height: 1.25rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
@@ -396,16 +398,18 @@ exports[`Gist should render the gist with one list item 1`] = `
   }
 }
 
-@media (min-width: 63rem) {
+@media (min-width: 37.5rem) {
   .emotion-0 {
     padding-left: 2rem;
   }
 
-  .emotion-0 ul {
+  .emotion-0 ul>li {
     padding-left: 1rem;
   }
+}
 
-  .emotion-0 ul>li {
+@media (min-width: 63rem) {
+  .emotion-0 ul {
     padding-left: 1rem;
   }
 }
@@ -422,15 +426,15 @@ exports[`Gist should render the gist with one list item 1`] = `
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-2 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
   .emotion-2 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
   }
 }
 

--- a/src/app/containers/Gist/index.jsx
+++ b/src/app/containers/Gist/index.jsx
@@ -10,9 +10,10 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { C_METAL, C_POSTBOX, C_WHITE } from '@bbc/psammead-styles/colours';
 import { getSansRegular, getSansBold } from '@bbc/psammead-styles/font-styles';
-import { getPica, getGreatPrimer } from '@bbc/gel-foundations/typography';
+import { getDoublePica, getGreatPrimer } from '@bbc/gel-foundations/typography';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
+  GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_4_SCREEN_WIDTH_MIN,
 } from '@bbc/gel-foundations/breakpoints';
 import { string, arrayOf, shape } from 'prop-types';
@@ -23,7 +24,7 @@ import Text from '#containers/CpsText';
 
 const GistWrapper = styled.div`
   ${({ service }) => getSansRegular(service)}
-  ${({ script }) => getPica(script)}
+  ${({ script }) => getGreatPrimer(script)}
   color: ${C_METAL};
   border-top: ${GEL_SPACING_HLF} solid ${C_POSTBOX};
   background-color: ${C_WHITE};
@@ -53,18 +54,21 @@ const GistWrapper = styled.div`
     }
   }
 
-  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
     ${({ dir }) =>
       dir === 'ltr'
         ? `padding-left: ${GEL_SPACING_QUAD};`
         : `padding-right: ${GEL_SPACING_QUAD};`}
-    ul {
+    ul > li {
       ${({ dir }) =>
         dir === 'ltr'
           ? `padding-left: ${GEL_SPACING_DBL};`
           : `padding-right: ${GEL_SPACING_DBL};`}
     }
-    ul > li {
+  }
+
+  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) {
+    ul {
       ${({ dir }) =>
         dir === 'ltr'
           ? `padding-left: ${GEL_SPACING_DBL};`
@@ -75,7 +79,7 @@ const GistWrapper = styled.div`
 
 const GistIntroduction = styled.strong`
   ${({ service }) => getSansBold(service)}
-  ${({ script }) => getGreatPrimer(script)}
+  ${({ script }) => getDoublePica(script)}
   display: inline-block;
   padding-bottom: ${GEL_SPACING_DBL};
 `;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
UX feedback: Font size is too small + left padding for 600+ should be 32px, not 16px

**Code changes:**

- Changed from Great Primer to Double Pica for the 'At a glance' title
- Changed from Pica to Great Primer for the bulleted list
- Increased left padding (right for RTL scripts) of component from 16px to 32px on screens 600+

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
