### PR TITLE
replace arabic podcast promo image

### DIFF
--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -69,7 +69,7 @@ export const service = {
       brandDescription:
         'بي بي سي إكسترا بودكاست يناقش كل أمور حياتنا اليومية، يأتيكم ثلاثة أيام أسبوعياً',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09kh14x.jpg',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09t9xpv.jpg',
         alt: 'بي بي سي إكسترا',
       },
       linkLabel: {


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9374

**Overall change:**
Replaces the Arabic podcast promo image so that the BBC logo is not cropped.

**Code changes:**

- Updates the arabic.js service config file with the appropriate iChef image

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
