### PR TITLE
Hindi Var C - blocks check

### DIFF
--- a/src/app/components/ExperimentalEOJ/index.jsx
+++ b/src/app/components/ExperimentalEOJ/index.jsx
@@ -82,7 +82,7 @@ const ExperimentalEOJ = ({ blocks, blockGroupIndex }) => {
   const viewRef = useViewTracker(eventTrackingData);
   const handleClickTracking = useClickTrackerHandler(eventTrackingData);
 
-  if (isEmpty(blocks)) {
+  if (!blocks || isEmpty(blocks)) {
     return null;
   }
 

--- a/src/app/components/ScrollablePromo/index.jsx
+++ b/src/app/components/ScrollablePromo/index.jsx
@@ -37,7 +37,7 @@ const ScrollablePromo = ({ blocks, blockGroupIndex }) => {
   const viewRef = useViewTracker(eventTrackingData);
   const handleClickTracking = useClickTrackerHandler(eventTrackingData);
 
-  if (isEmpty(blocks)) {
+  if (!blocks || isEmpty(blocks)) {
     return null;
   }
 


### PR DESCRIPTION
Resolves https://github.com/bbc/simorgh/issues/9972

**Overall change:**
Adds a check for the existence of the `blocks` prop before attempting to access them. This could occasionally happen and cause the page to not render properly.

**Code changes:**
- Adds a null check for `blocks`, as the current `isEmpty(blocks)` Ramda function will return `false` if the value is null, allowing the rest of the code to execute

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
