### PR TITLE
Revert CSP to using the default report endpoint

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -9,8 +9,6 @@ import { bbcDomains, advertisingServiceCountryDomains } from './domainLists';
  * View the developer console for errors.
  */
 
-const REPORT_TO_GROUP_NAME = 'worldsvc';
-
 const advertisingDirectives = {
   connectSrc: [
     'https://csi.gstatic.com',
@@ -386,7 +384,8 @@ const helmetCsp = ({ isAmp, isLive }) => ({
     'media-src': generateMediaSrc({ isAmp, isLive }),
     'worker-src': generateWorkerSrc({ isAmp }),
     'prefetch-src': generatePrefetchSrc({ isAmp, isLive }),
-    'report-to': REPORT_TO_GROUP_NAME,
+    // The "default" report-to group header is injected by GTM
+    'report-to': 'default',
     'upgrade-insecure-requests': [],
   },
 });
@@ -394,10 +393,11 @@ const helmetCsp = ({ isAmp, isLive }) => ({
 const injectCspHeader = (req, res, next) => {
   const { isAmp } = getRouteProps(req.url);
 
+  // We will switch our reporting to this soon, but GTM does not currently handle this header correctly
   res.setHeader(
     'report-to',
     JSON.stringify({
-      group: REPORT_TO_GROUP_NAME,
+      group: 'worldsvc',
       max_age: 2592000,
       endpoints: [
         {

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -564,7 +564,7 @@ describe('cspHeader', () => {
             `media-src ${mediaSrcExpectation.join(' ')};` +
             `worker-src ${workerSrcExpectation.join(' ')};` +
             `prefetch-src ${prefetchSrcExpectation.join(' ')};` +
-            `report-to worldsvc;` +
+            `report-to default;` +
             `upgrade-insecure-requests`;
 
           expect(headers['Content-Security-Policy']).toEqual(


### PR DESCRIPTION
GTM is not currently merging our new `report-to` header correctly.

This PR switches us back to using `default` temporarily, but leaves the new header there so we and GTM can validate when it is working.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
