### PR TITLE
Add MetadataContainer and LinkedData to Topic page

### DIFF
--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -16,6 +16,15 @@ const Wrapper = styled.div`
 const TopicPage = ({ pageData }) => {
   const { lang } = useContext(ServiceContext);
   const { title, description, promos } = pageData;
+
+  const promoEntities = promos.map(promo => ({
+    '@type': 'Article',
+    name: promo.title,
+    headline: promo.title,
+    url: promo.link,
+    dateCreated: promo.firstPublished,
+  }));
+
   return (
     <Wrapper>
       <MetadataContainer
@@ -24,7 +33,12 @@ const TopicPage = ({ pageData }) => {
         description={description}
         openGraphType="website"
       />
-      <LinkedData type="CollectionPage" seoTitle={title} headline={title} />
+      <LinkedData
+        type="CollectionPage"
+        seoTitle={title}
+        headline={title}
+        entities={promoEntities}
+      />
       <TopicTitle>{title}</TopicTitle>
       <TopicGrid promos={promos} />
       <ATIAnalytics data={pageData} />;

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import { shape, arrayOf, string } from 'prop-types';
 import styled from '@emotion/styled';
+import MetadataContainer from '#app/containers/Metadata';
+import LinkedData from '#app/containers/LinkedData';
+import { ServiceContext } from '../../contexts/ServiceContext';
 import TopicTitle from './TopicTitle';
 import TopicGrid from './TopicGrid';
 
@@ -11,10 +14,19 @@ const Wrapper = styled.div`
 `;
 
 const TopicPage = ({ pageData }) => {
+  const { lang } = useContext(ServiceContext);
+  const { title, description, promos } = pageData;
   return (
     <Wrapper>
-      <TopicTitle>{pageData.title}</TopicTitle>
-      <TopicGrid promos={pageData.promos} />
+      <MetadataContainer
+        title={title}
+        lang={lang}
+        description={description}
+        openGraphType="website"
+      />
+      <LinkedData type="CollectionPage" seoTitle={title} headline={title} />
+      <TopicTitle>{title}</TopicTitle>
+      <TopicGrid promos={promos} />
       <ATIAnalytics data={pageData} />;
     </Wrapper>
   );

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -25,6 +25,7 @@ export default async ({ getAgent, service, path: pathname, variant }) => {
       status,
       pageData: {
         title: data.title,
+        description: data.description || data.title,
         promos: data.summaries,
         metadata: {
           type: 'Topic',

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -1,3 +1,4 @@
+import assocPath from 'ramda/src/assocPath';
 import * as fetchPageData from '#app/routes/utils/fetchPageData';
 import getInitialData from '.';
 
@@ -6,6 +7,7 @@ process.env.BFF_PATH = 'https://mock-bff-path';
 const topicJSON = {
   data: {
     title: 'Donald Trump',
+    description: 'Donald Trump articles',
     summaries: [
       {
         title: 'Wetin happun for January 6 one year ago?',
@@ -34,6 +36,7 @@ describe('get initial data for topic', () => {
       service: 'pidgin',
     });
     expect(pageData.title).toEqual('Donald Trump');
+    expect(pageData.description).toEqual('Donald Trump articles');
     expect(pageData.promos[0].title).toEqual(
       'Wetin happun for January 6 one year ago?',
     );
@@ -45,6 +48,22 @@ describe('get initial data for topic', () => {
     expect(pageData.promos[0].link).toEqual('mock-link');
     expect(pageData.promos[0].imageAlt).toEqual('mock-image-alt');
     expect(pageData.promos[0].id).toEqual('54321');
+  });
+
+  it('should use the title as description if description is empty', async () => {
+    const topicJSONWithoutDescription = assocPath(
+      ['data', 'description'],
+      '',
+      topicJSON,
+    );
+    fetch.mockResponse(JSON.stringify(topicJSONWithoutDescription));
+    const { pageData } = await getInitialData({
+      path: 'mock-topic-path',
+      getAgent,
+      service: 'pidgin',
+    });
+    expect(pageData.title).toEqual('Donald Trump');
+    expect(pageData.description).toEqual('Donald Trump');
   });
 
   it('should call fetchPageData with the correct request URL', async () => {


### PR DESCRIPTION
Part of #9884

**Overall change:**
Adding metadata + linked data to Topic page

**Code changes:**

- Added MetadataContainer to Topic page
- Added LinkedData to Topic page
- Topics do not always have a description so using title as description if this is the case

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
