### PR TITLE
Switch async to defer for Chartbeat script

### DIFF
--- a/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
+++ b/src/app/containers/ChartbeatAnalytics/canonical/index.jsx
@@ -29,7 +29,7 @@ const CanonicalChartbeatBeacon = ({ chartbeatConfig }) => {
         })();
       `}
       </script>
-      <script async type="text/javascript" src={chartbeatSource} />
+      <script defer type="text/javascript" src={chartbeatSource} />
     </Helmet>
   );
 };


### PR DESCRIPTION
Resolves #6326

**Overall change:**
Chartbeat caused an increase in load event/fully loaded when added to our pages. This PR switches out the async attribute for the defer attribute.

**Code changes:**

- Change from async to defer attribute

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
