### PR TITLE
Localise English strings in Burmese podcast promo string

### DIFF
--- a/src/app/lib/config/services/burmese.js
+++ b/src/app/lib/config/services/burmese.js
@@ -61,12 +61,12 @@ export const service = {
     showAdPlaceholder: false,
     showRelatedTopics: true,
     podcastPromo: {
-      title: 'ပေါ့တ်ကာစ်',
-      brandTitle: 'Burmese Evening Podcast',
-      brandDescription: 'Up-to-date news and current affairs in Burmese',
+      title: 'ပေါ့ဒ်ကတ်စ်',
+      brandTitle: 'ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်',
+      brandDescription: 'နောက်ဆုံးရ သတင်းနဲ့ မျက်မှောက်ရေးရာအစီအစဉ်များ',
       image: {
         src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p02h1lyd.jpg',
-        alt: 'Burmese Evening Podcast',
+        alt: 'ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်',
       },
       linkLabel: {
         text: 'ပေါ့ဒ်ကတ်စ်အစီအစဉ်များ',


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Updated Burmese podcast promo replacing existing English text with their Burmese translation

**Code changes:**

- Added Burmese translations for Heading, Podcast title, Podcast description and Image Alt text

The promo sandbox screenshot attached has been reviewed and approved by the Burmese Service editor

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
![burmese_podcast_promo](https://user-images.githubusercontent.com/10046386/141778388-8a7856dc-108d-4154-80fe-e682c44ace9c.jpg)

