### PR TITLE
Update mundo japanese nav

### DIFF
--- a/src/app/lib/config/services/japanese.js
+++ b/src/app/lib/config/services/japanese.js
@@ -306,6 +306,10 @@ export const service = {
         url: '/japanese/52137815',
       },
       {
+        title: '気候変動',
+        url: '/japanese/58771282',
+      },
+      {
         title: '日本',
         url: '/japanese/topics/cyx5k201n3qt',
       },

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -343,6 +343,10 @@ export const service = {
         url: '/mundo/internacional',
       },
       {
+        title: 'Medio ambiente',
+        url: '/mundo/noticias-58984987',
+      },
+      {
         title: 'Coronavirus',
         url: '/mundo/topics/c67q9nnn8z7t',
       },

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,68 +230,75 @@ Object {
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -96,68 +96,75 @@ Object {
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,68 +230,75 @@ Object {
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`AMP Photo Gallery Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Photo Gallery Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -96,68 +96,75 @@ Object {
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -230,68 +230,75 @@ Object {
 
 exports[`AMP Story Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`AMP Story Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Story Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -103,68 +103,75 @@ Object {
 
 exports[`Canonical Story Page Header Navigation link should match text and url 4`] = `
 Object {
+  "text": "Medio ambiente",
+  "url": "/mundo/noticias-58984987",
+}
+`;
+
+exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
+Object {
   "text": "Coronavirus",
   "url": "/mundo/topics/c67q9nnn8z7t",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Hay Festival",
   "url": "/mundo/noticias-36795069",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
   "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
   "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
   "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
   "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
   "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "Video",
   "url": "/mundo/media/video",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "Centroamérica Cuenta",
   "url": "/mundo/noticias-43826245",
 }
 `;
 
-exports[`Canonical Story Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Story Page Header Navigation link should match text and url 14`] = `
 Object {
   "text": "BBC Extra",
   "url": "/mundo/noticias-48908206",


### PR DESCRIPTION
Resolves n/a

**Overall change:**
Adding link to climate change link to the Mundo and Japanese nav 

**Code changes:**

- Added Climate change FIX links to the nav bar of  BBC Mundo and BBC Japanese to coincide with COP26

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
