### PR TITLE
Add Hearken sub-domains to CSP header

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -130,6 +130,9 @@ const directives = {
     ],
     canonicalLive: [
       ...bbcDomains,
+      'https://assets.wearehearken.eu',
+      'https://modules.wearehearken.eu',
+      'https://ems.wearehearken.eu',
       'https://chartbeat.com',
       'https://*.chartbeat.com',
       'https://www.youtube.com', // Social Embeds
@@ -154,6 +157,9 @@ const directives = {
     ],
     canonicalNonLive: [
       ...bbcDomains,
+      'https://assets.wearehearken.eu',
+      'https://modules.wearehearken.eu',
+      'https://ems.wearehearken.eu',
       'https://chartbeat.com',
       'https://*.chartbeat.com',
       'https://www.youtube.com', // Social Embeds
@@ -229,6 +235,9 @@ const directives = {
     ],
     canonicalLive: [
       ...bbcDomains,
+      'https://assets.wearehearken.eu',
+      'https://modules.wearehearken.eu',
+      'https://ems.wearehearken.eu',
       'https://*.chartbeat.com',
       'https://platform.twitter.com', // Social Embeds
       'https://www.instagram.com', // Social Embeds
@@ -248,6 +257,9 @@ const directives = {
     ],
     canonicalNonLive: [
       ...bbcDomains,
+      'https://assets.wearehearken.eu',
+      'https://modules.wearehearken.eu',
+      'https://ems.wearehearken.eu',
       'https://*.chartbeat.com',
       'http://*.chartbeat.com', // for localhost canonical connecting via http
       'http://localhost:1124', // for localhost canonical JavaScript

--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -130,9 +130,6 @@ const directives = {
     ],
     canonicalLive: [
       ...bbcDomains,
-      'https://assets.wearehearken.eu',
-      'https://modules.wearehearken.eu',
-      'https://ems.wearehearken.eu',
       'https://chartbeat.com',
       'https://*.chartbeat.com',
       'https://www.youtube.com', // Social Embeds
@@ -157,9 +154,6 @@ const directives = {
     ],
     canonicalNonLive: [
       ...bbcDomains,
-      'https://assets.wearehearken.eu',
-      'https://modules.wearehearken.eu',
-      'https://ems.wearehearken.eu',
       'https://chartbeat.com',
       'https://*.chartbeat.com',
       'https://www.youtube.com', // Social Embeds

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -167,9 +167,6 @@ describe('cspHeader', () => {
       ],
       frameSrcExpectation: [
         ...bbcDomains,
-        'https://assets.wearehearken.eu',
-        'https://modules.wearehearken.eu',
-        'https://ems.wearehearken.eu',
         'https://chartbeat.com',
         'https://*.chartbeat.com',
         'https://www.youtube.com',
@@ -383,9 +380,6 @@ describe('cspHeader', () => {
       ],
       frameSrcExpectation: [
         ...bbcDomains,
-        'https://assets.wearehearken.eu',
-        'https://modules.wearehearken.eu',
-        'https://ems.wearehearken.eu',
         'https://chartbeat.com',
         'https://*.chartbeat.com',
         'https://www.youtube.com',

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -167,6 +167,9 @@ describe('cspHeader', () => {
       ],
       frameSrcExpectation: [
         ...bbcDomains,
+        'https://assets.wearehearken.eu',
+        'https://modules.wearehearken.eu',
+        'https://ems.wearehearken.eu',
         'https://chartbeat.com',
         'https://*.chartbeat.com',
         'https://www.youtube.com',
@@ -214,6 +217,9 @@ describe('cspHeader', () => {
       ],
       scriptSrcExpectation: [
         ...bbcDomains,
+        'https://assets.wearehearken.eu',
+        'https://modules.wearehearken.eu',
+        'https://ems.wearehearken.eu',
         'https://*.chartbeat.com',
         'https://platform.twitter.com',
         'https://www.instagram.com',
@@ -377,6 +383,9 @@ describe('cspHeader', () => {
       ],
       frameSrcExpectation: [
         ...bbcDomains,
+        'https://assets.wearehearken.eu',
+        'https://modules.wearehearken.eu',
+        'https://ems.wearehearken.eu',
         'https://chartbeat.com',
         'https://*.chartbeat.com',
         'https://www.youtube.com',
@@ -426,6 +435,9 @@ describe('cspHeader', () => {
       ],
       scriptSrcExpectation: [
         ...bbcDomains,
+        'https://assets.wearehearken.eu',
+        'https://modules.wearehearken.eu',
+        'https://ems.wearehearken.eu',
         'https://*.chartbeat.com',
         'http://*.chartbeat.com',
         'http://localhost:1124',


### PR DESCRIPTION
**Overall change:**
Adds Hearken sub-domains to our CSP header to allow includes to render

**Code changes:**

- Updates CSP header and relevant tests with the Hearken allowed sub-domains

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
