### PR TITLE
Restore default topic tag background colour

### DIFF
--- a/src/app/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
@@ -211,7 +211,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;
@@ -491,7 +491,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: #F2F2F2;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #222222;

--- a/src/app/containers/RelatedTopics/index.jsx
+++ b/src/app/containers/RelatedTopics/index.jsx
@@ -38,6 +38,7 @@ const RelatedTopics = ({
   bar,
   className,
   backgroundColour,
+  tagBackgroundColour,
 }) => {
   const { service, script, translations, dir } = useContext(ServiceContext);
   const { variant } = useContext(RequestContext);
@@ -73,7 +74,7 @@ const RelatedTopics = ({
         <TopicTags
           service={service}
           script={script}
-          tagBackgroundColour={C_WHITE}
+          {...(tagBackgroundColour && { tagBackgroundColour })}
         >
           {topics.length === 1 ? (
             <TopicTag
@@ -111,6 +112,7 @@ RelatedTopics.propTypes = {
   bar: bool,
   className: string,
   backgroundColour: string,
+  tagBackgroundColour: string,
 };
 
 RelatedTopics.defaultProps = {
@@ -119,6 +121,7 @@ RelatedTopics.defaultProps = {
   bar: true,
   className: null,
   backgroundColour: null,
+  tagBackgroundColour: null,
 };
 
 export default RelatedTopics;

--- a/src/app/containers/RelatedTopics/index.jsx
+++ b/src/app/containers/RelatedTopics/index.jsx
@@ -10,7 +10,6 @@ import {
   GEL_GROUP_3_SCREEN_WIDTH_MAX,
 } from '@bbc/gel-foundations/breakpoints';
 
-import { C_WHITE } from '@bbc/psammead-styles/colours';
 import { ServiceContext } from '#app/contexts/ServiceContext';
 import { RequestContext } from '#app/contexts/RequestContext';
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -20,7 +20,7 @@ import {
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
 } from '@bbc/gel-foundations/spacings';
-import { C_GREY_2 } from '@bbc/psammead-styles/colours';
+import { C_GREY_2, C_WHITE } from '@bbc/psammead-styles/colours';
 import { articleDataPropTypes } from '#models/propTypes/article';
 import ArticleMetadata from '#containers/ArticleMetadata';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -190,6 +190,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
               topics={topics}
               mobileDivider={false}
               backgroundColour={C_GREY_2}
+              tagBackgroundColour={C_WHITE}
             />
           )}
         </Primary>


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9564

**Overall change:**
_Only override the default topic tag background colour on articles._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
