### PR TITLE
Set CMP cookie to prevent pop up

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -3,6 +3,7 @@
 // We recommend using inline conditional logic to limit tests to services which differ.
 import checkA11y from '../../support/helpers/checkA11y';
 import getDataUrl from '../../support/helpers/getDataUrl';
+import visitPage from '../../support/helpers/visitPage';
 
 export const testsThatAlwaysRunForAllPages = ({ service, pageType }) => {
   describe(`testsToAlwaysRunForAllPages to run for ${service} ${pageType}`, () => {
@@ -51,7 +52,7 @@ export const testsThatAlwaysRunForAllPages = ({ service, pageType }) => {
 
               // Needs to go back to the first page for the rest of the test suite
               // cy.go('back') does not work on AMP as it returns to a canonical page
-              cy.visit(firstVisitedPage);
+              visitPage(firstVisitedPage, 'storyPage');
             } else if (topicTagsPresent && topicTagsLength === 1) {
               cy.get(`aside[aria-labelledby*='related-topics']`)
                 .find('a')

--- a/cypress/support/helpers/visitPage.js
+++ b/cypress/support/helpers/visitPage.js
@@ -17,6 +17,9 @@ export default (path, pageType) => {
     fixture: 'flagpoles/ngas.json',
   });
 
+  // This sets a cookie to stop the CMP consent pop up from appearing when the tests
+  // are run in Europe - causing test failures due to the overlay blocking elements
+  // This could be brittle as it is Google's cookie format which we can't control
   cy.setCookie(
     'FCCDCF',
     '[["AKsRol_BwEkc3ASfKEKVPeyMAwqICoHzH8NxlVr-Hh0TPFtwU_P6z2pKf8yvnOIlbfkSr5BGpCtal_EyIbeetCsHtGMU9lNGJaJ06kps2FHaY4c62aUnvarsjK7MIWPNR3bVUyNhZyUjTDIlWjH0mn-itSG_3MABGA=="],null,["[[],[],[],[],null,null,true]",1620291054220],["CPFxK7bPFxK7bEsABBENBYCoAP_AAE_AAAwIGWQHgAFAAMAAqABwAEAAKgAZAA0gCIAIsATABPAC-AIEAQgAlABLACkAHsATQAnYBSIC0ALSAXUA4gB-wFkALeAXmAvcBjIDLAMsgIgAVAA4ACAAGkARABFACYAE8AL4AhABLAD2AJ3AWgBaQC6gHEAXmAywAAA","1~1843.202.780.2325.1127.505","B6F8AF01-4E2B-4982-98CF-BC6EA8B00241"],null]',

--- a/cypress/support/helpers/visitPage.js
+++ b/cypress/support/helpers/visitPage.js
@@ -17,6 +17,11 @@ export default (path, pageType) => {
     fixture: 'flagpoles/ngas.json',
   });
 
+  cy.setCookie(
+    'FCCDCF',
+    '[["AKsRol_BwEkc3ASfKEKVPeyMAwqICoHzH8NxlVr-Hh0TPFtwU_P6z2pKf8yvnOIlbfkSr5BGpCtal_EyIbeetCsHtGMU9lNGJaJ06kps2FHaY4c62aUnvarsjK7MIWPNR3bVUyNhZyUjTDIlWjH0mn-itSG_3MABGA=="],null,["[[],[],[],[],null,null,true]",1620291054220],["CPFxK7bPFxK7bEsABBENBYCoAP_AAE_AAAwIGWQHgAFAAMAAqABwAEAAKgAZAA0gCIAIsATABPAC-AIEAQgAlABLACkAHsATQAnYBSIC0ALSAXUA4gB-wFkALeAXmAvcBjIDLAMsgIgAVAA4ACAAGkARABFACYAE8AL4AhABLAD2AJ3AWgBaQC6gHEAXmAywAAA","1~1843.202.780.2325.1127.505","B6F8AF01-4E2B-4982-98CF-BC6EA8B00241"],null]',
+  );
+
   cy.visit(path, {
     failOnStatusCode,
   });


### PR DESCRIPTION
**Overall change:**

We managed to stop the CMP appearing and failing tests before by setting a variable in a flagpole to false. This does not always work, and started causing a tet to fail on ukChina. Glen in simorgh ads channel suggested to set this cookie instead, and to see if this works. If not, there are some more lines of code we can try as well.

I have also replaced a cy.visit with the custom visitPage command in the topic tags test, as it will ensure the cookie is set on story pages when the page is returned to, which could then affect the rest of the test suite.

**Code changes:**

  cy.setCookie(
    'FCCDCF',
    '[["AKsRol_BwEkc3ASfKEKVPeyMAwqICoHzH8NxlVr-Hh0TPFtwU_P6z2pKf8yvnOIlbfkSr5BGpCtal_EyIbeetCsHtGMU9lNGJaJ06kps2FHaY4c62aUnvarsjK7MIWPNR3bVUyNhZyUjTDIlWjH0mn-itSG_3MABGA=="],null,["[[],[],[],[],null,null,true]",1620291054220],["CPFxK7bPFxK7bEsABBENBYCoAP_AAE_AAAwIGWQHgAFAAMAAqABwAEAAKgAZAA0gCIAIsATABPAC-AIEAQgAlABLACkAHsATQAnYBSIC0ALSAXUA4gB-wFkALeAXmAvcBjIDLAMsgIgAVAA4ACAAGkARABFACYAE8AL4AhABLAD2AJ3AWgBaQC6gHEAXmAywAAA","1~1843.202.780.2325.1127.505","B6F8AF01-4E2B-4982-98CF-BC6EA8B00241"],null]',
  );

was added to visitPage.js which is a way we visit the page with other actions done (like setting this cookie) before the actual visiting of the page.



---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

We cannot test if it has worked in the UK. Will see if it has worked in the AWS pipeline which runs in Ireland. However, when running it here it at least doesn't cause any failures.