### PR TITLE
fix tests failing on iframe

### DIFF
--- a/cypress/integration/pages/articles/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/articles/testsForCanonicalOnly.js
@@ -150,8 +150,6 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
         });
       });
 
-      // temporarily disable this test until this issue is completed to investigate it:
-      // https://github.com/bbc/simorgh-infrastructure/issues/983
       it('should render an iframe with a valid URL when a user clicks play', () => {
         cy.window().then(win => {
           const body = win.SIMORGH_DATA.pageData;
@@ -163,7 +161,7 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
             cy.get('[data-e2e="media-player"] button')
               .click()
               .then(() => {
-                cy.get(`iframe[src="${embedUrl}"]`).should('be.visible');
+                cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
               });
             cy.testResponseCodeAndTypeRetry({
               path: embedUrl,

--- a/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/mediaAssetPage/testsForCanonicalOnly.js
@@ -27,8 +27,8 @@ export const testsThatFollowSmokeTestConfigForCanonicalOnly = ({
             ({ body: jsonData }) => {
               if (hasMedia(jsonData)) {
                 const embedUrl = getEmbedUrl(jsonData, language);
-
-                cy.get(`iframe[src="${embedUrl}"]`).should('be.visible');
+                cy.log(embedUrl);
+                cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
                 cy.testResponseCodeAndTypeRetry({
                   path: embedUrl,
                   responseCode: 200,

--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -29,9 +29,10 @@ export default ({ service, pageType, variant, isAmp }) => {
 
           cy.get('iframe').then(iframe => {
             // If a brand, get the src of the iframe, otherwise, use the embed URL from the data
+            // Because of now using a relative URL in the iframe I now use embedUrl, but I want to print the iframe.prop for seeing what this is for now
             const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
-
-            cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
+            cy.log(`iframeURL ${iframeURL}`);
+            cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               path: embedUrl,
               responseCode: 200,

--- a/cypress/integration/pages/onDemandTV/tests.js
+++ b/cypress/integration/pages/onDemandTV/tests.js
@@ -30,8 +30,8 @@ export default ({ service, pageType, variant, isAmp }) => {
           cy.get('iframe').then(iframe => {
             // If a brand, get the src of the iframe, otherwise, use the embed URL from the data
             const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
-
-            cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
+            cy.log(`iframeURL ${iframeURL}`);
+            cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               path: embedUrl,
               responseCode: 200,


### PR DESCRIPTION

See explanation on slack

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Passes local, test and live