### PR TITLE
Optimizely page view tracking

### DIFF
--- a/src/app/containers/OptimizelyPageViewTracking/index.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.jsx
@@ -20,8 +20,8 @@ const OptimizelyPageViewTracking = () => {
     if (sendPageViewEvent) {
       optimizely.onReady().then(() => {
         optimizely.track('page_views');
+        setPageViewSent(true);
       });
-      setPageViewSent(true);
     }
   }, [sendPageViewEvent, optimizely]);
 

--- a/src/app/containers/OptimizelyPageViewTracking/index.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.jsx
@@ -14,11 +14,13 @@ const OptimizelyPageViewTracking = () => {
     setMobile(event.matches),
   );
 
-  const sendPageViewEvent = optimizely && mobile && !isAmp && !pageViewSent;
+  const sendPageViewEvent = mobile && !isAmp && !pageViewSent;
 
   useEffect(() => {
     if (sendPageViewEvent) {
-      optimizely.track('page_views');
+      optimizely.onReady().then(() => {
+        optimizely.track('page_views');
+      });
       setPageViewSent(true);
     }
   }, [sendPageViewEvent, optimizely]);

--- a/src/app/containers/OptimizelyPageViewTracking/index.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.jsx
@@ -1,20 +1,13 @@
 import { useState, useContext, useEffect } from 'react';
 import { OptimizelyContext } from '@optimizely/react-sdk';
 import { RequestContext } from '#contexts/RequestContext';
