### PR TITLE
Update podcast links and articles podcast promotion - Persian

### DIFF
--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -66,15 +66,15 @@ export const service = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'پادکست',
-      brandTitle: 'رادیو فارسی بی‌بی‌سی',
-      brandDescription: 'پادکست چشم‌انداز بامدادی رادیو بی‌بی‌سی',
+      brandTitle: 'شیرازه',
+      brandDescription: '«شیرازه» پادکستی درباره کتاب‌ها است که سام فرزانه تهیه می‌کند',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0bq9rkk.jpg',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0bw81l8.jpg',
         alt: 'رادیو فارسی بی‌بی‌سی',
       },
       linkLabel: {
-        text: 'برنامه ها',
-        href: 'https://www.bbc.com/persian/podcasts/p02pc9mc',
+        text: 'پادکست',
+        href: 'https://www.bbc.com/persian/podcasts/p0bw80rj',
       },
       skipLink: {
         text: 'از %title% رد شوید و به خواندن ادامه دهید',

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -67,7 +67,8 @@ export const service = {
     podcastPromo: {
       title: 'پادکست',
       brandTitle: 'شیرازه',
-      brandDescription: '«شیرازه» پادکستی درباره کتاب‌ها است که سام فرزانه تهیه می‌کند',
+      brandDescription:
+        '«شیرازه» پادکستی درباره کتاب‌ها است که سام فرزانه تهیه می‌کند',
       image: {
         src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0bw81l8.jpg',
         alt: 'رادیو فارسی بی‌بی‌سی',

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
@@ -72,8 +72,7 @@ const externalLinks = {
       },
       {
         linkText: 'Apple',
-        linkUrl:
-          'https://podcasts.apple.com/us/podcast/بین-سطور/id1615070108',
+        linkUrl: 'https://podcasts.apple.com/us/podcast/بین-سطور/id1615070108',
       },
       {
         linkText: 'Castbox',

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
@@ -65,6 +65,22 @@ const externalLinks = {
           'https://podcasts.apple.com/gb/podcast/%D8%A8%DB%8C%D9%86-%D8%B3%D8%B7%D9%88%D8%B1/id1584665242',
       },
     ],
+    p0bw80rj: [
+      {
+        linkText: 'Spotify',
+        linkUrl: 'https://open.spotify.com/show/4kInUtgdsMnUxlA7sBKxLL',
+      },
+      {
+        linkText: 'Apple',
+        linkUrl:
+          'https://podcasts.apple.com/us/podcast/بین-سطور/id1615070108',
+      },
+      {
+        linkText: 'Castbox',
+        linkUrl:
+          'https://castbox.fm/channel/%D8%B4%DB%8C%D8%B1%D8%A7%D8%B2%D9%87-id4841117?country=us',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
Resolves #NUMBER

**External links and podcast promotion change - BBC Persian**
Adding Spotify / Apple / Castbox links to new BBC Persian podcast and also changing the podcast promotion within article pages

**Code changes:**

modified:   src/app/lib/config/services/persian.js
modified:   src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
