### PR TITLE
Media Icons and Durations

### DIFF
--- a/src/app/components/Promo/image.jsx
+++ b/src/app/components/Promo/image.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import ImagePlaceholder from '@bbc/psammead-image-placeholder';
-import { string } from 'prop-types';
+import { string, node } from 'prop-types';
 import { GEL_SPACING } from '@bbc/gel-foundations/spacings';
 
 const Img = styled.img`
@@ -11,21 +11,34 @@ const Img = styled.img`
 
 const Wrapper = styled.div`
   margin-bottom: ${GEL_SPACING};
+  position: relative;
 `;
 
-// TODO: media indicators, srcsets and webp
+const ChildWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+`;
+
+// TODO: srcsets and webp
 const Image = props => {
+  const { children, ...rest } = props;
   return (
     <Wrapper>
       <ImagePlaceholder ratio={56.25}>
-        <Img {...props} />
+        <Img {...rest} />
       </ImagePlaceholder>
+      {children && <ChildWrapper>{children}</ChildWrapper>}
     </Wrapper>
   );
 };
 
 Image.propTypes = {
   alt: string.isRequired,
+  children: node,
+};
+
+Image.defaultProps = {
+  children: null,
 };
 
 export default Image;

--- a/src/app/components/Promo/index.jsx
+++ b/src/app/components/Promo/index.jsx
@@ -8,6 +8,7 @@ import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
 import { ServiceContext } from '#contexts/ServiceContext';
 
 import Image from './image';
+import MediaLabel, { TYPES } from './media-label';
 import Heading from './heading';
 import Body from './body';
 import Footer from './footer';
@@ -61,6 +62,7 @@ const Promo = ({ children }) => {
 };
 
 Promo.Image = withPromoContext(Image);
+Promo.MediaLabel = withPromoContext(MediaLabel);
 Promo.Heading = withPromoContext(Heading);
 Promo.Body = withPromoContext(Body);
 Promo.Footer = withPromoContext(Footer);
@@ -71,4 +73,5 @@ Promo.propTypes = {
   children: arrayOf(element).isRequired,
 };
 
+export const MEDIA_TYPES = TYPES;
 export default Promo;

--- a/src/app/components/Promo/index.jsx
+++ b/src/app/components/Promo/index.jsx
@@ -8,7 +8,7 @@ import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '@bbc/gel-foundations/breakpoints';
 import { ServiceContext } from '#contexts/ServiceContext';
 
 import Image from './image';
-import MediaLabel, { TYPES } from './media-label';
+import MediaIcon, { TYPES } from './media-icon';
 import Heading from './heading';
 import Body from './body';
 import Footer from './footer';
@@ -62,7 +62,7 @@ const Promo = ({ children }) => {
 };
 
 Promo.Image = withPromoContext(Image);
-Promo.MediaLabel = withPromoContext(MediaLabel);
+Promo.MediaIcon = withPromoContext(MediaIcon);
 Promo.Heading = withPromoContext(Heading);
 Promo.Body = withPromoContext(Body);
 Promo.Footer = withPromoContext(Footer);

--- a/src/app/components/Promo/media-icon.jsx
+++ b/src/app/components/Promo/media-icon.jsx
@@ -16,7 +16,7 @@ export const TYPES = {
   PHOTO_GALLERY: 'photogallery',
 };
 
-const StyledMediaIndicator = styled.div`
+const Wrapper = styled.div`
   padding: ${GEL_SPACING_HLF};
   color: ${C_EBON};
   background-color: ${C_WHITE};
@@ -38,26 +38,26 @@ const formatChildren = children => {
   return <StyledTime dateTime={isoDuration}>{durationString}</StyledTime>;
 };
 
-const MediaLabel = ({ script, service, children, type }) => {
+const MediaIcon = ({ script, service, children, type }) => {
   if (!type) return null;
   return (
-    <StyledMediaIndicator script={script} service={service}>
+    <Wrapper script={script} service={service}>
       {mediaIcons[TYPES[type]]}
       {formatChildren(children)}
-    </StyledMediaIndicator>
+    </Wrapper>
   );
 };
 
-MediaLabel.propTypes = {
+MediaIcon.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
   type: oneOf(Object.keys(TYPES)),
   children: number,
 };
 
-MediaLabel.defaultProps = {
+MediaIcon.defaultProps = {
   children: null,
   type: null,
 };
 
-export default MediaLabel;
+export default MediaIcon;

--- a/src/app/components/Promo/media-label.jsx
+++ b/src/app/components/Promo/media-label.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import moment from 'moment-timezone';
+import styled from '@emotion/styled';
+import { shape, string, number, oneOf } from 'prop-types';
+import { scriptPropType } from '@bbc/gel-foundations/prop-types';
+import { GEL_SPACING_HLF } from '@bbc/gel-foundations/spacings';
+import { C_WHITE, C_EBON } from '@bbc/psammead-styles/colours';
+import { getMinion } from '@bbc/gel-foundations/typography';
+import { getSansRegular } from '@bbc/psammead-styles/font-styles';
+import { mediaIcons } from '@bbc/psammead-assets/svgs';
+import formatDuration from '#lib/utilities/formatDuration';
+
+export const TYPES = {
+  VIDEO: 'video',
+  AUDIO: 'audio',
+  PHOTO_GALLERY: 'photogallery',
+};
+
+const StyledMediaIndicator = styled.div`
+  padding: ${GEL_SPACING_HLF};
+  color: ${C_EBON};
+  background-color: ${C_WHITE};
+  ${({ service }) => getSansRegular(service)}
+  ${({ script }) => script && getMinion(script)};
+`;
+
+const StyledTime = styled.time`
+  padding: ${GEL_SPACING_HLF};
+  position: relative;
+  top: 0.09rem;
+`;
+
+const formatChildren = children => {
+  if (!children) return null;
+  const duration = moment.duration(children, 'seconds');
+  const durationString = formatDuration({ duration });
+  const isoDuration = duration.toISOString();
+  return <StyledTime dateTime={isoDuration}>{durationString}</StyledTime>;
+};
+
+const MediaLabel = ({ script, service, children, type }) => {
+  if (!type) return null;
+  return (
+    <StyledMediaIndicator script={script} service={service}>
+      {mediaIcons[TYPES[type]]}
+      {formatChildren(children)}
+    </StyledMediaIndicator>
+  );
+};
+
+MediaLabel.propTypes = {
+  script: shape(scriptPropType).isRequired,
+  service: string.isRequired,
+  type: oneOf(Object.keys(TYPES)),
+  children: number,
+};
+
+MediaLabel.defaultProps = {
+  children: null,
+  type: null,
+};
+
+export default MediaLabel;

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
-import { string, number } from 'prop-types';
+import { string, number, oneOf } from 'prop-types';
 
-import Promo from '#components/Promo';
+import Promo, { MEDIA_TYPES } from '#components/Promo';
 
-const TopicPromo = ({ heading, timestamp, imageSrc, imageAlt, href }) => {
+const TopicPromo = ({
+  heading,
+  timestamp,
+  imageSrc,
+  imageAlt,
+  href,
+  mediaType,
+  mediaDuration,
+}) => {
   return (
     <Promo>
-      <Promo.Image src={imageSrc} alt={imageAlt} />
+      <Promo.Image src={imageSrc} alt={imageAlt}>
+        <Promo.MediaLabel type={mediaType}>{mediaDuration}</Promo.MediaLabel>
+      </Promo.Image>
       <Promo.A href={href}>
         <Promo.Heading>{heading}</Promo.Heading>
       </Promo.A>
@@ -21,8 +31,13 @@ TopicPromo.propTypes = {
   imageSrc: string.isRequired,
   imageAlt: string.isRequired,
   href: string.isRequired,
+  mediaType: oneOf(Object.keys(MEDIA_TYPES)),
+  mediaDuration: number,
 };
 
-TopicPromo.defaultProps = {};
+TopicPromo.defaultProps = {
+  mediaType: null,
+  mediaDuration: null,
+};
 
 export default TopicPromo;

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -15,7 +15,7 @@ const TopicPromo = ({
   return (
     <Promo>
       <Promo.Image src={imageSrc} alt={imageAlt}>
-        <Promo.MediaLabel type={mediaType}>{mediaDuration}</Promo.MediaLabel>
+        <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.A href={href}>
         <Promo.Heading>{heading}</Promo.Heading>

--- a/src/app/pages/TopicPage/fixtures.js
+++ b/src/app/pages/TopicPage/fixtures.js
@@ -9,12 +9,18 @@ const fixtureCat = () =>
 
 // eslint-disable-next-line import/prefer-default-export
 export const fixturePromos = () =>
-  new Array(23).fill().map((_, id) => ({
-    id,
-    heading: fixtureHeading(),
-    footer: '8th February 2022',
-    href: '#',
-    imageSrc: fixtureCat(),
-    imageAlt: 'evil monster',
-    timestamp: new Date().getTime() - rand(100000, 100000000),
-  }));
+  new Array(23).fill().map((_, id) => {
+    const mediaType = ['VIDEO', 'AUDIO', 'PHOTO_GALLERY', null][rand(0, 4)];
+    return {
+      id,
+      heading: fixtureHeading(),
+      href: '#',
+      imageSrc: fixtureCat(),
+      imageAlt: 'evil monster',
+      timestamp: new Date().getTime() - rand(100000, 100000000),
+      mediaType,
+      ...(['VIDEO', 'AUDIO'].includes(mediaType) && {
+        mediaDuration: rand(10, 10000),
+      }),
+    };
+  });


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh/issues/9836

**Overall change:**
_Add new component for displaying media icons and durations within the promo.  Update the topic promo demo to use it._

![Screen Shot 2022-02-17 at 05 48 02](https://user-images.githubusercontent.com/8601460/154413452-f5a9e8b9-9ad5-4873-9ae7-93768d0f0cd3.png)

**Code changes:**

- 🚀 

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing

