### PR TITLE
Optimizely article complete tracking

### DIFF
--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -12,10 +12,9 @@ const OptimizelyArticleCompleteTracking = () => {
   const [isVisible, setIsVisible] = useState(false);
 
   const variation = useOptimizelyVariation(OPTIMIZELY_CONFIG.featureId);
-  const hasVariationKey = variation !== null;
 
   const sendPageCompleteEvent =
-    hasVariationKey && !isAmp && !pageCompleteSent && isVisible;
+    variation && !isAmp && !pageCompleteSent && isVisible;
 
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) =>

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -14,7 +14,7 @@ const OptimizelyArticleCompleteTracking = () => {
   const variation = useOptimizelyVariation(OPTIMIZELY_CONFIG.featureId);
   const hasVariationKey = variation !== null;
 
-  const sendCompleteEvent =
+  const sendPageCompleteEvent =
     hasVariationKey && !isAmp && !pageCompleteSent && isVisible;
 
   useEffect(() => {
@@ -29,13 +29,13 @@ const OptimizelyArticleCompleteTracking = () => {
   }, []);
 
   useEffect(() => {
-    if (sendCompleteEvent) {
+    if (sendPageCompleteEvent) {
       optimizely.onReady().then(() => {
         optimizely.track('article_completes');
         setPageCompleteSent(true);
       });
     }
-  }, [sendCompleteEvent, optimizely]);
+  }, [sendPageCompleteEvent, optimizely]);
 
   return <div ref={ref} aria-hidden="true" />;
 };

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -17,12 +17,20 @@ const OptimizelyArticleCompleteTracking = () => {
   const sendPageCompleteEvent =
     variation && !isAmp && !pageCompleteSent && isVisible;
 
-  useEffect(() => {
+  const initObserver = async () => {
+    if (typeof window.IntersectionObserver === 'undefined') {
+      // Polyfill IntersectionObserver, e.g. for IE11
+      await import('intersection-observer');
+    }
     observer.current = new IntersectionObserver(([entry]) =>
       setIsVisible(entry.isIntersecting),
     );
 
     observer.current.observe(ref.current);
+  };
+
+  useEffect(() => {
+    initObserver();
     return () => {
       observer.current.disconnect();
     };

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -6,6 +6,7 @@ import OPTIMIZELY_CONFIG from '#lib/config/optimizely';
 
 const OptimizelyArticleCompleteTracking = () => {
   const ref = useRef();
+  const observer = useRef();
   const { isAmp } = useContext(RequestContext);
   const { optimizely } = useContext(OptimizelyContext);
   const [pageCompleteSent, setPageCompleteSent] = useState(false);
@@ -17,13 +18,13 @@ const OptimizelyArticleCompleteTracking = () => {
     variation && !isAmp && !pageCompleteSent && isVisible;
 
   useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) =>
+    observer.current = new IntersectionObserver(([entry]) =>
       setIsVisible(entry.isIntersecting),
     );
 
-    observer.observe(ref.current);
+    observer.current.observe(ref.current);
     return () => {
-      observer.disconnect();
+      observer.current.disconnect();
     };
   }, []);
 

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useContext, useEffect, useRef } from 'react';
+import { OptimizelyContext } from '@optimizely/react-sdk';
+import { RequestContext } from '#contexts/RequestContext';
+import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
+import OPTIMIZELY_CONFIG from '#lib/config/optimizely';
+
+const OptimizelyArticleCompleteTracking = () => {
+  const ref = useRef();
+  const { isAmp } = useContext(RequestContext);
+  const { optimizely } = useContext(OptimizelyContext);
+  const [pageCompleteSent, setPageCompleteSent] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const variation = useOptimizelyVariation(OPTIMIZELY_CONFIG.featureId);
+  const hasVariationKey = variation !== null;
+
+  const sendCompleteEvent =
+    hasVariationKey && !isAmp && !pageCompleteSent && isVisible;
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) =>
+      setIsVisible(entry.isIntersecting),
+    );
+
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (sendCompleteEvent) {
+      optimizely.onReady().then(() => {
+        optimizely.track('article_completes');
+        setPageCompleteSent(true);
+      });
+    }
+  }, [sendCompleteEvent, optimizely]);
+
+  return <div ref={ref} aria-hidden="true" />;
+};
+
+export default OptimizelyArticleCompleteTracking;

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.jsx
@@ -45,6 +45,8 @@ const OptimizelyArticleCompleteTracking = () => {
     }
   }, [sendPageCompleteEvent, optimizely]);
 
+  if (isAmp) return null;
+
   return <div ref={ref} aria-hidden="true" />;
 };
 

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
@@ -130,13 +130,9 @@ describe('Optimizely Page Complete tracking', () => {
       });
     });
 
-    act(() => {
-      jest.advanceTimersByTime(1100);
-    });
+    await Promise.resolve();
 
