### PR TITLE
Social embed E2E test failing

### DIFF
--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -120,7 +120,7 @@ export const testsThatNeverRunDuringSmokeTestingForCanonicalOnly = () => {
           cy.get(
             `[data-e2e="instagram-embed-${firstInstagramEmbedUrl}"]`,
           ).scrollIntoView();
-          cy.wait(3000);
+          cy.wait(5000);
           cy.get('.instagram-media-rendered').should(
             'have.length.of.at.most',
             2,
@@ -128,11 +128,11 @@ export const testsThatNeverRunDuringSmokeTestingForCanonicalOnly = () => {
           cy.get(
             `[data-e2e="instagram-embed-${secondInstagramEmbedUrl}"]`,
           ).scrollIntoView();
-          cy.wait(3000);
+          cy.wait(5000);
           cy.get(
             `[data-e2e="instagram-embed-${thirdInstagramEmbedUrl}"]`,
           ).scrollIntoView();
-          cy.wait(3000);
+          cy.wait(5000);
           // of.at.least is used here instead of having length of exactly 3
           // so the test does not fail if more than one instagram embed scrolls
           // into view


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9812

**Overall change:**
An E2E test (social embed test) is failing more often. Decided to Increase the wait time to 5 seconds to see if it improved the failure rate.

**Code changes:**

- Increase time from 3 to 5 seconds.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
