### PR TITLE
Exclude new loader ad label to fix intermitted a11y fails

### DIFF
--- a/cypress/support/helpers/checkA11y.js
+++ b/cypress/support/helpers/checkA11y.js
@@ -1,7 +1,7 @@
 const exclude = [
   // These elements can contain a11y violations as we have no control over what is rendered inside of them
   '.bbc-news-vj-embed-wrapper, [id^="include-"]', // VJ includes
-  '[class*=dotcom], [id*=dotcom], amp-ad', // GNL ads
+  '[class*=dotcom], [id*=dotcom], amp-ad, .i-amphtml-new-loader-ad-label', // GNL ads
 ];
 
 const logA11yViolations = violations => {


### PR DESCRIPTION
Resolves #9580 

**Overall change:**
Remove class that was causing the issue from automatic checks.

**Code changes:**
- Added .i-amphtml-new-loader-ad-label to excluded a11y checks
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
