### PR TITLE
`new_articles` route pageData fetch fix

### DIFF
--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -13,6 +13,7 @@ import {
 } from '#lib/statusCodes.const';
 import { PRIMARY_DATA_TIMEOUT } from '#app/lib/utilities/getFetchTimeouts';
 import onClient from '#lib/utilities/onClient';
+import isLive from '#lib/utilities/isLive';
 import getErrorStatusCode from './utils/getErrorStatusCode';
 import getUrl from './utils/getUrl';
 
@@ -36,7 +37,11 @@ const fetchPageData = async ({
   optHeaders,
   ...loggerArgs
 }) => {
-  const url = path.startsWith('http') ? path : getUrl(path);
+  const urlPath = path.startsWith('http') ? path : getUrl(path);
+
+  // TODO: Remove this once testing of routing Article pages through Belfrage is complete
+  const url = isLive() ? urlPath : urlPath.replace('new_articles', 'articles');
+
   const effectiveTimeout = timeout || PRIMARY_DATA_TIMEOUT;
   const fetchOptions = {
     headers: {

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -3,6 +3,7 @@ const ampRegex = '.amp';
 const assetUriRegex = '[a-z0-9-_]{0,}[0-9]{8,}';
 const legacyAssetUriRegex = '[a-z0-9-_]{1,}/[a-z0-9-_/]{1,}';
 const variantRegex = '/simp|/trad|/cyr|/lat';
+// TODO: Remove 'new_articles' once testing of routing Article pages through Belfrage is complete
 const articleLocalRegex = 'articles|new_articles|erthyglau|sgeulachdan';
 const mediaIdRegex = '[a-z0-9]+';
 const topicIdRegex = '[a-z0-9]+';


### PR DESCRIPTION
Part of https://github.com/bbc/simorgh-infrastructure/issues/1587

**Overall change:**
- Adds a check to the fetchPageData function to point to the Ares endpoint for article page data for the test `new_articles` route, as this is still routed through Mozart rather than Belfrage

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
