### PR TITLE
Increase Disclaimer line-height

### DIFF
--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -11,8 +11,11 @@ import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUIN,
 } from '@bbc/gel-foundations/spacings';
-import { C_GREY_6 } from '@bbc/psammead-styles/colours';
-import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
+import { C_GREY_6, C_GREY_2 } from '@bbc/psammead-styles/colours';
+import {
+  GEL_GROUP_4_SCREEN_WIDTH_MIN,
+  GEL_GROUP_B_MIN_WIDTH,
+} from '@bbc/gel-foundations/breakpoints';
 import { GridItemLarge } from '#app/components/Grid';
 
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -22,11 +25,14 @@ import isEmpty from 'ramda/src/isEmpty';
 const Inner = styled.section`
   ${({ script }) => script && getLongPrimer(script)}
   ${({ service }) => service && getSansLight(service)}
-  background: #f6f6f6;
+  background: ${C_GREY_2};
   color: ${C_GREY_6};
   text-transform: uppercase;
   margin-bottom: ${GEL_SPACING_TRPL};
   padding: ${GEL_SPACING_DBL};
+  @media (max-width: ${GEL_GROUP_B_MIN_WIDTH}rem) {
+    line-height: 1.4;
+  }
   ${({ increasePaddingOnDesktop }) =>
     increasePaddingOnDesktop &&
     `


### PR DESCRIPTION
Resolves #9947 

**Overall change:**
Disclaimer line-height increased to 1.4 (24px) for 320px< screen sizes, design in issue tickets 

**Code changes:**
- added media query for dynamic line height.
- 
**Extra**
- Added C_GREY_2 background colour from Psammead

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
