### PR TITLE
Change Topic route to new_topics

### DIFF
--- a/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
@@ -44,4 +44,4 @@ exports[`regex utils snapshots should create expected regex from getSecondaryCol
 
 exports[`regex utils snapshots should create expected regex from getSwRegex 1`] = `"/:service(news|persian|igbo)/sw.js"`;
 
-exports[`regex utils snapshots should create expected regex from getTopicPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/topics/:id([a-z0-9]+):amp(.amp)?"`;
+exports[`regex utils snapshots should create expected regex from getTopicPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/new_topics/:id([a-z0-9]+):amp(.amp)?"`;

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -81,7 +81,7 @@ export const getOnDemandTvRegex = services => {
 
 export const getTopicPageRegex = services => {
   const serviceRegex = getServiceRegex(services);
-  return `/:service(${serviceRegex}):variant(${variantRegex})?/topics/:id(${topicIdRegex}):amp(${ampRegex})?`;
+  return `/:service(${serviceRegex}):variant(${variantRegex})?/new_topics/:id(${topicIdRegex}):amp(${ampRegex})?`;
 };
 
 export const getErrorPageRegex = services => {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**

Changing topic route from

`service/topics/id`

to

`service/new_topics/id`

while we maintain `service/topics/id` for the existing test page.

This will be changed back once these pages go live.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
