### PR TITLE
Stop chromatic from testing media player

### DIFF
--- a/src/app/components/MediaPlayer/index.stories.jsx
+++ b/src/app/components/MediaPlayer/index.stories.jsx
@@ -16,7 +16,7 @@ export default {
   component: CanonicalMediaPlayer,
   parameters: {
     chromatic: {
-      diffThreshold: 0.2,
+      disable: true,
     },
     docs: { page: notes },
   },
@@ -123,7 +123,6 @@ export const AMP = () => (
   />
 );
 
-AMP.parameters = { chromatic: { disable: true } };
 AMP.decorators = [ampDecorator];
 
 export const AMPAudioSkin = () => (


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
