### PR TITLE
fix e2e ckns cookie assertion

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -12,8 +12,8 @@ import visitPage from '../../../support/helpers/visitPage';
  * A value of 1 is set when the user is inside the UK.
  * A value of 2 is set when the user is in the EU.
  */
-const USER_IS_IN_UK = 1;
-const USER_IS_IN_EU = 2;
+const USER_IS_IN_UK = '1';
+const USER_IS_IN_EU = '2';
 const ACCEPTED_CKNS_EXPLICIT_COOKIE_VALUES = [USER_IS_IN_UK, USER_IS_IN_EU];
 
 const assertCookieHasValue = (cookieName, value) => {

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -21,7 +21,9 @@ const assertCookieHasValue = (cookieName, value) => {
 };
 
 const assertCookieHasOneOfValues = (cookieName, values) => {
-  cy.getCookie(cookieName).value.to.be.oneOf(values);
+  cy.getCookie(cookieName).then(({ value }) => {
+    expect(value).to.be.oneOf(values);
+  });
 };
 
 const assertCookieExpiryDate = (cookieName, timestamp) => {


### PR DESCRIPTION
**Overall change:**
Fixes broken e2e test assertion related to the cookie banner.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
