### PR TITLE
Cherry-pick Ramda imports

### DIFF
--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -1,4 +1,4 @@
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 
 // For testing important features that differ between services, e.g. Timestamps.
 // We recommend using inline conditional logic to limit tests to services which differ.

--- a/src/app/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/containers/CpsFeaturesAnalysis/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { arrayOf, shape, number, oneOf, oneOfType, string } from 'prop-types';
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 
 import { StoryPromoLi, StoryPromoUl } from '@bbc/psammead-story-promo-list';
 

--- a/src/app/containers/CpsRelatedContent/index.jsx
+++ b/src/app/containers/CpsRelatedContent/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { arrayOf, shape, number, bool } from 'prop-types';
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 import { storyItem } from '#models/propTypes/storyItem';

--- a/src/app/containers/CpsTopStories/index.jsx
+++ b/src/app/containers/CpsTopStories/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { arrayOf, shape, number, oneOf, oneOfType, string } from 'prop-types';
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 
 import { StoryPromoLi, StoryPromoUl } from '@bbc/psammead-story-promo-list';
 

--- a/src/app/containers/Include/index.jsx
+++ b/src/app/containers/Include/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { string, bool, number } from 'prop-types';
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 
 import EmbedError from '@bbc/psammead-embed-error';
 import nodeLogger from '#lib/logger.node';

--- a/src/app/containers/RelatedTopics/index.jsx
+++ b/src/app/containers/RelatedTopics/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { TopicTag, TopicTags } from '@bbc/psammead-topic-tags';
-import { pathOr } from 'ramda';
+import pathOr from 'ramda/src/pathOr';
 import SectionLabel from '@bbc/psammead-section-label';
 import styled from '@emotion/styled';
 import { arrayOf, bool, shape, string } from 'prop-types';

--- a/src/app/lib/utilities/parseAssetData/index.test.js
+++ b/src/app/lib/utilities/parseAssetData/index.test.js
@@ -1,4 +1,4 @@
-import { mergeDeepLeft } from 'ramda';
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import {
   getHeadline,
   getFirstPublished,


### PR DESCRIPTION
Resolves #9572

**Overall change:**
Remove use of destructuring for Ramda imports

**Code changes:**

- Cherry-pick necessary methods

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
