### PR TITLE
Use disclaimer to promote the Russian Apps 

### DIFF
--- a/scripts/bundleSize/bundleSizeConfig.js
+++ b/scripts/bundleSize/bundleSizeConfig.js
@@ -5,5 +5,5 @@ module.exports = {
   // below the smallest value in the build output; this avoids the
   // need for frequent changes as bundle sizes fluctuate.
   MIN_SIZE: 615,
-  MAX_SIZE: 1026,
+  MAX_SIZE: 1027,
 };

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -63,17 +63,17 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
       >
         <strong>
           {disclaimerBlock.map(element => {
-          const isLink = pathOr(false, ['link'], element);
-          const linkText = pathOr('', ['link', 'text'], element);
-          const linkHref = pathOr('', ['link', 'href'], element);
-          return isLink ? (
-            <InlineLink href={linkHref} key={linkText}>
-              {linkText}
-            </InlineLink>
-          ) : (
-            element?.text
-          );
-        })}
+            const isLink = pathOr(false, ['link'], element);
+            const linkText = pathOr('', ['link', 'text'], element);
+            const linkHref = pathOr('', ['link', 'href'], element);
+            return isLink ? (
+              <InlineLink href={linkHref} key={linkText}>
+                {linkText}
+              </InlineLink>
+            ) : (
+              element?.text
+            );
+          })}
         </strong>
       </Inner>
     </GridItemLarge>

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -62,16 +62,15 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         aria-label={disclaimerLabelTranslation}
       >
         <strong>
