### PR TITLE
High impact promo performance fixes

### DIFF
--- a/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
+++ b/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
@@ -85,7 +85,7 @@ const FrostedGlassPanel = ({
       <Children colour={colour.rgb} isLoading={isLoading}>
         {children}
       </Children>
-      {isCanonical && <Background style={backgroundImageStyle} image={image} />}
+      {isCanonical && <Background style={backgroundImageStyle} />}
     </Wrapper>
   );
 };

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -59,18 +59,6 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-9 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-11 {
   position: relative;
   overflow: hidden;
   display: -webkit-box;
@@ -83,7 +71,7 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
   height: 100%;
 }
 
-.emotion-13 {
+.emotion-8 {
   position: relative;
   z-index: 3;
   padding-bottom: 1rem;
@@ -93,11 +81,11 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
   height: 100%;
 }
 
-.emotion-15 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-17 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -111,24 +99,24 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-17 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-17:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-19 {
+.emotion-14 {
   display: none;
 }
 
 @supports (filter: blur(15px)) {
-  .emotion-19 {
+  .emotion-14 {
     display: block;
     z-index: 1;
     position: absolute;
@@ -167,28 +155,26 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
       data-e2e="image-placeholder"
       style="padding-bottom: 52%;"
     >
-      <picture
-        class="emotion-6 emotion-7"
+      <div
+        class="lazyload-wrapper "
       >
-        <img
-          alt="Orange 2"
-          class="emotion-8 emotion-9 emotion-10"
-          src="https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg"
-          width="976"
+        <div
+          class="lazyload-placeholder"
         />
-      </picture>
+      </div>
+      <noscript />
     </div>
     <div
-      class="emotion-11 emotion-12"
+      class="emotion-6 emotion-7"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-8 emotion-9"
       >
         <h3
-          class="emotion-15 emotion-16"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-17 emotion-18"
+            class="emotion-12 emotion-13"
             href="/mundo/internacional-23038380"
           >
             Además de sus decenas de museos tradicionales, Ciudad de México es una galería al aire libre de arte callejero, en la que exponen artistas nacionales y extranjeros. Lo invitamos a un recorrido.
@@ -197,7 +183,7 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
         4 mayo 2021
       </div>
       <div
-        class="emotion-19 emotion-20"
+        class="emotion-14 emotion-15"
         style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg);"
       />
     </div>
@@ -264,18 +250,6 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-9 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-11 {
   position: relative;
   overflow: hidden;
   display: -webkit-box;
@@ -288,7 +262,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   height: 100%;
 }
 
-.emotion-13 {
+.emotion-8 {
   position: relative;
   z-index: 3;
   padding-bottom: 1rem;
@@ -298,11 +272,11 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   height: 100%;
 }
 
-.emotion-15 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-17 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -316,19 +290,19 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-17 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-17:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-20 {
+.emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -342,32 +316,32 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-17 {
   display: none;
 }
 
 @supports (filter: blur(15px)) {
-  .emotion-22 {
+  .emotion-17 {
     display: block;
     z-index: 1;
     position: absolute;
@@ -406,54 +380,41 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
       data-e2e="image-placeholder"
       style="padding-bottom: 52%;"
     >
-      <picture
-        class="emotion-6 emotion-7"
+      <div
+        class="lazyload-wrapper "
       >
-        <source
-          sizes="(max-width: 300px) 280px, (min-width: 1008px) 280px, 400px"
-          srcset="https://ichef.bbci.co.uk/news/280/cpsdevpb/DDFC/test/_63482865_orange2.jpg.webp 280w, https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg.webp 400w"
-          type="image/webp"
+        <div
+          class="lazyload-placeholder"
         />
-        <source
-          sizes="(max-width: 300px) 280px, (min-width: 1008px) 280px, 400px"
-          srcset="https://ichef.bbci.co.uk/news/280/cpsdevpb/DDFC/test/_63482865_orange2.jpg 280w, https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg 400w"
-          type="image/jpeg"
-        />
-        <img
-          alt="naranja 2"
-          class="emotion-8 emotion-9 emotion-10"
-          height="549"
-          src="https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg"
-          width="976"
-        />
-      </picture>
+      </div>
+      <noscript />
     </div>
     <div
-      class="emotion-11 emotion-12"
+      class="emotion-6 emotion-7"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-8 emotion-9"
       >
         <h3
-          class="emotion-15 emotion-16"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-17 emotion-18"
+            class="emotion-12 emotion-13"
             href="/mundo/internacional-23038380"
           >
             El colorido encanto del arte callejero chilango 17
           </a>
         </h3>
         <time
-          class="emotion-19 emotion-20 emotion-21"
+          class="emotion-14 emotion-15 emotion-16"
           datetime="2016-05-05"
         >
           5 mayo 2016
         </time>
       </div>
       <div
-        class="emotion-22 emotion-23"
-        style="background-image: url(https://ichef.bbci.co.uk/news/240/cpsdevpb/DDFC/test/_63482865_orange2.jpg.webp);"
+        class="emotion-17 emotion-18"
+        style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg.webp);"
       />
     </div>
   </div>
@@ -519,18 +480,6 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 .emotion-6 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-9 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-11 {
   position: relative;
   overflow: hidden;
   display: -webkit-box;
@@ -543,7 +492,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   height: 100%;
 }
 
-.emotion-13 {
+.emotion-8 {
   position: relative;
   z-index: 3;
   padding-bottom: 1rem;
@@ -553,11 +502,11 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   height: 100%;
 }
 
-.emotion-15 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-17 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -571,19 +520,19 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-17 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-17:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-20 {
+.emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -597,32 +546,32 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-20 {
+  .emotion-15 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-17 {
   display: none;
 }
 
 @supports (filter: blur(15px)) {
-  .emotion-22 {
+  .emotion-17 {
     display: block;
     z-index: 1;
     position: absolute;
@@ -661,54 +610,41 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
       data-e2e="image-placeholder"
       style="padding-bottom: 52%;"
     >
-      <picture
-        class="emotion-6 emotion-7"
+      <div
+        class="lazyload-wrapper "
       >
-        <source
-          sizes="(max-width: 300px) 280px, (min-width: 1008px) 280px, 400px"
-          srcset="https://ichef.bbci.co.uk/news/280/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg.webp 280w, https://ichef.bbci.co.uk/news/400/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg.webp 400w"
-          type="image/webp"
+        <div
+          class="lazyload-placeholder"
         />
-        <source
-          sizes="(max-width: 300px) 280px, (min-width: 1008px) 280px, 400px"
-          srcset="https://ichef.bbci.co.uk/news/280/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg 280w, https://ichef.bbci.co.uk/news/400/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg 400w"
-          type="image/jpeg"
-        />
-        <img
-          alt="E dey good for your"
-          class="emotion-8 emotion-9 emotion-10"
-          height="351"
-          src="https://ichef.bbci.co.uk/news/400/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg"
-          width="624"
-        />
-      </picture>
+      </div>
+      <noscript />
     </div>
     <div
-      class="emotion-11 emotion-12"
+      class="emotion-6 emotion-7"
     >
       <div
-        class="emotion-13 emotion-14"
+        class="emotion-8 emotion-9"
       >
         <h3
-          class="emotion-15 emotion-16"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-17 emotion-18"
+            class="emotion-12 emotion-13"
             href="https://www.bbc.com/pidgin/sport-51434980"
           >
             Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
           </a>
         </h3>
         <time
-          class="emotion-19 emotion-20 emotion-21"
+          class="emotion-14 emotion-15 emotion-16"
           datetime="2020-02-17"
         >
           17 febrero 2020
         </time>
       </div>
       <div
-        class="emotion-22 emotion-23"
-        style="background-image: url(https://ichef.bbci.co.uk/news/240/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg.webp);"
+        class="emotion-17 emotion-18"
+        style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg.webp);"
       />
     </div>
   </div>

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -99,6 +99,7 @@ const FrostedGlassPromo = ({
         tabIndex="-1"
       ></ClickableArea>
       <ImageWithPlaceholder
+        lazyLoad
         darkMode={isCanonical}
         {...pick(
           [
@@ -117,7 +118,7 @@ const FrostedGlassPromo = ({
         )}
       />
       <FrostedGlassPanel
-        image={image.smallSrc || image.src}
+        image={image.src}
         minimumContrast={minimumContrast}
         paletteSize={paletteSize}
       >

--- a/src/app/components/FrostedGlassPromo/index.test.jsx
+++ b/src/app/components/FrostedGlassPromo/index.test.jsx
@@ -53,13 +53,11 @@ describe('Frosted Glass Promo', () => {
 
   it('should render the appropriate elements - CPS Promo', () => {
     const { container, getByText } = render(<Component {...cpsPromoFixture} />);
+
     expect(getByText('5 mayo 2016'));
     expect(getByText(cpsPromoFixture.item.headlines.headline));
-    expect(
-      container.querySelector(
-        `img[alt="${cpsPromoFixture.item.indexImage.altText}"]`,
-      ),
-    ).toBeInTheDocument();
+    // Main image is lazy-loaded
+    expect(container.querySelector('noscript')).toBeInTheDocument();
     expect(
       container.querySelector(
         `a[href="${cpsPromoFixture.item.locators.assetUri}"]`,
@@ -73,11 +71,8 @@ describe('Frosted Glass Promo', () => {
     );
     expect(getByText('17th February 2020'));
     expect(getByText(linkPromoFixture.item.summary));
-    expect(
-      container.querySelector(
-        `img[alt="${linkPromoFixture.item.indexImage.altText}"]`,
-      ),
-    ).toBeInTheDocument();
+    // Main image is lazy-loaded
+    expect(container.querySelector('noscript')).toBeInTheDocument();
     expect(
       container.querySelector(`a[href="${linkPromoFixture.item.uri}"]`),
     ).toBeInTheDocument();

--- a/src/app/components/FrostedGlassPromo/withData.jsx
+++ b/src/app/components/FrostedGlassPromo/withData.jsx
@@ -22,19 +22,13 @@ const buildImageProperties = image => {
       originCode,
       locator,
       originalImageWidth: width,
-      imageResolutions: [280, 400],
+      imageResolutions: [400],
     });
 
   const src = buildIChefURL({
     originCode,
     locator,
     resolution: 400,
-  });
-
-  const smallSrc = buildIChefURL({
-    originCode,
-    locator,
-    resolution: 240,
     isWebP: true,
   });
 
@@ -42,9 +36,8 @@ const buildImageProperties = image => {
     ratio: 52,
     srcset: primarySrcset,
     fallbackSrcset,
-    sizes: '(max-width: 300px) 280px, (min-width: 1008px) 280px, 400px',
+    sizes: '(min-width: 1008px) 400px',
     src,
-    smallSrc,
     primaryMimeType,
     fallbackMimeType,
     alt: altText,


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
The high impact promos were rendering 2 different sizes of the same image, one for the main feature image and another small sized image for the blurred background effect. This has been changed to the one image size so that the browser can attempt to use the cached version of the same image in both scenarios. The lazy load attribute has also been added to the main feature image to reduce page weight when its outside the viewport

**Code changes:**
- Updates the `FrostedGlassPromo/index` file to include the `lazyLoad` attribute for the `<ImageWithPlaceholder />` component
- Updates the `withData` HOC to remove the smaller sized image. It also now renders the main feature image in WebP

**Further notes**
We could implement lazy-loading for the `FrostedGlassPanel` component, so that it only renders when almost in the viewport. This has some ramifications for AMP though, so it has not been done in this PR.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
