### PR TITLE
Remove flakey onDemandAudio and onDemand TV URLs

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1472,10 +1472,10 @@ module.exports = () => ({
               '/burmese/podcasts/p02pc9lh', // Podcast brand
               '/burmese/podcasts/p02pc9lh/p0967thw', // Podcast Episode
             ],
-            enabled: true,
+            enabled: false,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       onDemandTV: {
         environments: {

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -6862,14 +6862,14 @@ module.exports = () => ({
               '/somali/bbc_somali_tv/tv_programmes/w13xttqt', // Brand
               '/somali/bbc_somali_tv/tv/w172xtqvt5hrd9z', // Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: [
               '/somali/bbc_somali_tv/tv_programmes/w13xttqt', // Brand
               '/somali/bbc_somali_tv/tv/w172xtqvt5hrd9z', // Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: [
@@ -6878,7 +6878,7 @@ module.exports = () => ({
             enabled: false,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       mediaAssetPage: {
         environments: {
@@ -7199,7 +7199,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       mediaAssetPage: {
         environments: {

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1475,7 +1475,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       onDemandTV: {
         environments: {
@@ -2960,7 +2960,7 @@ module.exports = () => ({
               '/indonesia/podcasts/p02pc9v6', // Podcast Brand
               '/indonesia/podcasts/p02pc9v6/p09l1mhb', // Podcast Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: [
@@ -2969,7 +2969,7 @@ module.exports = () => ({
               '/indonesia/podcasts/p02pc9v6', // Podcast Brand
               '/indonesia/podcasts/p02pc9v6/p09l1mhb', // Podcast Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: [
@@ -5088,7 +5088,7 @@ module.exports = () => ({
               '/persian/podcasts/p02pc9wf', // Podcast Brand
               '/persian/podcasts/p02pc9wf/p09knl1v', // Podcast Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: [
@@ -5099,7 +5099,7 @@ module.exports = () => ({
               '/persian/podcasts/p02pc9wf', // Podcast Brand
               '/persian/podcasts/p02pc9wf/p09knl1v', // Podcast Episode
             ],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: [
@@ -5111,7 +5111,7 @@ module.exports = () => ({
             enabled: true,
           },
         },
-        smoke: false,
+        smoke: true,
       },
       onDemandTV: {
         environments: {

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -7196,10 +7196,10 @@ module.exports = () => ({
             paths: [
               '/swahili/bbc_swahili_tv/tv/w172xcqnsxfj1bk', // Episode
             ],
-            enabled: true,
+            enabled: false,
           },
         },
-        smoke: true,
+        smoke: false,
       },
       mediaAssetPage: {
         environments: {


### PR DESCRIPTION
**Overall change:**

Indonesia and Persian are two services we run the OD Audio tests on, but they fail occasionally on tests for the schedule and recent episodes list. We think this is because the time window sometimes means that sometimes there aren't enough recent items to show in the schedule or recent episodes, and then later as another episode becomes available there is enough data. The test runs on a page that is not rendering the most recent data (cached), so fails sometimes.

I have removed Indonesia and Persian from the list of services these tests are run on as these seem to be the tests that mainly have this problem (gathered from looking back at failures for a few days in the past. If another comes up, I can also remove that). It may be because of the nature of the broadcast schedules for these services that make the data vary more than other services.

Although the failures are usually on On Demand Audio pages, occasionally we also get an On Demand TV failure for Somali, so I have also removed that service.

In the case where one of these services was being used as a smoke test, I have selected another service to use as the smoke test instead. There are no ODTV smoke tests as all media on the local fixtures is unavailable and gives an error.


**Code changes:**

Trues changed to falses, for the environments and smoke toggle, to disable and enable


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
We will need to see it run a few times on AWS to check that the flakes do not still happen over different time periods.

Currently checking on computer