### PR TITLE
Update Persian podcast promo image and Azeri top stories label

### DIFF
--- a/src/app/lib/config/services/azeri.js
+++ b/src/app/lib/config/services/azeri.js
@@ -237,7 +237,7 @@ export const service = {
           'Sorry, we can’t display this part of the story on this lightweight mobile page.',
         linkText: 'View the full version of the page to see all the content.',
       },
-      topStoriesTitle: 'Bu günün xəbərləri',
+      topStoriesTitle: 'Digər xəbərlər',
       featuresAnalysisTitle: 'Bunları da oxuyun',
     },
     brandSVG,

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -69,7 +69,7 @@ export const service = {
       brandTitle: 'رادیو فارسی بی‌بی‌سی',
       brandDescription: 'پادکست چشم‌انداز بامدادی رادیو بی‌بی‌سی',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p02h1lnx.jpg',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0bq9rkk.jpg',
         alt: 'رادیو فارسی بی‌بی‌سی',
       },
       linkLabel: {


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
_Updates to the Persian podcast promo and to the Top stories label for Azeri._

**Code changes:**

- Replaced old image with new recent-guidelines-compliant image URL on the Persian in article podcast promo 
- Updated heading on Azeri top stories block on the secondary column

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
