### PR TITLE
Set left property of podcast icons on RTL services

### DIFF
--- a/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
@@ -312,6 +312,7 @@ exports[`PodcastPromo Should render correctly 1`] = `
       >
         <h2
           class="emotion-6 emotion-7"
+          dir="ltr"
           id="podcast-promo"
         >
           <svg
@@ -373,6 +374,7 @@ exports[`PodcastPromo Should render correctly 1`] = `
           </p>
           <p
             class="emotion-24 emotion-25"
+            dir="ltr"
           >
             <svg
               aria-hidden="true"

--- a/src/app/containers/PodcastPromo/components/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastPromo/components/__snapshots__/index.test.jsx.snap
@@ -111,6 +111,7 @@ exports[`Podcast Promo Card Episodes Text should match snapshot 1`] = `
 <div>
   <p
     class="emotion-0 emotion-1"
+    dir="ltr"
   >
     <svg
       aria-hidden="true"
@@ -346,6 +347,7 @@ exports[`Podcast Promo Title should match snapshot 1`] = `
   >
     <h2
       class="emotion-2 emotion-3"
+      dir="ltr"
     >
       <svg
         aria-hidden="true"

--- a/src/app/containers/PodcastPromo/components/card-episodes-text.jsx
+++ b/src/app/containers/PodcastPromo/components/card-episodes-text.jsx
@@ -19,7 +19,7 @@ const EpisodesText = styled.p`
     height: ${GEL_SPACING_DBL};
     position: relative;
     bottom: 0.125rem;
-    right: 0.1875rem;
+    ${({ dir }) => (dir === 'ltr' ? `right: 0.1875rem;` : `left: 0.1875rem;`)}
   }
 `;
 

--- a/src/app/containers/PodcastPromo/components/index.test.jsx
+++ b/src/app/containers/PodcastPromo/components/index.test.jsx
@@ -22,7 +22,7 @@ describe('Podcast Promo', () => {
     assertTypeOfElement(PodcastPromo.Title, 'h2');
     shouldMatchSnapshot(
       'should match snapshot',
-      <PodcastPromo.Title script={scripts.latin} service="russian">
+      <PodcastPromo.Title script={scripts.latin} service="russian" dir="ltr">
         Content
       </PodcastPromo.Title>,
     );
@@ -86,7 +86,11 @@ describe('Podcast Promo', () => {
     assertTypeOfElement(PodcastPromo.Card.EpisodesText, 'p');
     shouldMatchSnapshot(
       'should match snapshot',
-      <PodcastPromo.Card.EpisodesText script={scripts.latin} service="russian">
+      <PodcastPromo.Card.EpisodesText
+        script={scripts.latin}
+        service="russian"
+        dir="ltr"
+      >
         Episodes
       </PodcastPromo.Card.EpisodesText>,
     );

--- a/src/app/containers/PodcastPromo/components/title.jsx
+++ b/src/app/containers/PodcastPromo/components/title.jsx
@@ -20,8 +20,7 @@ const Heading = styled.h2`
     fill: currentColor;
     position: relative;
     bottom: 0.3125rem;
-    right: 0.1875rem;
-  }
+    ${({ dir }) => (dir === 'ltr' ? `right: 0.1875rem;` : `left: 0.1875rem;`)}
 `;
 
 const Wrapper = styled.div`

--- a/src/app/containers/PodcastPromo/components/title.jsx
+++ b/src/app/containers/PodcastPromo/components/title.jsx
@@ -21,6 +21,7 @@ const Heading = styled.h2`
     position: relative;
     bottom: 0.3125rem;
     ${({ dir }) => (dir === 'ltr' ? `right: 0.1875rem;` : `left: 0.1875rem;`)}
+  }
 `;
 
 const Wrapper = styled.div`

--- a/src/app/containers/PodcastPromo/index.jsx
+++ b/src/app/containers/PodcastPromo/index.jsx
@@ -33,7 +33,7 @@ const getSrcSet = (url, sizes) =>
   sizes.map(size => getSrcFromSize(url, size)).join(',');
 
 const Promo = () => {
-  const { podcastPromo, script, service } = useContext(ServiceContext);
+  const { podcastPromo, script, service, dir } = useContext(ServiceContext);
   const podcastPromoTitle = path(['title'], podcastPromo);
   const podcastBrandTitle = path(['brandTitle'], podcastPromo);
   const description = path(['brandDescription'], podcastPromo);
@@ -67,7 +67,7 @@ const Promo = () => {
         role="region"
         aria-labelledby="podcast-promo"
       >
-        <PromoComponent.Title id="podcast-promo">
+        <PromoComponent.Title id="podcast-promo" dir={dir}>
           {podcastPromoTitle}
         </PromoComponent.Title>
         <PromoComponent.Card>
@@ -94,7 +94,7 @@ const Promo = () => {
             <PromoComponent.Card.Description>
               {description}
             </PromoComponent.Card.Description>
-            <PromoComponent.Card.EpisodesText>
+            <PromoComponent.Card.EpisodesText dir={dir}>
               {label}
             </PromoComponent.Card.EpisodesText>
           </PromoComponent.Card.Content>

--- a/src/app/containers/PodcastPromo/index.stories.jsx
+++ b/src/app/containers/PodcastPromo/index.stories.jsx
@@ -6,6 +6,7 @@ import PodcastPromoComponent from '.';
 const serviceContextMock = {
   service: 'news',
   script: latin,
+  dir: 'ltr',
   podcastPromo: {
     title: 'Podcast',
     brandTitle: 'Sounds of the 90s with Fearne Cotton',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Small UX tweak for icon positioning

**Code changes:**

- Setting the left or right property depending on RTL/LTR script

Before:
![image](https://user-images.githubusercontent.com/59573468/129933584-37b6ccf6-2b7c-4b89-a047-04e0d4051243.png)

After: 
![image](https://user-images.githubusercontent.com/59573468/129933653-3f9f4c8a-5fc8-4f95-942a-b6132022b0ee.png)

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
