### PR TITLE
Fix and logs for failing iframe test (OD TV and Audio)

### DIFF
--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -39,7 +39,7 @@ export default ({ service, pageType, variant, isAmp }) => {
             cy.log(`selector for iframe = iframe[src*="${iframeURL}"]`);
             const pathTested = embedUrl.replace(/^\//, `${envConfig.baseUrl}/`);
             cy.log(`path that will have response tested is ${pathTested}`);
-            iframeURL = iframeURL.split('.com').pop();
+
             cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               // embedUrl may be relative - making it absolute to test the response

--- a/cypress/integration/pages/onDemandAudio/tests.js
+++ b/cypress/integration/pages/onDemandAudio/tests.js
@@ -29,12 +29,18 @@ export default ({ service, pageType, variant, isAmp }) => {
           const isBrandPage = isBrand(jsonData);
 
           cy.get('iframe').then(iframe => {
-            // If a brand, get the src of the iframe, otherwise, use the embed URL from the data
-            // Because of now using a relative URL in the iframe I now use embedUrl, but I want to print the iframe.prop for seeing what this is for now
-            const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
-            cy.log(`iframeURL ${iframeURL}`);
-
-            cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
+            let iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
+            iframeURL = iframeURL.split('.com').pop();
+            cy.log(`cy.get('iframe') assertion has already happened`);
+            cy.log(
+              `used for Brand - iframe.prop('src') = ${iframe.prop('src')}`,
+            );
+            cy.log(`used for Episode - embedURL = ${embedUrl}`);
+            cy.log(`selector for iframe = iframe[src*="${iframeURL}"]`);
+            const pathTested = embedUrl.replace(/^\//, `${envConfig.baseUrl}/`);
+            cy.log(`path that will have response tested is ${pathTested}`);
+            iframeURL = iframeURL.split('.com').pop();
+            cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               // embedUrl may be relative - making it absolute to test the response
               path: embedUrl.replace(/^\//, `${envConfig.baseUrl}/`),

--- a/cypress/integration/pages/onDemandTV/tests.js
+++ b/cypress/integration/pages/onDemandTV/tests.js
@@ -39,7 +39,7 @@ export default ({ service, pageType, variant, isAmp }) => {
             cy.log(`selector for iframe = iframe[src*="${iframeURL}"]`);
             const pathTested = embedUrl.replace(/^\//, `${envConfig.baseUrl}/`);
             cy.log(`path that will have response tested is ${pathTested}`);
-            iframeURL = iframeURL.split('.com').pop();
+
             cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               // embedUrl may be relative - making it absolute to test the response

--- a/cypress/integration/pages/onDemandTV/tests.js
+++ b/cypress/integration/pages/onDemandTV/tests.js
@@ -29,11 +29,18 @@ export default ({ service, pageType, variant, isAmp }) => {
           const isBrandPage = isBrand(jsonData);
 
           cy.get('iframe').then(iframe => {
-            // This variable is unused, but printing it out to help with debugging
-            const iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
-            cy.log(`iframeURL ${iframeURL}`);
-
-            cy.get(`iframe[src*="${embedUrl}"]`).should('be.visible');
+            let iframeURL = isBrandPage ? iframe.prop('src') : embedUrl;
+            iframeURL = iframeURL.split('.com').pop();
+            cy.log(`cy.get('iframe') assertion has already happened`);
+            cy.log(
+              `used for Brand - iframe.prop('src') = ${iframe.prop('src')}`,
+            );
+            cy.log(`used for Episode - embedURL = ${embedUrl}`);
+            cy.log(`selector for iframe = iframe[src*="${iframeURL}"]`);
+            const pathTested = embedUrl.replace(/^\//, `${envConfig.baseUrl}/`);
+            cy.log(`path that will have response tested is ${pathTested}`);
+            iframeURL = iframeURL.split('.com').pop();
+            cy.get(`iframe[src*="${iframeURL}"]`).should('be.visible');
             cy.testResponseCodeAndTypeRetry({
               // embedUrl may be relative - making it absolute to test the response
               path: embedUrl.replace(/^\//, `${envConfig.baseUrl}/`),


### PR DESCRIPTION
embedURL being used as the selector was not working for Brands because it is using the media URL from the page data in the selector for the episode in the media player, but sometimes (and this is why it doesn’t always fail) when an episode is being updated to the most recent one, the URL in the page data is different to the URL of the media on the page for a short period of time (how long? another thing to discover). So using the ‘src’ from the iframe in the DOM is more reliable for using to check the media URL in the iframe is correct, because, well… it told us itself what it was. Not actually the best test, but at least it still checks that the iframe with that media URL is visible. It doesn’t tell us whether the episode is the most recent one - so there is a gap there. But a test for that will probably always have these intermittent failures because of the lag in updating the most recent episode.
Then, the src URL needed the base URL trimmed from it before using it to select. We had actually tried using the src URL directly before and it had been failing because it wasn’t trimmed, and before looking closer this was not obvious. The console logs were not as clear that this was the problem, but the new cy logs helped illuminate it.
This has now passed after running it a few times. Let’s see if it also always passes in the pipeline.

The logging can be removed when we know this works.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Ran it a few times on test and live with no failures. Let's see if the test stops failing in the pipeline