### PR TITLE
Replaces Iskoola Pota, Latha, Shonar Bangla fonts in Simorgh to new fonts

### DIFF
--- a/src/app/lib/config/services/bengali.js
+++ b/src/app/lib/config/services/bengali.js
@@ -4,33 +4,26 @@ import {
   C_GHOST,
   C_POSTBOX_30,
 } from '@bbc/psammead-styles/colours';
-import { bengali, bengaliNotoSerif } from '@bbc/gel-foundations/scripts';
+import { bengaliNotoSerif } from '@bbc/gel-foundations/scripts';
 import { bengali as brandSVG } from '@bbc/psammead-assets/svgs';
 import {
-  F_SHONAR_BANGLA_BOLD,
-  F_SHONAR_BANGLA_REGULAR,
   F_NOTO_SERIF_BENGALI_BOLD,
   F_NOTO_SERIF_BENGALI_REGULAR,
 } from '@bbc/psammead-styles/fonts';
 import '@bbc/moment-timezone-include/tz/Asia/Dhaka';
 import '@bbc/psammead-locales/moment/bn';
 import withContext from '../../../contexts/utils/withContext';
-import isTest from '../../utilities/isTest';
 
-const fonts = isTest()
-  ? [
-      () =>
-        F_NOTO_SERIF_BENGALI_BOLD(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifBengali/v1.00/',
-        ),
-      () =>
-        F_NOTO_SERIF_BENGALI_REGULAR(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifBengali/v1.00/',
-        ),
-    ]
-  : [F_SHONAR_BANGLA_BOLD, F_SHONAR_BANGLA_REGULAR];
-
-const script = isTest() ? bengaliNotoSerif : bengali;
+const fonts = [
+  () =>
+    F_NOTO_SERIF_BENGALI_BOLD(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifBengali/v1.00/',
+    ),
+  () =>
+    F_NOTO_SERIF_BENGALI_REGULAR(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifBengali/v1.00/',
+    ),
+];
 
 export const service = {
   default: {
@@ -67,7 +60,7 @@ export const service = {
       'https://www.bbc.com/bengali/institutional-50409861#authorexpertise',
     publishingPrinciples: 'https://www.bbc.com/bengali/institutional-50409861',
     isTrustProjectParticipant: true,
-    script,
+    script: bengaliNotoSerif,
     manifestPath: '/manifest.json',
     swPath: '/sw.js',
     frontPageTitle:

--- a/src/app/lib/config/services/sinhala.js
+++ b/src/app/lib/config/services/sinhala.js
@@ -4,33 +4,26 @@ import {
   C_GHOST,
   C_POSTBOX_30,
 } from '@bbc/psammead-styles/colours';
-import { sinhalese, sinhaleseNotoSerif } from '@bbc/gel-foundations/scripts';
+import { sinhaleseNotoSerif } from '@bbc/gel-foundations/scripts';
 import { sinhala as brandSVG } from '@bbc/psammead-assets/svgs';
 import {
-  F_ISKOOLA_POTA_BBC_BOLD,
-  F_ISKOOLA_POTA_BBC_REGULAR,
   F_NOTO_SERIF_SINHALA_BOLD,
   F_NOTO_SERIF_SINHALA_REGULAR,
 } from '@bbc/psammead-styles/fonts';
 import '@bbc/moment-timezone-include/tz/GMT';
 import '@bbc/psammead-locales/moment/si';
 import withContext from '../../../contexts/utils/withContext';
-import isTest from '../../utilities/isTest';
 
-const fonts = isTest()
-  ? [
-      () =>
-        F_NOTO_SERIF_SINHALA_BOLD(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/',
-        ),
-      () =>
-        F_NOTO_SERIF_SINHALA_REGULAR(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/',
-        ),
-    ]
-  : [F_ISKOOLA_POTA_BBC_BOLD, F_ISKOOLA_POTA_BBC_REGULAR];
-
-const script = isTest() ? sinhaleseNotoSerif : sinhalese;
+const fonts = [
+  () =>
+    F_NOTO_SERIF_SINHALA_BOLD(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/',
+    ),
+  () =>
+    F_NOTO_SERIF_SINHALA_REGULAR(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/',
+    ),
+];
 
 export const service = {
   default: {
@@ -67,7 +60,7 @@ export const service = {
       'https://www.bbc.com/sinhala/institutional-50288553#authorexpertise',
     publishingPrinciples: 'https://www.bbc.com/sinhala/institutional-50288553',
     isTrustProjectParticipant: true,
-    script,
+    script: sinhaleseNotoSerif,
     manifestPath: '/manifest.json',
     swPath: '/sw.js',
     frontPageTitle: 'මුල් පිටුව',

--- a/src/app/lib/config/services/tamil.js
+++ b/src/app/lib/config/services/tamil.js
@@ -7,28 +7,23 @@ import {
 import { tamil } from '@bbc/gel-foundations/scripts';
 import { tamil as brandSVG } from '@bbc/psammead-assets/svgs';
 import {
-  F_LATHA_BOLD,
-  F_LATHA_REGULAR,
   F_NOTO_SANS_TAMIL_BOLD,
   F_NOTO_SANS_TAMIL_REGULAR,
 } from '@bbc/psammead-styles/fonts';
 import '@bbc/moment-timezone-include/tz/GMT';
 import '@bbc/psammead-locales/moment/ta';
 import withContext from '../../../contexts/utils/withContext';
-import isTest from '../../utilities/isTest';
 
-const fonts = isTest()
-  ? [
-      () =>
-        F_NOTO_SANS_TAMIL_BOLD(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSansTamil/v1.00/',
-        ),
-      () =>
-        F_NOTO_SANS_TAMIL_REGULAR(
-          'https://ws-downloads.files.bbci.co.uk/fonts/NotoSansTamil/v1.00/',
-        ),
-    ]
-  : [F_LATHA_BOLD, F_LATHA_REGULAR];
+const fonts = [
+  () =>
+    F_NOTO_SANS_TAMIL_BOLD(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSansTamil/v1.00/',
+    ),
+  () =>
+    F_NOTO_SANS_TAMIL_REGULAR(
+      'https://ws-downloads.files.bbci.co.uk/fonts/NotoSansTamil/v1.00/',
+    ),
+];
 
 export const service = {
   default: {


### PR DESCRIPTION
Relates to https://github.com/bbc/simorgh/pull/9434

**Overall change:**
Removes references to the Sinhalese, Tamil and Bengali service fonts which are being replaced

**Code changes:**

- Removes references to test environment
- Removes previous font config info from service files

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
