### PR TITLE
Use BFF Data on a Topic Page

### DIFF
--- a/data/pidgin/topics/c95y35941vrt.json
+++ b/data/pidgin/topics/c95y35941vrt.json
@@ -1,0 +1,199 @@
+{
+  "data": {
+    "title": "Donald Trump",
+    "summaries": [
+      {
+        "title": "Trump social-media platform don go live",
+        "type": "article",
+        "firstPublished": "2022-02-21T15:32:39.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-60465144",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/2C6A/production/_123307311_trump__truth_index_976-nc.png",
+        "id": "92422e0f-00eb-47f9-9795-696d826313b1"
+      },
+      {
+        "title": "Wetin happun for January 6 one year ago?",
+        "type": "article",
+        "firstPublished": "2022-01-06T19:00:29.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-59901959",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/DE3A/production/_122609865_january6timelinewetinhappunforjanuary6oneyearago.jpg",
+        "id": "e2263a1c-8d5a-4a73-a00c-881acfa34381"
+      },
+      {
+        "title": "Why Donald Trump say Bitcoin na scam",
+        "type": "article",
+        "firstPublished": "2021-06-08T07:41:51.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-57396574",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/10BB/production/_118838240_3164b6b1-d415-43c8-9bce-3e497aac61bf.jpg",
+        "id": "11cd8a9d-0d67-4b92-b20b-df71740a4fdd"
+      },
+      {
+        "title": "Wetin be dis new 'website' wey Donald Trump launch?",
+        "type": "article",
+        "firstPublished": "2021-05-05T09:12:36.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-56991816",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/D8D0/production/_116340555_gettyimages-1230086798.jpg",
+        "id": "682b5bcd-0dfd-4e9f-b1a0-14dfe206df83"
+      },
+      {
+        "title": "Three things Donald Trump reveal during Hannity TV interview",
+        "type": "article",
+        "firstPublished": "2021-04-20T09:00:36.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-56813336",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/C816/production/_118122215_donaldtrumpinterviewtoday-seanhannitytelevisionprogramwit46thuspresident.jpg",
+        "id": "567227f0-4783-4637-a2cc-9cfed501476d"
+      },
+      {
+        "title": "How pipo react to Trump ''Radical left Crazies'' Easter Message",
+        "type": "article",
+        "firstPublished": "2021-04-05T14:22:58.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-56641015",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/8C22/production/_117847853_p096152f.jpg",
+        "id": "a891c423-3f36-4c6d-a838-50f6cd3eb03f"
+      },
+      {
+        "title": "How many law suits Trump go face now wey im no be president",
+        "type": "article",
+        "firstPublished": "2021-03-31T12:00:25.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-56587964",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/ADF9/production/_117773544_45officeofdonaldtrump.jpg",
+        "id": "64dbe4ba-7f2a-4eaf-9c5e-4bdb0fd159d8"
+      },
+      {
+        "title": "Five tins Trump tok for im first political appearance afta e comot White House",
+        "type": "article",
+        "firstPublished": "2021-03-01T15:26:35.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-56243119",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/77AA/production/_117343603_f0869a29-2abf-4775-be06-ecbbf00626f0.jpg",
+        "id": "f6ec81d9-1152-4648-a319-33e116b219e8"
+      },
+      {
+        "title": "US Senate fail to convict Trump, everytin you suppose know about Trump impeachment",
+        "type": "article",
+        "firstPublished": "2021-02-14T05:26:11.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-56059489",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/3290/production/_116944921_trump.jpg",
+        "id": "97463752-18f3-4783-ada6-56f3aa841384"
+      },
+      {
+        "title": "Trump second impeachment trial don begin",
+        "type": "article",
+        "firstPublished": "2021-02-09T17:17:07.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/56000740",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/C6E6/production/_116881905_trump.jpg",
+        "id": "7ca69c90-2ccb-42bf-85de-9db681119f73"
+      },
+      {
+        "title": "See when Trump's impeachment trial go start",
+        "type": "article",
+        "firstPublished": "2021-01-14T08:01:10.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55646739",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/194F/production/_116497460_gettyimages-1230553398.jpg",
+        "id": "2b7c3210-51a3-49d6-a1f9-a32206dd4eb0"
+      },
+      {
+        "title": "Watch di inauguration of Joe Biden, Kamala Haris here",
+        "type": "article",
+        "firstPublished": "2021-01-20T14:46:23.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55737536",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/174BC/production/_116602459_michelleobamainauguration2021.jpg",
+        "id": "33d53e44-2f7a-9f43-8050-bcb4a27a4c8a"
+      },
+      {
+        "title": "Wetin Trump pardon Lil Wayne and Black Kodak for?",
+        "type": "article",
+        "firstPublished": "2021-01-20T15:09:29.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55737127",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/2449/production/_116598290_untitleddesign-83.jpg",
+        "id": "8ac85b66-d103-4617-b148-ac83dabe27ae"
+      },
+      {
+        "title": "See wetin Donald Trump tok as e say bye-bye to White House",
+        "type": "article",
+        "firstPublished": "2021-01-20T05:29:45.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55729116",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/D24E/production/_116583835_trumptexas.jpg",
+        "id": "143222cd-e039-4fab-9e8e-de6cd2562469"
+      },
+      {
+        "title": "Eight fotos wey tell di tori of Trump time as US president",
+        "type": "article",
+        "firstPublished": "2021-01-19T19:06:40.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/media-55707598",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/9CD4/production/_116584104_gettyimages-1230553472.jpg",
+        "id": "f3c4d93e-c14f-4f22-aabf-f377945a8819"
+      },
+      {
+        "title": "Eviritin you need to know about Joe Biden Inauguration, Including how to watch",
+        "type": "article",
+        "firstPublished": "2021-01-17T07:36:48.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55693912",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/12543/production/_116357057_gettyimages-1228132294.jpg",
+        "id": "04e47ea8-e68a-4c0d-9562-8399201324c0"
+      },
+      {
+        "title": "All US impeached presidents, wetin happun to dem? Click here to find out",
+        "type": "article",
+        "firstPublished": "2021-01-14T10:20:49.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55658140",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/3CCA/production/_110226551_clinton_976alamy.jpg",
+        "id": "20977caf-fa90-492a-bf6f-28063ef7dcac"
+      },
+      {
+        "title": "US House of Reps don impeach Donald Trump again",
+        "type": "article",
+        "firstPublished": "2021-01-13T08:44:42.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55643506",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/162C3/production/_116491809_trum-_reuters_12jan.png",
+        "id": "e5cb9689-809f-4664-9c26-87b2b6989732"
+      },
+      {
+        "title": "Democrats don formally introduce resolution to impeach President Trump",
+        "type": "article",
+        "firstPublished": "2021-01-11T16:50:32.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55621082",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/13BCB/production/_110234808_057890408.jpg",
+        "id": "ed8c01f0-e76b-4d5c-8a17-2f9885e30fed"
+      },
+      {
+        "title": "Seven tins Arnold schwarzenegger tok afta US Capitol Hill attack",
+        "type": "article",
+        "firstPublished": "2021-01-11T15:46:33.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55621329",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/17A4A/production/_116424869_gettyimages-1188327487.jpg",
+        "id": "a129c42d-9ca7-49b4-b24a-1b39e4e3edd2"
+      },
+      {
+        "title": "How Parler app dey work and wetin to know about di \"free speech\" social network",
+        "type": "article",
+        "firstPublished": "2021-01-09T13:57:46.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55603399",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/132EA/production/_116407587_gettyimages-1225872885.jpg",
+        "id": "054f7769-197a-47d1-b0d6-87fbf658b726"
+      },
+      {
+        "title": "Twitter don permanently suspend Trump account",
+        "type": "article",
+        "firstPublished": "2021-01-09T07:06:22.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55600093",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/F384/production/_116404326_gettyimages-1223057458-1.jpg",
+        "id": "fe825b4f-af61-4a46-8990-e68f7db05b66"
+      },
+      {
+        "title": "Trump no go attend Joe Biden inauguration, see oda times US presidents skip inauguration",
+        "type": "article",
+        "firstPublished": "2021-01-08T18:41:38.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/tori-55595822",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/21AC/production/_116402680_05ae4770-988a-4a27-9960-2e5cf9f7eb87.jpg",
+        "id": "b9c95528-e0b5-47ae-aad4-17cf3090e40f"
+      },
+      {
+        "title": "Wetin happun for Capitol Hill? See key moments plus world reactions afta one of US 'darkest day in history'",
+        "type": "article",
+        "firstPublished": "2021-01-07T07:11:13.000Z",
+        "link": "https://www.bbc.co.uk/pidgin/world-55570816",
+        "imageUrl": "https://ichef.bbci.co.uk/news/{width}/cpsprodpb/4B57/production/_116378291_50517c6d-3702-4bbf-a46c-84a3d9e1b8b2.jpg",
+        "id": "28b7b0d1-0bcc-4660-9591-7553208f433f"
+      }
+    ]
+  }
+}

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -5,7 +5,7 @@ import Promo, { MEDIA_TYPES } from '#components/Promo';
 
 const TopicPromo = ({
   title,
-  timestamp,
+  firstPublished,
   imageUrl,
   imageAlt,
   link,
@@ -14,7 +14,7 @@ const TopicPromo = ({
 }) => {
   return (
     <Promo>
-      <Promo.Image src={imageSrc} alt={imageAlt}>
+      <Promo.Image src={imageUrl} alt={imageAlt}>
         <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.A href={link}>

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -3,24 +3,24 @@ import { string, number } from 'prop-types';
 
 import Promo from '#components/Promo';
 
-const TopicPromo = ({ heading, timestamp, imageSrc, imageAlt, href }) => {
+const TopicPromo = ({ title, firstPublished, imageUrl, imageAlt, link }) => {
   return (
     <Promo>
-      <Promo.Image src={imageSrc} alt={imageAlt} />
-      <Promo.A href={href}>
-        <Promo.Heading>{heading}</Promo.Heading>
+      <Promo.Image src={imageUrl} alt={imageAlt} />
+      <Promo.A href={link}>
+        <Promo.Heading>{title}</Promo.Heading>
       </Promo.A>
-      <Promo.Timestamp>{timestamp}</Promo.Timestamp>
+      <Promo.Timestamp>{firstPublished}</Promo.Timestamp>
     </Promo>
   );
 };
 
 TopicPromo.propTypes = {
-  heading: string.isRequired,
-  timestamp: number.isRequired,
-  imageSrc: string.isRequired,
+  title: string.isRequired,
+  firstPublished: number.isRequired,
+  imageUrl: string.isRequired,
   imageAlt: string.isRequired,
-  href: string.isRequired,
+  link: string.isRequired,
 };
 
 TopicPromo.defaultProps = {};

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -7,6 +7,8 @@ import fetchPageData from '../../utils/fetchPageData';
 const logger = nodeLogger(__filename);
 
 export default async ({ getAgent, service }) => {
+  const BFF_PATH =
+    'https://fabl.api.bbci.co.uk/preview/module/spike-simorgh-bff?id=c95y35941vrt&service=pidgin';
   const agent = await getAgent();
   try {
     const path = process.env.BFF_PATH;

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -1,7 +1,7 @@
 import { BFF_FETCH_ERROR } from '#lib/logger.const';
-import { INTERNAL_SERVER_ERROR } from '#lib/statusCodes.const';
 import nodeLogger from '#lib/logger.node';
 import fetchPageData from '../../utils/fetchPageData';
+import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 
 const logger = nodeLogger(__filename);
 
@@ -21,11 +21,12 @@ export default async ({ getAgent, service, path: pathname, variant }) => {
         promos: data.summaries,
       },
     };
-  } catch (error) {
+  } catch ({ message, status = getErrorStatusCode() }) {
     logger.error(BFF_FETCH_ERROR, {
       service,
-      error,
+      status,
+      pathname,
     });
-    return { error, status: INTERNAL_SERVER_ERROR };
+    return { error: message, status };
   }
 };

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -7,8 +7,6 @@ import fetchPageData from '../../utils/fetchPageData';
 const logger = nodeLogger(__filename);
 
 export default async ({ getAgent, service }) => {
-  const BFF_PATH =
-    'https://fabl.api.bbci.co.uk/preview/module/spike-simorgh-bff?id=c95y35941vrt&service=pidgin';
   const agent = await getAgent();
   try {
     const path = process.env.BFF_PATH;

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -1,15 +1,14 @@
 import { BFF_FETCH_ERROR } from '#lib/logger.const';
 import { INTERNAL_SERVER_ERROR } from '#lib/statusCodes.const';
 import nodeLogger from '#lib/logger.node';
-import { fixturePromos } from '#pages/TopicPage/fixtures';
 import fetchPageData from '../../utils/fetchPageData';
 
 const logger = nodeLogger(__filename);
 
-export default async ({ getAgent, service }) => {
+export default async ({ getAgent, service, path: pathname, variant }) => {
   const agent = await getAgent();
   try {
-    const path = process.env.BFF_PATH;
+    const path = process.env.BFF_PATH || pathname;
     const { status, json } = await fetchPageData({ path, agent });
     return {
       status,

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -8,9 +8,10 @@ const logger = nodeLogger(__filename);
 export default async ({ getAgent, service, path: pathname, variant }) => {
   const agent = await getAgent();
   try {
-    // append ID, service, and variant (if exists)
-    // to bff_path and pass to fetchPageData
-    const path = process.env.BFF_PATH;
+    const id = pathname.split('/').pop();
+    const path = `${process.env.BFF_PATH}?id=${id}&service=${service}${
+      variant ? `&variant=${variant}` : ``
+    }`;
     const { status, json } = await fetchPageData({ path, agent });
     const { data } = json;
     return {

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -8,7 +8,7 @@ const logger = nodeLogger(__filename);
 export default async ({ getAgent, service, path: pathname, variant }) => {
   const agent = await getAgent();
   try {
-    const path = process.env.BFF_PATH || pathname;
+    const path = process.env.BFF_PATH;
     const { status, json } = await fetchPageData({ path, agent });
     return {
       status,

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -6,15 +6,15 @@ import fetchPageData from '../../utils/fetchPageData';
 
 const logger = nodeLogger(__filename);
 
-export default async ({ getAgent, service }) => {
+export default async ({ getAgent, service, path: pathname }) => {
   const agent = await getAgent();
   try {
-    const path = process.env.BFF_PATH;
+    const path = pathname || process.env.BFF_PATH;
     const { status, json } = await fetchPageData({ path, agent });
     return {
       status,
       pageData: {
-        ...json,
+        ...json.data,
         promos: fixturePromos(),
       },
     };

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -15,7 +15,7 @@ export default async ({ getAgent, service, path: pathname }) => {
       status,
       pageData: {
         ...json.data,
-        promos: fixturePromos(),
+        promos: json.data.summaries,
       },
     };
   } catch (error) {

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -6,10 +6,10 @@ import fetchPageData from '../../utils/fetchPageData';
 
 const logger = nodeLogger(__filename);
 
-export default async ({ getAgent, service, path: pathname }) => {
+export default async ({ getAgent, service }) => {
   const agent = await getAgent();
   try {
-    const path = pathname || process.env.BFF_PATH;
+    const path = process.env.BFF_PATH;
     const { status, json } = await fetchPageData({ path, agent });
     return {
       status,

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -8,13 +8,16 @@ const logger = nodeLogger(__filename);
 export default async ({ getAgent, service, path: pathname, variant }) => {
   const agent = await getAgent();
   try {
+    // append ID, service, and variant (if exists)
+    // to bff_path and pass to fetchPageData
     const path = process.env.BFF_PATH;
     const { status, json } = await fetchPageData({ path, agent });
+    const { data } = json;
     return {
       status,
       pageData: {
-        ...json.data,
-        promos: json.data.summaries,
+        title: data.title,
+        promos: data.summaries,
       },
     };
   } catch (error) {

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,9 +1,12 @@
 import getInitialData from '.';
+import getAgent from '../../../../server/utilities/getAgent';
 
 describe('get initial data for topic', () => {
-  it.skip('should return our topic title', () => {
-    const { pageData } = getInitialData();
-    expect(pageData.title).toEqual('Hello world');
+  it('should return our topic title', () => {
+    const { pageData } = getInitialData(getAgent(), 'pidgin');
+    expect(pageData)
+      .toEqual('Hello world')
+      .catch(e => expect(e).toMatch('error'));
   });
 
   it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -34,17 +34,17 @@ describe('get initial data for topic', () => {
       service: 'pidgin',
     });
     expect(pageData.title).toEqual('Donald Trump');
-    expect(pageData.summaries[0].title).toEqual(
+    expect(pageData.promos[0].title).toEqual(
       'Wetin happun for January 6 one year ago?',
     );
-    expect(pageData.summaries[0].type).toEqual('article');
-    expect(pageData.summaries[0].firstPublished).toEqual(
+    expect(pageData.promos[0].type).toEqual('article');
+    expect(pageData.promos[0].firstPublished).toEqual(
       '2022-01-06T19:00:29.000Z',
     );
-    expect(pageData.summaries[0].imageUrl).toEqual('mock-image-url');
-    expect(pageData.summaries[0].link).toEqual('mock-link');
-    expect(pageData.summaries[0].imageAlt).toEqual('mock-image-alt');
-    expect(pageData.summaries[0].id).toEqual('54321');
+    expect(pageData.promos[0].imageUrl).toEqual('mock-image-url');
+    expect(pageData.promos[0].link).toEqual('mock-link');
+    expect(pageData.promos[0].imageAlt).toEqual('mock-image-alt');
+    expect(pageData.promos[0].id).toEqual('54321');
   });
 
   it('should call fetchPageData with the correct request URL', async () => {

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -19,4 +19,6 @@ describe('get error codes for initial data request responses ', () => {
   it.skip('should throw an error and status code - code 404', () => {});
 
   it.skip('should throw an error and status code - code 400', () => {});
+
+  it.skip('should throw an error when the page data is undefined', () => {});
 });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -3,12 +3,9 @@ import getAgent from '../../../../server/utilities/getAgent';
 
 describe('get initial data for topic', () => {
   it('should return our topic title', async () => {
-    const BFF_PATH =
-      'https://fabl.api.bbci.co.uk/preview/module/spike-simorgh-bff?id=c95y35941vrt&service=pidgin';
     const { pageData } = await getInitialData({
       getAgent,
       service: 'pidgin',
-      path: BFF_PATH,
     });
     expect(pageData.title)
       .toEqual('Donald Trump')

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,15 +1,21 @@
 import getInitialData from '.';
-import getAgent from '../../../../server/utilities/getAgent';
+
+const topicJSON = {
+  data: {
+    title: 'Donald Trump',
+  },
+};
 
 describe('get initial data for topic', () => {
   it('should return our topic title', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const getAgent = jest.fn();
     const { pageData } = await getInitialData({
+      path: 'mock-topic-path',
       getAgent,
       service: 'pidgin',
     });
-    expect(pageData.title)
-      .toEqual('Donald Trump')
-      .catch(e => expect(e).toMatch('error'));
+    expect(pageData.title).toEqual('Donald Trump');
   });
 
   it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,8 +1,16 @@
 import getInitialData from '.';
 
 describe('get initial data for topic', () => {
-  it.skip('should return our title', () => {
+  it.skip('should return our topic title', () => {
     const { pageData } = getInitialData();
     expect(pageData.title).toEqual('Hello world');
   });
+
+  it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});
+
+  it.skip('should throw an error if the topic id is invalid', () => {});
+
+  it.skip('should append the service and id to the BFF_PATH as a query string and return the topic - using a topic without a variant', () => {});
+
+  it.skip('should append the service, id and optional service variant to the BFF_PATH as a query string and return the topic - using a topic with a service variant', () => {});
 });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,3 +1,4 @@
+import * as fetchPageData from '#app/routes/utils/fetchPageData';
 import getInitialData from '.';
 
 const topicJSON = {
@@ -7,6 +8,9 @@ const topicJSON = {
 };
 
 describe('get initial data for topic', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   it('should return our topic title', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
     const getAgent = jest.fn();
@@ -20,23 +24,38 @@ describe('get initial data for topic', () => {
 
   it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});
 
-  it.skip('should append the service and id to the BFF_PATH as a query string and return the topic - using a topic without a variant', () => {});
-
-  it.skip('should append the service, id and optional service variant to the BFF_PATH as a query string and return the topic - using a topic with a service variant', () => {});
-});
-
-describe('get error codes for initial data request responses ', () => {
-  it.skip('should throw an error and status code - code 500', () => {});
-
-  it.skip('should throw an error and status code - code 404', () => {});
-
-  it.skip('should throw an error and status code - code 400', () => {});
-
-  it.skip('should throw an error when the page data is undefined', async () => {
+  it('should call fetchPageData with the correct request URL', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const agent = { ca: 'ca', key: 'key' };
+    const getAgent = jest.fn(() => agent);
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
     const { pageData } = await getInitialData({
+      path: 'pidgin/topics/54321',
       getAgent,
-      service: 'pigeon',
+      service: 'pidgin',
     });
-    expect(pageData).toEqual(undefined);
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'mock-bff-path?id=54321&service=pidgin',
+      agent,
+    });
+  });
+
+  it('should call fetchPageData with the correct request URL - with variant', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const agent = { ca: 'ca', key: 'key' };
+    const getAgent = jest.fn(() => agent);
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+    const { pageData } = await getInitialData({
+      path: 'serbian/cyr/topics/54321',
+      getAgent,
+      service: 'serbian',
+      variant: 'sr-cyrl',
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'mock-bff-path?id=54321&service=serbian&variant=sr-cyrl',
+      agent,
+    });
   });
 });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -2,8 +2,11 @@ import getInitialData from '.';
 import getAgent from '../../../../server/utilities/getAgent';
 
 describe('get initial data for topic', () => {
-  it('should return our topic title', () => {
-    const { pageData } = getInitialData(getAgent(), 'pidgin');
+  it('should return our topic title', async () => {
+    const { pageData } = await getInitialData({
+      agent: getAgent(),
+      service: 'pidgin',
+    });
     expect(pageData)
       .toEqual('Hello world')
       .catch(e => expect(e).toMatch('error'));

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -4,30 +4,49 @@ import getInitialData from '.';
 const topicJSON = {
   data: {
     title: 'Donald Trump',
+    summaries: [
+      {
+        title: 'Wetin happun for January 6 one year ago?',
+        type: 'article',
+        firstPublished: '2022-01-06T19:00:29.000Z',
+        imageUrl: 'mock-image-url',
+        link: 'mock-link',
+        imageAlt: 'mock-image-alt',
+        id: '54321',
+      },
+    ],
   },
 };
 
 describe('get initial data for topic', () => {
+  const agent = { ca: 'ca', key: 'key' };
+  const getAgent = jest.fn(() => agent);
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it('should return our topic title', async () => {
+  it('should return the correct topic data', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
-    const getAgent = jest.fn();
     const { pageData } = await getInitialData({
       path: 'mock-topic-path',
       getAgent,
       service: 'pidgin',
     });
     expect(pageData.title).toEqual('Donald Trump');
+    expect(pageData.summaries[0].title).toEqual(
+      'Wetin happun for January 6 one year ago?',
+    );
+    expect(pageData.summaries[0].type).toEqual('article');
+    expect(pageData.summaries[0].firstPublished).toEqual(
+      '2022-01-06T19:00:29.000Z',
+    );
+    expect(pageData.summaries[0].imageUrl).toEqual('mock-image-url');
+    expect(pageData.summaries[0].link).toEqual('mock-link');
+    expect(pageData.summaries[0].imageAlt).toEqual('mock-image-alt');
+    expect(pageData.summaries[0].id).toEqual('54321');
   });
-
-  it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});
 
   it('should call fetchPageData with the correct request URL', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
-    const agent = { ca: 'ca', key: 'key' };
-    const getAgent = jest.fn(() => agent);
     const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
     const { pageData } = await getInitialData({
       path: 'pidgin/topics/54321',
@@ -43,8 +62,6 @@ describe('get initial data for topic', () => {
 
   it('should call fetchPageData with the correct request URL - with variant', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
-    const agent = { ca: 'ca', key: 'key' };
-    const getAgent = jest.fn(() => agent);
     const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
     const { pageData } = await getInitialData({
       path: 'serbian/cyr/topics/54321',

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -8,9 +8,15 @@ describe('get initial data for topic', () => {
 
   it.skip('should return title, type, firstPublished, link, imageUrl and id from a summary', () => {});
 
-  it.skip('should throw an error if the topic id is invalid', () => {});
-
   it.skip('should append the service and id to the BFF_PATH as a query string and return the topic - using a topic without a variant', () => {});
 
   it.skip('should append the service, id and optional service variant to the BFF_PATH as a query string and return the topic - using a topic with a service variant', () => {});
+});
+
+describe('get error codes for initial data request responses ', () => {
+  it.skip('should throw an error and status code - code 500', () => {});
+
+  it.skip('should throw an error and status code - code 404', () => {});
+
+  it.skip('should throw an error and status code - code 400', () => {});
 });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -4,10 +4,10 @@ import getAgent from '../../../../server/utilities/getAgent';
 describe('get initial data for topic', () => {
   it('should return our topic title', async () => {
     const { pageData } = await getInitialData({
-      agent: getAgent(),
+      getAgent,
       service: 'pidgin',
     });
-    expect(pageData)
+    expect(pageData.title)
       .toEqual('Hello world')
       .catch(e => expect(e).toMatch('error'));
   });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,6 +1,8 @@
 import * as fetchPageData from '#app/routes/utils/fetchPageData';
 import getInitialData from '.';
 
+process.env.BFF_PATH = 'https://mock-bff-path';
+
 const topicJSON = {
   data: {
     title: 'Donald Trump',
@@ -55,7 +57,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'mock-bff-path?id=54321&service=pidgin',
+      path: 'https://mock-bff-path?id=54321&service=pidgin',
       agent,
     });
   });
@@ -71,7 +73,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'mock-bff-path?id=54321&service=serbian&variant=sr-cyrl',
+      path: 'https://mock-bff-path?id=54321&service=serbian&variant=sr-cyrl',
       agent,
     });
   });

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -50,7 +50,7 @@ describe('get initial data for topic', () => {
   it('should call fetchPageData with the correct request URL', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
     const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
-    const { pageData } = await getInitialData({
+    await getInitialData({
       path: 'pidgin/topics/54321',
       getAgent,
       service: 'pidgin',
@@ -65,7 +65,7 @@ describe('get initial data for topic', () => {
   it('should call fetchPageData with the correct request URL - with variant', async () => {
     fetch.mockResponse(JSON.stringify(topicJSON));
     const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
-    const { pageData } = await getInitialData({
+    await getInitialData({
       path: 'serbian/cyr/topics/54321',
       getAgent,
       service: 'serbian',

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -3,12 +3,15 @@ import getAgent from '../../../../server/utilities/getAgent';
 
 describe('get initial data for topic', () => {
   it('should return our topic title', async () => {
+    const BFF_PATH =
+      'https://fabl.api.bbci.co.uk/preview/module/spike-simorgh-bff?id=c95y35941vrt&service=pidgin';
     const { pageData } = await getInitialData({
       getAgent,
       service: 'pidgin',
+      path: BFF_PATH,
     });
     expect(pageData.title)
-      .toEqual('Hello world')
+      .toEqual('Donald Trump')
       .catch(e => expect(e).toMatch('error'));
   });
 
@@ -26,5 +29,11 @@ describe('get error codes for initial data request responses ', () => {
 
   it.skip('should throw an error and status code - code 400', () => {});
 
-  it.skip('should throw an error when the page data is undefined', () => {});
+  it.skip('should throw an error when the page data is undefined', async () => {
+    const { pageData } = await getInitialData({
+      getAgent,
+      service: 'pigeon',
+    });
+    expect(pageData).toEqual(undefined);
+  });
 });


### PR DESCRIPTION
Resolves #[1543](https://github.com/bbc/simorgh-infrastructure/issues/1543)

**Overall change:**
Use BFF data on the Topic page. Append topic ID, service, and variant to BFF URL.

**Code changes:**

- Append service, ID, and variant to BFF path
- Add tests to check request URL and response data
- Use BFF data on Topic page

**Image srcset and webp to follow in separate PR**

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
