### PR TITLE
Remove TODO block from getBaseUrl/index.js

### DIFF
--- a/src/app/routes/utils/fetchPageData/utils/getBaseUrl/index.js
+++ b/src/app/routes/utils/fetchPageData/utils/getBaseUrl/index.js
@@ -18,12 +18,6 @@ const getBaseUrl = origin => {
     tld = '.co.uk';
   }
 
-  /* TODO: Remove this from the PR prior to merging! */
-  if (origin.includes('simorgh-infrastructure')) {
-    base = 'https://www.test.bbc';
-    tld = '.com';
-  }
-
   return base + tld;
 };
 


### PR DESCRIPTION
No Git issue. Removes a TODO block that was left in which was supposed to be removed before a PR was merged some time ago.

**Overall change:**
- Removes a TODO block that was used for testing

**Code changes:**
- Removed a block from getBaseUrl/index.js

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
