### PR TITLE
GNADTECH-2349: Add Nielsen Analytics in AU

### DIFF
--- a/src/app/containers/NielsenAnalytics/Amp/index.jsx
+++ b/src/app/containers/NielsenAnalytics/Amp/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const JsonInlinedScript = data => (
+  <script
+    type="application/json"
+    /* eslint-disable-next-line react/no-danger */
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+  />
+);
+
+// styled-components removes non-standard attributes (such as AMP attributes) on
+// server rendering. spreading props like this allows us to add AMP attributes
+// to the element.
+const AccessDiv = props => <div {...props} />;
+
+// Nielsen should only run in AU,
+// Using amp-geo to hide/display ased in the country
+// amp-analytics doesn't generate any call if display none
+const DisplayWrapper = styled(AccessDiv)`
+  .amp-geo-pending &,
+  .amp-geo-group-gbOrUnknown & {
+    display: none;
+    visibility: hidden;
+  }
+  .amp-iso-country-au & {
+    display: block;
+  }
+`;
+
+const AmpNielsenAnalytics = ({ nielsenData }) => (
+  <DisplayWrapper>
+    <amp-analytics type="nielsen">
+      {JsonInlinedScript(nielsenData)}
+    </amp-analytics>
+  </DisplayWrapper>
+
+);
+
+export default AmpNielsenAnalytics;

--- a/src/app/containers/NielsenAnalytics/Amp/index.test.jsx
+++ b/src/app/containers/NielsenAnalytics/Amp/index.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AmpComscore from '.';
+
+describe('Assertions', () => {
+  it('should render comscore amp-analytics component', () => {
+    render(<AmpComscore />);
+
+    const ampAnalyticsEl = document.querySelector('amp-analytics');
+    const scriptEl = document.querySelector('script');
+    const scriptContent =
+      '{"vars":{"c2":"17986528"},"extraUrlParams":{"comscorekw":"amp"}}';
+
+    expect(ampAnalyticsEl).toBeInTheDocument();
+    expect(scriptEl).toBeInTheDocument();
+    expect(ampAnalyticsEl).toContainElement(scriptEl);
+    expect(scriptEl.textContent).toEqual(scriptContent);
+  });
+});

