### PR TITLE
a11y violation fix for duplicate ID in top stories / features sections

### DIFF
--- a/src/app/containers/CpsFeaturesAnalysis/index.jsx
+++ b/src/app/containers/CpsFeaturesAnalysis/index.jsx
@@ -81,6 +81,7 @@ const PromoListComponent = ({ promoItems, dir }) => {
               displaySummary={false}
               serviceDatetimeLocale={serviceDatetimeLocale}
               eventTrackingData={eventTrackingData}
+              sectionType="features-and-analysis"
             />
           </StoryPromoLi>
         );
@@ -138,6 +139,7 @@ const PromoComponent = ({ promo, dir }) => {
         displayImage
         serviceDatetimeLocale={serviceDatetimeLocale}
         eventTrackingData={getEventTrackingData(optimizely)}
+        sectionType="features-and-analysis"
       />
     </div>
   );

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -615,12 +615,12 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
-                  aria-labelledby="promo-mundonoticiasinternacional51939501-1"
+                  aria-labelledby="top-stories-promo-mundonoticiasinternacional51939501-1"
                   class="emotion-31 emotion-32"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
-                    id="promo-mundonoticiasinternacional51939501-1"
+                    id="top-stories-promo-mundonoticiasinternacional51939501-1"
                   >
                     China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
                   </span>
@@ -650,12 +650,12 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 class="emotion-29 emotion-30"
               >
                 <a
-                  aria-labelledby="promo-pidgintori51945757-1"
+                  aria-labelledby="top-stories-promo-pidgintori51945757-1"
                   class="emotion-31 emotion-32"
                   href="/pidgin/tori-51945757"
                 >
                   <span
-                    id="promo-pidgintori51945757-1"
+                    id="top-stories-promo-pidgintori51945757-1"
                   >
                     Nigeria don get five new cases of Coronavirus - See how e happun
                   </span>
@@ -1254,12 +1254,12 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
                 class="emotion-27 emotion-28"
               >
                 <a
-                  aria-labelledby="promo-mundonoticiasinternacional51939501-1"
+                  aria-labelledby="top-stories-promo-mundonoticiasinternacional51939501-1"
                   class="emotion-29 emotion-30"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
-                    id="promo-mundonoticiasinternacional51939501-1"
+                    id="top-stories-promo-mundonoticiasinternacional51939501-1"
                   >
                     China dice tener una vacuna contra el nuevo coronavirus lista para pruebas en humanos
                   </span>

--- a/src/app/containers/CpsTopStories/index.jsx
+++ b/src/app/containers/CpsTopStories/index.jsx
@@ -29,6 +29,7 @@ const PromoComponent = ({ promo, dir }) => {
         displaySummary={false}
         serviceDatetimeLocale={serviceDatetimeLocale}
         eventTrackingData={eventTrackingData}
+        sectionType="top-stories"
       />
     </div>
   );