-import useMediaQuery from '#app/hooks/useMediaQuery';
-import { GEL_GROUP_3_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/dist/breakpoints';
 
 const OptimizelyPageViewTracking = () => {
   const { isAmp } = useContext(RequestContext);
   const { optimizely } = useContext(OptimizelyContext);
-  const [mobile, setMobile] = useState(false);
   const [pageViewSent, setPageViewSent] = useState(false);
 
-  useMediaQuery(`(max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX})`, event =>
-    setMobile(event.matches),
-  );
-
-  const sendPageViewEvent = mobile && !isAmp && !pageViewSent;
+  const sendPageViewEvent = !isAmp && !pageViewSent;
 
   useEffect(() => {
     if (sendPageViewEvent) {

--- a/src/app/containers/OptimizelyPageViewTracking/index.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.jsx
@@ -1,0 +1,29 @@
+import { useState, useContext, useEffect } from 'react';
+import { OptimizelyContext } from '@optimizely/react-sdk';
+import { RequestContext } from '#contexts/RequestContext';
+import useMediaQuery from '#app/hooks/useMediaQuery';
+import { GEL_GROUP_3_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/dist/breakpoints';
+
+const OptimizelyPageViewTracking = () => {
+  const { isAmp } = useContext(RequestContext);
+  const { optimizely } = useContext(OptimizelyContext);
+  const [mobile, setMobile] = useState(false);
+  const [pageViewSent, setPageViewSent] = useState(false);
+
+  useMediaQuery(`(max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX})`, event =>
+    setMobile(event.matches),
+  );
+
+  const sendPageViewEvent = optimizely && mobile && !isAmp && !pageViewSent;
+
+  useEffect(() => {
+    if (sendPageViewEvent) {
+      optimizely.track('page_views');
+      setPageViewSent(true);
+    }
+  }, [sendPageViewEvent, optimizely]);
+
+  return null;
+};
+
+export default OptimizelyPageViewTracking;

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -34,6 +34,14 @@ ContextWrap.propTypes = {
 describe('Optimizely Page View tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    window.matchMedia = jest.fn().mockImplementation(() => {
+      return {
+        matches: true,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      };
+    });
   });
 
   it('should call Optimizely track function for Article Page on page render', () => {

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { node, string, bool } from 'prop-types';
+import { render } from '@testing-library/react';
+import { OptimizelyProvider } from '@optimizely/react-sdk';
+
+import { RequestContextProvider } from '#contexts/RequestContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+import OptimizelyPageViewTracking from '.';
+
+const optimizely = {
+  track: jest.fn(),
+};
+
+const ContextWrap = ({ pageType, isAmp, children, service }) => (
+  <RequestContextProvider
+    isAmp={isAmp}
+    pageType={pageType}
+    service={service}
+    pathname="/pathname"
+  >
+    <OptimizelyProvider optimizely={optimizely} isServerSide>
+      {children}
+    </OptimizelyProvider>
+  </RequestContextProvider>
+);
+
+ContextWrap.propTypes = {
+  children: node.isRequired,
+  pageType: string.isRequired,
+  isAmp: bool.isRequired,
+  service: string.isRequired,
+};
+
+describe('Optimizely Page View tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call Optimizely track function for Article Page on page render', () => {
+    render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyPageViewTracking />
+      </ContextWrap>,
+    );
+
+    expect(optimizely.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call Optimizely track function for Article Page on AMP', () => {
+    render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp>
+        <OptimizelyPageViewTracking />
+      </ContextWrap>,
+    );
+
+    expect(optimizely.track).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not call Optimizely track function for Article Page on desktop', () => {
+    window.matchMedia = jest.fn().mockImplementation(() => {
+      return {
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      };
+    });
+
+    render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyPageViewTracking />
+      </ContextWrap>,
+    );
+
+    expect(optimizely.track).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { node, string, bool } from 'prop-types';
-import { render } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import { OptimizelyProvider } from '@optimizely/react-sdk';
 
 import { RequestContextProvider } from '#contexts/RequestContext';
@@ -8,7 +8,7 @@ import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import OptimizelyPageViewTracking from '.';
 
 const optimizely = {
-  onReady: jest.fn().mockResolvedValue(),
+  onReady: jest.fn(() => Promise.resolve()),
   track: jest.fn(),
 };
 
@@ -46,13 +46,15 @@ describe('Optimizely Page View tracking', () => {
   });
 
   it('should call Optimizely track function for Article Page on page render', async () => {
-    render(
-      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
-        <OptimizelyPageViewTracking />
-      </ContextWrap>,
-    );
+    await act(async () => {
+      render(
+        <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+          <OptimizelyPageViewTracking />
+        </ContextWrap>,
+      );
+    });
 
-    await optimizely.onReady().then(() => {
+    await waitFor(() => {
       expect(optimizely.track).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -8,6 +8,7 @@ import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import OptimizelyPageViewTracking from '.';
 
 const optimizely = {
+  onReady: jest.fn().mockResolvedValue(),
   track: jest.fn(),
 };
 
@@ -44,14 +45,16 @@ describe('Optimizely Page View tracking', () => {
     });
   });
 
-  it('should call Optimizely track function for Article Page on page render', () => {
+  it('should call Optimizely track function for Article Page on page render', async () => {
     render(
       <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
         <OptimizelyPageViewTracking />
       </ContextWrap>,
     );
 
-    expect(optimizely.track).toHaveBeenCalledTimes(1);
+    await optimizely.onReady().then(() => {
+      expect(optimizely.track).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should not call Optimizely track function for Article Page on AMP', () => {

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { node, string, bool } from 'prop-types';
-import { render, act, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { OptimizelyProvider } from '@optimizely/react-sdk';
 
 import { RequestContextProvider } from '#contexts/RequestContext';
@@ -46,13 +46,11 @@ describe('Optimizely Page View tracking', () => {
   });
 
   it('should call Optimizely track function for Article Page on page render', async () => {
-    await act(async () => {
-      render(
-        <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
-          <OptimizelyPageViewTracking />
-        </ContextWrap>,
-      );
-    });
+    render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyPageViewTracking />
+      </ContextWrap>,
+    );
 
     await waitFor(() => {
       expect(optimizely.track).toHaveBeenCalledTimes(1);

--- a/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.test.jsx
@@ -35,14 +35,6 @@ ContextWrap.propTypes = {
 describe('Optimizely Page View tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    window.matchMedia = jest.fn().mockImplementation(() => {
-      return {
-        matches: true,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-      };
-    });
   });
 
   it('should call Optimizely track function for Article Page on page render', async () => {
@@ -60,24 +52,6 @@ describe('Optimizely Page View tracking', () => {
   it('should not call Optimizely track function for Article Page on AMP', () => {
     render(
       <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp>
-        <OptimizelyPageViewTracking />
-      </ContextWrap>,
-    );
-
-    expect(optimizely.track).toHaveBeenCalledTimes(0);
-  });
-
-  it('should not call Optimizely track function for Article Page on desktop', () => {
-    window.matchMedia = jest.fn().mockImplementation(() => {
-      return {
-        matches: false,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-      };
-    });
-
-    render(
-      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
         <OptimizelyPageViewTracking />
       </ContextWrap>,
     );

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -39,6 +39,7 @@ import Timestamp from '#containers/ArticleTimestamp';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
+import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
 import articleMediaPlayer from '#containers/ArticleMediaPlayer';
 import LinkedData from '#containers/LinkedData';
 import MostReadContainer from '#containers/MostRead';
@@ -173,6 +174,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <ChartbeatAnalytics data={pageData} />
       <ComscoreAnalytics />
       <NielsenAnalytics />
+      <OptimizelyPageViewTracking />
       <ArticleMetadata
         articleId={getArticleId(pageData)}
         title={headline}

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -29,6 +29,11 @@ jest.mock('#containers/ChartbeatAnalytics', () => {
   return ChartbeatAnalytics;
 });
 
+jest.mock('#containers/OptimizelyPageViewTracking', () => {
+  const OptimizelyPageViewTracking = () => null;
+  return OptimizelyPageViewTracking;
+});
+
 // eslint-disable-next-line react/prop-types
 const Context = ({ service, children }) => (
   <ToggleContextProvider>

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -32,6 +32,7 @@ import FeaturesAnalysis from '#containers/CpsFeaturesAnalysis';
 import MostReadContainer from '#containers/MostRead';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
+import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
 import fauxHeadline from '#containers/FauxHeadline';
 import visuallyHiddenHeadline from '#containers/VisuallyHiddenHeadline';
 import CpsTable from '#containers/CpsTable';
@@ -315,6 +316,7 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
       <ChartbeatAnalytics data={pageData} />
       <ComscoreAnalytics />
       <NielsenAnalytics />
+      <OptimizelyPageViewTracking />
       {/* dotcom and dotcomConfig need to be setup before the main dotcom javascript file is loaded */}
       {isAdsEnabled && !isAmp && (
         <CanonicalAdBootstrapJs adcampaign={adcampaign} />

--- a/src/app/pages/StoryPage/index.test.jsx
+++ b/src/app/pages/StoryPage/index.test.jsx
@@ -44,6 +44,11 @@ jest.mock('#containers/ComscoreAnalytics', () => {
   return ComscoreAnalytics;
 });
 
+jest.mock('#containers/OptimizelyPageViewTracking', () => {
+  const OptimizelyPageViewTracking = () => null;
+  return OptimizelyPageViewTracking;
+});
+
 jest.mock('#containers/Ad', () => {
   const AdsContainer = () => <div data-testid="sty-ads">STY ADS</div>;
   return AdsContainer;


### PR DESCRIPTION
Resolves #9788

**Overall change:**
Adds page view tracking to Story and Article page types, using the `page_views` Optimizely identifier. This tracking event will only occur under the following criteria:
- Optimizely is available
- It is a canonical Story / Article page 

**Code changes:**

- Adds a new component called `<OptimizelyPageViewTracking />`, which is used in a similar fashion to the existing ATI/Chartbeat components in the Story and Article pages

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
