### PR TITLE
Prevent web-vitals upgrade from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
       "matchPackagePatterns": ["^@bbc/psammead"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["web-vitals"],
+      "allowedVersions": "1.1.1"
     }
   ]
 }


### PR DESCRIPTION
**Overall change:**
Adds configuration to prevent automatic RenovateBot upgrades to the `web-vitals` package, as currently any upgrades to this package will break Opera Mini Extreme Mode.

**Code changes:**

- Updates `renovate.json` to lock the version of `web-vitals` to its current `1.1.1` version 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
