### PR TITLE
simplify status endpoint + introduce error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,10 +269,5 @@
       "cloud-init"
     ]
   },
-  "buildMetadata": {
-    "commitHash": "383522b",
-    "deployEnvironment": "green",
-    "version": "1.0.0"
-  },
   "packageManager": "yarn@3.1.1"
 }

--- a/src/app/lib/logger.const.js
+++ b/src/app/lib/logger.const.js
@@ -51,6 +51,7 @@ const logCodes = {
   SERVER_SIDE_RENDER_REQUEST_RECEIVED: 'ssr_request_received',
   SERVER_SIDE_REQUEST_FAILED: 'ssr_request_failed',
   SERVICE_WORKER_SENDFILE_ERROR: 'server_sendfile_error_sw',
+  SERVER_STATUS_ENDPOINT_ERROR: 'server_status_endpoint_error',
 
   // Config
   CONFIG_REQUEST_RECEIVED: 'config_request_received',

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -13,6 +13,7 @@ import {
   SERVER_SIDE_RENDER_REQUEST_RECEIVED,
   SERVER_SIDE_REQUEST_FAILED,
   ROUTING_INFORMATION,
+  SERVER_STATUS_ENDPOINT_ERROR,
 } from '#lib/logger.const';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import { OK } from '#lib/statusCodes.const';
@@ -52,11 +53,6 @@ const server = express();
  * Default headers, compression, logging, status route
  */
 
-const getBuildMetadata = () => {
-  const { buildMetadata } = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-  return buildMetadata;
-};
-
 const skipMiddleware = (_req, _res, next) => {
   next();
 };
@@ -82,7 +78,12 @@ server
   .use(gnuTP())
   .use(logResponseTime)
   .get('/status', (req, res) => {
-    res.status(200).send(getBuildMetadata());
+    try {
+      res.status(200).send('Ok');
+    } catch (error) {
+      logger.error(SERVER_STATUS_ENDPOINT_ERROR, { error });
+      res.status(500).send('Unable to determine status');
+    }
   });
 
 /*

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -30,8 +30,6 @@ import sendCustomMetric from './utilities/customMetrics';
 import { NON_200_RESPONSE } from './utilities/customMetrics/metrics.const';
 import local from './local';
 
-const fs = require('fs');
-
 const morgan = require('morgan');
 
 const logger = nodeLogger(__filename);

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -792,13 +792,9 @@ describe('Server', () => {
 
   describe('/status', () => {
     it('should respond with a 200', async () => {
-      const { statusCode, body } = await makeRequest('/status');
+      const { statusCode, text } = await makeRequest('/status');
       expect(statusCode).toBe(200);
-      expect(body).toStrictEqual({
-        commitHash: '383522b',
-        deployEnvironment: 'green',
-        version: '1.0.0',
-      });
+      expect(text).toEqual('Ok');
     });
   });
 


### PR DESCRIPTION
May fix https://github.com/bbc/simorgh-infrastructure/issues/1493

**Overall change:**
Removes some logic that extracted some 'build metadata' from our `package.json`. This appears to have been a stub implementation that formed part of our abandoned blue green deployment.

The status endpoint just returns 'Ok' and a 200 status code now.

This change introduces error handling but also removes virtually all complexity from the status endpoint in case this was intermitently failing.

**Code changes:**
- Removed stub buildmetadata from package.json
- Returns 'Ok' + 200 status code
- Updated test

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
