### PR TITLE
remove the fade animation from lazy loaded article, STY, PGL and MAP images

### DIFF
--- a/src/app/containers/Image/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Image/__snapshots__/index.test.jsx.snap
@@ -314,16 +314,6 @@ exports[`Image with data should render a lazyload container and not preload the 
 `;
 
 exports[`Image with data should render an image with alt text and caption 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 @media (max-width: 14.9375rem) {
   .emotion-0 {
     margin-left: 0%;
@@ -603,10 +593,6 @@ exports[`Image with data should render an image with alt text and caption 1`] = 
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -832,16 +818,6 @@ exports[`Image with data should render an image with alt text and caption 1`] = 
 `;
 
 exports[`Image with data should render an image with alt text and offscreen copyright 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 @media (max-width: 14.9375rem) {
   .emotion-0 {
     margin-left: 0%;
@@ -1121,10 +1097,6 @@ exports[`Image with data should render an image with alt text and offscreen copy
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -1203,16 +1175,6 @@ exports[`Image with data should render an image with alt text and offscreen copy
 `;
 
 exports[`Image with data should render an image with other originCode - this would be a broken image 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 @media (max-width: 14.9375rem) {
   .emotion-0 {
     margin-left: 0%;
@@ -1492,10 +1454,6 @@ exports[`Image with data should render an image with other originCode - this wou
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 

--- a/src/app/containers/Image/index.jsx
+++ b/src/app/containers/Image/index.jsx
@@ -85,7 +85,6 @@ const ImageContainer = ({ blocks, position, sizes, shouldPreload }) => {
         showCopyright
         lazyLoad={lazyLoad}
         preload={ShouldPreLoadLeadImage}
-        fade
         type="image"
       />
     </GridWrapper>

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -2,17 +2,7 @@
 
 exports[`Photo Gallery Page should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
-  @keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-.emotion-2 {
+  .emotion-2 {
   width: 100%;
   padding-bottom: 1.5rem;
 }
@@ -641,10 +631,6 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -1922,16 +1908,6 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
 `;
 
 exports[`Photo Gallery Page snapshots should match snapshot for PGL with about tags 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-2 {
   width: 100%;
   padding-bottom: 1.5rem;
@@ -2702,10 +2678,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -3995,16 +3967,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
 `;
 
 exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS onward journeys 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-2 {
   width: 100%;
   padding-bottom: 1.5rem;
@@ -4775,10 +4737,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -6515,16 +6473,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 `;
 
 exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onward journeys 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-2 {
   width: 100%;
   padding-bottom: 1.5rem;
@@ -7295,10 +7243,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -8016,16 +7960,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
 `;
 
 exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS onward journeys filtered 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-2 {
   width: 100%;
   padding-bottom: 1.5rem;
@@ -8796,10 +8730,6 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2,17 +2,7 @@
 
 exports[`Story Page should not show the pop-out timestamp when allowDateStamp is false 1`] = `
 <DocumentFragment>
-  @keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-.emotion-1 {
+  .emotion-1 {
   width: 100%;
   width: 100%;
   margin: 0 auto;
@@ -801,10 +791,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -4194,16 +4180,6 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 `;
 
 exports[`Story Page should render correctly when the secondary column data is not available 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-1 {
   width: 100%;
   width: 100%;
@@ -5134,10 +5110,6 @@ exports[`Story Page should render correctly when the secondary column data is no
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 
@@ -7344,16 +7316,6 @@ exports[`Story Page should render correctly when the secondary column data is no
 `;
 
 exports[`Story Page snapshots should match snapshot for STY 1`] = `
-@keyframes animation-0 {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
 .emotion-1 {
   width: 100%;
   width: 100%;
@@ -8284,10 +8246,6 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   display: block;
   width: 100%;
   visibility: visible;
-  -webkit-animation: animation-0 0.2s linear;
-  animation: animation-0 0.2s linear;
-  -webkit-transition: visibility 0.2s linear;
-  transition: visibility 0.2s linear;
   height: auto;
 }
 

--- a/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
@@ -162,7 +162,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"Image captio
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="group of residents"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="549"
   sizes="(min-width: 1008px) 760px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/e49c/test/a0b28560-50a9-11e9-8100-2defb9ff0749.jpg"

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -176,7 +176,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"توضیح �
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="قهوه"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="576"
   sizes="(min-width: 1008px) 760px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/87F5/production/_103150843_mediaitem103146787.jpg"

--- a/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
@@ -78,7 +78,7 @@ exports[`Canonical Articles Image Caption should match text 1`] = `"Image captio
 exports[`Canonical Articles Image should match snapshot 1`] = `
 <img
   alt="Map of France showing Paris and Cognac"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="351"
   sizes="(min-width: 1008px) 760px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/feb2/test/36ddabc0-d622-11e9-851e-f35866034a7a.jpg"

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -169,7 +169,7 @@ exports[`Canonical Photo Gallery Page Image Caption should match text 1`] = `"Pi
 exports[`Canonical Photo Gallery Page Image should match snapshot 1`] = `
 <img
   alt="Tenista de 1904"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="549"
   sizes="(min-width: 600px) 80vw, (min-width: 1008px) 632px, 95vw"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/4C33/production/_90570591_gettyimages-3046790.jpg"

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -120,7 +120,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Сүрөт
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <img
   alt="social media"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="351"
   sizes="(min-width: 1008px) 645px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/11D53/test/_63734037_socialmedia.jpg"

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -176,7 +176,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Pie de fot
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <img
   alt="A person holding a union jack umbrella in front of Big Ben"
-  class="eehpdyc0 bbc-oabvne e1enwo3v0"
+  class="eehpdyc0 bbc-100dhyn e1enwo3v0"
   height="549"
   sizes="(min-width: 1008px) 645px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg"


### PR DESCRIPTION
https://github.com/bbc/simorgh/issues/8954

**Overall change:**
Article, STY, PGL and MAP images have a fade-in animation which may be causing rendering issues.

StoryPromo images on the home page do not have this animation and do not have the rendering issue.

**Code changes:**

- remove the fade prop from the Image component that article, STY, PGL and MAP pages use.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
