### PR TITLE
fix for e2es - new url for failing topic tag test

### DIFF
--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -47,13 +47,13 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
         }
       });
     });
-    it.skip('FOR /news/uk-60508671.amp ONLY - should render topic tags if they are in the json, and they should navigate to correct topic page', () => {
+    it('FOR /news/technology-60561162.amp ONLY - should render topic tags if they are in the json, and they should navigate to correct topic page', () => {
       if (service === 'news' && Cypress.env('APP_ENV') !== 'local') {
-        const url = '/news/uk-60508671.amp?renderer_env=live';
+        const url = '/news/technology-60561162.amp?renderer_env=live';
         cy.visit(`${envConfig.baseUrl}${url}`);
         topicTagsTest();
       } else {
-        cy.log('Test is only for /news/uk-60508671.amp');
+        cy.log('Test is only for /news/technology-60561162.amp');
       }
     });
     it.skip('should render podcast promo if in json and should navigate to correct podcast page', () => {

--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -47,7 +47,7 @@ export const testsThatFollowSmokeTestConfig = ({ service, pageType }) => {
         }
       });
     });
-    it('FOR /news/uk-60508671.amp ONLY - should render topic tags if they are in the json, and they should navigate to correct topic page', () => {
+    it.skip('FOR /news/uk-60508671.amp ONLY - should render topic tags if they are in the json, and they should navigate to correct topic page', () => {
       if (service === 'news' && Cypress.env('APP_ENV') !== 'local') {
         const url = '/news/uk-60508671.amp?renderer_env=live';
         cy.visit(`${envConfig.baseUrl}${url}`);


### PR DESCRIPTION
The topic tag Russia-Ukraine war leads to War in Ukraine index page instead of a topic tag page.

I changed the URL to one that goes to elon musk topic page
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Passes on test and live