-    await waitFor(() => {
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
+    expect(optimizely.track).not.toHaveBeenCalled();
   });
 
   it('should not send tracking event when element is in view, but not in experiment variation', async () => {
@@ -158,13 +154,9 @@ describe('Optimizely Page Complete tracking', () => {
       });
     });
 
-    act(() => {
-      jest.advanceTimersByTime(1100);
-    });
+    await Promise.resolve();
 
-    await waitFor(() => {
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
+    expect(optimizely.track).not.toHaveBeenCalled();
   });
 
   it('should not return intersecting element when on AMP', async () => {
@@ -202,9 +194,9 @@ describe('Optimizely Page Complete tracking', () => {
       });
     });
 
-    await waitFor(() => {
-      expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
-      expect(optimizely.track).toHaveBeenCalledTimes(1);
-    });
+    await Promise.resolve();
+
+    expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
+    expect(optimizely.track).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
@@ -1,0 +1,211 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { node, string, bool } from 'prop-types';
+import { render, waitFor, act } from '@testing-library/react';
+import { OptimizelyProvider } from '@optimizely/react-sdk';
+
+import { RequestContextProvider } from '#contexts/RequestContext';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+import useOptimizelyVariation from '#hooks/useOptimizelyVariation';
+
+import OptimizelyArticleCompleteTracking from '.';
+
+jest.mock('#hooks/useOptimizelyVariation', () => jest.fn(() => null));
+
+const optimizely = {
+  onReady: jest.fn(() => Promise.resolve()),
+  track: jest.fn(),
+};
+
+const observers = new Map();
+
+const IntersectionObserver = jest.fn(cb => {
+  const item = {
+    callback: cb,
+    elements: new Set(),
+  };
+
+  const instance = {
+    observe: jest.fn(element => {
+      item.elements.add(element);
+    }),
+    disconnect: jest.fn(() => {
+      item.elements.clear();
+    }),
+  };
+
+  observers.set(instance, item);
+
+  return instance;
+});
+
+const getObserverInstance = element => {
+  try {
+    const [instance] = Array.from(observers).find(([, item]) =>
+      item.elements.has(element),
+    );
+
+    return instance;
+  } catch (e) {
+    throw new Error('Failed to find IntersectionObserver for element.');
+  }
+};
+
+const triggerIntersection = ({ changes, observer }) => {
+  const item = observers.get(observer);
+
+  item.callback(changes);
+};
+
+const ContextWrap = ({ pageType, isAmp, children, service }) => (
+  <RequestContextProvider
+    isAmp={isAmp}
+    pageType={pageType}
+    service={service}
+    pathname="/pathname"
+  >
+    <OptimizelyProvider optimizely={optimizely} isServerSide>
+      {children}
+    </OptimizelyProvider>
+  </RequestContextProvider>
+);
+
+ContextWrap.propTypes = {
+  children: node.isRequired,
+  pageType: string.isRequired,
+  isAmp: bool.isRequired,
+  service: string.isRequired,
+};
+
+const { error } = console;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  console.error = jest.fn();
+  global.IntersectionObserver = IntersectionObserver;
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  console.error = error;
+  observers.clear();
+});
+
+describe('Optimizely Page Complete tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a function that can be assigned to an element to observe for intersections', () => {
+    const { container } = render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyArticleCompleteTracking />
+      </ContextWrap>,
+    );
+
+    const element = container.getElementsByTagName('div')[0];
+    const { observe } = getObserverInstance(element);
+
+    expect(observe).toHaveBeenCalledWith(element);
+  });
+
+  it('should not send tracking event when element is not in view', async () => {
+    useOptimizelyVariation.mockReturnValue('variation_1');
+
+    const { container } = render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyArticleCompleteTracking />
+      </ContextWrap>,
+    );
+
+    const element = container.getElementsByTagName('div')[0];
+    const observerInstance = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: false }],
+        observer: observerInstance,
+      });
+    });
+
+    await waitFor(() => {
+      expect(optimizely.track).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('should not send tracking event when element is in view, but not in experiment variation', async () => {
+    useOptimizelyVariation.mockReturnValue(null);
+
+    const { container } = render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyArticleCompleteTracking />
+      </ContextWrap>,
+    );
+
+    const element = container.getElementsByTagName('div')[0];
+    const observerInstance = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
+    });
+
+    await waitFor(() => {
+      expect(optimizely.track).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('should not send tracking event when element is in view, but is on AMP', async () => {
+    useOptimizelyVariation.mockReturnValue('variation_1');
+
+    const { container } = render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp>
+        <OptimizelyArticleCompleteTracking />
+      </ContextWrap>,
+    );
+
+    const element = container.getElementsByTagName('div')[0];
+    const observerInstance = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
+    });
+
+    await waitFor(() => {
+      expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
+      expect(optimizely.track).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('should send tracking event when element is in view and in experiment variation', async () => {
+    useOptimizelyVariation.mockReturnValue('variation_1');
+
+    const { container } = render(
+      <ContextWrap pageType={ARTICLE_PAGE} service="news" isAmp={false}>
+        <OptimizelyArticleCompleteTracking />
+      </ContextWrap>,
+    );
+
+    const element = container.getElementsByTagName('div')[0];
+    const observerInstance = getObserverInstance(element);
+
+    act(() => {
+      triggerIntersection({
+        changes: [{ isIntersecting: true }],
+        observer: observerInstance,
+      });
+    });
+
+    await waitFor(() => {
+      expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
+      expect(optimizely.track).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
+++ b/src/app/containers/OptimizelyArticleCompleteTracking/index.test.jsx
@@ -130,8 +130,12 @@ describe('Optimizely Page Complete tracking', () => {
       });
     });
 
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
     await waitFor(() => {
-      expect(optimizely.track).toHaveBeenCalledTimes(0);
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -154,12 +158,16 @@ describe('Optimizely Page Complete tracking', () => {
       });
     });
 
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
     await waitFor(() => {
-      expect(optimizely.track).toHaveBeenCalledTimes(0);
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 
-  it('should not send tracking event when element is in view, but is on AMP', async () => {
+  it('should not return intersecting element when on AMP', async () => {
     useOptimizelyVariation.mockReturnValue('variation_1');
 
     const { container } = render(
@@ -168,19 +176,10 @@ describe('Optimizely Page Complete tracking', () => {
       </ContextWrap>,
     );
 
-    const element = container.getElementsByTagName('div')[0];
-    const observerInstance = getObserverInstance(element);
-
-    act(() => {
-      triggerIntersection({
-        changes: [{ isIntersecting: true }],
-        observer: observerInstance,
-      });
-    });
+    const elements = container.getElementsByTagName('div');
 
     await waitFor(() => {
-      expect(global.IntersectionObserver).toHaveBeenCalledTimes(1);
-      expect(optimizely.track).toHaveBeenCalledTimes(0);
+      expect(elements.length).toBe(0);
     });
   });
 

--- a/src/app/pages/StoryPage/StoryPage.jsx
+++ b/src/app/pages/StoryPage/StoryPage.jsx
@@ -35,6 +35,7 @@ import MostReadContainer from '#containers/MostRead';
 import ATIAnalytics from '#containers/ATIAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
+import OptimizelyArticleCompleteTracking from '#containers/OptimizelyArticleCompleteTracking';
 import fauxHeadline from '#containers/FauxHeadline';
 import visuallyHiddenHeadline from '#containers/VisuallyHiddenHeadline';
 import CpsTable from '#containers/CpsTable';
@@ -384,6 +385,7 @@ const StoryPage = ({ pageData, mostReadEndpointOverride }) => {
         >
           <main role="main">
             <Blocks blocks={blocks} componentsToRender={componentsToRender} />
+            <OptimizelyArticleCompleteTracking />
           </main>
 
           {showRelatedTopics && topics && (

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -2968,6 +2968,9 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                       Cheese strings stilton cheesy feet. Cheese strings fondue cow fromage edam halloumi cut the cheese cream cheese. Melted cheese brie rubber cheese parmesan cut the cheese queso st. agur blue cheese dolcelatte. Port-salut croque monsieur cheese and wine cheese triangles cheesy grin.
                     </p>
                   </div>
+                  <div
+                    aria-hidden="true"
+                  />
                 </main>
               </div>
               <div
@@ -6947,6 +6950,9 @@ exports[`Story Page should render correctly when the secondary column data is no
                       Cheese strings stilton cheesy feet. Cheese strings fondue cow fromage edam halloumi cut the cheese cream cheese. Melted cheese brie rubber cheese parmesan cut the cheese queso st. agur blue cheese dolcelatte. Port-salut croque monsieur cheese and wine cheese triangles cheesy grin.
                     </p>
                   </div>
+                  <div
+                    aria-hidden="true"
+                  />
                 </main>
               </div>
               <div
@@ -10508,6 +10514,9 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       Cheese strings stilton cheesy feet. Cheese strings fondue cow fromage edam halloumi cut the cheese cream cheese. Melted cheese brie rubber cheese parmesan cut the cheese queso st. agur blue cheese dolcelatte. Port-salut croque monsieur cheese and wine cheese triangles cheesy grin.
                     </p>
                   </div>
+                  <div
+                    aria-hidden="true"
+                  />
                 </main>
               </div>
               <div


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9941

**Overall change:**
Adds a new component after the article body to send an Optimizely 'article_completes' event when scrolled into the viewport

**Code changes:**
- Adds a new component `<OptimizelyArticleCompleteTracking />` below the StoryPage article body. This component makes use of the IntersectionObserver, similar to the `useViewTracker` hook, to send the view event to Optimizely once the component is in view. Similar checks are in place to only fire this event if the user is in an experiment, the component is on screen, its not on AMP and the event hasn't been fired already
- The element uses the `aria-hidden` attribute to remove it from the screen-reader flow

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
