### PR TITLE
a11y improvements on disclaimer

### DIFF
--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -43,6 +43,10 @@ const Inner = styled.section`
     `}
 `;
 
+const DisclaimerP = styled(Paragraph)`
+  padding: 0;
+`;
+
 const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
   const { service, script, disclaimer, translations } =
     useContext(ServiceContext);
@@ -67,7 +71,7 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         role="region"
         aria-label={disclaimerLabelTranslation}
       >
-        <Paragraph>
+        <DisclaimerP>
           {disclaimer &&
             Object.values(disclaimer).map((para, index) => {
               const linkText = path(['text'], para);
@@ -90,7 +94,7 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
                 para
               );
             })}
-        </Paragraph>
+        </DisclaimerP>
       </Inner>
     </GridItemLarge>
   );

--- a/src/app/containers/Disclaimer/index.jsx
+++ b/src/app/containers/Disclaimer/index.jsx
@@ -3,7 +3,7 @@ import { bool } from 'prop-types';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
-import InlineLink from '@bbc/psammead-inline-link';
+import Paragraph from '@bbc/psammead-paragraph';
 import { getSansLight } from '@bbc/psammead-styles/font-styles';
 import { getLongPrimer } from '@bbc/gel-foundations/typography';
 import {
@@ -21,6 +21,7 @@ import { GridItemLarge } from '#app/components/Grid';
 import { ServiceContext } from '#contexts/ServiceContext';
 import useToggle from '#hooks/useToggle';
 import isEmpty from 'ramda/src/isEmpty';
+import InlineLink from '../InlineLink';
 
 const Inner = styled.section`
   ${({ script }) => script && getLongPrimer(script)}
@@ -66,19 +67,30 @@ const DisclaimerComponent = ({ increasePaddingOnDesktop }) => {
         role="region"
         aria-label={disclaimerLabelTranslation}
       >
-        <strong>
-          {Object.values(disclaimer).map(para => {
-            const linkText = path(['text'], para);
-            const linkUrl = path(['url'], para);
-            return linkUrl ? (
-              <InlineLink href={linkUrl} key={linkText}>
-                {linkText}
-              </InlineLink>
-            ) : (
-              para
-            );
-          })}
-        </strong>
+        <Paragraph>
+          {disclaimer &&
+            Object.values(disclaimer).map((para, index) => {
+              const linkText = path(['text'], para);
+              const linkUrl = path(['url'], para);
+              const isExternalLink = path(['isExternal'], para);
+              return linkUrl ? (
+                <InlineLink
+                  key={linkText}
+                  locator={linkUrl}
+                  blocks={[
+                    {
+                      id: `disclaimerLink-${index}`,
+                      type: 'fragment',
+                      model: { text: linkText, attributes: [] },
+                    },
+                  ]}
+                  isExternal={isExternalLink}
+                />
+              ) : (
+                para
+              );
+            })}
+        </Paragraph>
       </Inner>
     </GridItemLarge>
   );

--- a/src/app/containers/Disclaimer/index.stories.jsx
+++ b/src/app/containers/Disclaimer/index.stories.jsx
@@ -13,11 +13,13 @@ const DISCLAIMER_FIXTURE = {
     para2: {
       text: 'IOS',
       url: 'https://apps.apple.com/gb/app/bbc-news/id377382255',
+      isExternal: true,
     },
     para3: ' and ',
     para4: {
       text: 'Android',
       url: 'https://play.google.com/store/apps/details?id=bbc.mobile.news.uk&hl=en_GB&gl=US',
+      isExternal: true,
     },
     para5:
       '. Download them to your device and continue to receive news from the BBC.',
@@ -27,20 +29,25 @@ const DISCLAIMER_FIXTURE = {
     para2: {
       text: 'IOS',
       url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+      isExternal: true,
     },
     para3: ' и ',
     para4: {
       text: 'Android',
       url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+      isExternal: true,
     },
     para5: '. Вы можете также подписаться на наш канал в ',
     para6: {
       text: 'Telegram',
       url: 'https://t.me/bbcrussian',
+      isExternal: true,
     },
     para7: '.',
   },
 };
+
+const externalLinkText = ', внешняя';
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ service }) => {
@@ -57,7 +64,9 @@ const Component = ({ service }) => {
         },
       }}
     >
-      <ServiceContext.Provider value={{ service, disclaimer }}>
+      <ServiceContext.Provider
+        value={{ service, disclaimer, externalLinkText }}
+      >
         <DisclaimerComponent />
       </ServiceContext.Provider>
     </ToggleContextProvider>
@@ -67,7 +76,10 @@ const Component = ({ service }) => {
 export default {
   title: 'Containers/Disclaimer',
   Component,
-  decorators: [withKnobs, withServicesKnob({ defaultService: 'russian' })],
+  decorators: [
+    withKnobs,
+    withServicesKnob({ defaultService: 'russian', externalLinkText: 'hello' }),
+  ],
   parameters: { chromatic: { disable: true } },
 };
 

--- a/src/app/containers/Disclaimer/index.test.jsx
+++ b/src/app/containers/Disclaimer/index.test.jsx
@@ -11,19 +11,24 @@ const DISCLAIMER_FIXTURE = {
   para2: {
     text: 'IOS',
     url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+    isExternal: true,
   },
   para3: ' и ',
   para4: {
     text: 'Android',
     url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+    isExternal: false,
   },
   para5: '. Вы можете также подписаться на наш канал в ',
   para6: {
     text: 'Telegram',
     url: 'https://t.me/bbcrussian',
+    isExternal: false,
   },
   para7: '.',
 };
+
+const externalLinkText = ', внешняя';
 
 // eslint-disable-next-line react/prop-types
 const renderComponent = (
@@ -38,7 +43,7 @@ const renderComponent = (
         },
       }}
     >
-      <ServiceContext.Provider value={{ disclaimer }}>
+      <ServiceContext.Provider value={{ disclaimer, externalLinkText }}>
         <DisclaimerComponent />
       </ServiceContext.Provider>
     </ToggleContextProvider>,
@@ -83,5 +88,15 @@ describe('Disclaimer Component', () => {
   it('should not render when disclaimer is empty object', () => {
     const { container } = renderComponent({ enabled: true }, {});
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render links with external label if links are external', () => {
+    const { getByLabelText } = renderComponent();
+    expect(getByLabelText('IOS, внешняя')).toBeInTheDocument();
+  });
+
+  it('should not render links with external label if isExternal is false', () => {
+    const { queryByLabelText } = renderComponent();
+    expect(queryByLabelText('Android, внешняя')).toBeNull();
   });
 });

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -308,16 +308,19 @@ export const service = {
       para2: {
         text: 'IOS',
         url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+        isExternal: true,
       },
       para3: ' и ',
       para4: {
         text: 'Android',
         url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
+        isExternal: true,
       },
       para5: '. Вы можете также подписаться на наш канал в ',
       para6: {
         text: 'Telegram',
         url: 'https://t.me/bbcrussian',
+        isExternal: true,
       },
       para7: '.',
     },


### PR DESCRIPTION
Resolves #9996

**Overall change:**
Before a final a11y swarm, UX has provided some a11y related improvements to the disclaimer component: https://app.zeplin.io/project/5d4d77b1fcbfc79bf47e0294/screen/622ef23984e71f48dcf4f80e

**Code changes:**

- Added external links.
- Added paragraph instead of a strong element.
- We currently don't have the translation to change the region label

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
