### PR TITLE
Update Russian nav to add Ukraine crisis item

### DIFF
--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -367,6 +367,10 @@ export const service = {
         url: '/russian',
       },
       {
+        title: 'Украина',
+        url: '/russian/topics/cez0n29ggrdt',
+      },
+      {
         title: 'Коронавирус',
         url: '/russian/in-depth-51962199',
       },


### PR DESCRIPTION
Resolves # n/a

**Overall change:**
Added link to Ukraine crisis topic to BBC Russian navigation bar 

**Code changes:**

- Added link to /russian/topics/cez0n29ggrdt as second item in the navigation in src/app/lib/config/russian.js 


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
