### PR TITLE
Remove Cypress promise exception handler

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -7,7 +7,7 @@ Cypress.Screenshot.defaults({
 });
 
 Cypress.on(`window:before:load`, win => {
-  cy.stub(win.console, `error`, msg => {
+  cy.stub(win.console, `error`).callsFake(msg => {
     cy.now(`task`, `error`, msg);
     throw new Error(msg);
   });
@@ -18,25 +18,12 @@ Cypress.on(`window:before:load`, win => {
 // We decided we could not invest any more time in the unexplained error as the test
 // successfully functioned with this specific error caught and discarded.
 // eslint-disable-next-line consistent-return
-Cypress.on('uncaught:exception', (err, runnable, promise) => {
+Cypress.on('uncaught:exception', err => {
   // returning false here prevents Cypress from failing the test
   if (
     err.message &&
     err.message.includes("Cannot read property 'postMessage' of undefined")
   ) {
-    return false;
-  }
-
-  if (promise) {
-    // When the exception originated from an unhandled promise
-    // rejection, prevent Cypress from failing the test.
-
-    // This feature was added in v7 - https://github.com/bbc/simorgh/pull/9026
-    // however it's failing our AMP ads tests on feature index pages.
-
-    // We should investigate this error when we have more time and
-    // potentially re-enable unhandled promise rejections failing tests
-    // Issue - https://github.com/bbc/simorgh/issues/9178
     return false;
   }
 });


### PR DESCRIPTION
Resolves #9178

**Overall change:**
Removes condition that allowed unhandled promise exceptions to pass Cypress in tests.

**Code changes:**

- Removes condition from `cypress/support/index.js` that allowed unhandled promise exceptions to not fail Cypress tests
- Small update to the `window:before:load` listener as the stubbing function syntax used is now deprecated.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
