### PR TITLE
fix ODTV Heading spacing

### DIFF
--- a/src/app/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly - dark mode 
   .emotion-2 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -193,7 +193,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
   .emotion-2 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 

--- a/src/app/containers/OnDemandHeading/index.jsx
+++ b/src/app/containers/OnDemandHeading/index.jsx
@@ -7,7 +7,6 @@ import {
   GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
-  GEL_SPACING_QUAD,
 } from '@bbc/gel-foundations/spacings';
 import {
   MEDIA_QUERY_TYPOGRAPHY,
@@ -29,7 +28,7 @@ const BrandTitle = styled.span`
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {
     padding-bottom: ${GEL_SPACING_DBL};
     word-break: break-word;
-    line-height: ${GEL_SPACING_QUAD};
+    line-height: 1.09;
   }
 `;
 

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
@@ -451,7 +451,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   .emotion-14 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -1385,7 +1385,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   .emotion-14 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -2299,7 +2299,7 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   .emotion-14 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -3155,7 +3155,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   .emotion-14 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 

--- a/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandTvPage/__snapshots__/index.test.jsx.snap
@@ -337,7 +337,7 @@ exports[`OnDemand TV Brand Page  Dark Mode Design - should match snapshot 1`] = 
   .emotion-21 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -932,7 +932,7 @@ exports[`should show the expired content message if episode is expired 1`] = `
   .emotion-18 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -1517,7 +1517,7 @@ exports[`should show the future content message if episode is not yet available 
   .emotion-18 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 
@@ -2102,7 +2102,7 @@ exports[`should show the future content message if episode is pending 1`] = `
   .emotion-18 {
     padding-bottom: 1rem;
     word-break: break-word;
-    line-height: 2rem;
+    line-height: 1.09;
   }
 }
 


### PR DESCRIPTION
Resolves #9647 

**Overall change:**
Line height changed to 1.09 for 1008px screens or larger as from [Zeplin](https://app.zeplin.io/project/5d4d77b1fcbfc79bf47e0294/screen/5f9afa83abff6a1fa7f2c4e7)

**Code changes:**
As above

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
