### PR TITLE
Reduce Intersection Threshold on Recent Podcasts Component

### DIFF
--- a/data/portuguese/podcasts/p07r3r3t.json
+++ b/data/portuguese/podcasts/p07r3r3t.json
@@ -1,112 +1,126 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:brand:bbc_brasil/p07r3r3t",
-    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "locators": {
+      "pid": "p09clshz",
+      "brandPid": "p07r3r3t"
+    },
     "type": "WSRADIO",
     "createdBy": "bbc_brasil",
     "language": "pt-br",
-    "lastUpdated": 1616672972760,
-    "firstPublished": 1582557642000,
-    "lastPublished": 1582557642000,
-    "timestamp": 1582557642000,
+    "lastUpdated": 1632814820385,
+    "firstPublished": 1617374636000,
+    "lastPublished": 1617374636000,
+    "timestamp": 1617374636000,
     "options": {},
     "analyticsLabels": {
       "pageTitle": "Que História! - BBC News Brasil",
-      "pageIdentifier": "portuguese.bbc_brasil.programmes.p07r3r3t.page",
+      "pageIdentifier": "portuguese.bbc_brasil.podcasts.programmes.p07r3r3t.page",
       "producerId": "33",
       "contentType": "player-episode",
       "producer": "PORTUGUESE"
     },
     "tags": {},
-    "version": "v1.3.11",
+    "version": "v1.3.13",
     "blockTypes": ["media"],
     "title": "Que História!",
