### PR TITLE
Update Brazil podcast promo with new config

### DIFF
--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -72,16 +72,16 @@ export const service = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'Podcast',
-      brandTitle: 'Que História!',
+      brandTitle: 'BBC Lê',
       brandDescription:
-        'Incríveis histórias reais que nem a mente mais criativa poderia ter inventado',
+        'A BBC lê para você algumas de suas melhores reportagens',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09dsdxd.jpg',
-        alt: 'Que História!',
+        src: 'https://ichef.bbc.co.uk/images/ic/448xn/p09qw181.jpg',
+        alt: 'BBC Lê',
       },
       linkLabel: {
         text: 'Episódios',
-        href: 'https://www.bbc.com/portuguese/podcasts/p07r3r3t',
+        href: 'https://www.bbc.com/portuguese/podcasts/p09qw1cn',
       },
     },
     translations: {

--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -76,7 +76,7 @@ export const service = {
       brandDescription:
         'A BBC lê para você algumas de suas melhores reportagens',
       image: {
-        src: 'https://ichef.bbc.co.uk/images/ic/448xn/p09qw181.jpg',
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p09qw181.jpg',
         alt: 'BBC Lê',
       },
       linkLabel: {


### PR DESCRIPTION
Resolves #9588

**Overall change:**
Updates Brazil podcast promo config with newer brand.

**Code changes:**

- Updated existing podcastPromo in https://github.com/bbc/simorgh/blob/latest/src/app/lib/config/services/portuguese.js to newer brand config

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
