### PR TITLE
Update Russian nav to change Ukraine war text link

### DIFF
--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -383,7 +383,7 @@ export const service = {
         url: '/russian',
       },
       {
-        title: 'Украина',
+        title: 'Война в Украине',
         url: '/russian/topics/cez0n29ggrdt',
       },
       {


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
_Change the text link on the Ukraine war item on BBC Russian's navigation bar_

**Code changes:**

- Changed title for the Ukraine war link (second item) in the navigation bar in src/app/lib/config/services/russian.js
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing



![Screenshot 2022-03-15 at 07 17 19](https://user-images.githubusercontent.com/10046386/158329927-5e62e8be-09b7-44f3-8ae0-27546e0f53c8.png)
