### PR TITLE
Update Gujarati and Mundo navs to replace long URL topics

### DIFF
--- a/src/app/lib/config/services/gujarati.js
+++ b/src/app/lib/config/services/gujarati.js
@@ -320,7 +320,7 @@ export const service = {
       },
       {
         title: 'ભારત',
-        url: '/gujarati/topics/5a08f030-710f-4168-acee-67294a90fc75',
+        url: '/gujarati/topics/c06gq3993v3t',
       },
       {
         title: 'આંતરરાષ્ટ્રીય',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -356,23 +356,23 @@ export const service = {
       },
       {
         title: 'Economía',
-        url: '/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342',
+        url: '/mundo/topics/c06gq9v4xp3t',
       },
       {
         title: 'Ciencia',
-        url: '/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53',
+        url: '/mundo/topics/ckdxnw959n7t',
       },
       {
         title: 'Salud',
-        url: '/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2',
+        url: '/mundo/topics/cpzd498zkxgt',
       },
       {
         title: 'Cultura',
-        url: '/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864',
+        url: '/mundo/topics/c2dwq9zyv4yt',
       },
       {
         title: 'Tecnología',
-        url: '/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a',
+        url: '/mundo/topics/cyx5krnw38vt',
       },
       {
         title: 'Video',

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -252,35 +252,35 @@ Object {
 exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -118,35 +118,35 @@ Object {
 exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -252,35 +252,35 @@ Object {
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`AMP Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -118,35 +118,35 @@ Object {
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`Canonical Photo Gallery Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -252,35 +252,35 @@ Object {
 exports[`AMP Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`AMP Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`AMP Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`AMP Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`AMP Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -125,35 +125,35 @@ Object {
 exports[`Canonical Story Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "Economía",
-  "url": "/mundo/topics/ca170ae3-99c1-48db-9b67-2866f85e7342",
+  "url": "/mundo/topics/c06gq9v4xp3t",
 }
 `;
 
 exports[`Canonical Story Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "Ciencia",
-  "url": "/mundo/topics/0f469e6a-d4a6-46f2-b727-2bd039cb6b53",
+  "url": "/mundo/topics/ckdxnw959n7t",
 }
 `;
 
 exports[`Canonical Story Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "Salud",
-  "url": "/mundo/topics/c4794229-7f87-43ce-ac0a-6cfcd6d3cef2",
+  "url": "/mundo/topics/cpzd498zkxgt",
 }
 `;
 
 exports[`Canonical Story Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Cultura",
-  "url": "/mundo/topics/6a73afa3-ea6b-45c1-80bb-49060b99f864",
+  "url": "/mundo/topics/c2dwq9zyv4yt",
 }
 `;
 
 exports[`Canonical Story Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "Tecnología",
-  "url": "/mundo/topics/31684f19-84d6-41f6-b033-7ae08098572a",
+  "url": "/mundo/topics/cyx5krnw38vt",
 }
 `;
 


### PR DESCRIPTION
Resolves #9957 

**Overall change:**
Replace long LDP guid topic URL still remaining on Gujarati and Mundo with equivalent short TIpo guid topics URLs to spare users the unnecessary redirect.

**Code changes:**

- Replaced long topic URLs on Gujarati and Mundo navs in their config files.
- Updated snapshots.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
