### PR TITLE
exclude amps-ad elements from axe core checks

### DIFF
--- a/cypress/support/helpers/checkA11y.js
+++ b/cypress/support/helpers/checkA11y.js
@@ -1,7 +1,7 @@
 const exclude = [
   // These elements can contain a11y violations as we have no control over what is rendered inside of them
   '.bbc-news-vj-embed-wrapper, [id^="include-"]', // VJ includes
-  '[class*=dotcom], [id*=dotcom]', // GNL ads
+  '[class*=dotcom], [id*=dotcom], amp-ad', // GNL ads
 ];
 
 const logA11yViolations = violations => {


### PR DESCRIPTION
**Overall change:**
Excludes AMP ad elements from axe core checks.

**Code changes:**

- Adds a `amp-ad` element selector to the checkA11y exclusion list
---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
