### PR TITLE
support `new_topics` and `topics` routes

### DIFF
--- a/src/app/routes/topic/index.js
+++ b/src/app/routes/topic/index.js
@@ -1,10 +1,10 @@
 import { TopicPage } from '#pages';
-import { topicPath } from '#utils/regex';
+import { temporaryTopicPath, topicPath } from '#utils/regex';
 import { TOPIC_PAGE } from '#utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {
-  path: topicPath,
+  path: [temporaryTopicPath, topicPath],
   exact: true,
   component: TopicPage,
   getInitialData,

--- a/src/app/routes/utils/regex/index.js
+++ b/src/app/routes/utils/regex/index.js
@@ -12,6 +12,7 @@ import {
   getPodcastBrandRegex,
   getOnDemandRadioRegex,
   getOnDemandTvRegex,
+  getTemporaryTopicPageRegex,
   getTopicPageRegex,
   getErrorPageRegex,
   getLegacyAssetRegex,
@@ -57,6 +58,7 @@ export const podcastBrandDataPath = `${podcastBrandPath}.json`;
 export const onDemandTvPath = getOnDemandTvRegex(allServices);
 export const onDemandTvDataPath = `${onDemandTvPath}.json`;
 
+export const temporaryTopicPath = getTemporaryTopicPageRegex(allServices);
 export const topicPath = getTopicPageRegex(allServices);
 export const topicDataPath = `${topicPath}.json`;
 

--- a/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
@@ -44,4 +44,6 @@ exports[`regex utils snapshots should create expected regex from getSecondaryCol
 
 exports[`regex utils snapshots should create expected regex from getSwRegex 1`] = `"/:service(news|persian|igbo)/sw.js"`;
 
-exports[`regex utils snapshots should create expected regex from getTopicPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/new_topics/:id([a-z0-9]+):amp(.amp)?"`;
+exports[`regex utils snapshots should create expected regex from getTemporaryTopicPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/new_topics/:id([a-z0-9]+)?"`;
+
+exports[`regex utils snapshots should create expected regex from getTopicPageRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/topics/:id([a-z0-9]+)?"`;

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -80,9 +80,14 @@ export const getOnDemandTvRegex = services => {
   return `/:service(${serviceRegex})/:serviceId(${tvMasterBrandRegex})/:brandEpisode(${brandEpisodeRegex})/:mediaId(${mediaIdRegex}):amp(${ampRegex})?`;
 };
 
+export const getTemporaryTopicPageRegex = services => {
+  const serviceRegex = getServiceRegex(services);
+  return `/:service(${serviceRegex}):variant(${variantRegex})?/new_topics/:id(${topicIdRegex})?`;
+};
+
 export const getTopicPageRegex = services => {
   const serviceRegex = getServiceRegex(services);
-  return `/:service(${serviceRegex}):variant(${variantRegex})?/new_topics/:id(${topicIdRegex}):amp(${ampRegex})?`;
+  return `/:service(${serviceRegex}):variant(${variantRegex})?/topics/:id(${topicIdRegex})?`;
 };
 
 export const getErrorPageRegex = services => {


### PR DESCRIPTION
**Overall change:**
Add support for both `new_topics` and `topics` routes so that we can have services using the Simorgh topics pages live and also on test under the `new_topics` route that doesn't replace the Morph topics page on test.

Also removes the amp regex matcher from the topics route because we are not supporting amp for topics pages.

**Code changes:**

- Adds in a `/topics/` route and uses a `temporary` prefix in the var name for the `/new_topics/` route

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
