### PR TITLE
Fix overflow and word-wrap

### DIFF
--- a/src/app/components/ScrollablePromo/Promo/index.jsx
+++ b/src/app/components/ScrollablePromo/Promo/index.jsx
@@ -21,7 +21,7 @@ const Link = styled.a`
   ${({ script }) => script && getPica(script)}
   ${({ service }) => service && getSerifBold(service)}
   width: 100%;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   text-overflow: ellipsis;
   text-decoration: none;
 

--- a/src/app/components/ScrollablePromo/Promo/index.jsx
+++ b/src/app/components/ScrollablePromo/Promo/index.jsx
@@ -21,11 +21,12 @@ const Link = styled.a`
   ${({ script }) => script && getPica(script)}
   ${({ service }) => service && getSerifBold(service)}
   width: 100%;
-  word-break: break-word;
+  word-wrap: break-word;
   text-overflow: ellipsis;
   text-decoration: none;
 
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;

--- a/src/app/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
@@ -182,11 +182,12 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
 
 .emotion-8 {
   width: 100%;
-  word-break: break-word;
+  overflow-wrap: break-word;
   text-overflow: ellipsis;
   -webkit-text-decoration: none;
   text-decoration: none;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -394,11 +395,12 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
 
 .emotion-6 {
   width: 100%;
-  word-break: break-word;
+  overflow-wrap: break-word;
   text-overflow: ellipsis;
   -webkit-text-decoration: none;
   text-decoration: none;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
Resolves #9797

**Overall change:**
Updated properties to work for Firefox 48 and Edge 18

**Code changes:**

**Changed `word-break: break-word` to `overflow-wrap: break-word`**
- Not supported on Edge 18.xx or Firefox 48
- https://caniuse.com/mdn-css_properties_word-break_break-word

**Changed `overflow: hidden` to `overflow-x: hidden; overflow-y: hidden`**
- Overflow is shorthand for overflow-x and overflow-y
- The shorthand is not supported by Edge 18.xx and Firefox 48
- https://caniuse.com/css-overflow

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
