### PR TITLE
Removes yarn cache check for offline install test

### DIFF
--- a/scripts/installNodeModules.sh
+++ b/scripts/installNodeModules.sh
@@ -2,5 +2,5 @@
 if [ "$1" = "--production" ]; then
   rm -rf node_modules | yarn workspaces focus --all --production
 else
-  rm -rf node_modules | yarn install --immutable --check-cache
+  rm -rf node_modules | yarn install --immutable
 fi


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Removes the cache integrity check for testing offline cache

**Code changes:**

- Removes `--check-cache` from yarn install bash script

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
