### PR TITLE
add dotcom elements to a11y check exclusions

### DIFF
--- a/cypress/support/helpers/checkA11y.js
+++ b/cypress/support/helpers/checkA11y.js
@@ -1,5 +1,7 @@
 const exclude = [
   '[id^="include-"]', // VJ includes (we have no control over these)
+  '[class*=dotcom]', // GNL ads (these can a11y violations)
+  '[id*=dotcom]', // GNL ads (these can a11y violations)
 ];
 
 const logA11yViolations = violations => {

--- a/cypress/support/helpers/checkA11y.js
+++ b/cypress/support/helpers/checkA11y.js
@@ -1,7 +1,7 @@
 const exclude = [
-  '[id^="include-"]', // VJ includes (we have no control over these)
-  '[class*=dotcom]', // GNL ads (these can a11y violations)
-  '[id*=dotcom]', // GNL ads (these can a11y violations)
+  // These elements can contain a11y violations as we have no control over what is rendered inside of them
+  '.bbc-news-vj-embed-wrapper, [id^="include-"]', // VJ includes
+  '[class*=dotcom], [id*=dotcom]', // GNL ads
 ];
 
 const logA11yViolations = violations => {
@@ -46,7 +46,7 @@ const checkA11y = () => {
   });
   cy.checkA11y(
     {
-      exclude: [exclude],
+      exclude,
     },
     null,
     logA11yViolations,


### PR DESCRIPTION
**Overall change:**
Fixes failing e2es running in CI related to 3rd party ad iframe content.

**Code changes:**

- Adds elements containing ads to the exclude list in the axe-core config

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
