### PR TITLE
Check Optimizely variation for page_view event

### DIFF
--- a/src/app/containers/OptimizelyPageViewTracking/index.jsx
+++ b/src/app/containers/OptimizelyPageViewTracking/index.jsx
@@ -1,13 +1,19 @@
 import { useState, useContext, useEffect } from 'react';
 import { OptimizelyContext } from '@optimizely/react-sdk';
 import { RequestContext } from '#contexts/RequestContext';
+import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
+
+const IMPROVED_PROMO_EXPERIMENT_ID = 'improved_promos';
 
 const OptimizelyPageViewTracking = () => {
   const { isAmp } = useContext(RequestContext);
   const { optimizely } = useContext(OptimizelyContext);
   const [pageViewSent, setPageViewSent] = useState(false);
 
-  const sendPageViewEvent = !isAmp && !pageViewSent;
+  const promoVariation = useOptimizelyVariation(IMPROVED_PROMO_EXPERIMENT_ID);
+  const hasVariationKey = promoVariation !== null;
+
+  const sendPageViewEvent = hasVariationKey && !isAmp && !pageViewSent;
 
   useEffect(() => {
     if (sendPageViewEvent) {


### PR DESCRIPTION
Follow on from #9788

**Overall change:**
Checks if the user is being served an experiment from Optimizely before firing a `page_views` event

**Code changes:**

- Updates the `<OptimizelyPageViewTracking />` component to check for an experiment variation before sending a `page_views` event

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
