### PR TITLE
Test updates

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -7,6 +7,7 @@ import {
   getEmbedUrl,
   isBrand,
 } from '../../../support/helpers/onDemandRadioTv';
+import envConfig from '../../../support/config/envs';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
 import getDataUrl from '../../../support/helpers/getDataUrl';
 import processRecentEpisodes from '../../../../src/app/routes/utils/processRecentEpisodes';
@@ -32,9 +33,11 @@ export default ({ service, pageType, variant, isAmp }) => {
             // Because of now using a relative URL in the iframe I now use embedUrl, but I want to print the iframe.prop for seeing what this is for now
             const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
             cy.log(`iframeURL ${iframeURL}`);
+
             cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
-              path: embedUrl,
+              // embedUrl may be relative - making it absolute to test the response
+              path: embedUrl.replace(/^\//, envConfig.baseUrl),
               responseCode: 200,
               type: 'text/html',
               allowFallback: true,

--- a/cypress/integration/pages/onDemandTV/tests.js
+++ b/cypress/integration/pages/onDemandTV/tests.js
@@ -1,5 +1,6 @@
 /* eslint-disable consistent-return */
 import path from 'ramda/src/path';
+import envConfig from '../../../support/config/envs';
 import {
   isAvailable,
   overrideRendererOnTest,
@@ -28,12 +29,14 @@ export default ({ service, pageType, variant, isAmp }) => {
           const isBrandPage = isBrand(jsonData);
 
           cy.get('iframe').then(iframe => {
-            // If a brand, get the src of the iframe, otherwise, use the embed URL from the data
+            // This variable is unused, but printing it out to help with debugging
             const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
             cy.log(`iframeURL ${iframeURL}`);
+
             cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
-              path: embedUrl,
+              // embedUrl may be relative - making it absolute to test the response
+              path: embedUrl.replace(/^\//, envConfig.baseUrl),
               responseCode: 200,
               type: 'text/html',
               allowFallback: true,

--- a/cypress/support/helpers/onDemandRadioTv.js
+++ b/cypress/support/helpers/onDemandRadioTv.js
@@ -19,14 +19,13 @@ export const getEmbedUrl = ({ body, language, isAmp }) => {
   const brandId = getBrandId(externalId);
   const producerName = body.metadata.analyticsLabels.producer;
   const serviceName = getServiceName(producerName);
-  const { pid } = body.metadata.locators;
 
   const embedUrl = [
     isAmp ? envConfig.avEmbedBaseUrlAmp : envConfig.avEmbedBaseUrlCanonical,
     'ws/av-embeds/media',
     serviceName,
     brandId,
-    pid,
+    path(['content', 'blocks', 0, 'id'], body),
     language,
   ].join('/');
 


### PR DESCRIPTION
Resolves [No Issue]

**Overall change:**
_Updates cypress to get media PID from the same place as the application code._
_Update a test to ensure it is always using an absolute url._

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
