### PR TITLE
Remove amp and query string from ID

### DIFF
--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -1,16 +1,16 @@
 import { BFF_FETCH_ERROR } from '#lib/logger.const';
 import nodeLogger from '#lib/logger.node';
 import pipe from 'ramda/src/pipe';
+import { getUrlPath } from '#lib/utilities/urlParser';
 import fetchPageData from '../../utils/fetchPageData';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 
 const logger = nodeLogger(__filename);
 
-const removeQueryParams = path => path.split('?')[0];
 const removeAmp = path => path.split('.')[0];
 const popId = path => path.split('/').pop();
 
-const getId = pipe(removeQueryParams, removeAmp, popId);
+const getId = pipe(getUrlPath, removeAmp, popId);
 
 export default async ({ getAgent, service, path: pathname, variant }) => {
   try {

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -1,14 +1,21 @@
 import { BFF_FETCH_ERROR } from '#lib/logger.const';
 import nodeLogger from '#lib/logger.node';
+import pipe from 'ramda/src/pipe';
 import fetchPageData from '../../utils/fetchPageData';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 
 const logger = nodeLogger(__filename);
 
+const removeQueryParams = path => path.split('?')[0];
+const removeAmp = path => path.split('.')[0];
+const popId = path => path.split('/').pop();
+
+const getId = pipe(removeQueryParams, removeAmp, popId);
+
 export default async ({ getAgent, service, path: pathname, variant }) => {
   try {
     const agent = await getAgent();
-    const id = pathname.split('/').pop();
+    const id = getId(pathname);
     const path = `${process.env.BFF_PATH}?id=${id}&service=${service}${
       variant ? `&variant=${variant}` : ``
     }`;

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -77,4 +77,49 @@ describe('get initial data for topic', () => {
       agent,
     });
   });
+
+  it('should remove .amp from ID', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+    await getInitialData({
+      path: 'pidgin/topics/54321.amp',
+      getAgent,
+      service: 'pidgin',
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'https://mock-bff-path?id=54321&service=pidgin',
+      agent,
+    });
+  });
+
+  it('should remove query string from ID', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+    await getInitialData({
+      path: 'pidgin/topics/54321?foo=bar',
+      getAgent,
+      service: 'pidgin',
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'https://mock-bff-path?id=54321&service=pidgin',
+      agent,
+    });
+  });
+
+  it('should remove .amp and query string from ID', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+    await getInitialData({
+      path: 'pidgin/topics/54321.amp?foo=bar',
+      getAgent,
+      service: 'pidgin',
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'https://mock-bff-path?id=54321&service=pidgin',
+      agent,
+    });
+  });
 });


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Remove amp and query string from ID before making request to BFF

**Code changes:**

- Strip off query string
- Strip off amp
- Pop off ID

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
