### PR TITLE
add crossorigin=anonymous to preload links

### DIFF
--- a/src/server/Document/index.jsx
+++ b/src/server/Document/index.jsx
@@ -11,6 +11,19 @@ import getAssetOrigins from '../utilities/getAssetOrigins';
 import DocumentComponent from './component';
 import encodeChunkFilename from '../utilities/encodeChunkUri';
 
+const crossOrigin = 'anonymous';
+
+const getScriptAttributes = chunk => ({
+  crossOrigin,
+  defer: true,
+  ...(chunk && chunk.url && { src: encodeChunkFilename(chunk) }),
+});
+
+const getLinkAttributes = chunk => ({
+  crossOrigin,
+  ...(chunk && chunk.url && { href: encodeChunkFilename(chunk) }),
+});
+
 const renderDocument = async ({
   bbcOrigin,
   data,
@@ -57,23 +70,8 @@ const renderDocument = async ({
     return { redirectUrl: context.url, html: null };
   }
 
-  const scripts = extractor.getScriptElements(chunk => {
-    const commonAttributes = {
-      crossOrigin: 'anonymous',
-      defer: true,
-    };
-
-    if (chunk && chunk.url) {
-      return {
-        ...commonAttributes,
-        src: encodeChunkFilename(chunk),
-      };
-    }
-
-    return commonAttributes;
-  });
-
-  const links = extractor.getLinkElements();
+  const scripts = extractor.getScriptElements(getScriptAttributes);
+  const links = extractor.getLinkElements(getLinkAttributes);
   const headHelmet = Helmet.renderStatic();
   const assetOrigins = getAssetOrigins(service);
   const doc = renderToStaticMarkup(


### PR DESCRIPTION
Relates to the work in this PR https://github.com/bbc/simorgh/pull/9640

**Overall change:**
Fixes preload link credentials not matching and preventing scripts from preloading by adding a crossorigin="anonymous" attribute to link elements in a similar way to scripts elements.

**Warning in console about preload links and the crossorigin attribute**
<img width="1631" alt="Screenshot 2021-11-09 at 09 44 00" src="https://user-images.githubusercontent.com/4798332/140901109-097e192e-2940-48d4-9440-b02c1404b6f0.png">

**Code changes:**

- Passes an attribute function to loadable's `getLinkElements` function that adds the crossorigin attribute.
- Refactors the attribute function for `getScriptElements` to be terser and in line with the `getLinkElements` attribute function.

**Preload links with these changes**
<img width="1140" alt="Screenshot 2021-11-09 at 09 52 19" src="https://user-images.githubusercontent.com/4798332/140902100-32869ddd-754c-44b8-88aa-eaf40b3b901f.png">

There are also no more warnings in the browser console after these changes.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
