### PR TITLE
render loadable preload links

### DIFF
--- a/src/server/Document/component.jsx
+++ b/src/server/Document/component.jsx
@@ -12,7 +12,15 @@ import serialiseForScript from '#lib/utilities/serialiseForScript';
 import ResourceHints from '#app/components/ResourceHints';
 import IfAboveIE9 from '#app/components/IfAboveIE9Comment';
 
-const Document = ({ assetOrigins, app, data, helmet, isAmp, scripts }) => {
+const Document = ({
+  assetOrigins,
+  app,
+  data,
+  helmet,
+  isAmp,
+  scripts,
+  links,
+}) => {
   const htmlAttrs = helmet.htmlAttributes.toComponent();
   const meta = helmet.meta.toComponent();
   const title = helmet.title.toComponent();
@@ -40,6 +48,7 @@ const Document = ({ assetOrigins, app, data, helmet, isAmp, scripts }) => {
     <html lang="en-GB" {...noJsHtmlAttrs} {...htmlAttrs}>
       <head>
         {meta}
+        {links}
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
         <ResourceHints assetOrigins={assetOrigins} />
         {title}

--- a/src/server/Document/index.jsx
+++ b/src/server/Document/index.jsx
@@ -79,7 +79,6 @@ const renderDocument = async ({
   const doc = renderToStaticMarkup(
     <DocumentComponent
       assetOrigins={assetOrigins}
-      scriptPreloads={scripts}
       scripts={scripts}
       links={links}
       app={app}

--- a/src/server/Document/index.jsx
+++ b/src/server/Document/index.jsx
@@ -73,12 +73,15 @@ const renderDocument = async ({
     return commonAttributes;
   });
 
+  const links = extractor.getLinkElements();
   const headHelmet = Helmet.renderStatic();
   const assetOrigins = getAssetOrigins(service);
   const doc = renderToStaticMarkup(
     <DocumentComponent
       assetOrigins={assetOrigins}
+      scriptPreloads={scripts}
       scripts={scripts}
+      links={links}
       app={app}
       data={data}
       helmet={headHelmet}

--- a/src/server/Document/index.test.jsx
+++ b/src/server/Document/index.test.jsx
@@ -11,6 +11,7 @@ jest.mock('@loadable/server', () => ({
   ChunkExtractor: jest.fn().mockImplementation(() => ({
     collectChunks: arg => arg,
     getScriptElements: () => '__mock_script_elements__',
+    getLinkElements: () => '__mock_link_elements__',
   })),
 }));
 
@@ -73,6 +74,7 @@ describe('Render Document', () => {
         helmet: undefined,
         isAmp: false,
         scripts: '__mock_script_elements__',
+        links: '__mock_link_elements__',
         service: 'news',
       });
 

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -50,6 +50,7 @@ jest.mock('@loadable/server', () => ({
   ChunkExtractor: () => ({
     collectChunks: arg => arg,
     getScriptElements: () => '__mock_script_elements__',
+    getLinkElements: () => '__mock_link_elements__',
   }),
 }));
 
@@ -129,6 +130,7 @@ const testRenderedData =
         isAmp={isAmp}
         service={service}
         scripts="__mock_script_elements__"
+        links="__mock_link_elements__"
       />,
     );
 
@@ -1340,6 +1342,7 @@ describe('Server', () => {
             isAmp={isAmp}
             service={service}
             scripts="__mock_script_elements__"
+            links="__mock_link_elements__"
           />,
         );
 


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9637 also related to infra issue 1312

**Overall change:**
Renders loadable's preload link tags that include preload links to all critical JS.

This can improve metrics such as TTI. More info here https://web.dev/preload-critical-assets/#preloading-javascript-files and https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf

This also fixes an issue where fonts downloads were being prioritised over JS downloads. JS and fonts now download in parallel. Execution of JS is still deferred.

**On live showing font prioritisation**
<img width="243" alt="Screenshot 2021-11-05 at 08 53 20" src="https://user-images.githubusercontent.com/4798332/140484262-04373689-df8f-40a3-829e-e2a67075016a.png">

<img width="536" alt="Screenshot 2021-11-05 at 09 18 39" src="https://user-images.githubusercontent.com/4798332/140487837-c5f79e36-2fb7-4bc4-8a45-08433923c06f.png">


**These PR changes showing JS is now prioritised and downloads in parallel with fonts**
<img width="371" alt="Screenshot 2021-11-05 at 08 53 38" src="https://user-images.githubusercontent.com/4798332/140484348-49b96302-9526-4cea-b954-a19a2e799aa7.png">

<img width="470" alt="Screenshot 2021-11-05 at 09 20 48" src="https://user-images.githubusercontent.com/4798332/140487852-ac26a5bc-e16a-4887-9c91-64daa83a2e2c.png">

<img width="500" alt="Screenshot 2021-11-05 at 09 26 25" src="https://user-images.githubusercontent.com/4798332/140489648-e4969158-4854-4750-9d4f-2ab0776386f9.png">

**Code changes:**
- Use loadable's `extractor.getLinkElements()` to extract link elements
- place link elements in the head of the document.

**Example of preload links in head of the document**
<img width="848" alt="Screenshot 2021-11-04 at 14 29 50" src="https://user-images.githubusercontent.com/4798332/140332705-c2557f0b-7d2f-41e4-abc4-d85e785b208c.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
