### PR TITLE
Add test override for topic data

### DIFF
--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -14,12 +14,19 @@ const getId = pipe(getUrlPath, removeAmp, popId);
 
 export default async ({ getAgent, service, path: pathname, variant }) => {
   try {
+    const env = pathname.includes('renderer_env=test') ? 'test' : 'live';
     const agent = await getAgent();
     const id = getId(pathname);
     const path = `${process.env.BFF_PATH}?id=${id}&service=${service}${
       variant ? `&variant=${variant}` : ``
     }`;
-    const { status, json } = await fetchPageData({ path, agent });
+
+    const optHeaders = { 'ctx-service-env': env };
+    const { status, json } = await fetchPageData({
+      path,
+      agent,
+      optHeaders,
+    });
     const { data } = json;
     return {
       status,

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -20,6 +20,8 @@ const topicJSON = {
   },
 };
 
+const optHeaders = { 'ctx-service-env': 'live' };
+
 describe('get initial data for topic', () => {
   const agent = { ca: 'ca', key: 'key' };
   const getAgent = jest.fn(() => agent);
@@ -59,6 +61,7 @@ describe('get initial data for topic', () => {
     expect(fetchDataSpy).toHaveBeenCalledWith({
       path: 'https://mock-bff-path?id=54321&service=pidgin',
       agent,
+      optHeaders,
     });
   });
 
@@ -75,6 +78,7 @@ describe('get initial data for topic', () => {
     expect(fetchDataSpy).toHaveBeenCalledWith({
       path: 'https://mock-bff-path?id=54321&service=serbian&variant=sr-cyrl',
       agent,
+      optHeaders,
     });
   });
 
@@ -90,6 +94,7 @@ describe('get initial data for topic', () => {
     expect(fetchDataSpy).toHaveBeenCalledWith({
       path: 'https://mock-bff-path?id=54321&service=pidgin',
       agent,
+      optHeaders,
     });
   });
 
@@ -105,6 +110,7 @@ describe('get initial data for topic', () => {
     expect(fetchDataSpy).toHaveBeenCalledWith({
       path: 'https://mock-bff-path?id=54321&service=pidgin',
       agent,
+      optHeaders,
     });
   });
 
@@ -120,6 +126,25 @@ describe('get initial data for topic', () => {
     expect(fetchDataSpy).toHaveBeenCalledWith({
       path: 'https://mock-bff-path?id=54321&service=pidgin',
       agent,
+      optHeaders,
+    });
+  });
+
+  it('should request test data when renderer_env is set to test', async () => {
+    fetch.mockResponse(JSON.stringify(topicJSON));
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+    await getInitialData({
+      path: 'pidgin/topics/54321.?renderer_env=test',
+      getAgent,
+      service: 'pidgin',
+    });
+
+    const testHeader = { 'ctx-service-env': 'test' };
+
+    expect(fetchDataSpy).toHaveBeenCalledWith({
+      path: 'https://mock-bff-path?id=54321&service=pidgin',
+      agent,
+      optHeaders: testHeader,
     });
   });
 });

--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -33,6 +33,7 @@ const fetchPageData = async ({
   timeout,
   shouldLogFetchTime = !onClient(),
   agent,
+  optHeaders,
   ...loggerArgs
 }) => {
   const url = path.startsWith('http') ? path : getUrl(path);
@@ -40,6 +41,7 @@ const fetchPageData = async ({
   const fetchOptions = {
     headers: {
       'User-Agent': 'Simorgh/ws-web-rendering',
+      ...(optHeaders && optHeaders),
     },
     timeout: effectiveTimeout,
     ...(agent && { agent }),

--- a/src/app/routes/utils/fetchPageData/index.test.js
+++ b/src/app/routes/utils/fetchPageData/index.test.js
@@ -101,6 +101,21 @@ describe('fetchPageData', () => {
       expect(fetch).toHaveBeenCalledWith(expectedUrl, fetchOptions);
     });
 
+    it('should call fetch with the correct headers when passed additional headers', async () => {
+      const optHeaders = { 'ctx-service-env': 'live' };
+
+      const expectedFetchOptions = {
+        headers: {
+          'User-Agent': 'Simorgh/ws-web-rendering',
+          'ctx-service-env': 'live',
+        },
+        timeout: 4000,
+      };
+      await fetchPageData({ path: requestedPathname, pageType, optHeaders });
+
+      expect(fetch).toHaveBeenCalledWith(expectedUrl, expectedFetchOptions);
+    });
+
     it('should return expected response', async () => {
       const response = await fetchPageData({
         path: requestedPathname,


### PR DESCRIPTION
Resolves [#1567](https://github.com/bbc/simorgh-infrastructure/issues/1567)

**Overall change:**
Pass request context header to fetchPageData. Allows test data to be accessed on Topic page. 

**Code changes:**

- Pass live or test header based on renderer_env override

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