@@ -58,6 +59,7 @@ const PromoListComponent = ({ promoItems, dir }) => {
             displaySummary={false}
             serviceDatetimeLocale={serviceDatetimeLocale}
             eventTrackingData={eventTrackingData}
+            sectionType="top-stories"
           />
         </StoryPromoLi>
       ))}

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -138,7 +138,12 @@ const StoryPromoContainer = ({
   const { pageType } = useContext(RequestContext);
   const handleClickTracking = useCombinedClickTrackerHandler(eventTrackingData);
 
-  const linkId = buildUniquePromoId(sectionType, labelId, item, index);
+  const linkId = buildUniquePromoId({
+    sectionType,
+    promoGroupId: labelId,
+    promoItem: item,
+    promoIndex: index,
+  });
 
   const liveLabel = pathOr('LIVE', ['media', 'liveLabel'], translations);
 

--- a/src/app/containers/StoryPromo/index.jsx
+++ b/src/app/containers/StoryPromo/index.jsx
@@ -132,12 +132,13 @@ const StoryPromoContainer = ({
   eventTrackingData,
   labelId,
   imageComponent,
+  sectionType,
 }) => {
   const { script, service, translations } = useContext(ServiceContext);
   const { pageType } = useContext(RequestContext);
   const handleClickTracking = useCombinedClickTrackerHandler(eventTrackingData);
 
-  const linkId = buildUniquePromoId(labelId, item, index);
+  const linkId = buildUniquePromoId(sectionType, labelId, item, index);
 
   const liveLabel = pathOr('LIVE', ['media', 'liveLabel'], translations);
 
@@ -327,6 +328,7 @@ StoryPromoContainer.propTypes = {
   labelId: string,
   index: number,
   imageComponent: elementType,
+  sectionType: string,
 };
 
 StoryPromoContainer.defaultProps = {
@@ -341,6 +343,7 @@ StoryPromoContainer.defaultProps = {
   labelId: '',
   index: 0,
   imageComponent: undefined,
+  sectionType: '',
 };
 
 export default StoryPromoContainer;

--- a/src/app/containers/StoryPromo/index.test.jsx
+++ b/src/app/containers/StoryPromo/index.test.jsx
@@ -158,8 +158,14 @@ describe('StoryPromo Container', () => {
     afterEach(cleanup);
 
     it('should render h3, a, p, time', () => {
-      const uriLabelId = buildUniquePromoId(labelId, assetTypeItem);
-      const assetUriId = buildUniquePromoId(labelId, cpsItem);
+      const uriLabelId = buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: assetTypeItem,
+      });
+      const assetUriId = buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: cpsItem,
+      });
 
       expect(cpsContainer.querySelectorAll('h3 a')[0].innerHTML).toEqual(
         `<span id="${assetUriId}">${cpsItem.headlines.headline}</span>`,

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -25,7 +25,12 @@ export const getHeadingTagOverride = ({ pageType, isContentTypeGuide }) => {
 
 export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 
-export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex = 0) => {
+export const buildUniquePromoId = (
+  sectionType,
+  promoGroupId,
+  promoItem,
+  promoIndex = 0,
+) => {
   const assetUri = pathOr('', ['locators', 'assetUri'], promoItem);
   const uri = pathOr('', ['uri'], promoItem);
   const asset = assetUri || uri;
@@ -33,7 +38,14 @@ export const buildUniquePromoId = (promoGroupId, promoItem, promoIndex = 0) => {
   const assetId = assetParts[assetParts.length - 1].replace(/\W/g, '');
   const contentType = pathOr('', ['contentType'], promoItem);
 
-  return ['promo', promoGroupId, assetId, contentType, promoIndex + 1]
+  return [
+    sectionType,
+    'promo',
+    promoGroupId,
+    assetId,
+    contentType,
+    promoIndex + 1,
+  ]
     .filter(Boolean)
     .join('-')
     .toLowerCase();

--- a/src/app/containers/StoryPromo/utilities/index.js
+++ b/src/app/containers/StoryPromo/utilities/index.js
@@ -25,12 +25,12 @@ export const getHeadingTagOverride = ({ pageType, isContentTypeGuide }) => {
 
 export const isPgl = item => pathOr(null, ['cpsType'], item) === 'PGL';
 
-export const buildUniquePromoId = (
+export const buildUniquePromoId = ({
   sectionType,
   promoGroupId,
   promoItem,
   promoIndex = 0,
-) => {
+}) => {
   const assetUri = pathOr('', ['locators', 'assetUri'], promoItem);
   const uri = pathOr('', ['uri'], promoItem);
   const asset = assetUri || uri;

--- a/src/app/containers/StoryPromo/utilities/index.test.js
+++ b/src/app/containers/StoryPromo/utilities/index.test.js
@@ -81,53 +81,73 @@ describe('buildUniquePromoId', () => {
   const labelId = 'test-group-id';
   it('should return id of promo-link with contentType and URI if contentType exists', () => {
     expect(
-      buildUniquePromoId('', labelId, secondaryColumnNoAssetURI, 0),
+      buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: secondaryColumnNoAssetURI,
+        promoIndex: 0,
+      }),
     ).toEqual('promo-test-group-id-news-radiobulletin-1');
   });
 
   it('should return id using URI if assetURI does not exist', () => {
-    expect(buildUniquePromoId('', labelId, standardLinkItem, 1)).toEqual(
-      'promo-test-group-id-azeri-text-2',
-    );
+    expect(
+      buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: standardLinkItem,
+        promoIndex: 1,
+      }),
+    ).toEqual('promo-test-group-id-azeri-text-2');
   });
 
   it('should return id using assetURI does not exist and contentType does not exist', () => {
-    expect(buildUniquePromoId('', labelId, completeItem, 2)).toEqual(
-      'promo-test-group-id-3',
-    );
+    expect(
+      buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: completeItem,
+        promoIndex: 2,
+      }),
+    ).toEqual('promo-test-group-id-3');
   });
 
   it('should return id with contentType only if assetURI and URI do not exist', () => {
     expect(
-      buildUniquePromoId('', labelId, secondaryColumnContentType, 3),
+      buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: secondaryColumnContentType,
+        promoIndex: 3,
+      }),
     ).toEqual('promo-test-group-id-radiobulletin-4');
   });
 
   it('should sanitise link from item and split from last forward slash', () => {
     expect(
-      buildUniquePromoId(
-        '',
-        labelId,
-        { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
-        4,
-      ),
+      buildUniquePromoId({
+        promoGroupId: labelId,
+        promoItem: { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
+        promoIndex: 4,
+      }),
     ).toEqual('promo-test-group-id-aaabbbccc-5');
   });
 
   it('should return id of promo-link with contentType and URI if contentType exists for a "Top Stories" promo', () => {
     expect(
-      buildUniquePromoId('top-stories', labelId, secondaryColumnNoAssetURI, 0),
+      buildUniquePromoId({
+        sectionType: 'top-stories',
+        promoGroupId: labelId,
+        promoItem: secondaryColumnNoAssetURI,
+        promoIndex: 0,
+      }),
     ).toEqual('top-stories-promo-test-group-id-news-radiobulletin-1');
   });
 
   it('should return id of promo-link with contentType and URI if contentType exists for a "Features and Analysis" promo', () => {
     expect(
-      buildUniquePromoId(
-        'features-and-analysis',
-        labelId,
-        secondaryColumnNoAssetURI,
-        0,
-      ),
+      buildUniquePromoId({
+        sectionType: 'features-and-analysis',
+        promoGroupId: labelId,
+        promoItem: secondaryColumnNoAssetURI,
+        promoIndex: 0,
+      }),
     ).toEqual('features-and-analysis-promo-test-group-id-news-radiobulletin-1');
   });
 });

--- a/src/app/containers/StoryPromo/utilities/index.test.js
+++ b/src/app/containers/StoryPromo/utilities/index.test.js
@@ -80,36 +80,54 @@ describe('getHeadingTagOverride', () => {
 describe('buildUniquePromoId', () => {
   const labelId = 'test-group-id';
   it('should return id of promo-link with contentType and URI if contentType exists', () => {
-    expect(buildUniquePromoId(labelId, secondaryColumnNoAssetURI, 0)).toEqual(
-      'promo-test-group-id-news-radiobulletin-1',
-    );
+    expect(
+      buildUniquePromoId('', labelId, secondaryColumnNoAssetURI, 0),
+    ).toEqual('promo-test-group-id-news-radiobulletin-1');
   });
 
   it('should return id using URI if assetURI does not exist', () => {
-    expect(buildUniquePromoId(labelId, standardLinkItem, 1)).toEqual(
+    expect(buildUniquePromoId('', labelId, standardLinkItem, 1)).toEqual(
       'promo-test-group-id-azeri-text-2',
     );
   });
 
   it('should return id using assetURI does not exist and contentType does not exist', () => {
-    expect(buildUniquePromoId(labelId, completeItem, 2)).toEqual(
+    expect(buildUniquePromoId('', labelId, completeItem, 2)).toEqual(
       'promo-test-group-id-3',
     );
   });
 
   it('should return id with contentType only if assetURI and URI do not exist', () => {
-    expect(buildUniquePromoId(labelId, secondaryColumnContentType, 3)).toEqual(
-      'promo-test-group-id-radiobulletin-4',
-    );
+    expect(
+      buildUniquePromoId('', labelId, secondaryColumnContentType, 3),
+    ).toEqual('promo-test-group-id-radiobulletin-4');
   });
 
   it('should sanitise link from item and split from last forward slash', () => {
     expect(
       buildUniquePromoId(
+        '',
         labelId,
         { locators: { assetUri: 'a/a/ab.b.b@c@c@c' } },
         4,
       ),
     ).toEqual('promo-test-group-id-aaabbbccc-5');
+  });
+
+  it('should return id of promo-link with contentType and URI if contentType exists for a "Top Stories" promo', () => {
+    expect(
+      buildUniquePromoId('top-stories', labelId, secondaryColumnNoAssetURI, 0),
+    ).toEqual('top-stories-promo-test-group-id-news-radiobulletin-1');
+  });
+
+  it('should return id of promo-link with contentType and URI if contentType exists for a "Features and Analysis" promo', () => {
+    expect(
+      buildUniquePromoId(
+        'features-and-analysis',
+        labelId,
+        secondaryColumnNoAssetURI,
+        0,
+      ),
+    ).toEqual('features-and-analysis-promo-test-group-id-news-radiobulletin-1');
   });
 });

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -3030,12 +3030,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-213 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182501-1"
+                                aria-labelledby="top-stories-promo-igbo23182501-1"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182501"
                               >
                                 <span
-                                  id="promo-igbo23182501-1"
+                                  id="top-stories-promo-igbo23182501-1"
                                 >
                                   DSS: Wepụ aka enwe n'ofe na Benue
                                 </span>
@@ -3065,12 +3065,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-213 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igboliveinstitutional23162153-1"
+                                aria-labelledby="top-stories-promo-igboliveinstitutional23162153-1"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/live/institutional-23162153"
                               >
                                 <span
-                                  id="promo-igboliveinstitutional23162153-1"
+                                  id="top-stories-promo-igboliveinstitutional23162153-1"
                                   role="text"
                                 >
                                   <span
@@ -3129,12 +3129,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-213 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23183171-1"
+                                aria-labelledby="top-stories-promo-igbo23183171-1"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23183171"
                               >
                                 <span
-                                  id="promo-igbo23183171-1"
+                                  id="top-stories-promo-igbo23183171-1"
                                   role="text"
                                 >
                                   <span
@@ -3242,12 +3242,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182930-1"
+                                aria-labelledby="features-and-analysis-promo-igbo23182930-1"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182930"
                               >
                                 <span
-                                  id="promo-igbo23182930-1"
+                                  id="features-and-analysis-promo-igbo23182930-1"
                                 >
                                   Lee ihe Barcelona mere Real Betis
                                 </span>
@@ -3302,12 +3302,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182890-2"
+                                aria-labelledby="features-and-analysis-promo-igbo23182890-2"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182890"
                               >
                                 <span
-                                  id="promo-igbo23182890-2"
+                                  id="features-and-analysis-promo-igbo23182890-2"
                                 >
                                   Aubameyang nwere ike ifu ndị Arsenal ọnụ ego karịrị nderi pounds iri ise
                                 </span>
@@ -3362,12 +3362,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182810-3"
+                                aria-labelledby="features-and-analysis-promo-igbo23182810-3"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182810"
                               >
                                 <span
-                                  id="promo-igbo23182810-3"
+                                  id="features-and-analysis-promo-igbo23182810-3"
                                 >
                                   "Alexis Sanchez ga-abanye Manchester united ma ọ buru na....." Wenger
                                 </span>
@@ -3422,12 +3422,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182766-4"
+                                aria-labelledby="features-and-analysis-promo-igbo23182766-4"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182766"
                               >
                                 <span
-                                  id="promo-igbo23182766-4"
+                                  id="features-and-analysis-promo-igbo23182766-4"
                                 >
                                   Dịka osi ga n'ime asọmpi Premier League
                                 </span>
@@ -3482,12 +3482,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182760-5"
+                                aria-labelledby="features-and-analysis-promo-igbo23182760-5"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182760"
                               >
                                 <span
-                                  id="promo-igbo23182760-5"
+                                  id="features-and-analysis-promo-igbo23182760-5"
                                 >
                                   Djokovic enwela mmeri Agbanyeghị ihe mmerụ ahụ
                                 </span>
@@ -3542,12 +3542,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23182710-6"
+                                aria-labelledby="features-and-analysis-promo-igbo23182710-6"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23182710"
                               >
                                 <span
-                                  id="promo-igbo23182710-6"
+                                  id="features-and-analysis-promo-igbo23182710-6"
                                 >
                                   CHAN: Naịjirịa na Guinea nọ na ịrụ Group C
                                 </span>
@@ -3635,12 +3635,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23177465-7"
+                                aria-labelledby="features-and-analysis-promo-igbo23177465-7"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23177465"
                               >
                                 <span
-                                  id="promo-igbo23177465-7"
+                                  id="features-and-analysis-promo-igbo23177465-7"
                                   role="text"
                                 >
                                   <span
@@ -3708,12 +3708,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23173771-8"
+                                aria-labelledby="features-and-analysis-promo-igbo23173771-8"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23173771"
                               >
                                 <span
-                                  id="promo-igbo23173771-8"
+                                  id="features-and-analysis-promo-igbo23173771-8"
                                 >
                                   O nwere ihe o mere ma Dino Melaye nọrọ n'egwu m?
                                 </span>
@@ -3768,12 +3768,12 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               class="emotion-286 emotion-214"
                             >
                               <a
-                                aria-labelledby="promo-igbo23174391-9"
+                                aria-labelledby="features-and-analysis-promo-igbo23174391-9"
                                 class="emotion-215 emotion-216"
                                 href="/igbo/23174391"
                               >
                                 <span
-                                  id="promo-igbo23174391-9"
+                                  id="features-and-analysis-promo-igbo23174391-9"
                                 >
                                   Ọkụ Festac: Ajọ ọnwụnwa nke keresimesi
                                 </span>
@@ -10568,12 +10568,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-214 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgin23248287-1"
+                                aria-labelledby="top-stories-promo-pidgin23248287-1"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/23248287"
                               >
                                 <span
-                                  id="promo-pidgin23248287-1"
+                                  id="top-stories-promo-pidgin23248287-1"
                                 >
                                   ATMs across the country
                                 </span>
@@ -10603,12 +10603,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-214 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgintori23146434-1"
+                                aria-labelledby="top-stories-promo-pidgintori23146434-1"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/tori-23146434"
                               >
                                 <span
-                                  id="promo-pidgintori23146434-1"
+                                  id="top-stories-promo-pidgintori23146434-1"
                                 >
                                   Jacob Zuma: Staying!!!
                                 </span>
@@ -10638,12 +10638,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-214 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-news-feature-1"
+                                aria-labelledby="top-stories-promo-news-feature-1"
                                 class="emotion-216 emotion-217"
                                 href="https://www.bbc.co.uk/news"
                               >
                                 <span
-                                  id="promo-news-feature-1"
+                                  id="top-stories-promo-news-feature-1"
                                 >
                                   Feature promo
                                 </span>
@@ -10743,12 +10743,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgintori23146625-1"
+                                aria-labelledby="features-and-analysis-promo-pidgintori23146625-1"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/tori-23146625"
                               >
                                 <span
-                                  id="promo-pidgintori23146625-1"
+                                  id="features-and-analysis-promo-pidgintori23146625-1"
                                 >
                                   How Lagos Dey Fight Lassa Fever
                                 </span>
@@ -10833,12 +10833,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidginmedia23267821-2"
+                                aria-labelledby="features-and-analysis-promo-pidginmedia23267821-2"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/media-23267821"
                               >
                                 <span
-                                  id="promo-pidginmedia23267821-2"
+                                  id="features-and-analysis-promo-pidginmedia23267821-2"
                                   role="text"
                                 >
                                   <span
@@ -10933,12 +10933,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgin23267823-3"
+                                aria-labelledby="features-and-analysis-promo-pidgin23267823-3"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/23267823"
                               >
                                 <span
-                                  id="promo-pidgin23267823-3"
+                                  id="features-and-analysis-promo-pidgin23267823-3"
                                   role="text"
                                 >
                                   <span
@@ -11001,12 +11001,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgintori23169387-4"
+                                aria-labelledby="features-and-analysis-promo-pidgintori23169387-4"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/tori-23169387"
                               >
                                 <span
-                                  id="promo-pidgintori23169387-4"
+                                  id="features-and-analysis-promo-pidgintori23169387-4"
                                 >
                                   Libya: omo ile Ghana márùndínláàdóje pada sile
                                 </span>
@@ -11061,12 +11061,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-newsworldafrica23143884-5"
+                                aria-labelledby="features-and-analysis-promo-newsworldafrica23143884-5"
                                 class="emotion-216 emotion-217"
                                 href="/news/world-africa-23143884"
                               >
                                 <span
-                                  id="promo-newsworldafrica23143884-5"
+                                  id="features-and-analysis-promo-newsworldafrica23143884-5"
                                 >
                                   Like Scaramucci, Like Others
                                 </span>
@@ -11121,12 +11121,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgintori23146975-6"
+                                aria-labelledby="features-and-analysis-promo-pidgintori23146975-6"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/tori-23146975"
                               >
                                 <span
-                                  id="promo-pidgintori23146975-6"
+                                  id="features-and-analysis-promo-pidgintori23146975-6"
                                 >
                                   Anambra Attack: 'My Friend Uchenna na Nice Girl'- Gabros
                                 </span>
@@ -11181,12 +11181,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidginsport51434980-radiobulletin-7"
+                                aria-labelledby="features-and-analysis-promo-pidginsport51434980-radiobulletin-7"
                                 class="emotion-216 emotion-217"
                                 href="https://www.bbc.com/pidgin/sport-51434980"
                               >
                                 <span
-                                  id="promo-pidginsport51434980-radiobulletin-7"
+                                  id="features-and-analysis-promo-pidginsport51434980-radiobulletin-7"
                                 >
                                   Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
                                 </span>
@@ -11241,12 +11241,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgintori23145776-8"
+                                aria-labelledby="features-and-analysis-promo-pidgintori23145776-8"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/tori-23145776"
                               >
                                 <span
-                                  id="promo-pidgintori23145776-8"
+                                  id="features-and-analysis-promo-pidgintori23145776-8"
                                 >
                                   Anambra Church: Police Arrest 3
                                 </span>
@@ -11330,12 +11330,12 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               class="emotion-279 emotion-215"
                             >
                               <a
-                                aria-labelledby="promo-pidgin23146654-9"
+                                aria-labelledby="features-and-analysis-promo-pidgin23146654-9"
                                 class="emotion-216 emotion-217"
                                 href="/pidgin/23146654"
                               >
                                 <span
-                                  id="promo-pidgin23146654-9"
+                                  id="features-and-analysis-promo-pidgin23146654-9"
                                   role="text"
                                 >
                                   <span


### PR DESCRIPTION
Resolves #9848

**Overall change:**
Adds a section type to the `aria-labelledby` ID to determine if the promo sits within the 'Top Stories' and/or ' Features & Analysis' page sections

**Code changes:**

- Updates the `CpsTopStories` and `CpsFeaturesAnalysis` components to pass a new `sectionType` prop to the `StoryPromo` component
- The `buildUniquePromoId` has also been updated to take this new prop and use it for generating the `aria-labelledby` ID value
- `buildUniquePromoId` has been changed to accept an object to avoid passing an empty string as the first parameter should a `sectionType` not be needed

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
