### PR TITLE
Fix TalkBack incorrectly reading links in nested spans on StoryPromoContainer Links

### DIFF
--- a/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
@@ -696,6 +696,7 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/afirika-23252735"
                   class="emotion-39 emotion-40"
                   href="/igbo/afirika-23252735"
                 >
@@ -751,6 +752,7 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/afirika-49666505"
                   class="emotion-39 emotion-40"
                   href="/igbo/afirika-49666505"
                 >
@@ -1470,6 +1472,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                 class="emotion-35 emotion-36"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/afirika-23252735"
                   class="emotion-37 emotion-38"
                   href="/igbo/afirika-23252735"
                 >

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
@@ -351,10 +351,12 @@ exports[`RelatedContentPromo it renders a Story Promo wrapped in a Grid componen
           class="emotion-14 emotion-15"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/44508901"
             class="emotion-16 emotion-17"
             href="/pidgin/44508901"
           >
             <span
+              id="urn:bbc:ares::asset:pidgin/44508901"
               role="text"
             >
               <span>

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
@@ -427,10 +427,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/44508901"
               class="emotion-21 emotion-22"
               href="/pidgin/44508901"
             >
               <span
+                id="urn:bbc:ares::asset:pidgin/44508901"
                 role="text"
               >
                 <span>
@@ -489,6 +491,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-46975713"
               class="emotion-21 emotion-22"
               href="/pidgin/tori-46975713"
             >
@@ -545,6 +548,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-42494678"
               class="emotion-21 emotion-22"
               href="/pidgin/tori-42494678"
             >
@@ -977,10 +981,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/44508901"
               class="emotion-20 emotion-21"
               href="/pidgin/44508901"
             >
               <span
+                id="urn:bbc:ares::asset:pidgin/44508901"
                 role="text"
               >
                 <span>
@@ -1039,6 +1045,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-46975713"
               class="emotion-20 emotion-21"
               href="/pidgin/tori-46975713"
             >
@@ -1095,6 +1102,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-42494678"
               class="emotion-20 emotion-21"
               href="/pidgin/tori-42494678"
             >

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -805,10 +805,12 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/44508901"
                   class="emotion-41 emotion-42"
                   href="/pidgin/44508901"
                 >
                   <span
+                    id="urn:bbc:ares::asset:pidgin/44508901"
                     role="text"
                   >
                     <span>
@@ -867,6 +869,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-46975713"
                   class="emotion-41 emotion-42"
                   href="/pidgin/tori-46975713"
                 >
@@ -923,6 +926,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-42494678"
                   class="emotion-41 emotion-42"
                   href="/pidgin/tori-42494678"
                 >
@@ -1702,10 +1706,12 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/44508901"
                   class="emotion-39 emotion-40"
                   href="/pidgin/44508901"
                 >
                   <span
+                    id="urn:bbc:ares::asset:pidgin/44508901"
                     role="text"
                   >
                     <span>

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -615,6 +615,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:mundo/noticias-internacional-51939501"
                   class="emotion-31 emotion-32"
                   href="/mundo/noticias-internacional-51939501"
                 >
@@ -645,6 +646,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-51945757"
                   class="emotion-31 emotion-32"
                   href="/pidgin/tori-51945757"
                 >
@@ -1244,6 +1246,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
                 class="emotion-27 emotion-28"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:mundo/noticias-internacional-51939501"
                   class="emotion-29 emotion-30"
                   href="/mundo/noticias-internacional-51939501"
                 >

--- a/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
@@ -880,6 +880,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
           class="emotion-46 emotion-47"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-887ffb25-0f39-4ff1-94f8-bf8a3f00dc43"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
@@ -1545,6 +1546,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
           class="emotion-7 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-6b7f2f2d-23e0-4113-aef4-d41700fee05e"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
@@ -1653,6 +1655,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
           class="emotion-42 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-01d0ed6a-9dd2-4ce4-9c2c-11545ec06d96"
             class="emotion-9 emotion-10"
             href="http://www.bbc.com/pidgin"
           >
@@ -2466,6 +2469,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-fcc3b07c-872d-458a-aebe-4dbbd9653894"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
@@ -2527,6 +2531,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-bcf0342d-808f-4dbf-872c-6ed7f35ad78c"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/pakistan-48346840"
           >
@@ -2588,6 +2593,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-ead2901c-c4c1-4bae-a1ed-87a6198c9d78"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/sport-48361817"
           >
@@ -3041,6 +3047,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-4e7da30a-9cf6-4ec8-b2e4-f908ce69efeb"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
@@ -3124,6 +3131,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-eca404ae-09e2-4fac-b0eb-11b04d4a1afd"
             class="emotion-17 emotion-18"
             href="http://www.bbc.com/pidgin"
           >
@@ -3185,6 +3193,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-961361cb-d6ca-420c-a1f0-e1f4d85b6453"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44439411"
           >
@@ -3241,6 +3250,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-770c0a5f-1136-4730-b1f4-216cf4b8de28"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44425543"
           >
@@ -4042,6 +4052,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-db8f0e46-be3d-4e5d-b9c2-ed3e6ed97317"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
@@ -4073,6 +4084,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-f4614c6c-f302-46d7-95ba-2a9231606eed"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/pakistan-48346840"
           >
@@ -4104,6 +4116,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-e62af57e-1f76-4e1e-9848-dcfb1335cb67"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/sport-48361817"
           >
@@ -4518,6 +4531,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-0e664989-0587-4b4a-8658-48411d772e30"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
@@ -4575,6 +4589,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-327404f2-b69f-4544-adc1-7dacc950b6ae"
             class="emotion-9 emotion-10"
             href="http://www.bbc.com/pidgin"
           >
@@ -4606,6 +4621,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-a7918e8f-d166-4c82-bbdc-24ea6193def9"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44439411"
           >
@@ -4637,6 +4653,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-aae28971-08a9-4b62-be82-7dd0963d1a07"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44425543"
           >
@@ -5466,6 +5483,7 @@ exports[`FrontPageStoryRows Container - snapshots TopRow 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
+            aria-labelledby="StoryPromoContainerId-30a3b3ed-24aa-4844-9c3c-e497c9b76bc0"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >

--- a/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -1018,6 +1018,7 @@ HTMLCollection [
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000001"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
@@ -1079,6 +1080,7 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000002"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
@@ -1140,6 +1142,7 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000003"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
@@ -1201,6 +1204,7 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000004"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
@@ -1262,6 +1266,7 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000005"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
@@ -2324,6 +2329,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-39 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000001"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
@@ -2385,6 +2391,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000002"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
@@ -2446,6 +2453,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000003"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
@@ -2507,6 +2515,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000004"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
@@ -2568,6 +2577,7 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000005"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
@@ -3557,6 +3567,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
               class="emotion-26 emotion-27"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000001"
                 class="emotion-28 emotion-29"
                 href="https://www.bbc.co.uk"
               >
@@ -3643,6 +3654,7 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
               class="emotion-57 emotion-27"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000002"
                 class="emotion-28 emotion-29"
                 href="https://www.bbc.co.uk"
               >
@@ -4180,6 +4192,7 @@ exports[`IndexPageSection Container snapshots should render with only one item 1
             class="emotion-33 emotion-34"
           >
             <a
+              aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000001"
               class="emotion-35 emotion-36"
               href="https://www.bbc.co.uk"
             >
@@ -5184,6 +5197,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-32 emotion-33"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000001"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
@@ -5245,6 +5259,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000002"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
@@ -5306,6 +5321,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000003"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
@@ -5367,6 +5383,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000004"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
@@ -5428,6 +5445,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
+                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/testasset-00000005"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >

--- a/src/app/containers/StoryPromo/LinkContents/index.jsx
+++ b/src/app/containers/StoryPromo/LinkContents/index.jsx
@@ -65,7 +65,7 @@ const LinkContents = ({ item, isInline }) => {
   return (
     // role="text" is required to correct a text splitting bug on iOS VoiceOver.
     // eslint-disable-next-line jsx-a11y/aria-role
-    <span role="text">
+    <span role="text" id={item.id}>
       {mediaType && <VisuallyHiddenText>{`${mediaType}, `}</VisuallyHiddenText>}
       <span>{content}</span>
       {offScreenDuration}

--- a/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -386,6 +386,7 @@ exports[`StoryPromo Container should render audio correctly for amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
@@ -808,6 +809,7 @@ exports[`StoryPromo Container should render audio correctly for canonical 1`] = 
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
@@ -1194,6 +1196,7 @@ exports[`StoryPromo Container should render audio promoType leading on amp 1`] =
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -1678,6 +1681,7 @@ exports[`StoryPromo Container should render audio promoType top on amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
@@ -2092,6 +2096,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
         class="emotion-18 emotion-19"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
@@ -2499,6 +2504,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
         class="emotion-18 emotion-19"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
@@ -2876,6 +2882,7 @@ exports[`StoryPromo Container should render audio with no duration promoType lea
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -3339,6 +3346,7 @@ exports[`StoryPromo Container should render audio with no duration promoType top
         class="emotion-18 emotion-19"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
@@ -3664,6 +3672,7 @@ exports[`StoryPromo Container should render featureLink correctly for amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -3976,6 +3985,7 @@ exports[`StoryPromo Container should render featureLink correctly for canonical 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -4285,6 +4295,7 @@ exports[`StoryPromo Container should render featureLink promoType leading on amp
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="http://www.bbc.com/azeri"
         >
@@ -4626,6 +4637,7 @@ exports[`StoryPromo Container should render featureLink promoType top on amp 1`]
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -4946,6 +4958,7 @@ exports[`StoryPromo Container should render full width promos correctly for amp 
         class="emotion-13 emotion-14"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-15 emotion-16"
           href="https://www.bbc.co.uk"
         >
@@ -5264,6 +5277,7 @@ exports[`StoryPromo Container should render full width promos correctly for cano
         class="emotion-13 emotion-14"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-15 emotion-16"
           href="https://www.bbc.co.uk"
         >
@@ -5568,6 +5582,7 @@ exports[`StoryPromo Container should render item without an image correctly for 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -5872,6 +5887,7 @@ exports[`StoryPromo Container should render item without an image correctly for 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -6181,6 +6197,7 @@ exports[`StoryPromo Container should render item without an image promoType lead
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -6502,6 +6519,7 @@ exports[`StoryPromo Container should render item without an image promoType top 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -6801,6 +6819,7 @@ exports[`StoryPromo Container should render live correctly for amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -7102,6 +7121,7 @@ exports[`StoryPromo Container should render live correctly for canonical 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -7400,6 +7420,7 @@ exports[`StoryPromo Container should render live promoType leading on amp 1`] = 
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -7730,6 +7751,7 @@ exports[`StoryPromo Container should render live promoType top on amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -8161,6 +8183,7 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -8527,6 +8550,7 @@ exports[`StoryPromo Container should render podcastLink correctly for amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
@@ -8801,6 +8825,7 @@ exports[`StoryPromo Container should render podcastLink correctly for canonical 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
@@ -9080,6 +9105,7 @@ exports[`StoryPromo Container should render podcastLink promoType leading on amp
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
@@ -9371,6 +9397,7 @@ exports[`StoryPromo Container should render podcastLink promoType top on amp 1`]
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
@@ -9679,6 +9706,7 @@ exports[`StoryPromo Container should render standard correctly for amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -9991,6 +10019,7 @@ exports[`StoryPromo Container should render standard correctly for canonical 1`]
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -10300,6 +10329,7 @@ exports[`StoryPromo Container should render standard promoType leading on amp 1`
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -10641,6 +10671,7 @@ exports[`StoryPromo Container should render standard promoType top on amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -10955,6 +10986,7 @@ exports[`StoryPromo Container should render standardLink correctly for amp 1`] =
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -11267,6 +11299,7 @@ exports[`StoryPromo Container should render standardLink correctly for canonical
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -11576,6 +11609,7 @@ exports[`StoryPromo Container should render standardLink promoType leading on am
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="http://www.bbc.com/azeri"
         >
@@ -11917,6 +11951,7 @@ exports[`StoryPromo Container should render standardLink promoType top on amp 1`
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
@@ -12231,6 +12266,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -12543,6 +12579,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -12852,6 +12889,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType l
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -13193,6 +13231,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType t
         class="emotion-12 emotion-13"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
@@ -13598,6 +13637,7 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
@@ -14017,6 +14057,7 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
@@ -14403,6 +14444,7 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
         class="emotion-4 emotion-5"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
@@ -14881,6 +14923,7 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
+          aria-labelledby="StoryPromoContainerId-undefined"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -188,6 +188,8 @@ const StoryPromoContainer = ({
         <StyledLink
           href={url}
           onClick={eventTrackingData ? handleClickTracking : null}
+          index={item.id}
+          aria-labelledby={`StoryPromoContainerId-${item.id}`}
         >
           {isLive ? (
             <LiveLabel

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -2420,6 +2420,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52735886"
                   class="emotion-39 emotion-40"
                   href="/persian/afghanistan-52735886"
                 >
@@ -2551,10 +2552,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-37 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52726383"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52726383"
                   >
                     <span
+                      id="urn:bbc:ares::asset:persian/afghanistan-52726383"
                       role="text"
                     >
                       <span
@@ -2658,10 +2661,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52710877"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52710877"
                   >
                     <span
+                      id="urn:bbc:ares::asset:persian/afghanistan-52710877"
                       role="text"
                     >
                       <span
@@ -2765,10 +2770,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52699256"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52699256"
                   >
                     <span
+                      id="urn:bbc:ares::asset:persian/afghanistan-52699256"
                       role="text"
                     >
                       <span
@@ -2872,10 +2879,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52651714"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52651714"
                   >
                     <span
+                      id="urn:bbc:ares::asset:persian/afghanistan-52651714"
                       role="text"
                     >
                       <span
@@ -2979,10 +2988,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52640314"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52640314"
                   >
                     <span
+                      id="urn:bbc:ares::asset:persian/afghanistan-52640314"
                       role="text"
                     >
                       <span
@@ -3663,6 +3674,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-37 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52722865"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52722865"
                   >
@@ -3724,6 +3736,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52697976"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52697976"
                   >
@@ -3785,6 +3798,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/blog-viewpoints-52616632"
                     class="emotion-39 emotion-40"
                     href="/persian/blog-viewpoints-52616632"
                   >
@@ -3846,6 +3860,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/afghanistan-52700014"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52700014"
                   >
@@ -3907,6 +3922,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:persian/blog-viewpoints-52692067"
                     class="emotion-39 emotion-40"
                     href="/persian/blog-viewpoints-52692067"
                   >
@@ -5926,6 +5942,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                 class="emotion-37 emotion-38"
               >
                 <a
+                  aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52721557"
                   class="emotion-39 emotion-40"
                   href="/ukrainian/news-russian-52721557"
                 >
@@ -6037,6 +6054,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52261329"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52261329"
                   >
@@ -6123,6 +6141,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52357130"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52357130"
                   >
@@ -6200,6 +6219,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52663545"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52663545"
                   >
@@ -6286,6 +6306,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/vert-fut-russian-52663551"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/vert-fut-russian-52663551"
                   >
@@ -6347,6 +6368,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52633464"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52633464"
                   >
@@ -6408,6 +6430,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52647120"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52647120"
                   >
@@ -6469,6 +6492,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52493624"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52493624"
                   >
@@ -6530,6 +6554,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52395098"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52395098"
                   >
@@ -6591,6 +6616,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52443350"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52443350"
                   >
@@ -6652,6 +6678,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52339462"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52339462"
                   >
@@ -6713,6 +6740,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52336989"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52336989"
                   >
@@ -6774,6 +6802,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52344279"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52344279"
                   >
@@ -6889,6 +6918,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-37 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-50186307"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-50186307"
                   >
@@ -6950,6 +6980,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-49780932"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49780932"
                   >
@@ -7011,6 +7042,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-49621722"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49621722"
                   >
@@ -7072,6 +7104,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-49613573"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-49613573"
                   >
@@ -7133,6 +7166,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-49382281"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49382281"
                   >
@@ -7210,6 +7244,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52653319"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52653319"
                   >
@@ -7296,6 +7331,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52675911"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52675911"
                   >
@@ -7357,6 +7393,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52688931"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52688931"
                   >
@@ -7418,6 +7455,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52620256"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52620256"
                   >
@@ -7479,6 +7517,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/news-russian-52597888"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52597888"
                   >
@@ -7540,6 +7579,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
+                    aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:ukrainian/features-russian-52573535"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52573535"
                   >

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -4363,6 +4363,7 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23145776"
                             class="emotion-266 emotion-267"
                             href="/pidgin/tori-23145776"
                           >
@@ -4419,6 +4420,7 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23143754"
                             class="emotion-266 emotion-267"
                             href="/pidgin/tori-23143754"
                           >
@@ -4496,10 +4498,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/23146654"
                             class="emotion-266 emotion-267"
                             href="/pidgin/23146654"
                           >
                             <span
+                              id="urn:bbc:ares::asset:pidgin/23146654"
                               role="text"
                             >
                               <span
@@ -4596,10 +4600,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/media-23147054"
                             class="emotion-266 emotion-267"
                             href="/pidgin/media-23147054"
                           >
                             <span
+                              id="urn:bbc:ares::asset:pidgin/media-23147054"
                               role="text"
                             >
                               <span

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -825,10 +825,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
+                        aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/media-53580248"
                         class="emotion-40 emotion-41"
                         href="/pidgin/media-53580248"
                       >
                         <span
+                          id="urn:bbc:ares::asset:pidgin/media-53580248"
                           role="text"
                         >
                           <span
@@ -916,10 +918,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
+                        aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/media-53591139"
                         class="emotion-40 emotion-41"
                         href="/pidgin/media-53591139"
                       >
                         <span
+                          id="urn:bbc:ares::asset:pidgin/media-53591139"
                           role="text"
                         >
                           <span
@@ -1007,10 +1011,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
+                        aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-53509788"
                         class="emotion-40 emotion-41"
                         href="/pidgin/tori-53509788"
                       >
                         <span
+                          id="urn:bbc:ares::asset:pidgin/tori-53509788"
                           role="text"
                         >
                           <span

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -6351,10 +6351,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           class="emotion-235 emotion-236"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/media-45132087"
                             class="emotion-237 emotion-238"
                             href="/pidgin/media-45132087"
                           >
                             <span
+                              id="urn:bbc:ares::asset:pidgin/media-45132087"
                               role="text"
                             >
                               <span>
@@ -6434,10 +6436,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           class="emotion-235 emotion-236"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-45242255"
                             class="emotion-237 emotion-238"
                             href="/pidgin/tori-45242255"
                           >
                             <span
+                              id="urn:bbc:ares::asset:pidgin/tori-45242255"
                               role="text"
                             >
                               <span
@@ -11287,6 +11291,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-44124647"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44124647"
                           >
@@ -11343,6 +11348,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-43540056"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43540056"
                           >
@@ -11399,6 +11405,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-44022776"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44022776"
                           >
@@ -11455,6 +11462,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-43713137"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43713137"
                           >
@@ -11511,6 +11519,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-37688691"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-37688691"
                           >
@@ -11567,10 +11576,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-37691096"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-37691096"
                           >
                             <span
+                              id="urn:bbc:ares::asset:azeri/azerbaijan-37691096"
                               role="text"
                             >
                               <span>
@@ -11629,6 +11640,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-43499221"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43499221"
                           >
@@ -11685,6 +11697,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-44004471"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44004471"
                           >
@@ -11741,6 +11754,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
+                            aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:azeri/azerbaijan-43870815"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43870815"
                           >

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -3014,6 +3014,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182501"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182501"
                               >
@@ -3044,6 +3045,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/live/institutional-23162153"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/live/institutional-23162153"
                               >
@@ -3104,10 +3106,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23183171"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23183171"
                               >
                                 <span
+                                  id="urn:bbc:ares::asset:igbo/23183171"
                                   role="text"
                                 >
                                   <span
@@ -3215,6 +3219,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182930"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182930"
                               >
@@ -3270,6 +3275,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182890"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182890"
                               >
@@ -3325,6 +3331,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182810"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182810"
                               >
@@ -3380,6 +3387,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182766"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182766"
                               >
@@ -3435,6 +3443,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182760"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182760"
                               >
@@ -3490,6 +3499,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23182710"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182710"
                               >
@@ -3578,10 +3588,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23177465"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23177465"
                               >
                                 <span
+                                  id="urn:bbc:ares::asset:igbo/23177465"
                                   role="text"
                                 >
                                   <span
@@ -3649,6 +3661,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23173771"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23173771"
                               >
@@ -3704,6 +3717,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-284 emotion-212"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:igbo/23174391"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23174391"
                               >
@@ -10467,6 +10481,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/23248287"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/23248287"
                               >
@@ -10497,6 +10512,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23146434"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23146434"
                               >
@@ -10527,6 +10543,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-undefined"
                                 class="emotion-214 emotion-215"
                                 href="https://www.bbc.co.uk/news"
                               >
@@ -10627,6 +10644,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23146625"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23146625"
                               >
@@ -10712,10 +10730,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/media-23267821"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/media-23267821"
                               >
                                 <span
+                                  id="urn:bbc:ares::asset:pidgin/media-23267821"
                                   role="text"
                                 >
                                   <span
@@ -10810,10 +10830,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/23267823"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/23267823"
                               >
                                 <span
+                                  id="urn:bbc:ares::asset:pidgin/23267823"
                                   role="text"
                                 >
                                   <span
@@ -10876,6 +10898,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23169387"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23169387"
                               >
@@ -10931,6 +10954,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:news/world-africa-23143884"
                                 class="emotion-214 emotion-215"
                                 href="/news/world-africa-23143884"
                               >
@@ -10986,6 +11010,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23146975"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23146975"
                               >
@@ -11041,6 +11066,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-undefined"
                                 class="emotion-214 emotion-215"
                                 href="https://www.bbc.com/pidgin/sport-51434980"
                               >
@@ -11096,6 +11122,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/tori-23145776"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23145776"
                               >
@@ -11180,10 +11207,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-277 emotion-213"
                             >
                               <a
+                                aria-labelledby="StoryPromoContainerId-urn:bbc:ares::asset:pidgin/23146654"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/23146654"
                               >
                                 <span
+                                  id="urn:bbc:ares::asset:pidgin/23146654"
                                   role="text"
                                 >
                                   <span


### PR DESCRIPTION
Resolves #9561

**Overall change:**
Now Links require only one swipe/gesture

**Code changes:**

- Added unique aria-labelledby to link within StoryPromoContainer
- Added id matching aria-labelledby to LinkContents

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
