### PR TITLE
High Impact Promo Style Changes

### DIFF
--- a/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
+++ b/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
@@ -4,10 +4,12 @@ import styled from '@emotion/styled';
 import { node, number, string } from 'prop-types';
 
 import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { C_GHOST } from '@bbc/psammead-styles/colours';
 import useImageColour from '../../hooks/useImageColour';
 
 const BLUR_RADIUS = 15;
 const FALLBACK_COLOUR = '#202224';
+const FALLBACK_COLOUR_AMP = C_GHOST;
 
 const Wrapper = styled.div`
   position: relative;
@@ -58,14 +60,15 @@ const FrostedGlassPanel = ({
   minimumContrast,
   paletteSize,
 }) => {
+  const { isAmp } = useContext(RequestContext);
+
   const { isLoading, colour } = useImageColour(image, {
-    fallbackColour: FALLBACK_COLOUR,
+    fallbackColour: isAmp ? FALLBACK_COLOUR_AMP : FALLBACK_COLOUR,
     minimumContrast,
     contrastColour: '#ffffff',
     paletteSize,
   });
 
-  const { isAmp } = useContext(RequestContext);
   const isCanonical = !isAmp;
 
   const backgroundImageStyle = {

--- a/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
+++ b/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
@@ -4,12 +4,12 @@ import styled from '@emotion/styled';
 import { node, number, string } from 'prop-types';
 
 import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
-import { C_GHOST } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_GREY_8 } from '@bbc/psammead-styles/colours';
 import useImageColour from '../../hooks/useImageColour';
 
 const BLUR_RADIUS = 15;
-const FALLBACK_COLOUR = '#202224';
-const FALLBACK_COLOUR_AMP = C_GHOST;
+const FALLBACK_COLOUR = C_GREY_8;
+const FALLBACK_COLOUR_AMP = C_WHITE;
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
+++ b/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 
 import { getSansRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
-import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import {
+  GEL_SPACING,
+  GEL_SPACING_DBL,
+  GEL_SPACING_HLF_TRPL,
+} from '@bbc/gel-foundations/spacings';
 
 import PromoTimestamp from '#components/Promo/timestamp';
 
@@ -11,10 +15,10 @@ const StyledTimestamp = styled(PromoTimestamp)`
   color: white;
 
   font-size: 0.8125rem;
-  padding: 0.625rem ${GEL_SPACING} 0 ${GEL_SPACING};
+  padding: ${GEL_SPACING_HLF_TRPL} ${GEL_SPACING} 0 ${GEL_SPACING};
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     font-size: 0.875rem;
-    padding: 0.625rem ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
+    padding: ${GEL_SPACING_HLF_TRPL} ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
   }
 `;
 

--- a/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
+++ b/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
@@ -12,7 +12,7 @@ import PromoTimestamp from '#components/Promo/timestamp';
 
 const StyledTimestamp = styled(PromoTimestamp)`
   ${({ service }) => service && getSansRegular(service)}
-  color: white;
+  color: ${({ isAmp }) => (isAmp ? 'black' : 'white')};
 
   font-size: 0.8125rem;
   padding: ${GEL_SPACING_HLF_TRPL} ${GEL_SPACING} 0 ${GEL_SPACING};

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -92,14 +92,14 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
   color: white;
   font-size: 0.9375rem;
   line-height: 1.33;
-  margin: 0.625rem 0.5rem 0 0.5rem;
+  margin: 0.875rem 0.5rem 0 0.5rem;
 }
 
 @media (min-width: 25rem) {
   .emotion-17 {
     font-size: 1rem;
     line-height: 1.25;
-    margin: 0.75rem 1rem 0 1rem;
+    margin: 0.875rem 1rem 0 1rem;
   }
 }
 
@@ -282,14 +282,14 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   color: white;
   font-size: 0.9375rem;
   line-height: 1.33;
-  margin: 0.625rem 0.5rem 0 0.5rem;
+  margin: 0.875rem 0.5rem 0 0.5rem;
 }
 
 @media (min-width: 25rem) {
   .emotion-17 {
     font-size: 1rem;
     line-height: 1.25;
-    margin: 0.75rem 1rem 0 1rem;
+    margin: 0.875rem 1rem 0 1rem;
   }
 }
 
@@ -308,7 +308,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   font-style: normal;
   color: white;
   font-size: 0.8125rem;
-  padding: 0.625rem 0.5rem 0 0.5rem;
+  padding: 0.75rem 0.5rem 0 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -328,7 +328,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 @media (min-width: 25rem) {
   .emotion-20 {
     font-size: 0.875rem;
-    padding: 0.625rem 1rem 0 1rem;
+    padding: 0.75rem 1rem 0 1rem;
   }
 }
 
@@ -522,14 +522,14 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   color: white;
   font-size: 0.9375rem;
   line-height: 1.33;
-  margin: 0.625rem 0.5rem 0 0.5rem;
+  margin: 0.875rem 0.5rem 0 0.5rem;
 }
 
 @media (min-width: 25rem) {
   .emotion-17 {
     font-size: 1rem;
     line-height: 1.25;
-    margin: 0.75rem 1rem 0 1rem;
+    margin: 0.875rem 1rem 0 1rem;
   }
 }
 
@@ -548,7 +548,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   font-style: normal;
   color: white;
   font-size: 0.8125rem;
