### PR TITLE
Add experimental blocks to CPS `pageData` for Optimizely experiment

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -18,7 +18,7 @@ import timestampToMilliseconds from './timestampToMilliseconds';
 import addSummaryBlock from './addSummaryBlock';
 import cpsOnlyOnwardJourneys from './cpsOnlyOnwardJourneys';
 import insertPodcastPromo from './insertPodcastPromo';
-import addRecommendationsBlock from './addRecommendationsBlock';
+// import addRecommendationsBlock from './addRecommendationsBlock'; // OPTIMIZELY: 003_hindi_experiment_feature
 import addBylineBlock from './addBylineBlock';
 import addMpuBlock from './addMpuBlock';
 import addAnalyticsCounterName from './addAnalyticsCounterName';
@@ -29,7 +29,7 @@ import getAdditionalPageData from '../utils/getAdditionalPageData';
 import getErrorStatusCode from '../../utils/fetchPageData/utils/getErrorStatusCode';
 import isListWithLink from '../../utils/isListWithLink';
 import addIndexToBlockGroups from '../../utils/sharedDataTransformers/addIndexToBlockGroups';
-// import addExperimentPlaceholderBlocks from './addExperimentPlaceholderBlocks';
+import addExperimentPlaceholderBlocks from './addExperimentPlaceholderBlocks'; // OPTIMIZELY: 003_hindi_experiment_feature
 
 export const only =
   (pageTypes, transformer) =>
@@ -59,10 +59,10 @@ const processOptimoBlocks = toggles => service =>
       augmentWithDisclaimer(toggles),
     ),
     addBylineBlock,
-    addRecommendationsBlock,
+    // addRecommendationsBlock, // OPTIMIZELY: 003_hindi_experiment_feature
     addMpuBlock,
     applyBlockPositioning,
-    // addExperimentPlaceholderBlocks(service),
+    addExperimentPlaceholderBlocks(service), // OPTIMIZELY: 003_hindi_experiment_feature
     addIdsToBlocks,
     cpsOnlyOnwardJourneys,
     addIndexToBlockGroups(isListWithLink, {


### PR DESCRIPTION
**Overall change:**
Adds the experimental block type to the pageData, so that the Hindi experiment can run correctly in Optimizely

**Code changes:**

- Updates the `getInitialData` function for CPS assets to insert the `experimentBlock` type into the pageData for the Hindi service, maintaining the current `wsoj` type for all other services

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