-    "releaseDateTimeStamp": 1584057600000,
-    "atiAnalytics": {}
+    "releaseDateTimeStamp": 1623974400000
   },
   "content": {
     "blocks": [
       {
-        "id": "p083x9gr",
+        "id": "p09clshz",
         "subType": "episode",
         "format": "Audio",
         "title": "",
         "synopses": {
-          "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
-          "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+          "short": "Andrea e Troy se conheceram no salão e resolveram pesquisar suas origens.",
+          "medium": "Andrea Fleck fez descoberta surpreendente após resolver pesquisar passado de seu pai, que tinha sido adotado quando bebê."
         },
-        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09clsjd.jpg",
         "embedding": false,
         "advertising": false,
         "versions": [
           {
-            "versionId": "p083x8gs",
+            "versionId": "p09cls93",
             "types": ["Podcast"],
-            "duration": 982,
-            "durationISO8601": "PT16M22S",
+            "duration": 760,
+            "durationISO8601": "PT12M40S",
             "warnings": {},
             "availableTerritories": {
               "uk": true,
               "nonUk": true,
               "world": false
             },
-            "availableFrom": 1584090000000,
+            "availableFrom": 1624006800000,
             "availabilityStatus": "available"
           }
         ],
         "availability": "available",
         "smpKind": "radioProgramme",
-        "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+        "episodeTitle": "'Descobri que meu cabeleireiro é meu irmão'",
         "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": { "headline": "Que História!" },
-    "locators": { "pid": "p083x9gr", "brandPid": "p07r3r3t" },
+    "headlines": {
+      "headline": "Que História!"
+    },
+    "locators": {
+      "pid": "p09clshz",
+      "brandPid": "p07r3r3t"
+    },
     "media": {
-      "id": "p083x9gr",
+      "id": "p09clshz",
       "subType": "episode",
       "format": "Audio",
       "title": "",
       "synopses": {
-        "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
-        "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+        "short": "Andrea e Troy se conheceram no salão e resolveram pesquisar suas origens.",
+        "medium": "Andrea Fleck fez descoberta surpreendente após resolver pesquisar passado de seu pai, que tinha sido adotado quando bebê."
       },
-      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09clsjd.jpg",
       "embedding": false,
       "advertising": false,
       "versions": [
         {
-          "versionId": "p083x8gs",
+          "versionId": "p09cls93",
           "types": ["Podcast"],
-          "duration": 982,
-          "durationISO8601": "PT16M22S",
+          "duration": 760,
+          "durationISO8601": "PT12M40S",
           "warnings": {},
-          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableFrom": 1584090000000,
+          "availableTerritories": {
+            "uk": true,
+            "nonUk": true,
+            "world": false
+          },
+          "availableFrom": 1624006800000,
           "availabilityStatus": "available"
         }
       ],
       "availability": "available",
       "smpKind": "radioProgramme",
-      "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+      "episodeTitle": "'Descobri que meu cabeleireiro é meu irmão'",
       "type": "media"
     },
     "indexImage": {
       "id": "",
       "subType": "index",
-      "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
-      "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p09clsjd.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p09clsjd.jpg",
       "height": 0,
       "width": 0,
       "altText": null,
       "copyrightHolder": null,
       "type": "image"
     },
-    "releaseDateTimestamp": 1584057600000,
-    "brand": { "pid": "p07r3r3t", "title": "Que História!" },
-    "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x9gr",
+    "releaseDateTimestamp": 1623974400000,
+    "brand": {
+      "pid": "p07r3r3t",
+      "title": "Que História!"
+    },
+    "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09clshz",
     "type": "ws_radio"
   },
   "relatedContent": {
@@ -121,8 +135,673 @@
         "type": "other-episode",
         "promos": [
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p083x87j", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09cls7w",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09cls7w",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Acidente obrigou velejador a abandonar barco a 3,2 mil km de terra firme.",
+                "medium": "Steve Callahan passou dois meses e meio à deriva em bote de borracha, no meio do oceano, tendo que arrumar comida e água todos os dias e enfrentar vários perigos."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09cls83.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09clrw4",
+                  "types": ["Podcast"],
+                  "duration": 912,
+                  "durationISO8601": "PT15M12S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1623402000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O homem que passou 76 dias à deriva no Atlântico",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09cls83.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09cls83.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1623369600000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09cls7w",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09clrrg",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09clrrg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Porta de carga abriu durante voo, abrindo buraco e jogando passageiros pra fora de avião.",
+                "medium": "Porta de compartimento de carga se abriu durante voo abrindo buraco na fuselagem de Boeing 747; 8 passageiros foram arrancados com o assento para fora de avião sobre o Pacífico."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09clrrv.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09clrfn",
+                  "types": ["Podcast"],
+                  "duration": 719,
+                  "durationISO8601": "PT11M59S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1622797200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O caso dos passageiros sugados para fora de avião",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09clrrv.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09clrrv.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1622764800000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09clrrg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09clrc9",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09clrc9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Duas semanas após acidente, Tony Cicoria começou a ficar obcecado com música de piano.",
+                "medium": "Tony Cicoria passou a sentir vontade irresistível de ouvir música de piano após ser atingido por raio durante telefonema em orelhão; aprendeu a tocar e a compor no instrumento."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09clrcn.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09clqzb",
+                  "types": ["Podcast"],
+                  "duration": 841,
+                  "durationISO8601": "PT14M1S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1622192400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O médico que virou pianista após ser atingido por um raio",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09clrcn.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09clrcn.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1622160000000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09clrc9",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09clqpf",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09clqpf",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Sua vida virou um inferno, porque não conseguia falar - até descobrir a razão.",
+                "medium": "As pessoas achavam que Marie McCreadie não falava porque não queria; pais chegaram a interná-la em uma clínica psiquiátrica. Mas um dia, ela descobriu a razão de seu impedimento."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09clqrj.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09jb3v8",
+                  "types": ["Podcast"],
+                  "duration": 911,
+                  "durationISO8601": "PT15M11S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1621587600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "A jovem que passou 12 anos sem conseguir emitir um som",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09clqrj.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09clqrj.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1621555200000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09clqpf",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09clpjz",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09clpjz",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Nos anos 1980, cientistas nos EUA investigaram uma misteriosa poção 'zumbificadora'.",
+                "medium": "Em 1980, Clairvius Narcisse apareceu em seu vilarejo no Haiti, 18 anos após ser dado com morto e enterrado; caso chamou atenção para uma misteriosa poção 'zumbificadora'."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09hl5fs.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09clnlt",
+                  "types": ["Podcast"],
+                  "duration": 906,
+                  "durationISO8601": "PT15M6S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1620982800000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "A poção que criava 'zumbis' no Haiti",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09hl5fs.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09hl5fs.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1620950400000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09clpjz",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09cl7zl",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09cl7zl",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "No Natal de 1914, alemães e britânicos deixaram as trincheiras para celebrar juntos.",
+                "medium": "Em meio a violentos combates nas frentes da Bélgica e França, soldados dos dois lados começaram a cantar canções natalinas; logo estavam bebendo juntos e trocando presentes."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09cl814.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09gxcyb",
+                  "types": ["Podcast"],
+                  "duration": 732,
+                  "durationISO8601": "PT12M12S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1620378000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "A espontânea 'trégua' de Natal em plena frente de combates da Primeira Guerra",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09cl814.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09cl814.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1620345600000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09cl7zl",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09cj16h",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09cj16h",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Chris Lemons teve suprimento rompido em acidente e ficou desacordado no fundo do mar.",
+                "medium": "Mergulhador trabalhava em campo petrolífero a 100 m de profundidade quando temporal arrastou navio e rompeu fornecimento de oxigênio; ele foi resgatado 30 min depois, com vida."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09gx985.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09chzm9",
+                  "types": ["Podcast"],
+                  "duration": 948,
+                  "durationISO8601": "PT15M48S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1619773200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O mergulhador que passou 30 minutos sem ar e escapou da morte",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09gx985.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09gx985.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1619740800000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09cj16h",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09chv2t",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09chv2t",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Livros de Amado e canção de Caymmi marcaram geração de presidente Putin.",
+                "medium": "Obras como 'Dona Flor e seus dois maridos', em que autor baiano celebrava 'alegria de viver', abriram 'novo mundo' para leitores de país comunista."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09chv4z.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09chr1b",
+                  "types": ["Podcast"],
+                  "duration": 1100,
+                  "durationISO8601": "PT18M20S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1619168400000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Como Jorge Amado e Dorival Caymmi encantaram a URSS",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09chv4z.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09chv4z.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1619136000000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09chv2t",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p099wpnb",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p099wpnb",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Carta de prisioneiro foi encontrada por americana que preparava festa para filha.",
+                "medium": "Carta escrita e escondida em caixa de decoração de Halloween por prisioneiro em campo de trabalhos forçados na China foi encontrada nos EUA e teve repercussão internacional."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p099wpr4.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p099wkfq",
+                  "types": ["Podcast"],
+                  "duration": 1005,
+                  "durationISO8601": "PT16M45S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1618563600000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O pedido de SOS em decoração de Dia das Bruxas",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p099wpr4.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p099wpr4.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1617926400000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p099wpnb",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p09chbv1",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p09chbv1",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "A partir de abril, podcast da BBC News Brasil traz mais dez casos reais extraordinários.",
+                "medium": "Após sucesso de primeira temporada, podcast apresentado por Thomas Pappon está de volta com novos episódios. Estreia: 16 de abril."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p09dsb34.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p09ch99c",
+                  "types": ["Podcast"],
+                  "duration": 49,
+                  "durationISO8601": "PT49S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1617278100000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "Segunda temporada vem aí: ouça o trailer",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p09dsb34.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p09dsb34.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1617235200000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p09chbv1",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p083x9gr",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p083x9gr",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Quando jovem morreu de doença degenerativa, pais descobriram que ele teve vida paralela.",
+                "medium": "Pais de Mats Steen achavam que filho teve vida solitária; mas quando anunciaram sua morte, não tinham ideia da comoção que isso causaria."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p083x8gs",
+                  "types": ["Podcast"],
+                  "duration": 982,
+                  "durationISO8601": "PT16M22S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1584090000000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "'A vida secreta de meu filho que só conheci quando ele morreu'",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p083x9j5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1584057600000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x9gr",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p083x87j",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p083x87j",
               "subType": "episode",
@@ -168,13 +847,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1583452800000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083x87j",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p083wkq9", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p083wkq9",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p083wkq9",
               "subType": "episode",
@@ -220,20 +907,28 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1582848000000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p083wkq9",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p0837nfw", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p0837nfw",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p0837nfw",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "Sobreviventes passaram quatro dias boiando em águas infestadas por tubarões.",
+                "short": "Naufrágio de navio afundado por torpedos japoneses na 2ª Guerra inspirou filme 'Tubarão'.",
                 "medium": "Em junho de 1945, torpedos japoneses afundaram cruzador americano, deixando centenas de marinheiros boiando no Oceano Pacífico, lutando contra desidratação, fome e tubarões."
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p0837njx.jpg",
@@ -257,7 +952,7 @@
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "O naufrágio de navio militar na 2ª Guerra que inspirou filme 'Tubarão'",
+              "episodeTitle": "Quatro dias boiando em águas infestadas por tubarões",
               "type": "media"
             },
             "indexImage": {
@@ -272,13 +967,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1582243200000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p0837nfw",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p082wrwc", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p082wrwc",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p082wrwc",
               "subType": "episode",
@@ -324,13 +1027,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1581638400000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p082wrwc",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p081mcd8", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p081mcd8",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p081mcd8",
               "subType": "episode",
@@ -376,13 +1087,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1581033600000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081mcd8",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p081jh7q", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p081jh7q",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p081jh7q",
               "subType": "episode",
@@ -428,13 +1147,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1580428800000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p081jh7q",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p08129g5", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p08129g5",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p08129g5",
               "subType": "episode",
@@ -480,13 +1207,21 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1579824000000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p08129g5",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Que História!" },
-            "locators": { "pid": "p080j23n", "brandPid": "p07r3r3t" },
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p080j23n",
+              "brandPid": "p07r3r3t"
+            },
             "media": {
               "id": "p080j23n",
               "subType": "episode",
@@ -532,8 +1267,71 @@
               "type": "image"
             },
             "releaseDateTimestamp": 1579219200000,
-            "brand": { "pid": "p07r3r3t", "title": "Que História!" },
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
             "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p080j23n",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "Que História!"
+            },
+            "locators": {
+              "pid": "p07zr485",
+              "brandPid": "p07r3r3t"
+            },
+            "media": {
+              "id": "p07zr485",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "O sequestro que se tornou um dos maiores mistérios da história criminal dos EUA.",
+                "medium": "FBI passou mais de três décadas tentando encontrar sequestrador de um avião, em 1971, que fugiu de paraquedas com o resgate. O caso inspirou artigos, filmes, livros e canções."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p07zr48t.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p07zr2zf",
+                  "types": ["Podcast"],
+                  "duration": 801,
+                  "durationISO8601": "PT13M21S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableFrom": 1578646800000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "O Caso D.B. Cooper",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p07zr48t.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p07zr48t.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1578614400000,
+            "brand": {
+              "pid": "p07r3r3t",
+              "title": "Que História!"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_brasil/p07zr485",
             "type": "ws_radio"
           }
         ]

--- a/src/app/containers/EpisodeList/RecentAudioEpisodes/index.jsx
+++ b/src/app/containers/EpisodeList/RecentAudioEpisodes/index.jsx
@@ -63,7 +63,10 @@ const RecentAudioEpisodes = ({ masterBrand, episodes, brandId, pageType }) => {
         : 'player-episode-radio',
   };
 
-  const viewTrackerRef = useViewTracker(eventTrackingData);
+  const viewTrackerRef = useViewTracker({
+    ...eventTrackingData,
+    minViewedPercent: 50 / episodes.length,
+  });
   const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
   const { variant } = useContext(RequestContext);
 

--- a/src/app/hooks/useViewTracker/README.md
+++ b/src/app/hooks/useViewTracker/README.md
@@ -23,6 +23,7 @@ A view event is triggered when:
 | format            | string  | no       | Can be used to track things like the position of a promo e.g. `[CHD=promo::2]`                                                                                                                                       |
 | url               | string  | no       | The url of the page e.g. `https://www.bbc.com/mundo/noticias-america-latina-56989232`                                                                                                                                |
 | preventNavigation | boolean | no       | Use this if you need to perform any additional tasks after sending the click event by setting to `true` and awaiting the event handler callback. Ensure you redirect the user to their destination when you are done |
+| minViewedPercent  | number  | no       | What is the minimum percentage of the component that needs be in view before the event is triggered. Defaults to `50`.                                                                                               |
 
 ### Usage
 

--- a/src/app/hooks/useViewTracker/README.md
+++ b/src/app/hooks/useViewTracker/README.md
@@ -23,7 +23,7 @@ A view event is triggered when:
 | format            | string  | no       | Can be used to track things like the position of a promo e.g. `[CHD=promo::2]`                                                                                                                                       |
 | url               | string  | no       | The url of the page e.g. `https://www.bbc.com/mundo/noticias-america-latina-56989232`                                                                                                                                |
 | preventNavigation | boolean | no       | Use this if you need to perform any additional tasks after sending the click event by setting to `true` and awaiting the event handler callback. Ensure you redirect the user to their destination when you are done |
-| minViewedPercent  | number  | no       | What is the minimum percentage of the component that needs be in view before the event is triggered. Defaults to `50`.                                                                                               |
+| minViewedPercent  | number  | no       | What is the minimum percentage of the component that needs be in the viewport before the event is triggered? Defaults to `50`.                                                                                               |
 
 ### Usage
 

--- a/src/app/hooks/useViewTracker/index.jsx
+++ b/src/app/hooks/useViewTracker/index.jsx
@@ -10,13 +10,18 @@ import useTrackingToggle from '#hooks/useTrackingToggle';
 
 const EVENT_TYPE = 'view';
 const VIEWED_DURATION_MS = 1000;
-const MIN_VIEWED_PERCENT = 0.5;
+const DEFAULT_MIN_VIEWED_PERCENT = 50;
 
 const useViewTracker = (props = {}) => {
   const componentName = path(['componentName'], props);
   const format = path(['format'], props);
   const advertiserID = path(['advertiserID'], props);
   const url = path(['url'], props);
+  const minViewedPercent = pathOr(
+    DEFAULT_MIN_VIEWED_PERCENT,
+    ['minViewedPercent'],
+    props,
+  );
 
   const observer = useRef();
   const timer = useRef(null);
@@ -47,7 +52,7 @@ const useViewTracker = (props = {}) => {
       setIsInView(someElementsAreInView);
     };
     const options = {
-      threshold: [MIN_VIEWED_PERCENT],
+      threshold: [minViewedPercent / 100],
     };
 
     observer.current = new IntersectionObserver(callback, options);

--- a/src/app/hooks/useViewTracker/index.test.jsx
+++ b/src/app/hooks/useViewTracker/index.test.jsx
@@ -247,6 +247,38 @@ describe('Expected use', () => {
     });
   });
 
+  it('allows users to override the minimum required viewed percent', async () => {
+    const { result } = renderHook(
+      () => useViewTracker({ ...trackingData, minViewedPercent: 10 }),
+      {
+        wrapper,
+        initialProps: {
+          pageData: fixtureData,
+        },
+      },
+    );
+    const element = document.createElement('div');
+
+    await result.current(element);
+
+    const observerInstance = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
+    const [[, options]] = global.IntersectionObserver.mock.calls;
+
+    expect(options).toEqual({ threshold: [0.1] });
+  });
+
   it('should only send one view event when mutiple elements are viewed', async () => {
     const { result } = renderHook(() => useViewTracker(trackingData), {
       wrapper,


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9426

**Overall change:**
Reduce intersection threshold on recent podcast episodes component

**Code changes:**

- _Add new field to `viewTracker`._
- _Use it in recent audio episodes component`._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
