### PR TITLE
make rel=amphtml link optional for page types

### DIFF
--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -50,7 +50,7 @@ const MetadataContainer = ({
   imageHeight,
   children,
   hasAppleItunesAppBanner,
-  renderAmpHtml,
+  hasAmpPage,
 }) => {
   const {
     isAmp,
@@ -110,6 +110,7 @@ const MetadataContainer = ({
 
   const metaImage = image || defaultImage;
   const metaImageAltText = imageAltText || defaultImageAltText;
+  const linkToAmpPage = hasAmpPage && !isAmp;
 
   return (
     <Helmet htmlAttributes={htmlAttributes}>
@@ -127,7 +128,7 @@ const MetadataContainer = ({
       {isoLang &&
         !isEnglishService &&
         alternateLinksWsSites.map(renderAlternateLinks)}
-      {!isAmp || !renderAmpHtml ? <link rel="amphtml" href={ampLink} /> : null}
+      {linkToAmpPage && <link rel="amphtml" href={ampLink} />}
       {renderAppleItunesApp({
         iTunesAppId,
         canonicalLink,
@@ -208,7 +209,7 @@ MetadataContainer.propTypes = {
   imageHeight: number,
   children: node,
   hasAppleItunesAppBanner: bool,
-  renderAmpHtml: bool,
+  hasAmpPage: bool,
 };
 
 MetadataContainer.defaultProps = {
@@ -221,7 +222,7 @@ MetadataContainer.defaultProps = {
   imageHeight: null,
   children: null,
   hasAppleItunesAppBanner: false,
-  renderAmpHtml: true,
+  hasAmpPage: true,
 };
 
 export default MetadataContainer;

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -6,7 +6,6 @@ import { RequestContext } from '#contexts/RequestContext';
 import {
   getIconAssetUrl,
   getIconLinks,
-  renderAmpHtml,
   getAppleTouchUrl,
   renderAlternateLinks,
   renderAppleItunesApp,
@@ -51,6 +50,7 @@ const MetadataContainer = ({
   imageHeight,
   children,
   hasAppleItunesAppBanner,
+  renderAmpHtml,
 }) => {
   const {
     isAmp,
@@ -127,7 +127,7 @@ const MetadataContainer = ({
       {isoLang &&
         !isEnglishService &&
         alternateLinksWsSites.map(renderAlternateLinks)}
-      {renderAmpHtml(ampLink, isAmp)}
+      {!isAmp || !renderAmpHtml ? <link rel="amphtml" href={ampLink} /> : null}
       {renderAppleItunesApp({
         iTunesAppId,
         canonicalLink,
@@ -208,6 +208,7 @@ MetadataContainer.propTypes = {
   imageHeight: number,
   children: node,
   hasAppleItunesAppBanner: bool,
+  renderAmpHtml: bool,
 };
 
 MetadataContainer.defaultProps = {
@@ -220,6 +221,7 @@ MetadataContainer.defaultProps = {
   imageHeight: null,
   children: null,
   hasAppleItunesAppBanner: false,
+  renderAmpHtml: true,
 };
 
 export default MetadataContainer;

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -53,6 +53,7 @@ const MetadataWithContext = ({
   aboutTags,
   mentionsTags,
   hasAppleItunesAppBanner,
+  hasAmpPage,
   /* eslint-enable react/prop-types */
 }) => (
   <ServiceContextProvider service={service} pageLang={lang}>
@@ -77,12 +78,13 @@ const MetadataWithContext = ({
         imageHeight={imageHeight}
         imageWidth={imageWidth}
         hasAppleItunesAppBanner={hasAppleItunesAppBanner}
+        hasAmpPage={hasAmpPage}
       />
     </RequestContextProvider>
   </ServiceContextProvider>
 );
 
-const CanonicalNewsInternationalOrigin = () => (
+const CanonicalNewsInternationalOrigin = props => (
   <MetadataWithContext
     service="news"
     bbcOrigin={dotComOrigin}
@@ -91,6 +93,7 @@ const CanonicalNewsInternationalOrigin = () => (
     pageType={ARTICLE_PAGE}
     pathname="/news/articles/c0000000001o"
     {...newsArticleMetadataProps}
+    {...props}
   />
 );
 
@@ -540,6 +543,30 @@ it('should render the LDP tags', async () => {
     }));
 
     expect(actual).toEqual(expected);
+  });
+});
+
+it('should render the amp page link tag by default', async () => {
+  render(<CanonicalNewsInternationalOrigin />);
+
+  await waitFor(() => {
+    const ampLinkEl = document.querySelector('head > link[rel="amphtml"]');
+    const ampUrl = ampLinkEl.getAttribute('href');
+
+    expect(ampLinkEl).toBeInTheDocument();
+    expect(ampUrl).toEqual(
+      'https://www.bbc.com/news/articles/c0000000001o.amp',
+    );
+  });
+});
+
+it('should not render the amp page link tag is ', async () => {
+  render(<CanonicalNewsInternationalOrigin hasAmpPage={false} />);
+
+  await waitFor(() => {
+    const ampLinkEl = document.querySelector('head > link[rel="amphtml"]');
+
+    expect(ampLinkEl).not.toBeInTheDocument();
   });
 });
 

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -560,7 +560,7 @@ it('should render the amp page link tag by default', async () => {
   });
 });
 
-it('should not render the amp page link tag is ', async () => {
+it('should not render the amp page link tag if hasAmpPage is false', async () => {
   render(<CanonicalNewsInternationalOrigin hasAmpPage={false} />);
 
   await waitFor(() => {

--- a/src/app/containers/Metadata/utils.jsx
+++ b/src/app/containers/Metadata/utils.jsx
@@ -36,13 +36,6 @@ export const getIconLinks = (service, iconSizes) => {
   });
 };
 
-export const renderAmpHtml = (ampLink, isAmp) => {
-  if (isAmp) {
-    return null;
-  }
-  return <link rel="amphtml" href={ampLink} />;
-};
-
 export const getAppleTouchUrl = service => {
   return [
     process.env.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN,

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -45,6 +45,7 @@ const TopicPage = ({ pageData }) => {
         lang={lang}
         description={description}
         openGraphType="website"
+        renderAmpHtml={false}
       />
       <LinkedData
         type="CollectionPage"

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -45,7 +45,7 @@ const TopicPage = ({ pageData }) => {
         lang={lang}
         description={description}
         openGraphType="website"
-        renderAmpHtml={false}
+        hasAmpPage={false}
       />
       <LinkedData
         type="CollectionPage"


### PR DESCRIPTION
**Overall change:**
Makes the [amp page link](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery/) optional within the `Metadata` component. It will be rendered by default unless you state otherwise.

We use this new functionality in the topics page component to not render the amp link tag because we are not supporting amp for this page type

**Code changes:**

- adds `hasAmpPage` prop to the `Metadata` component. this prop is `true` by default
- sets `hasAmpPage` to `false` in the `TopicsPage` component so that we don't link to an amp page that does not exist.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [x] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
