### PR TITLE
Adding additional external platforms to BBC Marathi podcasts

### DIFF
--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/marathi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/marathi.js
@@ -10,6 +10,14 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%A4-%E0%A4%A8-%E0%A4%97-%E0%A4%B7-%E0%A4%9F/id1550093946',
       },
+      {
+        linkText: 'Gaana',
+        linkUrl: 'https://gaana.com/podcast/-season-1-2021-17',
+      },
+      {
+        linkText: 'JioSaavn',
+        linkUrl: 'https://www.jiosaavn.com/shows/तीन-गोष्टी/1/5k2iS6,xzZc_',
+      },
     ],
     p09437hm: [
       {
@@ -21,6 +29,14 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%B8-%E0%A4%AA-%E0%A4%97-%E0%A4%B7-%E0%A4%9F/id1550094137',
       },
+      {
+        linkText: 'Gaana',
+        linkUrl: 'https://gaana.com/podcast/-season-1-2021-18',
+      },
+      {
+        linkText: 'JioSaavn',
+        linkUrl: 'https://www.jiosaavn.com/shows/सोपी-गोष्ट/1/kVtGnMWt4kE_',
+      },
     ],
     p0b1s4nm: [
       {
@@ -31,6 +47,15 @@ const externalLinks = {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%97-%E0%A4%B7-%E0%A4%9F-%E0%A4%A6-%E0%A4%A8-%E0%A4%AF-%E0%A4%9A/id1595097031',
+      },
+      {
+        linkText: 'Gaana',
+        linkUrl: 'https://gaana.com/podcast/-season-1-2021-271',
+      },
+      {
+        linkText: 'JioSaavn',
+        linkUrl:
+          'https://www.jiosaavn.com/shows/%E0%A4%97%E0%A5%8B%E0%A4%B7%E0%A5%8D%E0%A4%9F-%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A5%87%E0%A4%9A%E0%A5%80/1/NeVi8wudirQ_',
       },
     ],
   },


### PR DESCRIPTION
Resolves #NUMBER

**Adding additional external platforms to BBC Marathi podcasts:**
Adding Gaana and JioSaavn external links to three Marathi podcasts

**Code changes:**

- adding key/value pairs to object in src/app/routes/onDemandAudio/tempData/podcastExternalLinks/marathi.js



---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
