### PR TITLE
Remove events from linked data

### DIFF
--- a/src/app/containers/LinkedData/getAboutTagsContent.js
+++ b/src/app/containers/LinkedData/getAboutTagsContent.js
@@ -1,10 +1,5 @@
 const checkType = types => {
-  const acceptableTypes = [
-    'core:Person',
-    'core:Event',
-    'core:Organization',
-    'core:Place',
-  ];
+  const acceptableTypes = ['core:Person', 'core:Organization', 'core:Place'];
 
   if (types.length === 0) {
     return 'Thing';


### PR DESCRIPTION
Resolves a request from Product / SEO: https://bbcnews.slack.com/archives/C01B5GFN11A/p1645605411016419

The BBC concept of an event (major news story) does not match with the google / schema.org concept of an event (eg a concert or a conference)