### PR TITLE
use index if available for promo id

### DIFF
--- a/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsFeaturesAnalysis/__snapshots__/index.test.jsx.snap
@@ -696,12 +696,12 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledafirika23252735"
+                  aria-labelledby="promo-igboafirika23252735-1"
                   class="emotion-39 emotion-40"
                   href="/igbo/afirika-23252735"
                 >
                   <span
-                    id="promo-link-unlabelledafirika23252735"
+                    id="promo-igboafirika23252735-1"
                   >
                     STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?
                   </span>
@@ -756,12 +756,12 @@ exports[`CpsRelatedContent should render Story Feature components when given app
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledafirika49666505"
+                  aria-labelledby="promo-igboafirika49666505-2"
                   class="emotion-39 emotion-40"
                   href="/igbo/afirika-49666505"
                 >
                   <span
-                    id="promo-link-unlabelledafirika49666505"
+                    id="promo-igboafirika49666505-2"
                   >
                     Robert Mugabe: Zimbabwe eferela nwa amadi a aka
                   </span>
@@ -1480,12 +1480,12 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                 class="emotion-35 emotion-36"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledafirika23252735"
+                  aria-labelledby="promo-igboafirika23252735-1"
                   class="emotion-37 emotion-38"
                   href="/igbo/afirika-23252735"
                 >
                   <span
-                    id="promo-link-unlabelledafirika23252735"
+                    id="promo-igboafirika23252735-1"
                   >
                     STY - Ọrụ bekee na ịrụrụ onwe gị ọrụ, kedụ nk?
                   </span>

--- a/src/app/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/containers/CpsFeaturesAnalysis/index.jsx
@@ -27,10 +27,11 @@ const PromoListComponent = ({ promoItems, dir }) => {
 
   return (
     <StoryPromoUl>
-      {promoItems.map(item => (
+      {promoItems.map((item, index) => (
         <StoryPromoLi key={item.id || item.uri} ref={viewRef}>
           <StoryPromo
             item={item}
+            index={index}
             dir={dir}
             displayImage
             displaySummary={false}

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
@@ -351,12 +351,12 @@ exports[`RelatedContentPromo it renders a Story Promo wrapped in a Grid componen
           class="emotion-14 emotion-15"
         >
           <a
-            aria-labelledby="promo-link-unlabelled44508901"
+            aria-labelledby="promo-pidgin44508901-1"
             class="emotion-16 emotion-17"
             href="/pidgin/44508901"
           >
             <span
-              id="promo-link-unlabelled44508901"
+              id="promo-pidgin44508901-1"
               role="text"
             >
               <span>

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
@@ -427,12 +427,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
-              aria-labelledby="promo-link-rel-content44508901"
+              aria-labelledby="promo-rel-content-pidgin44508901-1"
               class="emotion-21 emotion-22"
               href="/pidgin/44508901"
             >
               <span
-                id="promo-link-rel-content44508901"
+                id="promo-rel-content-pidgin44508901-1"
                 role="text"
               >
                 <span>
@@ -491,12 +491,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
-              aria-labelledby="promo-link-rel-contenttori46975713"
+              aria-labelledby="promo-rel-content-pidgintori46975713-2"
               class="emotion-21 emotion-22"
               href="/pidgin/tori-46975713"
             >
               <span
-                id="promo-link-rel-contenttori46975713"
+                id="promo-rel-content-pidgintori46975713-2"
               >
                 How light companies dey use estimated billing show Nigerians pepper
               </span>
@@ -552,12 +552,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
             class="emotion-19 emotion-20"
           >
             <a
-              aria-labelledby="promo-link-rel-contenttori42494678"
+              aria-labelledby="promo-rel-content-pidgintori42494678-3"
               class="emotion-21 emotion-22"
               href="/pidgin/tori-42494678"
             >
               <span
-                id="promo-link-rel-contenttori42494678"
+                id="promo-rel-content-pidgintori42494678-3"
               >
                 Nigeria: Wetin 5,222 megawatts electric fit do?
               </span>
@@ -989,12 +989,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
-              aria-labelledby="promo-link-rel-content44508901"
+              aria-labelledby="promo-rel-content-pidgin44508901-1"
               class="emotion-20 emotion-21"
               href="/pidgin/44508901"
             >
               <span
-                id="promo-link-rel-content44508901"
+                id="promo-rel-content-pidgin44508901-1"
                 role="text"
               >
                 <span>
@@ -1053,12 +1053,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
-              aria-labelledby="promo-link-rel-contenttori46975713"
+              aria-labelledby="promo-rel-content-pidgintori46975713-2"
               class="emotion-20 emotion-21"
               href="/pidgin/tori-46975713"
             >
               <span
-                id="promo-link-rel-contenttori46975713"
+                id="promo-rel-content-pidgintori46975713-2"
               >
                 How light companies dey use estimated billing show Nigerians pepper
               </span>
@@ -1114,12 +1114,12 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
             class="emotion-18 emotion-19"
           >
             <a
-              aria-labelledby="promo-link-rel-contenttori42494678"
+              aria-labelledby="promo-rel-content-pidgintori42494678-3"
               class="emotion-20 emotion-21"
               href="/pidgin/tori-42494678"
             >
               <span
-                id="promo-link-rel-contenttori42494678"
+                id="promo-rel-content-pidgintori42494678-3"
               >
                 Nigeria: Wetin 5,222 megawatts electric fit do?
               </span>

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromoList/index.jsx
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromoList/index.jsx
@@ -51,7 +51,7 @@ const RelatedContentPromoList = ({
       as={isMediaContent ? MostWatchedOl : StoryPromoUl}
       enableGelGutters
     >
-      {promoItems.map(item => (
+      {promoItems.map((item, index) => (
         <Grid
           item
           columns={{
@@ -68,6 +68,7 @@ const RelatedContentPromoList = ({
         >
           <StoryPromo
             item={item}
+            index={index}
             dir={dir}
             displaySummary={false}
             isSingleColumnLayout={isMediaContent}

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -805,12 +805,12 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-rel-content44508901"
+                  aria-labelledby="promo-rel-content-pidgin44508901-1"
                   class="emotion-41 emotion-42"
                   href="/pidgin/44508901"
                 >
                   <span
-                    id="promo-link-rel-content44508901"
+                    id="promo-rel-content-pidgin44508901-1"
                     role="text"
                   >
                     <span>
@@ -869,12 +869,12 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-rel-contenttori46975713"
+                  aria-labelledby="promo-rel-content-pidgintori46975713-2"
                   class="emotion-41 emotion-42"
                   href="/pidgin/tori-46975713"
                 >
                   <span
-                    id="promo-link-rel-contenttori46975713"
+                    id="promo-rel-content-pidgintori46975713-2"
                   >
                     How light companies dey use estimated billing show Nigerians pepper
                   </span>
@@ -930,12 +930,12 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 class="emotion-39 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-rel-contenttori42494678"
+                  aria-labelledby="promo-rel-content-pidgintori42494678-3"
                   class="emotion-41 emotion-42"
                   href="/pidgin/tori-42494678"
                 >
                   <span
-                    id="promo-link-rel-contenttori42494678"
+                    id="promo-rel-content-pidgintori42494678-3"
                   >
                     Nigeria: Wetin 5,222 megawatts electric fit do?
                   </span>
@@ -1714,12 +1714,12 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelled44508901"
+                  aria-labelledby="promo-pidgin44508901-1"
                   class="emotion-39 emotion-40"
                   href="/pidgin/44508901"
                 >
                   <span
-                    id="promo-link-unlabelled44508901"
+                    id="promo-pidgin44508901-1"
                     role="text"
                   >
                     <span>

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -615,12 +615,12 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
-                  aria-labelledby="promo-link-unlabellednoticiasinternacional51939501"
+                  aria-labelledby="promo-mundonoticiasinternacional51939501-1"
                   class="emotion-31 emotion-32"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
-                    id="promo-link-unlabellednoticiasinternacional51939501"
+                    id="promo-mundonoticiasinternacional51939501-1"
                   >
                     China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
                   </span>
@@ -650,12 +650,12 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledtori51945757"
+                  aria-labelledby="promo-pidgintori51945757-1"
                   class="emotion-31 emotion-32"
                   href="/pidgin/tori-51945757"
                 >
                   <span
-                    id="promo-link-unlabelledtori51945757"
+                    id="promo-pidgintori51945757-1"
                   >
                     Nigeria don get five new cases of Coronavirus - See how e happun
                   </span>
@@ -1254,12 +1254,12 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
                 class="emotion-27 emotion-28"
               >
                 <a
-                  aria-labelledby="promo-link-unlabellednoticiasinternacional51939501"
+                  aria-labelledby="promo-mundonoticiasinternacional51939501-1"
                   class="emotion-29 emotion-30"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
-                    id="promo-link-unlabellednoticiasinternacional51939501"
+                    id="promo-mundonoticiasinternacional51939501-1"
                   >
                     China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
                   </span>

--- a/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
@@ -880,12 +880,12 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
           class="emotion-46 emotion-47"
         >
           <a
-            aria-labelledby="promo-link-unlabelledw13xttn1limit4Video"
+            aria-labelledby="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-1"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
             <span
-              id="promo-link-unlabelledw13xttn1limit4Video"
+              id="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-1"
             >
               سیربین ٹی وی پروگرام آن ڈیمانڈ
             </span>
@@ -1550,12 +1550,12 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
           class="emotion-7 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44416820Text"
+            aria-labelledby="promo-pidginsport44416820-text-1"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
             <span
-              id="promo-link-unlabelledsport44416820Text"
+              id="promo-pidginsport44416820-text-1"
             >
               Take dis predictor choose who go reach World Cup final
             </span>
@@ -1663,12 +1663,12 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
           class="emotion-42 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledpidginAudio"
+            aria-labelledby="promo-pidgin-audio-1"
             class="emotion-9 emotion-10"
             href="http://www.bbc.com/pidgin"
           >
             <span
-              id="promo-link-unlabelledpidginAudio"
+              id="promo-pidgin-audio-1"
             >
               Audio promo
             </span>
@@ -2481,12 +2481,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
-            aria-labelledby="promo-link-unlabelledw13xttn1limit4Video"
+            aria-labelledby="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-2"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
             <span
-              id="promo-link-unlabelledw13xttn1limit4Video"
+              id="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-2"
             >
               سیربین ٹی وی پروگرام آن ڈیمانڈ
             </span>
@@ -2547,12 +2547,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
-            aria-labelledby="promo-link-unlabelledpakistan48346840Text"
+            aria-labelledby="promo-urdupakistan48346840-text-3"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/pakistan-48346840"
           >
             <span
-              id="promo-link-unlabelledpakistan48346840Text"
+              id="promo-urdupakistan48346840-text-3"
             >
               رمضان، عید اور سپیشل پکوان
             </span>
@@ -2613,12 +2613,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
           class="emotion-46 emotion-47"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport48361817Text"
+            aria-labelledby="promo-urdusport48361817-text-4"
             class="emotion-48 emotion-49"
             href="https://www.bbc.com/urdu/sport-48361817"
           >
             <span
-              id="promo-link-unlabelledsport48361817Text"
+              id="promo-urdusport48361817-text-4"
             >
               کرکٹ ورلڈ کپ پر بی بی سی اردو کا خصوصی ضمیمہ
             </span>
@@ -3071,12 +3071,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44416820Text"
+            aria-labelledby="promo-pidginsport44416820-text-1"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
             <span
-              id="promo-link-unlabelledsport44416820Text"
+              id="promo-pidginsport44416820-text-1"
             >
               Take dis predictor choose who go reach World Cup final
             </span>
@@ -3159,12 +3159,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
-            aria-labelledby="promo-link-unlabelledpidginAudio"
+            aria-labelledby="promo-pidgin-audio-2"
             class="emotion-17 emotion-18"
             href="http://www.bbc.com/pidgin"
           >
             <span
-              id="promo-link-unlabelledpidginAudio"
+              id="promo-pidgin-audio-2"
             >
               Audio promo
             </span>
@@ -3225,12 +3225,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44439411Text"
+            aria-labelledby="promo-pidginsport44439411-text-3"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44439411"
           >
             <span
-              id="promo-link-unlabelledsport44439411Text"
+              id="promo-pidginsport44439411-text-3"
             >
               World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?
             </span>
@@ -3286,12 +3286,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44425543Text"
+            aria-labelledby="promo-pidginsport44425543-text-4"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44425543"
           >
             <span
-              id="promo-link-unlabelledsport44425543Text"
+              id="promo-pidginsport44425543-text-4"
             >
               Select your best ever African 11 players for World Cup
             </span>
@@ -4092,12 +4092,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
-            aria-labelledby="promo-link-unlabelledw13xttn1limit4Video"
+            aria-labelledby="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-2"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/bbc_urdu_tv/tv_programmes/w13xttn1?limit=4"
           >
             <span
-              id="promo-link-unlabelledw13xttn1limit4Video"
+              id="promo-urdubbc_urdu_tvtv_programmesw13xttn1limit4-video-2"
             >
               سیربین ٹی وی پروگرام آن ڈیمانڈ
             </span>
@@ -4128,12 +4128,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
-            aria-labelledby="promo-link-unlabelledpakistan48346840Text"
+            aria-labelledby="promo-urdupakistan48346840-text-3"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/pakistan-48346840"
           >
             <span
-              id="promo-link-unlabelledpakistan48346840Text"
+              id="promo-urdupakistan48346840-text-3"
             >
               رمضان، عید اور سپیشل پکوان
             </span>
@@ -4164,12 +4164,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
           class="emotion-38 emotion-39"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport48361817Text"
+            aria-labelledby="promo-urdusport48361817-text-4"
             class="emotion-40 emotion-41"
             href="https://www.bbc.com/urdu/sport-48361817"
           >
             <span
-              id="promo-link-unlabelledsport48361817Text"
+              id="promo-urdusport48361817-text-4"
             >
               کرکٹ ورلڈ کپ پر بی بی سی اردو کا خصوصی ضمیمہ
             </span>
@@ -4583,12 +4583,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44416820Text"
+            aria-labelledby="promo-pidginsport44416820-text-1"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
             <span
-              id="promo-link-unlabelledsport44416820Text"
+              id="promo-pidginsport44416820-text-1"
             >
               Take dis predictor choose who go reach World Cup final
             </span>
@@ -4645,12 +4645,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledpidginAudio"
+            aria-labelledby="promo-pidgin-audio-2"
             class="emotion-9 emotion-10"
             href="http://www.bbc.com/pidgin"
           >
             <span
-              id="promo-link-unlabelledpidginAudio"
+              id="promo-pidgin-audio-2"
             >
               Audio promo
             </span>
@@ -4681,12 +4681,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44439411Text"
+            aria-labelledby="promo-pidginsport44439411-text-3"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44439411"
           >
             <span
-              id="promo-link-unlabelledsport44439411Text"
+              id="promo-pidginsport44439411-text-3"
             >
               World Cup 2018 Quiz: You fit name all di players wey don score Super Eagles goal for World Cup?
             </span>
@@ -4717,12 +4717,12 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
           class="emotion-7 emotion-8"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44425543Text"
+            aria-labelledby="promo-pidginsport44425543-text-4"
             class="emotion-9 emotion-10"
             href="https://www.bbc.com/pidgin/sport-44425543"
           >
             <span
-              id="promo-link-unlabelledsport44425543Text"
+              id="promo-pidginsport44425543-text-4"
             >
               Select your best ever African 11 players for World Cup
             </span>
@@ -5551,12 +5551,12 @@ exports[`FrontPageStoryRows Container - snapshots TopRow 1`] = `
           class="emotion-15 emotion-16"
         >
           <a
-            aria-labelledby="promo-link-unlabelledsport44416820Text"
+            aria-labelledby="promo-pidginsport44416820-text-1"
             class="emotion-17 emotion-18"
             href="https://www.bbc.com/pidgin/sport-44416820"
           >
             <span
-              id="promo-link-unlabelledsport44416820Text"
+              id="promo-pidginsport44416820-text-1"
             >
               Take dis predictor choose who go reach World Cup final
             </span>

--- a/src/app/containers/FrontPageStoryRows/index.jsx
+++ b/src/app/containers/FrontPageStoryRows/index.jsx
@@ -17,6 +17,7 @@ const isBulletin = item =>
 
 const renderPromo = ({
   item,
+  index,
   promoType = 'regular',
   isFirstSection = false,
   dir,
@@ -30,6 +31,7 @@ const renderPromo = ({
     <StoryPromoContainer
       labelId={labelId}
       item={item}
+      index={index}
       promoType={promoType}
       lazyLoadImage={lazyLoadImage}
       dir={dir}
@@ -164,6 +166,7 @@ export const RegularRow = ({
           border={border}
         >
           {renderPromo({
+            index: i,
             item: story,
             dir,
             displayImage: displayImages,

--- a/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -1018,12 +1018,12 @@ HTMLCollection [
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledwwwbbccouk"
+                  aria-labelledby="promo-1"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-unlabelledwwwbbccouk"
+                    id="promo-1"
                   >
                     Top Story 1 headline
                   </span>
@@ -1084,12 +1084,12 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-1"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-1"
                   >
                     Top Story 2 headline
                   </span>
@@ -1150,12 +1150,12 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-2"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-2"
                   >
                     Top Story 3 headline
                   </span>
@@ -1216,12 +1216,12 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-3"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-3"
                   >
                     Top Story 4 headline
                   </span>
@@ -1282,12 +1282,12 @@ HTMLCollection [
                 class="emotion-60 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-4"
                   class="emotion-39 emotion-40"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-4"
                   >
                     Top Story 5 headline
                   </span>
@@ -2349,12 +2349,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-39 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledwwwbbccouk"
+                  aria-labelledby="promo-1"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-unlabelledwwwbbccouk"
+                    id="promo-1"
                   >
                     Top Story 1 headline
                   </span>
@@ -2415,12 +2415,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-1"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-1"
                   >
                     Top Story 2 headline
                   </span>
@@ -2481,12 +2481,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-2"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-2"
                   >
                     Top Story 3 headline
                   </span>
@@ -2547,12 +2547,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-3"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-3"
                   >
                     Top Story 4 headline
                   </span>
@@ -2613,12 +2613,12 @@ exports[`IndexPageSection Container snapshots should render correctly for canoni
                 class="emotion-62 emotion-40"
               >
                 <a
-                  aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                  aria-labelledby="promo-top-stories-4"
                   class="emotion-41 emotion-42"
                   href="https://www.bbc.co.uk"
                 >
                   <span
-                    id="promo-link-Top-Storieswwwbbccouk"
+                    id="promo-top-stories-4"
                   >
                     Top Story 5 headline
                   </span>
@@ -3607,12 +3607,12 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
               class="emotion-26 emotion-27"
             >
               <a
-                aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                aria-labelledby="promo-top-stories-1"
                 class="emotion-28 emotion-29"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-Top-Storieswwwbbccouk"
+                  id="promo-top-stories-1"
                 >
                   Top Story 1 headline
                 </span>
@@ -3698,12 +3698,12 @@ exports[`IndexPageSection Container snapshots should render correctly with a lin
               class="emotion-57 emotion-27"
             >
               <a
-                aria-labelledby="promo-link-unlabelledwwwbbccouk"
+                aria-labelledby="promo-1"
                 class="emotion-28 emotion-29"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-unlabelledwwwbbccouk"
+                  id="promo-1"
                 >
                   Top Story 2 headline
                 </span>
@@ -4240,12 +4240,12 @@ exports[`IndexPageSection Container snapshots should render with only one item 1
             class="emotion-33 emotion-34"
           >
             <a
-              aria-labelledby="promo-link-unlabelledwwwbbccouk"
+              aria-labelledby="promo-1"
               class="emotion-35 emotion-36"
               href="https://www.bbc.co.uk"
             >
               <span
-                id="promo-link-unlabelledwwwbbccouk"
+                id="promo-1"
               >
                 Top Story 1 headline
               </span>
@@ -5249,12 +5249,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-32 emotion-33"
             >
               <a
-                aria-labelledby="promo-link-unlabelledwwwbbccouk"
+                aria-labelledby="promo-1"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-unlabelledwwwbbccouk"
+                  id="promo-1"
                 >
                   Top Story 1 headline
                 </span>
@@ -5315,12 +5315,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
-                aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                aria-labelledby="promo-top-stories-1"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-Top-Storieswwwbbccouk"
+                  id="promo-top-stories-1"
                 >
                   Top Story 2 headline
                 </span>
@@ -5381,12 +5381,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
-                aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                aria-labelledby="promo-top-stories-2"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-Top-Storieswwwbbccouk"
+                  id="promo-top-stories-2"
                 >
                   Top Story 3 headline
                 </span>
@@ -5447,12 +5447,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
-                aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                aria-labelledby="promo-top-stories-3"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-Top-Storieswwwbbccouk"
+                  id="promo-top-stories-3"
                 >
                   Top Story 4 headline
                 </span>
@@ -5513,12 +5513,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               class="emotion-55 emotion-33"
             >
               <a
-                aria-labelledby="promo-link-Top-Storieswwwbbccouk"
+                aria-labelledby="promo-top-stories-4"
                 class="emotion-34 emotion-35"
                 href="https://www.bbc.co.uk"
               >
                 <span
-                  id="promo-link-Top-Storieswwwbbccouk"
+                  id="promo-top-stories-4"
                 >
                   Top Story 5 headline
                 </span>

--- a/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -386,12 +386,12 @@ exports[`StoryPromo Container should render audio correctly for amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -810,12 +810,12 @@ exports[`StoryPromo Container should render audio correctly for canonical 1`] = 
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -1198,12 +1198,12 @@ exports[`StoryPromo Container should render audio promoType leading on amp 1`] =
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -1684,12 +1684,12 @@ exports[`StoryPromo Container should render audio promoType top on amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -2100,12 +2100,12 @@ exports[`StoryPromo Container should render audio with no duration correctly for
         class="emotion-18 emotion-19"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -2509,12 +2509,12 @@ exports[`StoryPromo Container should render audio with no duration correctly for
         class="emotion-18 emotion-19"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -2888,12 +2888,12 @@ exports[`StoryPromo Container should render audio with no duration promoType lea
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -3353,12 +3353,12 @@ exports[`StoryPromo Container should render audio with no duration promoType top
         class="emotion-18 emotion-19"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-20 emotion-21"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -3680,12 +3680,12 @@ exports[`StoryPromo Container should render featureLink correctly for amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriFeature"
+          aria-labelledby="promo-azeri-feature-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriFeature"
+            id="promo-azeri-feature-1"
           >
             Feature promo with summary
           </span>
@@ -3997,12 +3997,12 @@ exports[`StoryPromo Container should render featureLink correctly for canonical 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriFeature"
+          aria-labelledby="promo-azeri-feature-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriFeature"
+            id="promo-azeri-feature-1"
           >
             Feature promo with summary
           </span>
@@ -4311,12 +4311,12 @@ exports[`StoryPromo Container should render featureLink promoType leading on amp
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriFeature"
+          aria-labelledby="promo-azeri-feature-1"
           class="emotion-6 emotion-7"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriFeature"
+            id="promo-azeri-feature-1"
           >
             Feature promo with summary
           </span>
@@ -4657,12 +4657,12 @@ exports[`StoryPromo Container should render featureLink promoType top on amp 1`]
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriFeature"
+          aria-labelledby="promo-azeri-feature-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriFeature"
+            id="promo-azeri-feature-1"
           >
             Feature promo with summary
           </span>
@@ -4982,12 +4982,12 @@ exports[`StoryPromo Container should render full width promos correctly for amp 
         class="emotion-13 emotion-14"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-15 emotion-16"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -5305,12 +5305,12 @@ exports[`StoryPromo Container should render full width promos correctly for cano
         class="emotion-13 emotion-14"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-15 emotion-16"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -5614,12 +5614,12 @@ exports[`StoryPromo Container should render item without an image correctly for 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -5923,12 +5923,12 @@ exports[`StoryPromo Container should render item without an image correctly for 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -6237,12 +6237,12 @@ exports[`StoryPromo Container should render item without an image promoType lead
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -6563,12 +6563,12 @@ exports[`StoryPromo Container should render item without an image promoType top 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -6867,12 +6867,12 @@ exports[`StoryPromo Container should render live correctly for amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -7172,12 +7172,12 @@ exports[`StoryPromo Container should render live correctly for canonical 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -7474,12 +7474,12 @@ exports[`StoryPromo Container should render live promoType leading on amp 1`] = 
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -7808,12 +7808,12 @@ exports[`StoryPromo Container should render live promoType top on amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -8243,12 +8243,12 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -8616,12 +8616,12 @@ exports[`StoryPromo Container should render podcastLink correctly for amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledmedia45640737Podcast"
+          aria-labelledby="promo-indonesiamedia45640737-podcast-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
           <span
-            id="promo-link-unlabelledmedia45640737Podcast"
+            id="promo-indonesiamedia45640737-podcast-1"
           >
             Test indonesian podcast
           </span>
@@ -8895,12 +8895,12 @@ exports[`StoryPromo Container should render podcastLink correctly for canonical 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledmedia45640737Podcast"
+          aria-labelledby="promo-indonesiamedia45640737-podcast-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
           <span
-            id="promo-link-unlabelledmedia45640737Podcast"
+            id="promo-indonesiamedia45640737-podcast-1"
           >
             Test indonesian podcast
           </span>
@@ -9179,12 +9179,12 @@ exports[`StoryPromo Container should render podcastLink promoType leading on amp
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledmedia45640737Podcast"
+          aria-labelledby="promo-indonesiamedia45640737-podcast-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
           <span
-            id="promo-link-unlabelledmedia45640737Podcast"
+            id="promo-indonesiamedia45640737-podcast-1"
           >
             Test indonesian podcast
           </span>
@@ -9475,12 +9475,12 @@ exports[`StoryPromo Container should render podcastLink promoType top on amp 1`]
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledmedia45640737Podcast"
+          aria-labelledby="promo-indonesiamedia45640737-podcast-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.com/indonesia/media-45640737"
         >
           <span
-            id="promo-link-unlabelledmedia45640737Podcast"
+            id="promo-indonesiamedia45640737-podcast-1"
           >
             Test indonesian podcast
           </span>
@@ -9788,12 +9788,12 @@ exports[`StoryPromo Container should render standard correctly for amp 1`] = `
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -10105,12 +10105,12 @@ exports[`StoryPromo Container should render standard correctly for canonical 1`]
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -10419,12 +10419,12 @@ exports[`StoryPromo Container should render standard promoType leading on amp 1`
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -10765,12 +10765,12 @@ exports[`StoryPromo Container should render standard promoType top on amp 1`] = 
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -11084,12 +11084,12 @@ exports[`StoryPromo Container should render standardLink correctly for amp 1`] =
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriText"
+          aria-labelledby="promo-azeri-text-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriText"
+            id="promo-azeri-text-1"
           >
             Standard promo with summary
           </span>
@@ -11401,12 +11401,12 @@ exports[`StoryPromo Container should render standardLink correctly for canonical
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriText"
+          aria-labelledby="promo-azeri-text-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriText"
+            id="promo-azeri-text-1"
           >
             Standard promo with summary
           </span>
@@ -11715,12 +11715,12 @@ exports[`StoryPromo Container should render standardLink promoType leading on am
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriText"
+          aria-labelledby="promo-azeri-text-1"
           class="emotion-6 emotion-7"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriText"
+            id="promo-azeri-text-1"
           >
             Standard promo with summary
           </span>
@@ -12061,12 +12061,12 @@ exports[`StoryPromo Container should render standardLink promoType top on amp 1`
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledazeriText"
+          aria-labelledby="promo-azeri-text-1"
           class="emotion-14 emotion-15"
           href="http://www.bbc.com/azeri"
         >
           <span
-            id="promo-link-unlabelledazeriText"
+            id="promo-azeri-text-1"
           >
             Standard promo with summary
           </span>
@@ -12380,12 +12380,12 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -12697,12 +12697,12 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -13011,12 +13011,12 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType l
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -13357,12 +13357,12 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType t
         class="emotion-12 emotion-13"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-14 emotion-15"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
           >
             A headline
           </span>
@@ -13767,12 +13767,12 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -14188,12 +14188,12 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -14576,12 +14576,12 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
         class="emotion-4 emotion-5"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-6 emotion-7"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span
@@ -15056,12 +15056,12 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
         class="emotion-20 emotion-21"
       >
         <a
-          aria-labelledby="promo-link-unlabelledwwwbbccouk"
+          aria-labelledby="promo-1"
           class="emotion-22 emotion-23"
           href="https://www.bbc.co.uk"
         >
           <span
-            id="promo-link-unlabelledwwwbbccouk"
+            id="promo-1"
             role="text"
           >
             <span

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -105,7 +105,7 @@ const StoryPromoContainer = ({
   const { pageType } = useContext(RequestContext);
   const handleClickTracking = useCombinedClickTrackerHandler(eventTrackingData);
 
-  const linkId = buildUniquePromoId(item, labelId);
+  const linkId = buildUniquePromoId(labelId, item, index); // TODO add promo index here
 
   const liveLabel = pathOr('LIVE', ['media', 'liveLabel'], translations);
 

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { shape, bool, oneOf, oneOfType, string } from 'prop-types';
+import { shape, bool, oneOf, oneOfType, string, number } from 'prop-types';
 import styled from '@emotion/styled';
 import StoryPromo, { Headline, Summary, Link } from '@bbc/psammead-story-promo';
 import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
@@ -91,6 +91,7 @@ StoryPromoImage.defaultProps = {
 
 const StoryPromoContainer = ({
   item,
+  index,
   promoType,
   lazyLoadImage,
   dir,
@@ -290,6 +291,7 @@ StoryPromoContainer.propTypes = {
     }),
   }),
   labelId: string,
+  index: number,
 };
 
 StoryPromoContainer.defaultProps = {
@@ -301,7 +303,8 @@ StoryPromoContainer.defaultProps = {
   isSingleColumnLayout: false,
   serviceDatetimeLocale: null,
   eventTrackingData: null,
-  labelId: 'unlabelled',
+  labelId: '',
+  index: 0,
 };
 
 export default StoryPromoContainer;

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -106,7 +106,7 @@ const StoryPromoContainer = ({
   const { pageType } = useContext(RequestContext);
   const handleClickTracking = useCombinedClickTrackerHandler(eventTrackingData);
 
-  const linkId = buildUniquePromoId(labelId, item, index); // TODO add promo index here
+  const linkId = buildUniquePromoId(labelId, item, index);
 
   const liveLabel = pathOr('LIVE', ['media', 'liveLabel'], translations);
 

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -24,7 +24,7 @@ import MediaIndicatorContainer from './MediaIndicator';
 import IndexAlsosContainer from './IndexAlsos';
 import loggerNode from '#lib/logger.node';
 import { MEDIA_MISSING } from '#lib/logger.const';
-import { getHeadingTagOverride, getUniqueLinkId } from './utilities';
+import { getHeadingTagOverride, buildUniquePromoId } from './utilities';
 import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import useCombinedClickTrackerHandler from './useCombinedClickTrackerHandler';
 import PromoTimestamp from './Timestamp';
@@ -105,7 +105,7 @@ const StoryPromoContainer = ({
   const { pageType } = useContext(RequestContext);
   const handleClickTracking = useCombinedClickTrackerHandler(eventTrackingData);
 
-  const linkId = getUniqueLinkId(item, labelId);
+  const linkId = buildUniquePromoId(item, labelId);
 
   const liveLabel = pathOr('LIVE', ['media', 'liveLabel'], translations);
 

--- a/src/app/containers/StoryPromo/index.test.jsx
+++ b/src/app/containers/StoryPromo/index.test.jsx
@@ -28,7 +28,7 @@ import {
 } from './helpers/fixtureData';
 import StoryPromoContainer from '.';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
-import { getUniqueLinkId } from './utilities';
+import { buildUniquePromoId } from './utilities';
 
 const onlyOneRelatedItem = {
   ...indexAlsosItem,
@@ -157,8 +157,8 @@ describe('StoryPromo Container', () => {
     it('should render h3, a, p, time', () => {
       const labelId = `unlabelled`;
 
-      const uriLabelId = getUniqueLinkId(assetTypeItem, labelId);
-      const assetUriId = getUniqueLinkId(cpsItem, labelId);
+      const uriLabelId = buildUniquePromoId(assetTypeItem, labelId);
+      const assetUriId = buildUniquePromoId(cpsItem, labelId);
 
       expect(cpsContainer.querySelectorAll('h3 a')[0].innerHTML).toEqual(
         `<span id="${assetUriId}">${cpsItem.headlines.headline}</span>`,

--- a/src/app/containers/StoryPromo/index.test.jsx
+++ b/src/app/containers/StoryPromo/index.test.jsx
@@ -136,29 +136,30 @@ describe('StoryPromo Container', () => {
     let cpsContainer;
     let overtypedSummaryContainer;
     let assetTypeContainer;
+    const labelId = `test-group-id`;
 
     beforeEach(() => {
       cpsItem = deepClone(completeItem);
-      cpsContainer = render(<WrappedStoryPromo item={cpsItem} />).container;
+      cpsContainer = render(
+        <WrappedStoryPromo item={cpsItem} labelId={labelId} />,
+      ).container;
 
       overtypedSummaryItem = deepClone(itemWithOvertypedSummary);
       overtypedSummaryContainer = render(
-        <WrappedStoryPromo item={overtypedSummaryItem} />,
+        <WrappedStoryPromo item={overtypedSummaryItem} labelId={labelId} />,
       ).container;
 
       assetTypeItem = deepClone(standardLinkItem);
       assetTypeContainer = render(
-        <WrappedStoryPromo item={assetTypeItem} />,
+        <WrappedStoryPromo item={assetTypeItem} labelId={labelId} />,
       ).container;
     });
 
     afterEach(cleanup);
 
     it('should render h3, a, p, time', () => {
-      const labelId = `unlabelled`;
-
-      const uriLabelId = buildUniquePromoId(assetTypeItem, labelId);
-      const assetUriId = buildUniquePromoId(cpsItem, labelId);
+      const uriLabelId = buildUniquePromoId(labelId, assetTypeItem);
+      const assetUriId = buildUniquePromoId(labelId, cpsItem);
 
       expect(cpsContainer.querySelectorAll('h3 a')[0].innerHTML).toEqual(
         `<span id="${assetUriId}">${cpsItem.headlines.headline}</span>`,

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -28,7 +28,9 @@ export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex = 0) => {
   const assetUri = pathOr('', ['locators', 'assetUri'], promoItem);
   const uri = pathOr('', ['uri'], promoItem);
-  const assetId = (assetUri || uri).replace(/\W/g, '').split('/').pop();
+  const asset = assetUri || uri;
+  const assetParts = asset.split(/www\.bbc\.(co\.uk|com)/);
+  const assetId = assetParts[assetParts.length - 1].replace(/\W/g, '');
   const contentType = pathOr('', ['contentType'], promoItem);
 
   return ['promo', promoGroupId, assetId, contentType, promoIndex + 1]

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -25,12 +25,15 @@ export const getHeadingTagOverride = ({ pageType, isContentTypeGuide }) => {
 
 export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 
-export const getUniqueLinkId = (item, labelId) => {
+export const buildUniquePromoId = (item, labelId) => {
+  const id = pathOr('', ['id'], item);
   const assetUri = pathOr('', ['locators', 'assetUri'], item);
-  const contentType = pathOr('', ['contentType'], item);
   const uri = pathOr('', ['uri'], item);
-  const uniqueId = assetUri || uri;
-  const assetId = uniqueId.split('/').pop();
-  const sanitisedId = assetId.replace(/\W/g, '');
-  return `promo-link-${labelId}${sanitisedId || ''}${contentType}`;
+  const assetId = (id || assetUri || uri).replace(/\W/g, '').split('/').pop();
+  const contentType = pathOr('', ['contentType'], item);
+
+  return ['promo', labelId, assetId, contentType]
+    .filter(Boolean)
+    .join('-')
+    .toLowerCase();
 };

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -25,14 +25,13 @@ export const getHeadingTagOverride = ({ pageType, isContentTypeGuide }) => {
 
 export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 
-export const buildUniquePromoId = (item, labelId) => {
-  const id = pathOr('', ['id'], item);
-  const assetUri = pathOr('', ['locators', 'assetUri'], item);
-  const uri = pathOr('', ['uri'], item);
-  const assetId = (id || assetUri || uri).replace(/\W/g, '').split('/').pop();
-  const contentType = pathOr('', ['contentType'], item);
+export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex) => {
+  const assetUri = pathOr('', ['locators', 'assetUri'], promoItem);
+  const uri = pathOr('', ['uri'], promoItem);
+  const assetId = (assetUri || uri).replace(/\W/g, '').split('/').pop();
+  const contentType = pathOr('', ['contentType'], promoItem);
 
-  return ['promo', labelId, assetId, contentType]
+  return ['promo', promoGroupId, assetId, contentType, promoIndex]
     .filter(Boolean)
     .join('-')
     .toLowerCase();

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -25,13 +25,13 @@ export const getHeadingTagOverride = ({ pageType, isContentTypeGuide }) => {
 
 export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 
-export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex) => {
+export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex = 0) => {
   const assetUri = pathOr('', ['locators', 'assetUri'], promoItem);
   const uri = pathOr('', ['uri'], promoItem);
   const assetId = (assetUri || uri).replace(/\W/g, '').split('/').pop();
   const contentType = pathOr('', ['contentType'], promoItem);
 
-  return ['promo', promoGroupId, assetId, contentType, promoIndex]
+  return ['promo', promoGroupId, assetId, contentType, promoIndex + 1]
     .filter(Boolean)
     .join('-')
     .toLowerCase();

--- a/src/app/containers/StoryPromo/utilities/index.test.js
+++ b/src/app/containers/StoryPromo/utilities/index.test.js
@@ -78,28 +78,28 @@ describe('getHeadingTagOverride', () => {
 });
 
 describe('buildUniquePromoId', () => {
-  const labelId = 'unlabelled';
+  const labelId = 'test-group-id';
   it('should return id of promo-link with contentType and URI if contentType exists', () => {
     expect(buildUniquePromoId(labelId, secondaryColumnNoAssetURI, 0)).toEqual(
-      'promo-unlabelled-httpswwwbbccouknews-radiobulletin-1',
+      'promo-test-group-id-news-radiobulletin-1',
     );
   });
 
   it('should return id using URI if assetURI does not exist', () => {
     expect(buildUniquePromoId(labelId, standardLinkItem, 1)).toEqual(
-      'promo-unlabelled-httpwwwbbccomazeri-text-2',
+      'promo-test-group-id-azeri-text-2',
     );
   });
 
   it('should return id using assetURI does not exist and contentType does not exist', () => {
     expect(buildUniquePromoId(labelId, completeItem, 2)).toEqual(
-      'promo-unlabelled-httpswwwbbccouk-3',
+      'promo-test-group-id-3',
     );
   });
 
   it('should return id with contentType only if assetURI and URI do not exist', () => {
     expect(buildUniquePromoId(labelId, secondaryColumnContentType, 3)).toEqual(
-      'promo-unlabelled-radiobulletin-4',
+      'promo-test-group-id-radiobulletin-4',
     );
   });
 
@@ -110,6 +110,6 @@ describe('buildUniquePromoId', () => {
         { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
         4,
       ),
-    ).toEqual('promo-unlabelled-aaabbbccc-5');
+    ).toEqual('promo-test-group-id-aaabbbccc-5');
   });
 });

--- a/src/app/containers/StoryPromo/utilities/index.test.js
+++ b/src/app/containers/StoryPromo/utilities/index.test.js
@@ -1,4 +1,4 @@
-import { isMap, isPgl, getHeadingTagOverride, getUniqueLinkId } from '.';
+import { isMap, isPgl, getHeadingTagOverride, buildUniquePromoId } from '.';
 import {
   MOST_WATCHED_PAGE,
   PHOTO_GALLERY_PAGE,
@@ -77,35 +77,38 @@ describe('getHeadingTagOverride', () => {
   });
 });
 
-describe('getUniqueLinkId', () => {
+describe('buildUniquePromoId', () => {
   const labelId = 'unlabelled';
   it('should return id of promo-link with contentType and URI if contentType exists', () => {
-    expect(getUniqueLinkId(secondaryColumnNoAssetURI, labelId)).toEqual(
-      'promo-link-unlabellednewsRadioBulletin',
+    expect(buildUniquePromoId(secondaryColumnNoAssetURI, labelId)).toEqual(
+      'promo-unlabelled-httpswwwbbccouknews-radiobulletin',
     );
   });
 
   it('should return id using URI if assetURI does not exist', () => {
-    expect(getUniqueLinkId(standardLinkItem, labelId)).toEqual(
-      'promo-link-unlabelledazeriText',
+    expect(buildUniquePromoId(standardLinkItem, labelId)).toEqual(
+      'promo-unlabelled-httpwwwbbccomazeri-text',
     );
   });
 
   it('should return id using assetURI does not exist and contentType does not exist', () => {
-    expect(getUniqueLinkId(completeItem, labelId)).toEqual(
-      'promo-link-unlabelledwwwbbccouk',
+    expect(buildUniquePromoId(completeItem, labelId)).toEqual(
+      'promo-unlabelled-httpswwwbbccouk',
     );
   });
 
   it('should return id with contentType only if assetURI and URI do not exist', () => {
-    expect(getUniqueLinkId(secondaryColumnContentType, labelId)).toEqual(
-      'promo-link-unlabelledRadioBulletin',
+    expect(buildUniquePromoId(secondaryColumnContentType, labelId)).toEqual(
+      'promo-unlabelled-radiobulletin',
     );
   });
 
   it('should sanitise link from item and split from last forward slash', () => {
     expect(
-      getUniqueLinkId({ locators: { assetUri: 'a/a/ab.b.b@c@c@c' } }, labelId),
-    ).toEqual('promo-link-unlabelledabbbccc');
+      buildUniquePromoId(
+        { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
+        labelId,
+      ),
+    ).toEqual('promo-unlabelled-aaabbbccc');
   });
 });

--- a/src/app/containers/StoryPromo/utilities/index.test.js
+++ b/src/app/containers/StoryPromo/utilities/index.test.js
@@ -80,35 +80,36 @@ describe('getHeadingTagOverride', () => {
 describe('buildUniquePromoId', () => {
   const labelId = 'unlabelled';
   it('should return id of promo-link with contentType and URI if contentType exists', () => {
-    expect(buildUniquePromoId(secondaryColumnNoAssetURI, labelId)).toEqual(
-      'promo-unlabelled-httpswwwbbccouknews-radiobulletin',
+    expect(buildUniquePromoId(labelId, secondaryColumnNoAssetURI, 0)).toEqual(
+      'promo-unlabelled-httpswwwbbccouknews-radiobulletin-1',
     );
   });
 
   it('should return id using URI if assetURI does not exist', () => {
-    expect(buildUniquePromoId(standardLinkItem, labelId)).toEqual(
-      'promo-unlabelled-httpwwwbbccomazeri-text',
+    expect(buildUniquePromoId(labelId, standardLinkItem, 1)).toEqual(
+      'promo-unlabelled-httpwwwbbccomazeri-text-2',
     );
   });
 
   it('should return id using assetURI does not exist and contentType does not exist', () => {
-    expect(buildUniquePromoId(completeItem, labelId)).toEqual(
-      'promo-unlabelled-httpswwwbbccouk',
+    expect(buildUniquePromoId(labelId, completeItem, 2)).toEqual(
+      'promo-unlabelled-httpswwwbbccouk-3',
     );
   });
 
   it('should return id with contentType only if assetURI and URI do not exist', () => {
-    expect(buildUniquePromoId(secondaryColumnContentType, labelId)).toEqual(
-      'promo-unlabelled-radiobulletin',
+    expect(buildUniquePromoId(labelId, secondaryColumnContentType, 3)).toEqual(
+      'promo-unlabelled-radiobulletin-4',
     );
   });
 
   it('should sanitise link from item and split from last forward slash', () => {
     expect(
       buildUniquePromoId(
-        { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
         labelId,
+        { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
+        4,
       ),
-    ).toEqual('promo-unlabelled-aaabbbccc');
+    ).toEqual('promo-unlabelled-aaabbbccc-5');
   });
 });

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -2446,12 +2446,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabelledafghanistan52735886"
+                  aria-labelledby="promo-persianafghanistan52735886-1"
                   class="emotion-39 emotion-40"
                   href="/persian/afghanistan-52735886"
                 >
                   <span
-                    id="promo-link-unlabelledafghanistan52735886"
+                    id="promo-persianafghanistan52735886-1"
                   >
                     رهبر طالبان به آمریکا: اجازه ندهید موافقتنامه‌مان با ناکامی رو به رو شود؛ ارگ: پیام رهبر طالبان ارزش ندارد
                   </span>
@@ -2582,12 +2582,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-37 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabelledafghanistan52726383"
+                    aria-labelledby="promo-persianafghanistan52726383-1"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52726383"
                   >
                     <span
-                      id="promo-link-unlabelledafghanistan52726383"
+                      id="promo-persianafghanistan52726383-1"
                       role="text"
                     >
                       <span
@@ -2691,12 +2691,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-WatchListenafghanistan52710877"
+                    aria-labelledby="promo-watchlisten-persianafghanistan52710877-1"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52710877"
                   >
                     <span
-                      id="promo-link-WatchListenafghanistan52710877"
+                      id="promo-watchlisten-persianafghanistan52710877-1"
                       role="text"
                     >
                       <span
@@ -2800,12 +2800,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-WatchListenafghanistan52699256"
+                    aria-labelledby="promo-watchlisten-persianafghanistan52699256-2"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52699256"
                   >
                     <span
-                      id="promo-link-WatchListenafghanistan52699256"
+                      id="promo-watchlisten-persianafghanistan52699256-2"
                       role="text"
                     >
                       <span
@@ -2909,12 +2909,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-WatchListenafghanistan52651714"
+                    aria-labelledby="promo-watchlisten-persianafghanistan52651714-3"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52651714"
                   >
                     <span
-                      id="promo-link-WatchListenafghanistan52651714"
+                      id="promo-watchlisten-persianafghanistan52651714-3"
                       role="text"
                     >
                       <span
@@ -3018,12 +3018,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-WatchListenafghanistan52640314"
+                    aria-labelledby="promo-watchlisten-persianafghanistan52640314-4"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52640314"
                   >
                     <span
-                      id="promo-link-WatchListenafghanistan52640314"
+                      id="promo-watchlisten-persianafghanistan52640314-4"
                       role="text"
                     >
                       <span
@@ -3703,12 +3703,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-37 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabelledafghanistan52722865"
+                    aria-labelledby="promo-persianafghanistan52722865-1"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52722865"
                   >
                     <span
-                      id="promo-link-unlabelledafghanistan52722865"
+                      id="promo-persianafghanistan52722865-1"
                     >
                       پشت پرده توافق غنی و عبدالله؛ مارشال شدن دوستم و ماجراهای دیگر
                     </span>
@@ -3769,12 +3769,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresafghanistan52697976"
+                    aria-labelledby="promo-features-persianafghanistan52697976-1"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52697976"
                   >
                     <span
-                      id="promo-link-Featuresafghanistan52697976"
+                      id="promo-features-persianafghanistan52697976-1"
                     >
                       کرونا گردشگران را در افغانستان زمین‌گیر کرد
                     </span>
@@ -3835,12 +3835,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresblogviewpoints52616632"
+                    aria-labelledby="promo-features-persianblogviewpoints52616632-2"
                     class="emotion-39 emotion-40"
                     href="/persian/blog-viewpoints-52616632"
                   >
                     <span
-                      id="promo-link-Featuresblogviewpoints52616632"
+                      id="promo-features-persianblogviewpoints52616632-2"
                     >
                       ناظران می‌گویند؛ توافقنامه غنی و عبدالله؛ آخرین میخ بر تابوت دموکراسی افغانستان؟
                     </span>
@@ -3901,12 +3901,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresafghanistan52700014"
+                    aria-labelledby="promo-features-persianafghanistan52700014-3"
                     class="emotion-39 emotion-40"
                     href="/persian/afghanistan-52700014"
                   >
                     <span
-                      id="promo-link-Featuresafghanistan52700014"
+                      id="promo-features-persianafghanistan52700014-3"
                     >
                       توافق‌نامه غنی و عبدالله؛ اختلاف چه بود و چگونه حل شد؟
                     </span>
@@ -3967,12 +3967,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   class="emotion-122 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresblogviewpoints52692067"
+                    aria-labelledby="promo-features-persianblogviewpoints52692067-4"
                     class="emotion-39 emotion-40"
                     href="/persian/blog-viewpoints-52692067"
                   >
                     <span
-                      id="promo-link-Featuresblogviewpoints52692067"
+                      id="promo-features-persianblogviewpoints52692067-4"
                     >
                       'آرمان ایران، داشتن نفوذ شبیه عراق در افغانستان نیست'
                     </span>
@@ -5991,12 +5991,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                 class="emotion-37 emotion-38"
               >
                 <a
-                  aria-labelledby="promo-link-unlabellednewsrussian52721557"
+                  aria-labelledby="promo-ukrainiannewsrussian52721557-1"
                   class="emotion-39 emotion-40"
                   href="/ukrainian/news-russian-52721557"
                 >
                   <span
-                    id="promo-link-unlabellednewsrussian52721557"
+                    id="promo-ukrainiannewsrussian52721557-1"
                   >
                     Правительство запустит общественный транспорт. Но не во всех областях
                   </span>
@@ -6107,12 +6107,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Verticalsfeaturesrussian52261329"
+                    aria-labelledby="promo-verticals-ukrainianfeaturesrussian52261329-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52261329"
                   >
                     <span
-                      id="promo-link-Verticalsfeaturesrussian52261329"
+                      id="promo-verticals-ukrainianfeaturesrussian52261329-1"
                     >
                       Как не спиться на карантине
                     </span>
@@ -6198,12 +6198,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabelledfeaturesrussian52357130"
+                    aria-labelledby="promo-ukrainianfeaturesrussian52357130-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52357130"
                   >
                     <span
-                      id="promo-link-unlabelledfeaturesrussian52357130"
+                      id="promo-ukrainianfeaturesrussian52357130-1"
                     >
                       Как наш характер меняется с возрастом. Спойлер - мы становимся добрее. Но почему?
                     </span>
@@ -6280,12 +6280,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsnewsrussian52663545"
+                    aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52663545-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52663545"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsnewsrussian52663545"
+                      id="promo-also-in-the-news-ukrainiannewsrussian52663545-1"
                     >
                       IKEA запустила продажи в Украине: как покупать и где получать
                     </span>
@@ -6371,12 +6371,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabelledvertfutrussian52663551"
+                    aria-labelledby="promo-ukrainianvertfutrussian52663551-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/vert-fut-russian-52663551"
                   >
                     <span
-                      id="promo-link-unlabelledvertfutrussian52663551"
+                      id="promo-ukrainianvertfutrussian52663551-1"
                     >
                       38 дней в океане: как семья выжила после кораблекрушения
                     </span>
@@ -6437,12 +6437,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsfeaturesrussian52633464"
+                    aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52633464-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52633464"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsfeaturesrussian52633464"
+                      id="promo-also-in-the-news-ukrainianfeaturesrussian52633464-1"
                     >
                       Как Минск стал спасительным хабом для застрявших за рубежом украинцев
                     </span>
@@ -6503,12 +6503,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsnewsrussian52647120"
+                    aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52647120-2"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52647120"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsnewsrussian52647120"
+                      id="promo-also-in-the-news-ukrainiannewsrussian52647120-2"
                     >
                       Кличко просит правительство открыть метро с 25 мая
                     </span>
@@ -6569,12 +6569,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsnewsrussian52493624"
+                    aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52493624-3"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52493624"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsnewsrussian52493624"
+                      id="promo-also-in-the-news-ukrainiannewsrussian52493624-3"
                     >
                       Можно обнимать внуков: ученые говорят, что маленькие дети не передают коронавирус
                     </span>
@@ -6635,12 +6635,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsfeaturesrussian52395098"
+                    aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52395098-4"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52395098"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsfeaturesrussian52395098"
+                      id="promo-also-in-the-news-ukrainianfeaturesrussian52395098-4"
                     >
                       Мог ли коронавирус "убежать" из лаборатории?
                     </span>
@@ -6701,12 +6701,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsnewsrussian52443350"
+                    aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52443350-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52443350"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsnewsrussian52443350"
+                      id="promo-also-in-the-news-ukrainiannewsrussian52443350-1"
                     >
                       Правительство хочет открыть сотни рынков - несмотря на карантин
                     </span>
@@ -6767,12 +6767,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsfeaturesrussian52339462"
+                    aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52339462-2"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52339462"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsfeaturesrussian52339462"
+                      id="promo-also-in-the-news-ukrainianfeaturesrussian52339462-2"
                     >
                       Фейки о коронавирусе в соцсетях: 7 правил информационной гигиены
                     </span>
@@ -6833,12 +6833,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsfeaturesrussian52336989"
+                    aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52336989-3"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52336989"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsfeaturesrussian52336989"
+                      id="promo-also-in-the-news-ukrainianfeaturesrussian52336989-3"
                     >
                       Пожары, пылевая буря, смог: почему это происходит
                     </span>
@@ -6899,12 +6899,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Also-in-the-newsfeaturesrussian52344279"
+                    aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52344279-4"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52344279"
                   >
                     <span
-                      id="promo-link-Also-in-the-newsfeaturesrussian52344279"
+                      id="promo-also-in-the-news-ukrainianfeaturesrussian52344279-4"
                     >
                       Какие симптомы коронавируса
                     </span>
@@ -7019,12 +7019,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-37 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabelledfeaturesrussian50186307"
+                    aria-labelledby="promo-ukrainianfeaturesrussian50186307-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-50186307"
                   >
                     <span
-                      id="promo-link-unlabelledfeaturesrussian50186307"
+                      id="promo-ukrainianfeaturesrussian50186307-1"
                     >
                       Фотограф потратил год, чтобы сделать идеальное фото белок
                     </span>
@@ -7085,12 +7085,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Picture-galleriesfeaturesrussian49780932"
+                    aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49780932-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49780932"
                   >
                     <span
-                      id="promo-link-Picture-galleriesfeaturesrussian49780932"
+                      id="promo-picture-galleries-ukrainianfeaturesrussian49780932-1"
                     >
                       Украинка, фотографирующая сестер Кардашьян: в "голых" съемках главное - доверие
                     </span>
@@ -7151,12 +7151,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Picture-galleriesfeaturesrussian49621722"
+                    aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49621722-2"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49621722"
                   >
                     <span
-                      id="promo-link-Picture-galleriesfeaturesrussian49621722"
+                      id="promo-picture-galleries-ukrainianfeaturesrussian49621722-2"
                     >
                       Вернувшиеся домой. Фото
                     </span>
@@ -7217,12 +7217,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Picture-galleriesnewsrussian49613573"
+                    aria-labelledby="promo-picture-galleries-ukrainiannewsrussian49613573-3"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-49613573"
                   >
                     <span
-                      id="promo-link-Picture-galleriesnewsrussian49613573"
+                      id="promo-picture-galleries-ukrainiannewsrussian49613573-3"
                     >
                       Фото дня: принцесса Шарлотта впервые пошла в школу
                     </span>
@@ -7283,12 +7283,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Picture-galleriesfeaturesrussian49382281"
+                    aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49382281-4"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-49382281"
                   >
                     <span
-                      id="promo-link-Picture-galleriesfeaturesrussian49382281"
+                      id="promo-picture-galleries-ukrainianfeaturesrussian49382281-4"
                     >
                       Человек, который сделал 90 тысяч фото котов
                     </span>
@@ -7365,12 +7365,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-83 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresfeaturesrussian52653319"
+                    aria-labelledby="promo-features-ukrainianfeaturesrussian52653319-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52653319"
                   >
                     <span
-                      id="promo-link-Featuresfeaturesrussian52653319"
+                      id="promo-features-ukrainianfeaturesrussian52653319-1"
                     >
                       "Не надо шляться по брифингам!" Министр Степанов - своим оппонентам
                     </span>
@@ -7456,12 +7456,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-unlabellednewsrussian52675911"
+                    aria-labelledby="promo-ukrainiannewsrussian52675911-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52675911"
                   >
                     <span
-                      id="promo-link-unlabellednewsrussian52675911"
+                      id="promo-ukrainiannewsrussian52675911-1"
                     >
                       Действительно ли Германия заблокировала "Северный поток-2"? Объясняет Лана Зеркаль
                     </span>
@@ -7522,12 +7522,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresnewsrussian52688931"
+                    aria-labelledby="promo-features-ukrainiannewsrussian52688931-1"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52688931"
                   >
                     <span
-                      id="promo-link-Featuresnewsrussian52688931"
+                      id="promo-features-ukrainiannewsrussian52688931-1"
                     >
                       Клинические испытания ремдесивира для лечения Covid-19 свернули. Почему?
                     </span>
@@ -7588,12 +7588,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresfeaturesrussian52620256"
+                    aria-labelledby="promo-features-ukrainianfeaturesrussian52620256-2"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52620256"
                   >
                     <span
-                      id="promo-link-Featuresfeaturesrussian52620256"
+                      id="promo-features-ukrainianfeaturesrussian52620256-2"
                     >
                       Лечение коронавируса при помощи антител: нас спасут ламы?
                     </span>
@@ -7654,12 +7654,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresnewsrussian52597888"
+                    aria-labelledby="promo-features-ukrainiannewsrussian52597888-3"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/news-russian-52597888"
                   >
                     <span
-                      id="promo-link-Featuresnewsrussian52597888"
+                      id="promo-features-ukrainiannewsrussian52597888-3"
                     >
                       11 мая в Украине ослабляют карантин. Что разрешат, а что - нет
                     </span>
@@ -7720,12 +7720,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   class="emotion-114 emotion-38"
                 >
                   <a
-                    aria-labelledby="promo-link-Featuresfeaturesrussian52573535"
+                    aria-labelledby="promo-features-ukrainianfeaturesrussian52573535-4"
                     class="emotion-39 emotion-40"
                     href="/ukrainian/features-russian-52573535"
                   >
                     <span
-                      id="promo-link-Featuresfeaturesrussian52573535"
+                      id="promo-features-ukrainianfeaturesrussian52573535-4"
                     >
                       Коронавирус мутирует: ученые думают о последствиях
                     </span>

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -4375,12 +4375,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contenttori23145776"
+                            aria-labelledby="promo-rel-content-pidgintori23145776-1"
                             class="emotion-266 emotion-267"
                             href="/pidgin/tori-23145776"
                           >
                             <span
-                              id="promo-link-rel-contenttori23145776"
+                              id="promo-rel-content-pidgintori23145776-1"
                             >
                               Police Arrest 3 ontop Anambra Church Attack
                             </span>
@@ -4436,12 +4436,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contenttori23143754"
+                            aria-labelledby="promo-rel-content-pidgintori23143754-2"
                             class="emotion-266 emotion-267"
                             href="/pidgin/tori-23143754"
                           >
                             <span
-                              id="promo-link-rel-contenttori23143754"
+                              id="promo-rel-content-pidgintori23143754-2"
                             >
                               Lagos 'Gay' men Appear for Court, say Dem no dey Guilty
                             </span>
@@ -4518,12 +4518,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-content23146654"
+                            aria-labelledby="promo-rel-content-pidgin23146654-3"
                             class="emotion-266 emotion-267"
                             href="/pidgin/23146654"
                           >
                             <span
-                              id="promo-link-rel-content23146654"
+                              id="promo-rel-content-pidgin23146654-3"
                               role="text"
                             >
                               <span
@@ -4620,12 +4620,12 @@ exports[`Media Asset Page should render component 1`] = `
                           class="emotion-264 emotion-265"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentmedia23147054"
+                            aria-labelledby="promo-rel-content-pidginmedia23147054-4"
                             class="emotion-266 emotion-267"
                             href="/pidgin/media-23147054"
                           >
                             <span
-                              id="promo-link-rel-contentmedia23147054"
+                              id="promo-rel-content-pidginmedia23147054-4"
                               role="text"
                             >
                               <span

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -825,12 +825,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
-                        aria-labelledby="promo-link-rel-contentmedia53580248"
+                        aria-labelledby="promo-rel-content-pidginmedia53580248-1"
                         class="emotion-40 emotion-41"
                         href="/pidgin/media-53580248"
                       >
                         <span
-                          id="promo-link-rel-contentmedia53580248"
+                          id="promo-rel-content-pidginmedia53580248-1"
                           role="text"
                         >
                           <span
@@ -918,12 +918,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
-                        aria-labelledby="promo-link-rel-contentmedia53591139"
+                        aria-labelledby="promo-rel-content-pidginmedia53591139-2"
                         class="emotion-40 emotion-41"
                         href="/pidgin/media-53591139"
                       >
                         <span
-                          id="promo-link-rel-contentmedia53591139"
+                          id="promo-rel-content-pidginmedia53591139-2"
                           role="text"
                         >
                           <span
@@ -1011,12 +1011,12 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
                       class="emotion-38 emotion-39"
                     >
                       <a
-                        aria-labelledby="promo-link-rel-contenttori53509788"
+                        aria-labelledby="promo-rel-content-pidgintori53509788-3"
                         class="emotion-40 emotion-41"
                         href="/pidgin/tori-53509788"
                       >
                         <span
-                          id="promo-link-rel-contenttori53509788"
+                          id="promo-rel-content-pidgintori53509788-3"
                           role="text"
                         >
                           <span

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -6351,12 +6351,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           class="emotion-235 emotion-236"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentmedia45132087"
+                            aria-labelledby="promo-rel-content-pidginmedia45132087-1"
                             class="emotion-237 emotion-238"
                             href="/pidgin/media-45132087"
                           >
                             <span
-                              id="promo-link-rel-contentmedia45132087"
+                              id="promo-rel-content-pidginmedia45132087-1"
                               role="text"
                             >
                               <span>
@@ -6436,12 +6436,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           class="emotion-235 emotion-236"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contenttori45242255"
+                            aria-labelledby="promo-rel-content-pidgintori45242255-2"
                             class="emotion-237 emotion-238"
                             href="/pidgin/tori-45242255"
                           >
                             <span
-                              id="promo-link-rel-contenttori45242255"
+                              id="promo-rel-content-pidgintori45242255-2"
                               role="text"
                             >
                               <span
@@ -11291,12 +11291,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan44124647"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan44124647-1"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44124647"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan44124647"
+                              id="promo-rel-content-azeriazerbaijan44124647-1"
                             >
                               ADR və Qazaxdan Qarsadək müsəlman dəhlizi ideyası
                             </span>
@@ -11352,12 +11352,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan43540056"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan43540056-2"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43540056"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan43540056"
+                              id="promo-rel-content-azeriazerbaijan43540056-2"
                             >
                               ADR-100: Türk Əsgəri üçün Cəbrayıl çörəyi
                             </span>
@@ -11413,12 +11413,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan44022776"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan44022776-3"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44022776"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan44022776"
+                              id="promo-rel-content-azeriazerbaijan44022776-3"
                             >
                               Borçalı: Tortdan hərəyə bir tikə - təkbaşına isə onu yemək olmaz
                             </span>
@@ -11474,12 +11474,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan43713137"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan43713137-4"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43713137"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan43713137"
+                              id="promo-rel-content-azeriazerbaijan43713137-4"
                             >
                               Cümhuriyyət hökuməti Azərbaycanı necə idarə edirdi? İlk 6 ayın hadisələri
                             </span>
@@ -11535,12 +11535,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan37688691"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan37688691-5"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-37688691"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan37688691"
+                              id="promo-rel-content-azeriazerbaijan37688691-5"
                             >
                               1918-1991: Bir müstəqilliyin iki bəyanı
                             </span>
@@ -11596,12 +11596,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan37691096"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan37691096-6"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-37691096"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan37691096"
+                              id="promo-rel-content-azeriazerbaijan37691096-6"
                               role="text"
                             >
                               <span>
@@ -11660,12 +11660,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan43499221"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan43499221-7"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43499221"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan43499221"
+                              id="promo-rel-content-azeriazerbaijan43499221-7"
                             >
                               1918-ci ilə baxış: Mayın 28-nə aparan o yaz günlərində həyat necə idi?
                             </span>
@@ -11721,12 +11721,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan44004471"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan44004471-8"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-44004471"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan44004471"
+                              id="promo-rel-content-azeriazerbaijan44004471-8"
                             >
                               #ADR100 Zaqatala: Azərbaycanın qalib gəldiyi mübahisə
                             </span>
@@ -11782,12 +11782,12 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           class="emotion-449 emotion-450"
                         >
                           <a
-                            aria-labelledby="promo-link-rel-contentazerbaijan43870815"
+                            aria-labelledby="promo-rel-content-azeriazerbaijan43870815-9"
                             class="emotion-451 emotion-452"
                             href="/azeri/azerbaijan-43870815"
                           >
                             <span
-                              id="promo-link-rel-contentazerbaijan43870815"
+                              id="promo-rel-content-azeriazerbaijan43870815-9"
                             >
                               Cümhuriyyət hökumətinin İranla əlaqələri necə idi?
                             </span>

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2880,12 +2880,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabelled23182501"
+                                aria-labelledby="promo-igbo23182501-1"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23182501"
                               >
                                 <span
-                                  id="promo-link-unlabelled23182501"
+                                  id="promo-igbo23182501-1"
                                 >
                                   DSS: Wepụ aka enwe n'ofe na Benue
                                 </span>
@@ -2915,12 +2915,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabelledinstitutional23162153"
+                                aria-labelledby="promo-igboliveinstitutional23162153-1"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/live/institutional-23162153"
                               >
                                 <span
-                                  id="promo-link-unlabelledinstitutional23162153"
+                                  id="promo-igboliveinstitutional23162153-1"
                                   role="text"
                                 >
                                   <span
@@ -2979,12 +2979,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-211 emotion-212"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabelled23183171"
+                                aria-labelledby="promo-igbo23183171-1"
                                 class="emotion-213 emotion-214"
                                 href="/igbo/23183171"
                               >
                                 <span
-                                  id="promo-link-unlabelled23183171"
+                                  id="promo-igbo23183171-1"
                                   role="text"
                                 >
                                   <span
@@ -9654,12 +9654,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabelled23248287"
+                                aria-labelledby="promo-pidgin23248287-1"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/23248287"
                               >
                                 <span
-                                  id="promo-link-unlabelled23248287"
+                                  id="promo-pidgin23248287-1"
                                 >
                                   ATMs across the country
                                 </span>
@@ -9689,12 +9689,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabelledtori23146434"
+                                aria-labelledby="promo-pidgintori23146434-1"
                                 class="emotion-214 emotion-215"
                                 href="/pidgin/tori-23146434"
                               >
                                 <span
-                                  id="promo-link-unlabelledtori23146434"
+                                  id="promo-pidgintori23146434-1"
                                 >
                                   Jacob Zuma: Staying!!!
                                 </span>
@@ -9724,12 +9724,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-212 emotion-213"
                             >
                               <a
-                                aria-labelledby="promo-link-unlabellednewsFeature"
+                                aria-labelledby="promo-news-feature-1"
                                 class="emotion-214 emotion-215"
                                 href="https://www.bbc.co.uk/news"
                               >
                                 <span
-                                  id="promo-link-unlabellednewsFeature"
+                                  id="promo-news-feature-1"
                                 >
                                   Feature promo
                                 </span>


### PR DESCRIPTION
**Overall change:**
Fixes a11y violations where aria-labelledby and ID attributes on certain promos are not unique.

The PR essentially introduces the index into the aria-labelledby and ID to prevent duplicated attributes within the same group of promos.

**Code changes:**

- Drills the index as a prop to the story promo component
- Refactors/renames a few variables and the main ID building function.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
