### PR TITLE
Gist spacing update

### DIFF
--- a/src/app/containers/Gist/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Gist/__snapshots__/index.test.jsx.snap
@@ -122,7 +122,7 @@ exports[`Gist should render the gist with multiple list items 1`] = `
   font-size: 1.125rem;
   line-height: 1.375rem;
   display: inline-block;
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -255,8 +255,8 @@ exports[`Gist should render the gist with multiple list items 1`] = `
   font-style: normal;
   font-size: 1.125rem;
   line-height: 1.375rem;
-  padding-left: 0.5rem;
-  margin-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -579,7 +579,7 @@ exports[`Gist should render the gist with one list item 1`] = `
   font-size: 1.125rem;
   line-height: 1.375rem;
   display: inline-block;
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -712,8 +712,8 @@ exports[`Gist should render the gist with one list item 1`] = `
   font-style: normal;
   font-size: 1.125rem;
   line-height: 1.375rem;
-  padding-left: 0.5rem;
-  margin-bottom: 0.75rem;
+  padding-left: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/containers/Gist/index.jsx
+++ b/src/app/containers/Gist/index.jsx
@@ -38,7 +38,7 @@ const GistIntroduction = styled.strong`
   ${({ service }) => getSansBold(service)}
   ${({ script }) => getDoublePica(script)}
   display: inline-block;
-  padding-bottom: ${GEL_SPACING_DBL};
+  padding-bottom: ${GEL_SPACING_TRPL};
 `;
 
 const GistList = styled(UnorderedList)`
@@ -52,8 +52,8 @@ const GistList = styled(UnorderedList)`
   li {
     ${({ service }) => getSansRegular(service)}
     ${({ script }) => getGreatPrimer(script)}
-    ${({ direction }) => `padding-${direction}: ${GEL_SPACING};`}
-    margin-bottom: ${GEL_SPACING_HLF_TRPL};
+    ${({ direction }) => `padding-${direction}: ${GEL_SPACING_HLF};`}
+    margin-bottom: ${GEL_SPACING_DBL};
     &:last-child {
       padding-bottom: ${GEL_SPACING_DBL};
     }

--- a/src/app/containers/Gist/index.jsx
+++ b/src/app/containers/Gist/index.jsx
@@ -52,7 +52,7 @@ const GistList = styled(UnorderedList)`
   li {
     ${({ service }) => getSansRegular(service)}
     ${({ script }) => getGreatPrimer(script)}
-    ${({ direction }) => `padding-${direction}: ${GEL_SPACING_HLF};`}
+    ${({ direction }) => `padding-${direction}: ${GEL_SPACING_HLF_TRPL};`}
     margin-bottom: ${GEL_SPACING_DBL};
     &:last-child {
       padding-bottom: ${GEL_SPACING_DBL};

--- a/src/app/containers/Gist/index.jsx
+++ b/src/app/containers/Gist/index.jsx
@@ -3,7 +3,6 @@ import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import {
   GEL_SPACING_HLF,
-  GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_QUAD,
   GEL_SPACING_TRPL,


### PR DESCRIPTION
Resolves #9421 

**Overall change:**
Change on the Gist component spacing

**Code changes:**

- In src/app/containers/Gist/index.js
- Line 258 only 0.75rem (12px) have been added to take count of the default spacing in Psammead.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
