### PR TITLE
Remove .only from describe block

### DIFF
--- a/src/app/lib/analyticsUtils/index.test.js
+++ b/src/app/lib/analyticsUtils/index.test.js
@@ -447,7 +447,7 @@ describe('getAtUserId', () => {
   });
 
   it('should return the AT user id', () => {
-    Cookie.set('atuserid', { val: 'some-random-uuid' });
+    Cookie.set('atuserid', '{ "val": "some-random-uuid" }');
     cookieSetterSpy.mockClear();
     const atUserId = getAtUserId();
 
@@ -455,7 +455,7 @@ describe('getAtUserId', () => {
   });
 
   it('should store the existing AT user id as a stringified JSON value in cookies again so that we update the cookie expiration date', () => {
-    Cookie.set('atuserid', { val: 'some-random-uuid' });
+    Cookie.set('atuserid', '{ "val": "some-random-uuid" }');
     cookieSetterSpy.mockClear();
     const atUserId = getAtUserId();
     const [[cookieName, cookieValue, cookieOptions]] =
@@ -553,7 +553,7 @@ describe('getCampaignType', () => {
 });
 
 describe('getRSSMarketingString', () => {
-  describe.only('"RSS" prefix', () => {
+  describe('"RSS" prefix', () => {
     it('returns "src_medium" when marketing string is present in url', () => {
       const href = 'https://www.bbc.com/mundo?at_medium=RSS';
       expect(getRSSMarketingString(href, 'RSS')).toEqual([SRC_RSS_FIXTURE]);


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Noticed that a missed `.only` on a describe block; means only a subset of tests were running on that file. Introduced after merging this [PR](https://github.com/bbc/simorgh/pull/9498). Removed the `.only` and fixed two failing tests

**Code changes:**

- Remove `.only` from describe block.
- Editing test data in the cookie to be JSON string.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
