### PR TITLE
Improve include fetch error logging

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/fetchMarkup/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/fetchMarkup/index.js
@@ -10,7 +10,7 @@ import { SECONDARY_DATA_TIMEOUT } from '#app/lib/utilities/getFetchTimeouts';
 
 const logger = nodeLogger(__filename);
 
-const fetchMarkup = async url => {
+const fetchMarkup = async (url, assetId) => {
   logger.info(INCLUDE_REQUEST_RECEIVED, {
     url,
   });
@@ -23,6 +23,7 @@ const fetchMarkup = async url => {
       logger.error(INCLUDE_FETCH_ERROR, {
         status: res.status,
         url,
+        assetId,
       });
       return null;
     }

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/index.js
@@ -25,6 +25,7 @@ const convertInclude = async (includeBlock, pageData, ...restParams) => {
   // This will most likely change in issue #6784 so it is temporary for now
   const pathname = restParams[1];
   const blocks = path(['content', 'blocks'], pageData);
+  const assetId = path(['metadata', 'id'], pageData);
 
   const isAmp = isAmpPath(pathname);
 
@@ -53,7 +54,10 @@ const convertInclude = async (includeBlock, pageData, ...restParams) => {
   }
 
   if (!isAmp) {
-    html = await fetchMarkup(buildIncludeUrl(href, includeType, pathname));
+    html = await fetchMarkup(
+      buildIncludeUrl(href, includeType, pathname),
+      assetId,
+    );
   }
 
   const imageBlock = getImageBlock(includeType, includeBlock, isAmp);


### PR DESCRIPTION
Resolves [No Issue]

**Overall change:**
Improve the logging when an include fetch error occurs - include the asset ID that is requesting the include, so we have an easier time debugging.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
