### PR TITLE
lazy load all but first topics promos

### DIFF
--- a/src/app/pages/TopicPage/TopicGrid/index.jsx
+++ b/src/app/pages/TopicPage/TopicGrid/index.jsx
@@ -65,11 +65,15 @@ const TopicGrid = ({ promos }) => {
     <Wrapper>
       {hasMultiplePromos ? (
         <TopicList role="list">
-          {promos.map(promo => (
-            <Item key={promo.id} dir={dir} as="li">
-              <TopicPromo {...promo} />
-            </Item>
-          ))}
+          {promos.map((promo, index) => {
+            const isFirstPromo = index === 0;
+
+            return (
+              <Item key={promo.id} dir={dir} as="li">
+                <TopicPromo {...promo} lazy={!isFirstPromo} />
+              </Item>
+            );
+          })}
         </TopicList>
       ) : (
         <Item key={firstPromo.id} dir={dir}>

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, number, oneOf, oneOfType } from 'prop-types';
+import { bool, string, number, oneOf, oneOfType } from 'prop-types';
 
 import Promo, { MEDIA_TYPES } from '#components/Promo';
 
@@ -8,13 +8,14 @@ const TopicPromo = ({
   firstPublished,
   imageUrl,
   imageAlt,
+  lazy,
   link,
   mediaType,
   mediaDuration,
 }) => {
   return (
     <Promo>
-      <Promo.Image src={imageUrl} alt={imageAlt}>
+      <Promo.Image src={imageUrl} alt={imageAlt} loading={lazy ? 'lazy' : null}>
         <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.Heading>
@@ -31,12 +32,14 @@ TopicPromo.propTypes = {
   firstPublished: oneOfType([number, string]).isRequired,
   imageUrl: string.isRequired,
   imageAlt: string.isRequired,
+  lazy: bool,
   link: string.isRequired,
   mediaType: oneOf(Object.keys(MEDIA_TYPES)),
   mediaDuration: number,
 };
 
 TopicPromo.defaultProps = {
+  lazy: false,
   mediaType: null,
   mediaDuration: null,
 };

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -15,7 +15,11 @@ const TopicPromo = ({
 }) => {
   return (
     <Promo>
-      <Promo.Image src={imageUrl} alt={imageAlt} loading={lazy ? 'lazy' : null}>
+      <Promo.Image
+        src={imageUrl}
+        alt={imageAlt}
+        loading={lazy ? 'lazy' : 'eager'}
+      >
         <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.Heading>

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -15,11 +15,7 @@ const TopicPromo = ({
 }) => {
   return (
     <Promo>
-      <Promo.Image
-        src={imageUrl}
-        alt={imageAlt}
-        loading={lazy ? 'lazy' : 'eager'}
-      >
+      <Promo.Image src={imageUrl} alt={imageAlt} loading={lazy ? 'lazy' : null}>
         <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.Heading>

--- a/src/app/pages/TopicPage/TopicPromo/index.test.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ServiceContextProvider } from '#contexts/ServiceContext';
+import TopicPromo from '.';
+
+// eslint-disable-next-line react/prop-types
+const Fixture = ({ lazy }) => (
+  <ServiceContextProvider service="mundo">
+    <TopicPromo
+      lazy={lazy}
+      title="Promo title"
+      firstPublished="2022-03-30T07:37:18.253Z"
+      imageUrl="https://ichef.bbci.co.uk/news/240/cpsprodpb/17CDB/production/_123699479_indigena.jpg"
+      imageAlt="Campesino indígena peruano."
+      link="https://www.bbc.com/mundo/noticias-america-latina-60742314"
+    />
+    ,
+  </ServiceContextProvider>
+);
+
+describe('TopicPromo', () => {
+  describe('Lazy loading', () => {
+    it('should not lazy load when lazy is falsey', () => {
+      render(<Fixture lazy={false} />);
+
+      const loadingAttribute = screen
+        .getByAltText('Campesino indígena peruano.')
+        .getAttribute('loading');
+
+      expect(loadingAttribute).toBeNull();
+    });
+
+    it('should lazy load when lazy is truthy', () => {
+      render(<Fixture lazy />);
+
+      const loadingAttribute = screen
+        .getByAltText('Campesino indígena peruano.')
+        .getAttribute('loading');
+
+      expect(loadingAttribute).toBe('lazy');
+    });
+  });
+});


### PR DESCRIPTION
**Overall change:**
Adds native [lazy loading](https://caniuse.com/?search=loading) functionality to the `TopicPromo` component.

**Code changes:**

- Uses `loading="lazy"` attribute when `lazy` prop is truthy
- Adds unit tests for lazy loading

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
