### PR TITLE
fix: Sanitise aria-labelledBy

### DIFF
--- a/src/app/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ScrollablePromo/__snapshots__/index.test.jsx.snap
@@ -264,7 +264,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
 
 <div>
   <section
-    aria-labelledby="Show all links (no images)"
+    aria-labelledby="Show-all-links-no-images"
     class="emotion-0 emotion-1"
     dir="ltr"
     role="region"
@@ -272,7 +272,7 @@ exports[`ScrollablePromo it should match a11y snapshot for list 1`] = `
     <strong
       class="emotion-2 emotion-3"
       data-testid="eoj-recommendations-heading"
-      id="Show all links (no images)"
+      id="Show-all-links-no-images"
     >
       Show all links (no images)
     </strong>
@@ -757,7 +757,7 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
 
 <div>
   <section
-    aria-labelledby="Single link"
+    aria-labelledby="Single-link"
     class="emotion-0 emotion-1"
     dir="ltr"
     role="region"
@@ -765,7 +765,7 @@ exports[`ScrollablePromo it should match a11y snapshot for single card 1`] = `
     <strong
       class="emotion-2 emotion-3"
       data-testid="eoj-recommendations-heading"
-      id="Single link"
+      id="Single-link"
     >
       Single link
     </strong>

--- a/src/app/components/ScrollablePromo/index.jsx
+++ b/src/app/components/ScrollablePromo/index.jsx
@@ -19,6 +19,7 @@ import { GridItemMediumNoMargin } from '#app/components/Grid';
 import { ServiceContext } from '#contexts/ServiceContext';
 import useViewTracker from '#hooks/useViewTracker';
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
+import idSanitiser from '#lib/utilities/idSanitiser';
 import Promo from './Promo';
 import PromoList from './PromoList';
 
@@ -80,11 +81,13 @@ const ScrollablePromo = ({ blocks, blockGroupIndex }) => {
 
   const isSingleItem = blocksWithoutTitle.length === 1;
 
+  const ariaLabel = idSanitiser(title);
+
   const a11yAttributes = {
     as: 'section',
     role: 'region',
-    ...(title
-      ? { 'aria-labelledby': title }
+    ...(ariaLabel
+      ? { 'aria-labelledby': ariaLabel }
       : {
           'aria-label': pathOr(
             'Related Content',
@@ -98,7 +101,7 @@ const ScrollablePromo = ({ blocks, blockGroupIndex }) => {
     <GridItemMediumNoMargin {...a11yAttributes}>
       {title && (
         <LabelComponent
-          id={title}
+          id={ariaLabel}
           data-testid="eoj-recommendations-heading"
           script={script}
           service={service}

--- a/src/app/components/ScrollablePromo/index.jsx
+++ b/src/app/components/ScrollablePromo/index.jsx
@@ -81,7 +81,7 @@ const ScrollablePromo = ({ blocks, blockGroupIndex }) => {
 
   const isSingleItem = blocksWithoutTitle.length === 1;
 
-  const ariaLabel = idSanitiser(title);
+  const ariaLabel = title && idSanitiser(title);
 
   const a11yAttributes = {
     as: 'section',


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._

Issue:

<img width="1012" alt="screenshot_2022-03-28_at_09 26 07" src="https://user-images.githubusercontent.com/90621252/160363491-5941935e-7844-4afb-8164-f4cdb77071e8.png">

<img width="1283" alt="Screenshot 2022-03-28 at 09 41 41" src="https://user-images.githubusercontent.com/90621252/160363598-f091ed82-48e4-4833-a6c0-efe9412cf178.png">

<img width="1083" alt="Screenshot 2022-03-28 at 09 42 12" src="https://user-images.githubusercontent.com/90621252/160363658-0b07ca47-7d60-4ce9-97b2-ad3da5b38ad9.png">

Since the ID already exists, this is an issue with id-sanitisation.

**Code changes:**

- Added id-sanitisation to aria ids.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