--- a/src/app/containers/NielsenAnalytics/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/NielsenAnalytics/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Comscore Analytics Container AMP should render comscore amp-analytics component 1`] = `
+<amp-analytics
+  type="comscore"
+>
+  <script
+    type="application/json"
+  >
+    {"vars":{"c2":"17986528"},"extraUrlParams":{"comscorekw":"amp"}}
+  </script>
+</amp-analytics>
+`;
+
+exports[`Comscore Analytics Container Canonical should render comscore script when on canonical 1`] = `
+<div>
+  <amp-analytics
+    type="comscore"
+  >
+    <script
+      type="application/json"
+    >
+      {"vars":{"c2":"17986528"},"extraUrlParams":{"comscorekw":"amp"}}
+    </script>
+  </amp-analytics>
+</div>
+`;

--- a/src/app/containers/NielsenAnalytics/index.jsx
+++ b/src/app/containers/NielsenAnalytics/index.jsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+import { RequestContext } from '#contexts/RequestContext';
+import useToggle from '#hooks/useToggle';
+import AmpNielsenAnalytics from './Amp';
+
+const NielsenAnalytics = ({ articleId }) => {
+  const { isAmp } = useContext(RequestContext);
+  // We need a nielsenAnalytics toggle - using this now so it runs locally
+  const { enabled } = useToggle('comscoreAnalytics');
+  if (!enabled || !isAmp) {
+    return <div>NIELSEN DISABLE</div>;
+  }
+  // News and Sport only
+  // News 474C2B0B-0C04-4182-BCFB-FC9469A48C9B
+  // Sport DC4AFDB2-B352-4D51-81EF-38BE41114F22
+  const nielsenData = {
+    "vars": {
+      "apid": "474C2B0B-0C04-4182-BCFB-FC9469A48C9B",
+      "apv": "1.0",
+      "apn": "My AMP Website",
+      "section": "BBC News Business",
+      "segC": "BBC – Google AMP", //static data
+      "type": "static", //static data
+      "assetid": "c6v11qzyv8po" //Required and needs to be unique per asset
+    }
+  }
+  return <AmpNielsenAnalytics nielsenData={nielsenData}/>;
+};
+
+export default NielsenAnalytics;

--- a/src/app/containers/NielsenAnalytics/index.test.jsx
+++ b/src/app/containers/NielsenAnalytics/index.test.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { node, string, shape, bool } from 'prop-types';
+import { render } from '@testing-library/react';
+import { shouldMatchSnapshot } from '@bbc/psammead-test-helpers';
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { RequestContextProvider } from '#contexts/RequestContext';
+import { ToggleContext } from '#contexts/ToggleContext';
+import { UserContext } from '#contexts/UserContext';
+import ComscoreAnalytics from '.';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+
+const mockToggleDispatch = jest.fn();
+
+const defaultPersonalisation = { personalisationEnabled: false };
+
+const ContextWrap = ({
+  pageType,
+  platform,
+  origin,
+  children,
+  comscoreAnalyticsToggle,
+  personalisation,
+}) => (
+  <RequestContextProvider
+    isAmp={platform === 'amp'}
+    pageType={pageType}
+    service="news"
+    statusCode={200}
+    bbcOrigin={origin}
+    pathname="/pathname"
+  >
+    <ServiceContextProvider service="pidgin">
+      <ToggleContext.Provider
+        value={{
+          toggleState: {
+            comscoreAnalytics: {
+              enabled: comscoreAnalyticsToggle,
+            },
+          },
+          toggleDispatch: mockToggleDispatch,
+        }}
+      >
+        <UserContext.Provider value={personalisation}>
+          {children}
+        </UserContext.Provider>
+      </ToggleContext.Provider>
+    </ServiceContextProvider>
+  </RequestContextProvider>
+);
+
+ContextWrap.propTypes = {
+  children: node.isRequired,
+  pageType: string.isRequired,
+  origin: string.isRequired,
+  platform: string.isRequired,
+  comscoreAnalyticsToggle: bool.isRequired,
+  personalisation: shape({}),
+};
+
+ContextWrap.defaultProps = {
+  personalisation: defaultPersonalisation,
+};
+
+describe('Comscore Analytics Container', () => {
+  describe('AMP', () => {
+    it('should return null when toggle is disabled', () => {
+      const { container } = render(
+        <ContextWrap
+          platform="amp"
+          pageType={ARTICLE_PAGE}
+          origin="bbc.com"
+          comscoreAnalyticsToggle={false}
+        >
+          <ComscoreAnalytics />
+        </ContextWrap>,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render comscore amp-analytics component', () => {
+      const { container } = render(
+        <ContextWrap
+          platform="amp"
+          pageType={ARTICLE_PAGE}
+          origin="bbc.com"
+          comscoreAnalyticsToggle
+        >
+          <ComscoreAnalytics />
+        </ContextWrap>,
+      );
+
+      expect(container.firstChild).not.toBeNull();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('Canonical', () => {
+    shouldMatchSnapshot(
+      'should render comscore script when on canonical',
+      <ContextWrap
+        platform="amp"
+        pageType={ARTICLE_PAGE}
+        origin="bbc.com"
+        comscoreAnalyticsToggle
+      >
+        <ComscoreAnalytics />
+      </ContextWrap>,
+    );
+
+    it('should return null when toggle is disabled', async () => {
+      const { container } = render(
+        <ContextWrap
+          platform="canonical"
+          pageType={ARTICLE_PAGE}
+          origin="bbc.com"
+          comscoreAnalyticsToggle={false}
+        >
+          <ComscoreAnalytics />
+        </ContextWrap>,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -34,6 +34,7 @@ import { GelPageGrid, GridItemLarge } from '#components/Grid';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
+import NielsenAnalytics from '#containers/NielsenAnalytics';
 import articleMediaPlayer from '#containers/ArticleMediaPlayer';
 import LinkedData from '#containers/LinkedData';
 import MostReadContainer from '#containers/MostRead';
@@ -168,7 +169,9 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
     <>
       <ATIAnalytics data={pageData} />
       <ChartbeatAnalytics data={pageData} />
-      <ComscoreAnalytics />
+      <ComscoreAnalytics articleId={getArticleId(pageData)}
+      />
+      <NielsenAnalytics />
       <ArticleMetadata
         articleId={getArticleId(pageData)}
         title={headline}


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/GNADTECH-2349

**Overall change:**
Add Nielsen Analytics module on AMP pages for AU only

**Code changes:**

Created a nielsenAnalytics Container

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
