### PR TITLE
change live yoruba url no duplicate heading

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -9917,7 +9917,7 @@ module.exports = () => ({
       storyPage: {
         environments: {
           live: {
-            paths: ['/yoruba/afrika-51998079'],
+            paths: ['/yoruba/afrika-58539527'],
             enabled: true,
           },
           test: {


### PR DESCRIPTION
Previous Yoruba page used had duplicate headings causing a11y failures. This new one does not have duplicate headings.


**Code changes:**

Just a URL changed


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
This URL now passes with no violations
Other URLs are failing on colour contrast a11y tests
