### PR TITLE
e2e assert ckns cookie value is either 1 or 2

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -8,7 +8,7 @@ import {
 import visitPage from '../../../support/helpers/visitPage';
 
 /*
- * The ckns_explicit can have a value of 1 or 2 depending on a user's location.
+ * The ckns_explicit cookie can have a value of 1 or 2 depending on a user's location.
  * A value of 1 is set when the user is inside the UK.
  * A value of 2 is set when the user is in the EU.
  */

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -7,6 +7,15 @@ import {
 } from '../utilities/cookiePrivacyBanner';
 import visitPage from '../../../support/helpers/visitPage';
 
+/*
+ * The ckns_explicit can have a value of 1 or 2 depending on a user's location.
+ * A value of 1 is set when the user is inside the UK.
+ * A value of 2 is set when the user is in the EU.
+ */
+const USER_IS_IN_UK = 1;
+const USER_IS_IN_EU = 2;
+const ACCEPTED_CKNS_EXPLICIT_COOKIE_VALUES = [USER_IS_IN_UK, USER_IS_IN_EU];
+
 const assertCookieHasValue = (cookieName, value) => {
   cy.getCookie(cookieName).should('have.property', 'value', value);
 };
@@ -50,7 +59,10 @@ export default ({ service, variant, pageType, path }) => {
 
     getCookieBannerAcceptCanonical(service, variant).click();
 
-    assertCookieHasOneOfValues('ckns_explicit', ['1', '2']);
+    assertCookieHasOneOfValues(
+      'ckns_explicit',
+      ACCEPTED_CKNS_EXPLICIT_COOKIE_VALUES,
+    );
     assertCookieHasValue('ckns_privacy', 'july2019');
     assertCookieHasValue('ckns_policy', '111');
 
@@ -75,7 +87,10 @@ export default ({ service, variant, pageType, path }) => {
 
     visitPage(path, pageType);
 
-    assertCookieHasOneOfValues('ckns_explicit', ['1', '2']);
+    assertCookieHasOneOfValues(
+      'ckns_explicit',
+      ACCEPTED_CKNS_EXPLICIT_COOKIE_VALUES,
+    );
     assertCookieHasValue('ckns_privacy', 'july2019');
     assertCookieHasValue('ckns_policy', '000');
 

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -7,8 +7,12 @@ import {
 } from '../utilities/cookiePrivacyBanner';
 import visitPage from '../../../support/helpers/visitPage';
 
-const assertCookieValue = (cookieName, value) => {
+const assertCookieHasValue = (cookieName, value) => {
   cy.getCookie(cookieName).should('have.property', 'value', value);
+};
+
+const assertCookieHasOneOfValues = (cookieName, values) => {
+  cy.getCookie(cookieName).value.to.be.oneOf(values);
 };
 
 const assertCookieExpiryDate = (cookieName, timestamp) => {
@@ -28,12 +32,6 @@ const ensureCookieExpiryDates = () => {
   assertCookieExpiryDate('ckns_privacy', inOneYear);
 };
 
-const assertCookieValues = cookies => {
-  Object.keys(cookies).forEach(cookie => {
-    assertCookieValue(cookie, cookies[cookie]);
-  });
-};
-
 export default ({ service, variant, pageType, path }) => {
   it('should have a privacy & cookie banner, which disappears once "accepted" ', () => {
     cy.clearCookies();
@@ -42,10 +40,8 @@ export default ({ service, variant, pageType, path }) => {
     getPrivacyBanner(service, variant).should('be.visible');
     getCookieBannerCanonical(service, variant).should('not.exist');
 
-    assertCookieValues({
-      ckns_privacy: 'july2019',
-      ckns_policy: '000',
-    });
+    assertCookieHasValue('ckns_privacy', 'july2019');
+    assertCookieHasValue('ckns_policy', '000');
 
     getPrivacyBannerAccept(service, variant).click();
 
@@ -54,11 +50,9 @@ export default ({ service, variant, pageType, path }) => {
 
     getCookieBannerAcceptCanonical(service, variant).click();
 
-    assertCookieValues({
-      ckns_explicit: '1',
-      ckns_privacy: 'july2019',
-      ckns_policy: '111',
-    });
+    assertCookieHasOneOfValues('ckns_explicit', ['1', '2']);
+    assertCookieHasValue('ckns_privacy', 'july2019');
+    assertCookieHasValue('ckns_policy', '111');
 
     getCookieBannerCanonical(service, variant).should('not.exist');
     getPrivacyBanner(service, variant).should('not.exist');
@@ -73,21 +67,17 @@ export default ({ service, variant, pageType, path }) => {
     getPrivacyBanner(service, variant).should('be.visible');
     getCookieBannerCanonical(service, variant).should('not.exist');
 
-    assertCookieValues({
-      ckns_privacy: 'july2019',
-      ckns_policy: '000',
-    });
+    assertCookieHasValue('ckns_privacy', 'july2019');
+    assertCookieHasValue('ckns_policy', '000');
 
     getPrivacyBannerAccept(service, variant).click();
     getCookieBannerRejectCanonical(service, variant).click();
 
     visitPage(path, pageType);
 
-    assertCookieValues({
-      ckns_explicit: '1',
-      ckns_privacy: 'july2019',
-      ckns_policy: '000',
-    });
+    assertCookieHasOneOfValues('ckns_explicit', ['1', '2']);
+    assertCookieHasValue('ckns_privacy', 'july2019');
+    assertCookieHasValue('ckns_policy', '000');
 
     getCookieBannerCanonical(service, variant).should('not.exist');
     getPrivacyBanner(service, variant).should('not.exist');
@@ -109,8 +99,6 @@ export default ({ service, variant, pageType, path }) => {
     cy.setCookie('ckns_policy', 'made_up_value');
     visitPage(path, pageType);
 
-    assertCookieValues({
-      ckns_policy: 'made_up_value',
-    });
+    assertCookieHasValue('ckns_policy', 'made_up_value');
   });
 };


### PR DESCRIPTION
Resolves failing e2e tests related to the cookie banner.

**Overall change:**
Updates Cypress e2es to check that the `ckns_explicit` cookie is either `1` or `2` instead of only `1`.

**The reason**
The cookie banner has had a small bug we've not noticed before that the new cookie oven url changes have fixed.

The bug is that the `ckns_explicit` cookie should be set to 2 when you click the "Agree" button on the cookie banner when you are in Europe. We've always set it to 1. The new cookie oven url sets it to 2 when you're in Europe.

Because the e2e tests in our CI pipeline run in Ireland our tests are failing because they're checking for `ckns_explicit=1`.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