-  padding: 0.625rem 0.5rem 0 0.5rem;
+  padding: 0.75rem 0.5rem 0 0.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -568,7 +568,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 @media (min-width: 25rem) {
   .emotion-20 {
     font-size: 0.875rem;
-    padding: 0.625rem 1rem 0 1rem;
+    padding: 0.75rem 1rem 0 1rem;
   }
 }
 

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -5,11 +5,7 @@ import pick from 'ramda/src/pick';
 
 import { getSerifRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
-import {
-  GEL_SPACING,
-  GEL_SPACING_HLF_TRPL,
-  GEL_SPACING_DBL,
-} from '@bbc/gel-foundations/spacings';
+import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -56,11 +52,11 @@ const A = styled.a`
   color: white;
   font-size: 0.9375rem;
   line-height: 1.33;
-  margin: 0.625rem ${GEL_SPACING} 0 ${GEL_SPACING};
+  margin: 0.875rem ${GEL_SPACING} 0 ${GEL_SPACING};
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
     font-size: 1rem;
     line-height: 1.25;
-    margin: ${GEL_SPACING_HLF_TRPL} ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
+    margin: 0.875rem ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
   }
   &:focus {
     text-decoration: underline;

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -9,6 +9,7 @@ import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
 
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import { ServiceContext } from '#contexts/ServiceContext';
+import { RequestContext } from '#contexts/RequestContext';
 import FrostedGlassPanel from './FrostedGlassPanel';
 
 import ImageWithPlaceholder from '../../containers/ImageWithPlaceholder';
@@ -49,7 +50,7 @@ const A = styled.a`
   display: inline-block;
   ${({ service }) => service && getSerifRegular(service)}
   text-decoration: none;
-  color: white;
+  color: ${({ isAmp }) => (isAmp ? 'black' : 'white')};
   font-size: 0.9375rem;
   line-height: 1.33;
   margin: 0.875rem ${GEL_SPACING} 0 ${GEL_SPACING};
@@ -74,6 +75,7 @@ const FrostedGlassPromo = ({
   paletteSize,
 }) => {
   const { script, service } = useContext(ServiceContext);
+  const { isAmp } = useContext(RequestContext);
 
   const clickTracker = useClickTrackerHandler({
     ...(eventTrackingData || {}),
@@ -116,7 +118,13 @@ const FrostedGlassPromo = ({
         paletteSize={paletteSize}
       >
         <H3>
-          <A script={script} service={service} href={url} onClick={onClick}>
+          <A
+            script={script}
+            service={service}
+            href={url}
+            onClick={onClick}
+            isAmp={isAmp}
+          >
             {children}
           </A>
         </H3>
@@ -130,7 +138,7 @@ const FrostedGlassPromo = ({
 // It uses a withData HoC to convert the prop to a standardised schema
 // This array is the list of props that should just be passed straight through
 // to the component, without requiring any preprocessing
-const propsToPassThrough = ['minimumContrast', 'paletteSize'];
+const propsToPassThrough = ['minimumContrast', 'paletteSize', 'isAmp'];
 
 FrostedGlassPromo.propTypes = {
   children: node.isRequired,

--- a/src/app/components/FrostedGlassPromo/withData.jsx
+++ b/src/app/components/FrostedGlassPromo/withData.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { RequestContext } from '#contexts/RequestContext';
 import path from 'ramda/src/path';
 import hasPath from 'ramda/src/hasPath';
 import pick from 'ramda/src/pick';
@@ -53,15 +54,21 @@ const buildImageProperties = image => {
   };
 };
 
-const cpsPromoFormatter = props => ({
-  children: path(['item', 'headlines', 'headline'], props),
-  footer: (
+const TimestampFooterWithAmp = props => {
+  const { isAmp } = useContext(RequestContext);
+  return (
     <TimestampFooter
       serviceDatetimeLocale={path(['item', 'serviceDatetimeLocale'], props)}
+      isAmp={isAmp}
     >
       {path(['item', 'timestamp'], props)}
     </TimestampFooter>
-  ),
+  );
+};
+
+const cpsPromoFormatter = props => ({
+  children: path(['item', 'headlines', 'headline'], props),
+  footer: <TimestampFooterWithAmp {...props} />,
   url: path(['item', 'locators', 'assetUri'], props),
   image: buildImageProperties(path(['item', 'indexImage'], props)),
   eventTrackingData: path(['eventTrackingData', 'block'], props),
@@ -69,13 +76,7 @@ const cpsPromoFormatter = props => ({
 
 const linkPromoFormatter = props => ({
   children: path(['item', 'name'], props),
-  footer: (
-    <TimestampFooter
-      serviceDatetimeLocale={path(['item', 'serviceDatetimeLocale'], props)}
-    >
-      {path(['item', 'timestamp'], props)}
-    </TimestampFooter>
-  ),
+  footer: <TimestampFooterWithAmp {...props} />,
   url: path(['item', 'uri'], props),
   image: buildImageProperties(path(['item', 'indexImage'], props)),
   eventTrackingData: path(['eventTrackingData', 'block'], props),


### PR DESCRIPTION
Resolves #9971

**Overall change:**
Add new design tweaks for High Impact Promos.

**Code changes:**

- Changes top padding for timestamp
- Changes top padding for children container
- Changes colours for AMP

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
