### PR TITLE
Podcast promo event tracking

### DIFF
--- a/src/app/containers/PodcastPromo/index.jsx
+++ b/src/app/containers/PodcastPromo/index.jsx
@@ -60,7 +60,6 @@ const Promo = () => {
 
   const clickTrackerRef = useClickTrackerHandler({
     componentName: 'podcast-promo',
-    url,
   });
 
   if (!showPromo) {

--- a/src/app/containers/PodcastPromo/index.jsx
+++ b/src/app/containers/PodcastPromo/index.jsx
@@ -9,6 +9,8 @@ import {
   GEL_SPACING_SEXT,
 } from '@bbc/gel-foundations/spacings';
 import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
+import useViewTracker from '#hooks/useViewTracker';
+import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import PromoComponent from './components';
 
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -42,6 +44,14 @@ const Promo = () => {
   const url = path(['linkLabel', 'href'], podcastPromo);
   const label = path(['linkLabel', 'text'], podcastPromo);
 
+  const viewTrackerRef = useViewTracker({
+    componentName: 'podcast-promo',
+  });
+
+  const clickTrackerRef = useClickTrackerHandler({
+    componentName: 'podcast-promo',
+  });
+
   const showPromo = [
     podcastBrandTitle,
     podcastPromoTitle,
@@ -60,7 +70,7 @@ const Promo = () => {
   const sizes = '(min-width: 1008px) 228px, 30vw';
 
   return (
-    <ResponsivePodcastPromoWrapper>
+    <ResponsivePodcastPromoWrapper ref={viewTrackerRef}>
       <PromoComponent
         script={script}
         service={service}
@@ -85,7 +95,7 @@ const Promo = () => {
           </PromoComponent.Card.ImageWrapper>
           <PromoComponent.Card.Content>
             <PromoComponent.Card.Title>
-              <PromoComponent.Card.Link href={url}>
+              <PromoComponent.Card.Link href={url} onClick={clickTrackerRef}>
                 <span className="podcast-promo--hover podcast-promo--focus podcast-promo--visited">
                   {podcastBrandTitle}
                 </span>

--- a/src/app/containers/PodcastPromo/index.jsx
+++ b/src/app/containers/PodcastPromo/index.jsx
@@ -44,14 +44,6 @@ const Promo = () => {
   const url = path(['linkLabel', 'href'], podcastPromo);
   const label = path(['linkLabel', 'text'], podcastPromo);
 
-  const viewTrackerRef = useViewTracker({
-    componentName: 'podcast-promo',
-  });
-
-  const clickTrackerRef = useClickTrackerHandler({
-    componentName: 'podcast-promo',
-  });
-
   const showPromo = [
     podcastBrandTitle,
     podcastPromoTitle,
@@ -61,6 +53,16 @@ const Promo = () => {
     url,
     label,
   ].every(Boolean);
+
+  const viewTrackerRef = useViewTracker({
+    componentName: 'podcast-promo',
+  });
+
+  const clickTrackerRef = useClickTrackerHandler({
+    componentName: 'podcast-promo',
+    url,
+  });
+
   if (!showPromo) {
     return null;
   }

--- a/src/app/containers/PodcastPromo/index.stories.jsx
+++ b/src/app/containers/PodcastPromo/index.stories.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { latin } from '@bbc/gel-foundations/scripts';
 import { ServiceContext } from '#contexts/ServiceContext';
+import { ToggleContextProvider } from '#contexts/ToggleContext';
+
 import PodcastPromoComponent from '.';
 
 const serviceContextMock = {
@@ -23,9 +25,15 @@ const serviceContextMock = {
 };
 
 const Component = () => (
-  <ServiceContext.Provider value={serviceContextMock}>
-    <PodcastPromoComponent />
-  </ServiceContext.Provider>
+  <ToggleContextProvider
+    toggles={{
+      eventTracking: { enabled: true },
+    }}
+  >
+    <ServiceContext.Provider value={serviceContextMock}>
+      <PodcastPromoComponent />
+    </ServiceContext.Provider>
+  </ToggleContextProvider>
 );
 
 export default {

--- a/src/app/containers/PodcastPromo/index.test.jsx
+++ b/src/app/containers/PodcastPromo/index.test.jsx
@@ -118,12 +118,10 @@ describe('Event Tracking', () => {
 
   it('should call the click tracking hook with the correct params', () => {
     const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
-    const { container } = render(<PromoWithContext />);
-    const url = container.querySelector('a').getAttribute('href');
+    render(<PromoWithContext />);
 
     expect(clickTrackerSpy).toHaveBeenCalledWith({
       componentName: 'podcast-promo',
-      url,
     });
   });
 });

--- a/src/app/containers/PodcastPromo/index.test.jsx
+++ b/src/app/containers/PodcastPromo/index.test.jsx
@@ -3,13 +3,24 @@ import { render } from '@testing-library/react';
 import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
 
 import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { ToggleContextProvider } from '#contexts/ToggleContext';
+
 import PodcastPromo from '.';
+
+import * as viewTracking from '#hooks/useViewTracker';
+import * as clickTracking from '#hooks/useClickTrackerHandler';
 
 /* eslint-disable react/prop-types */
 const PromoWithContext = ({ service = 'russian', variant = null }) => (
-  <ServiceContextProvider service={service} variant={variant}>
-    <PodcastPromo />
-  </ServiceContextProvider>
+  <ToggleContextProvider
+    toggles={{
+      eventTracking: { enabled: true },
+    }}
+  >
+    <ServiceContextProvider service={service} variant={variant}>
+      <PodcastPromo />
+    </ServiceContextProvider>
+  </ToggleContextProvider>
 );
 
 describe('PodcastPromo', () => {
@@ -92,5 +103,25 @@ describe('PodcastPromo', () => {
 
     expect(focusableAttrs.every(attr => attr === 'false')).toBe(true);
     expect(ariaHiddenAttrs.every(attr => attr === 'true')).toBe(true);
+  });
+});
+
+describe('Event Tracking', () => {
+  const blockLevelEventTrackingData = {
+    componentName: 'podcast-promo',
+  };
+
+  it('should call the view tracking hook with the correct params', () => {
+    const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
+    render(<PromoWithContext />);
+
+    expect(viewTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
+  });
+
+  it('should call the click tracking hook with the correct params', () => {
+    const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
+    render(<PromoWithContext />);
+
+    expect(clickTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
   });
 });

--- a/src/app/containers/PodcastPromo/index.test.jsx
+++ b/src/app/containers/PodcastPromo/index.test.jsx
@@ -107,21 +107,23 @@ describe('PodcastPromo', () => {
 });
 
 describe('Event Tracking', () => {
-  const blockLevelEventTrackingData = {
-    componentName: 'podcast-promo',
-  };
-
   it('should call the view tracking hook with the correct params', () => {
     const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
     render(<PromoWithContext />);
 
-    expect(viewTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
+    expect(viewTrackerSpy).toHaveBeenCalledWith({
+      componentName: 'podcast-promo',
+    });
   });
 
   it('should call the click tracking hook with the correct params', () => {
     const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
-    render(<PromoWithContext />);
+    const { container } = render(<PromoWithContext />);
+    const url = container.querySelector('a').getAttribute('href');
 
-    expect(clickTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
+    expect(clickTrackerSpy).toHaveBeenCalledWith({
+      componentName: 'podcast-promo',
+      url,
+    });
   });
 });

--- a/src/app/hooks/useClickTrackerHandler/README.md
+++ b/src/app/hooks/useClickTrackerHandler/README.md
@@ -46,7 +46,7 @@ const Promo = () => {
    */
   const clickTrackerHandler = useClickTrackerHandler({
     componentName: 'promo',
-    link: 'promo-link',
+    url: 'promo-link',
   });
 
   return (
@@ -92,35 +92,35 @@ const TopStories = () => {
   const topStories = [
     {
       title: 'Top Story 1',
-      link: 'link-1',
+      url: 'link-1',
     },
     {
       title: 'Top Story 2',
-      link: 'link-2',
+      url: 'link-2',
     },
     {
       title: 'Top Story 3',
-      link: 'link-3',
+      url: 'link-3',
     },
   ];
-  const TopStory = ({ title, link }) => {
+  const TopStory = ({ title, url }) => {
 
     const clickTrackerHandler = useClickTrackerHandler({
       ...eventTrackingData,
-      link,
+      url,
     });
 
     return (
       <li onClick={clickTrackerHandler}>
-        <a href={link}>{title}</a>
+        <a href={url}>{title}</a>
       </li>,
     ),
   );
 
   return (
     <ol>
-      {topStories.map(({ title, link }) => (
-        <TopStory title={title} link={link} />
+      {topStories.map(({ title, url }) => (
+        <TopStory title={title} url={url} />
       ))}
     </ol>
   );


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9329

**Overall change:**
_Add event tracking to podcast promo component._

**Code changes:**

- _Add event tracking to podcast promo component._
- _Update docs to reflect renamed prop._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
