### PR TITLE
Update CSP violation reporting to use new endpoint

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -396,8 +396,7 @@ const helmetCsp = ({ isAmp, isLive }) => ({
     'media-src': generateMediaSrc({ isAmp, isLive }),
     'worker-src': generateWorkerSrc({ isAmp }),
     'prefetch-src': generatePrefetchSrc({ isAmp, isLive }),
-    // The "default" report-to group header is injected by GTM
-    'report-to': 'default',
+    'report-to': 'worldsvc',
     'upgrade-insecure-requests': [],
   },
 });
@@ -405,7 +404,6 @@ const helmetCsp = ({ isAmp, isLive }) => ({
 const injectCspHeader = (req, res, next) => {
   const { isAmp } = getRouteProps(req.url);
 
-  // We will switch our reporting to this soon, but GTM does not currently handle this header correctly
   res.setHeader(
     'report-to',
     JSON.stringify({

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -576,7 +576,7 @@ describe('cspHeader', () => {
             `media-src ${mediaSrcExpectation.join(' ')};` +
             `worker-src ${workerSrcExpectation.join(' ')};` +
             `prefetch-src ${prefetchSrcExpectation.join(' ')};` +
-            `report-to default;` +
+            `report-to worldsvc;` +
             `upgrade-insecure-requests`;
 
           expect(headers['Content-Security-Policy']).toEqual(


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh-infrastructure/issues/1465

**Overall change:**
Update CSP violatinreporting to use new endpoint

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