-          {disclaimerBlock.map(element => {
-            const isLink = pathOr(false, ['link'], element);
-            const linkText = pathOr('', ['link', 'text'], element);
-            const linkHref = pathOr('', ['link', 'href'], element);
-            return isLink ? (
-              <InlineLink href={linkHref} key={linkText}>
+          {Object.values(disclaimer).map(para => {
+            const linkText = path(['text'], para);
+            const linkUrl = path(['url'], para);
+            return linkUrl ? (
+              <InlineLink href={linkUrl} key={linkText}>
                 {linkText}
               </InlineLink>
             ) : (
-              element?.text
+              para
             );
           })}
         </strong>

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { bool } from 'prop-types';
 import path from 'ramda/src/path';
+import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import InlineLink from '@bbc/psammead-inline-link';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
@@ -52,9 +53,12 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         increasePaddingOnDesktop={increasePaddingOnDesktop}
       >
         {disclaimerBlock.map(element => {
-          return element?.link ? (
-            <InlineLink href={element.link.href} key={element.link.text}>
-              {element?.link?.text}
+          const isLink = pathOr(false, ['link'], element);
+          const linkText = pathOr('', ['link', 'text'], element);
+          const linkHref = pathOr('', ['link', 'href'], element);
+          return isLink ? (
+            <InlineLink href={linkHref} key={linkText}>
+              {linkText}
             </InlineLink>
           ) : (
             element?.text

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -1,9 +1,8 @@
 import React, { useContext } from 'react';
 import { bool } from 'prop-types';
 import path from 'ramda/src/path';
-import hasPath from 'ramda/src/hasPath';
 import styled from '@emotion/styled';
-
+import InlineLink from '@bbc/psammead-inline-link';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
 import { getLongPrimer } from '@bbc/gel-foundations/typography';
 import {
@@ -13,7 +12,6 @@ import {
 } from '@bbc/gel-foundations/spacings';
 import { C_GREY_6 } from '@bbc/psammead-styles/colours';
 import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
-
 import { GridItemLarge } from '#app/components/Grid';
 
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -40,9 +38,13 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
   const { service, script, disclaimer } = useContext(ServiceContext);
   const { enabled } = useToggle('disclaimer');
 
-  const shouldShow = hasPath(['text'], disclaimer) && enabled;
+  const disclaimerText = path(['text'], disclaimer);
+
+  const shouldShow = enabled && disclaimerText;
 
   if (!shouldShow) return null;
+
+  const [first, second, third] = disclaimerText.split('[link]');
 
   return (
     <GridItemLarge data-testid="disclaimer">
@@ -51,7 +53,11 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         script={script}
         increasePaddingOnDesktop={increasePaddingOnDesktop}
       >
-        {path(['text'], disclaimer)}
+        {first}
+        <InlineLink href="google.com">IOS</InlineLink>
+        {second}
+        <InlineLink href="google.com">Android</InlineLink>
+        {third}
       </Inner>
     </GridItemLarge>
   );

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { bool } from 'prop-types';
 import path from 'ramda/src/path';
+import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import InlineLink from '@bbc/psammead-inline-link';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
@@ -17,7 +18,7 @@ import { GridItemLarge } from '#app/components/Grid';
 import { ServiceContext } from '#contexts/ServiceContext';
 import useToggle from '#hooks/useToggle';
 
-const Inner = styled.div`
+const Inner = styled.section`
   ${({ script }) => script && getLongPrimer(script)}
   ${({ service }) => service && getSansLight(service)}
   background: #f6f6f6;
@@ -35,7 +36,8 @@ const Inner = styled.div`
 `;
 
 const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
-  const { service, script, disclaimer } = useContext(ServiceContext);
+  const { service, script, disclaimer, translations } =
+    useContext(ServiceContext);
   const { enabled } = useToggle('disclaimer');
 
   const disclaimerBlock = path(['block'], disclaimer);
@@ -44,22 +46,32 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
 
   if (!shouldShow) return null;
 
+  const disclaimerLabelTranslation = pathOr(
+    'Disclaimer',
+    ['disclaimerLabel'],
+    translations,
+  );
+
   return (
-    <GridItemLarge data-testid="disclaimer">
+    <GridItemLarge>
       <Inner
         service={service}
         script={script}
         increasePaddingOnDesktop={increasePaddingOnDesktop}
+        role="region"
+        aria-label={disclaimerLabelTranslation}
       >
-        {disclaimerBlock.map(element => {
-          return element?.link ? (
-            <InlineLink href={element.link.href} key={element.link.text}>
-              {element?.link?.text}
-            </InlineLink>
-          ) : (
-            element?.text
-          );
-        })}
+        <strong>
+          {disclaimerBlock.map(element => {
+            return element?.link ? (
+              <InlineLink href={element.link.href} key={element.link.text}>
+                {element?.link?.text}
+              </InlineLink>
+            ) : (
+              element?.text
+            );
+          })}
+        </strong>
       </Inner>
     </GridItemLarge>
   );

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -38,13 +38,11 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
   const { service, script, disclaimer } = useContext(ServiceContext);
   const { enabled } = useToggle('disclaimer');
 
-  const disclaimerText = path(['text'], disclaimer);
+  const disclaimerBlock = path(['block'], disclaimer);
 
-  const shouldShow = enabled && disclaimerText;
+  const shouldShow = enabled && disclaimerBlock;
 
   if (!shouldShow) return null;
-
-  const [first, second, third] = disclaimerText.split('[link]');
 
   return (
     <GridItemLarge data-testid="disclaimer">
@@ -53,11 +51,15 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         script={script}
         increasePaddingOnDesktop={increasePaddingOnDesktop}
       >
-        {first}
-        <InlineLink href="google.com">IOS</InlineLink>
-        {second}
-        <InlineLink href="google.com">Android</InlineLink>
-        {third}
+        {disclaimerBlock.map(element => {
+          return element?.link ? (
+            <InlineLink href={element.link.href} key={element.link.text}>
+              {element?.link?.text}
+            </InlineLink>
+          ) : (
+            element?.text
+          );
+        })}
       </Inner>
     </GridItemLarge>
   );

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { bool } from 'prop-types';
 import path from 'ramda/src/path';
+import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import InlineLink from '@bbc/psammead-inline-link';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
@@ -16,6 +17,7 @@ import { GridItemLarge } from '#app/components/Grid';
 
 import { ServiceContext } from '#contexts/ServiceContext';
 import useToggle from '#hooks/useToggle';
+import isEmpty from 'ramda/src/isEmpty';
 
 const Inner = styled.section`
   ${({ script }) => script && getLongPrimer(script)}
@@ -39,7 +41,7 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
     useContext(ServiceContext);
   const { enabled } = useToggle('disclaimer');
 
-  const shouldShow = enabled && disclaimer;
+  const shouldShow = enabled && disclaimer && !isEmpty(disclaimer);
 
   if (!shouldShow) return null;
 

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { bool } from 'prop-types';
 import path from 'ramda/src/path';
-import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import InlineLink from '@bbc/psammead-inline-link';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
@@ -39,9 +38,7 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
   const { service, script, disclaimer } = useContext(ServiceContext);
   const { enabled } = useToggle('disclaimer');
 
-  const disclaimerBlock = path(['block'], disclaimer);
-
-  const shouldShow = enabled && disclaimerBlock;
+  const shouldShow = enabled && disclaimer;
 
   if (!shouldShow) return null;
 
@@ -52,16 +49,15 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         script={script}
         increasePaddingOnDesktop={increasePaddingOnDesktop}
       >
-        {disclaimerBlock.map(element => {
-          const isLink = pathOr(false, ['link'], element);
-          const linkText = pathOr('', ['link', 'text'], element);
-          const linkHref = pathOr('', ['link', 'href'], element);
-          return isLink ? (
-            <InlineLink href={linkHref} key={linkText}>
+        {Object.values(disclaimer).map(para => {
+          const linkText = path(['text'], para);
+          const linkUrl = path(['url'], para);
+          return linkUrl ? (
+            <InlineLink href={linkUrl} key={linkText}>
               {linkText}
             </InlineLink>
           ) : (
-            element?.text
+            para
           );
         })}
       </Inner>

--- a/src/app/containers/Disclaimer/index.stories.jsx
+++ b/src/app/containers/Disclaimer/index.stories.jsx
@@ -1,25 +1,64 @@
 import React from 'react';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import { withKnobs } from '@storybook/addon-knobs';
-import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { ServiceContext } from '#contexts/ServiceContext';
+import pathOr from 'ramda/src/pathOr';
 
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import DisclaimerComponent from '.';
 
+const DISCLAIMER_FIXTURE = {
+  news: {
+    para1: 'The BBC News apps are available for ',
+    para2: {
+      text: 'IOS',
+      url: 'https://apps.apple.com/gb/app/bbc-news/id377382255',
+    },
+    para3: ' and ',
+    para4: {
+      text: 'Android',
+      url: 'https://play.google.com/store/apps/details?id=bbc.mobile.news.uk&hl=en_GB&gl=US',
+    },
+    para5:
+      '. Download them to your device and continue to receive news from the BBC.',
+  },
+  russian: {
+    para1: 'Приложение Русской службы BBC News доступно для ',
+    para2: {
+      text: 'IOS',
+      url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+    },
+    para3: ' и ',
+    para4: {
+      text: 'Android',
+      url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+    },
+    para5:
+      '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
+  },
+};
+
 // eslint-disable-next-line react/prop-types
-const Component = ({ service }) => (
-  <ToggleContextProvider
-    toggles={{
-      disclaimer: {
-        enabled: true,
-      },
-    }}
-  >
-    <ServiceContextProvider service={service}>
-      <DisclaimerComponent />
-    </ServiceContextProvider>
-  </ToggleContextProvider>
-);
+const Component = ({ service }) => {
+  const disclaimer = pathOr(
+    DISCLAIMER_FIXTURE.news,
+    [service],
+    DISCLAIMER_FIXTURE,
+  );
+  return (
+    <ToggleContextProvider
+      toggles={{
+        disclaimer: {
+          enabled: true,
+        },
+      }}
+    >
+      <ServiceContext.Provider value={{ service, disclaimer }}>
+        <DisclaimerComponent />
+      </ServiceContext.Provider>
+    </ToggleContextProvider>
+  );
+};
 
 export default {
   title: 'Containers/Disclaimer',

--- a/src/app/containers/Disclaimer/index.test.jsx
+++ b/src/app/containers/Disclaimer/index.test.jsx
@@ -9,10 +9,10 @@ import DisclaimerComponent from '.';
 const DISCLAIMER_FIXTURE = {
   para1: 'Приложение Русской службы BBC News доступно для ',
   para2: {
-    text: 'IOS ',
+    text: 'IOS',
     url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
   },
-  para3: 'и ',
+  para3: ' и ',
   para4: {
     text: 'Android',
     url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',

--- a/src/app/containers/Disclaimer/index.test.jsx
+++ b/src/app/containers/Disclaimer/index.test.jsx
@@ -6,8 +6,26 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 
 import DisclaimerComponent from '.';
 
+const DISCLAIMER_FIXTURE = {
+  para1: 'Приложение Русской службы BBC News доступно для ',
+  para2: {
+    text: 'IOS ',
+    url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+  },
+  para3: 'и ',
+  para4: {
+    text: 'Android',
+    url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+  },
+  para5:
+    '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
+};
+
 // eslint-disable-next-line react/prop-types
-const renderComponent = ({ enabled = true } = {}) =>
+const renderComponent = (
+  { enabled = true } = {},
+  disclaimer = DISCLAIMER_FIXTURE,
+) =>
   render(
     <ToggleContextProvider
       toggles={{
@@ -16,43 +34,19 @@ const renderComponent = ({ enabled = true } = {}) =>
         },
       }}
     >
-      <ServiceContext.Provider
-        value={{
-          disclaimer: {
-            block: [
-              { text: 'Приложение Русской службы BBC News доступно для ' },
-              {
-                link: {
-                  text: 'IOS ',
-                  href: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
-                },
-              },
-              { text: 'и ' },
-              {
-                link: {
-                  text: 'Android',
-                  href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
-                },
-              },
-              {
-                text: '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
-              },
-            ],
-          },
-        }}
-      >
+      <ServiceContext.Provider value={{ disclaimer }}>
         <DisclaimerComponent />
       </ServiceContext.Provider>
     </ToggleContextProvider>,
   );
 
 describe('Disclaimer Component', () => {
-  it('Renders a section with role region', () => {
+  it('should render a section with role region', () => {
     const { getByRole } = renderComponent();
     expect(getByRole('region', { container: 'section' })).toBeInTheDocument();
   });
 
-  it('Renders disclaimer text correctly', () => {
+  it('should render disclaimer text correctly', () => {
     const { getByText } = renderComponent();
     expect(
       getByText(
@@ -65,13 +59,23 @@ describe('Disclaimer Component', () => {
     expect(getByText('Android')).toBeInTheDocument();
   });
 
-  it('Renders links correctly', () => {
+  it('should render links correctly', () => {
     const { getAllByRole } = renderComponent();
     expect(getAllByRole('link').length).toBe(2);
   });
 
-  it('Does not render the disclaimer when toggled off', () => {
+  it('should not render the disclaimer when the disclaimer toggle is not enabled', () => {
     const { container } = renderComponent({ enabled: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should not render when disclaimer is null', () => {
+    const { container } = renderComponent({ enabled: true }, null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should not render when disclaimer is empty object', () => {
+    const { container } = renderComponent({ enabled: true }, {});
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/app/containers/Disclaimer/index.test.jsx
+++ b/src/app/containers/Disclaimer/index.test.jsx
@@ -7,10 +7,7 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 import DisclaimerComponent from '.';
 
 // eslint-disable-next-line react/prop-types
-const renderComponent = ({
-  disclaimerText = 'Disclaimer Text',
-  enabled = true,
-} = {}) =>
+const renderComponent = ({ enabled = true } = {}) =>
   render(
     <ToggleContextProvider
       toggles={{
@@ -19,16 +16,58 @@ const renderComponent = ({
         },
       }}
     >
-      <ServiceContext.Provider value={{ disclaimer: { text: disclaimerText } }}>
+      <ServiceContext.Provider
+        value={{
+          disclaimer: {
+            block: [
+              { text: 'Приложение Русской службы BBC News доступно для ' },
+              {
+                link: {
+                  text: 'IOS ',
+                  href: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+                },
+              },
+              { text: 'и ' },
+              {
+                link: {
+                  text: 'Android',
+                  href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+                },
+              },
+              {
+                text: '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
+              },
+            ],
+          },
+        }}
+      >
         <DisclaimerComponent />
       </ServiceContext.Provider>
     </ToggleContextProvider>,
   );
 
 describe('Disclaimer Component', () => {
-  it.skip('Renders the text from the service config', () => {
+  it('Renders a section with role region', () => {
+    const { getByRole } = renderComponent();
+    expect(getByRole('region', { container: 'section' })).toBeInTheDocument();
+  });
+
+  it('Renders disclaimer text correctly', () => {
     const { getByText } = renderComponent();
-    expect(getByText('Disclaimer Text')).toBeInTheDocument();
+    expect(
+      getByText(
+        'Приложение Русской службы BBC News доступно для и . Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(getByText('IOS')).toBeInTheDocument();
+
+    expect(getByText('Android')).toBeInTheDocument();
+  });
+
+  it('Renders links correctly', () => {
+    const { getAllByRole } = renderComponent();
+    expect(getAllByRole('link').length).toBe(2);
   });
 
   it('Does not render the disclaimer when toggled off', () => {

--- a/src/app/containers/Disclaimer/index.test.jsx
+++ b/src/app/containers/Disclaimer/index.test.jsx
@@ -26,7 +26,7 @@ const renderComponent = ({
   );
 
 describe('Disclaimer Component', () => {
-  it('Renders the text from the service config', () => {
+  it.skip('Renders the text from the service config', () => {
     const { getByText } = renderComponent();
     expect(getByText('Disclaimer Text')).toBeInTheDocument();
   });

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -315,7 +315,7 @@ export const service = {
         { text: 'и ' },
         {
           link: {
-            text: 'Android ',
+            text: 'Android',
             href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
           },
         },

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -303,7 +303,7 @@ export const service = {
       },
     },
     disclaimer: {
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla dignissim mattis enim, porta viverra nulla bibendum nec. In hac habitasse platea dictumst. Fusce dui urna, iaculis vel odio sed, faucibus ultricies turpis. Ut sit amet odio eu lectus rhoncus blandit. Donec porta dignissim fringilla. Integer vel erat tellus. Aenean nec dui sapien.',
+      text: `Приложение Русской службы BBC News доступно для [link] и [link]. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.`,
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -303,25 +303,18 @@ export const service = {
       },
     },
     disclaimer: {
-      block: [
-        { text: 'Приложение Русской службы BBC News доступно для ' },
-        {
-          link: {
-            text: 'IOS ',
-            href: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
-          },
-        },
-        { text: 'и ' },
-        {
-          link: {
-            text: 'Android ',
-            href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
-          },
-        },
-        {
-          text: '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
-        },
-      ],
+      para1: 'Приложение Русской службы BBC News доступно для ',
+      para2: {
+        text: 'IOS ',
+        url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+      },
+      para3: 'и ',
+      para4: {
+        text: 'Android',
+        url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+      },
+      para5:
+        '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -304,25 +304,18 @@ export const service = {
       },
     },
     disclaimer: {
-      block: [
-        { text: 'Приложение Русской службы BBC News доступно для ' },
-        {
-          link: {
-            text: 'IOS ',
-            href: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
-          },
-        },
-        { text: 'и ' },
-        {
-          link: {
-            text: 'Android',
-            href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
-          },
-        },
-        {
-          text: '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
-        },
-      ],
+      para1: 'Приложение Русской службы BBC News доступно для ',
+      para2: {
+        text: 'IOS ',
+        url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+      },
+      para3: 'и ',
+      para4: {
+        text: 'Android',
+        url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+      },
+      para5:
+        '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -303,7 +303,25 @@ export const service = {
       },
     },
     disclaimer: {
-      text: `Приложение Русской службы BBC News доступно для [link] и [link]. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.`,
+      block: [
+        { text: 'Приложение Русской службы BBC News доступно для ' },
+        {
+          link: {
+            text: 'IOS ',
+            href: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+          },
+        },
+        { text: 'и ' },
+        {
+          link: {
+            text: 'Android ',
+            href: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+          },
+        },
+        {
+          text: '. Грузите его на ваш девайс и продолжайте получать новости от Би-би-си.',
+        },
+      ],
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -306,10 +306,10 @@ export const service = {
     disclaimer: {
       para1: 'Приложение Русской службы BBC News доступно для ',
       para2: {
-        text: 'IOS ',
+        text: 'IOS',
         url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
       },
-      para3: 'и ',
+      para3: ' и ',
       para4: {
         text: 'Android',
         url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -220,6 +220,7 @@ export const mainTranslations = {
   },
   topStoriesTitle: 'Главное',
   featuresAnalysisTitle: 'Не пропустите',
+  disclaimerLabel: 'Уведомление',
 };
 
 export const service = {

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -32,7 +32,6 @@ import visuallyHiddenHeadline from '#containers/VisuallyHiddenHeadline';
 import gist from '#containers/Gist';
 import text from '#containers/Text';
 import Image from '#containers/Image';
-import Disclaimer from '#containers/Disclaimer';
 import Blocks from '#containers/Blocks';
 import Timestamp from '#containers/ArticleTimestamp';
 import ATIAnalytics from '#containers/ATIAnalytics';
@@ -201,7 +200,6 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <ArticlePageGrid>
         <Primary>
           <Main role="main">
-            <Disclaimer />
             <Blocks
               blocks={articleBlocks}
               componentsToRender={componentsToRender}


### PR DESCRIPTION
Resolves #9396 
Resolves https://github.com/bbc/simorgh-infrastructure/issues/1564

**Overall change:**
Added new disclaimer message with inLine links and uses semantic HTML.

We will have an a11y swarm for this component on at a second time due to its high priority.

**Code changes:**

- Added a new translation in Russian config for Section's aria-label (default to English 'Disclaimer')
- Added a new structure for the `disclaimer` in the Russian service's config.
- Convert the new disclaimer into an array of values and map through each value to allow dynamic inLine links

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
