### PR TITLE
Variation_C english storybook

### DIFF
--- a/src/app/components/ExperimentalEOJ/index.stories.jsx
+++ b/src/app/components/ExperimentalEOJ/index.stories.jsx
@@ -2,19 +2,40 @@
 import React from 'react';
 import { withServicesKnob } from '@bbc/psammead-storybook-helpers';
 import { withKnobs } from '@storybook/addon-knobs';
-import styled from '@emotion/styled';
-import mundoRecommendationsData from '#pages/StoryPage/fixtureData/recommendations.ltr.json';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import withOptimizelyProvider from '#containers/PageHandlers/withOptimizelyProvider';
 import ScrollablePromo from '.';
 
-const BackGround = styled.div`
-  background-color: #f6f6f6;
-  padding: 2rem;
-`;
-
 const ScrollablePromoWithOptimizely = withOptimizelyProvider(ScrollablePromo);
+
+const NEWS_FIXTURE = [
+  {
+    headlines: {
+      headline:
+        'Ashleigh Barty: World number one makes shock call to quit tennis',
+    },
+    locators: {
+      assetUri: 'news/world-australia-60843870',
+    },
+  },
+  {
+    headlines: {
+      headline: "Florida governor rejects transgender swimmer's win",
+    },
+    locators: {
+      assetUri: '/mundo/noticias-america-latina-52884902',
+    },
+  },
+  {
+    headlines: {
+      headline: 'Why are prices rising so quickly?',
+    },
+    locators: {
+      assetUri: '/mundo/noticias-internacional-53113381',
+    },
+  },
+];
 
 const ScrollablePromoComponent = ({
   data,
@@ -24,16 +45,14 @@ const ScrollablePromoComponent = ({
   translations,
 }) => (
   <ToggleContextProvider>
-    <BackGround>
-      <ServiceContextProvider
-        service={service}
-        script={script}
-        dir={dir}
-        translations={translations}
-      >
-        <ScrollablePromoWithOptimizely blocks={data} />
-      </ServiceContextProvider>
-    </BackGround>
+    <ServiceContextProvider
+      service={service}
+      script={script}
+      dir={dir}
+      translations={translations}
+    >
+      <ScrollablePromoWithOptimizely blocks={data} />
+    </ServiceContextProvider>
   </ToggleContextProvider>
 );
 
@@ -44,5 +63,5 @@ export default {
 };
 
 export const Recommendations = props => (
-  <ScrollablePromoComponent data={mundoRecommendationsData} {...props} />
+  <ScrollablePromoComponent data={NEWS_FIXTURE} {...props} />
 );


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Fully English storybook for variation_C. It also changes the style of the storybook to reflect UX updates on components.

**Code changes:**

- Remove Grey background
- Adds English titles to links.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
