### PR TITLE
Frosted Glass panel Lazy-loading

### DIFF
--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -123,6 +123,7 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
     >
       <div
         class="emotion-6 emotion-7"
+        data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
           class="emotion-8 emotion-9"
@@ -298,6 +299,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
     >
       <div
         class="emotion-6 emotion-7"
+        data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
           class="emotion-8 emotion-9"
@@ -478,6 +480,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
     >
       <div
         class="emotion-6 emotion-7"
+        data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
           class="emotion-8 emotion-9"

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -59,33 +59,15 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 .emotion-6 {
-  position: relative;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
+  background-color: #202224;
+  height: 100px;
 }
 
 .emotion-8 {
-  position: relative;
-  z-index: 3;
-  padding-bottom: 1rem;
-  -webkit-transition: background 0.5s ease-in-out;
-  transition: background 0.5s ease-in-out;
-  background: rgb(32,34,36);
-  height: 100%;
-}
-
-.emotion-10 {
   margin: 0;
 }
 
-.emotion-12 {
+.emotion-10 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -99,44 +81,16 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-12:focus {
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.emotion-14 {
-  display: none;
-}
-
-@supports (filter: blur(15px)) {
-  .emotion-14 {
-    display: block;
-    z-index: 1;
-    position: absolute;
-    bottom: 0;
-    top: -15px;
-    left: 0;
-    right: 0;
-    background-color: #202224;
-    background-repeat: no-repeat;
-    -webkit-background-size: cover;
-    background-size: cover;
-    -webkit-background-position: bottom;
-    background-position: bottom;
-    -webkit-transform: scaleX(1.15) scaleY(-1.15);
-    -moz-transform: scaleX(1.15) scaleY(-1.15);
-    -ms-transform: scaleX(1.15) scaleY(-1.15);
-    transform: scaleX(1.15) scaleY(-1.15);
-    -webkit-filter: blur(15px);
-    filter: blur(15px);
-  }
 }
 
 <div>
@@ -165,16 +119,16 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
       <noscript />
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="lazyload-wrapper "
     >
       <div
-        class="emotion-8 emotion-9"
+        class="emotion-6 emotion-7"
       >
         <h3
-          class="emotion-10 emotion-11"
+          class="emotion-8 emotion-9"
         >
           <a
-            class="emotion-12 emotion-13"
+            class="emotion-10 emotion-11"
             href="/mundo/internacional-23038380"
           >
             Además de sus decenas de museos tradicionales, Ciudad de México es una galería al aire libre de arte callejero, en la que exponen artistas nacionales y extranjeros. Lo invitamos a un recorrido.
@@ -182,10 +136,6 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
         </h3>
         4 mayo 2021
       </div>
-      <div
-        class="emotion-14 emotion-15"
-        style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg);"
-      />
     </div>
   </div>
 </div>
@@ -250,33 +200,15 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 .emotion-6 {
-  position: relative;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
+  background-color: #202224;
+  height: 100px;
 }
 
 .emotion-8 {
-  position: relative;
-  z-index: 3;
-  padding-bottom: 1rem;
-  -webkit-transition: background 0.5s ease-in-out;
-  transition: background 0.5s ease-in-out;
-  background: rgb(32,34,36);
-  height: 100%;
-}
-
-.emotion-10 {
   margin: 0;
 }
 
-.emotion-12 {
+.emotion-10 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -290,19 +222,19 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-12:focus {
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-15 {
+.emotion-13 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -316,51 +248,23 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
-  }
-}
-
-.emotion-17 {
-  display: none;
-}
-
-@supports (filter: blur(15px)) {
-  .emotion-17 {
-    display: block;
-    z-index: 1;
-    position: absolute;
-    bottom: 0;
-    top: -15px;
-    left: 0;
-    right: 0;
-    background-color: #202224;
-    background-repeat: no-repeat;
-    -webkit-background-size: cover;
-    background-size: cover;
-    -webkit-background-position: bottom;
-    background-position: bottom;
-    -webkit-transform: scaleX(1.15) scaleY(-1.15);
-    -moz-transform: scaleX(1.15) scaleY(-1.15);
-    -ms-transform: scaleX(1.15) scaleY(-1.15);
-    transform: scaleX(1.15) scaleY(-1.15);
-    -webkit-filter: blur(15px);
-    filter: blur(15px);
   }
 }
 
@@ -390,32 +294,28 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
       <noscript />
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="lazyload-wrapper "
     >
       <div
-        class="emotion-8 emotion-9"
+        class="emotion-6 emotion-7"
       >
         <h3
-          class="emotion-10 emotion-11"
+          class="emotion-8 emotion-9"
         >
           <a
-            class="emotion-12 emotion-13"
+            class="emotion-10 emotion-11"
             href="/mundo/internacional-23038380"
           >
             El colorido encanto del arte callejero chilango 17
           </a>
         </h3>
         <time
-          class="emotion-14 emotion-15 emotion-16"
+          class="emotion-12 emotion-13 emotion-14"
           datetime="2016-05-05"
         >
           5 mayo 2016
         </time>
       </div>
-      <div
-        class="emotion-17 emotion-18"
-        style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/DDFC/test/_63482865_orange2.jpg.webp);"
-      />
     </div>
   </div>
 </div>
@@ -480,33 +380,15 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 .emotion-6 {
-  position: relative;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
+  background-color: #202224;
+  height: 100px;
 }
 
 .emotion-8 {
-  position: relative;
-  z-index: 3;
-  padding-bottom: 1rem;
-  -webkit-transition: background 0.5s ease-in-out;
-  transition: background 0.5s ease-in-out;
-  background: rgb(32,34,36);
-  height: 100%;
-}
-
-.emotion-10 {
   margin: 0;
 }
 
-.emotion-12 {
+.emotion-10 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -520,19 +402,19 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-12:focus {
+.emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-15 {
+.emotion-13 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -546,51 +428,23 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-15 {
+  .emotion-13 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
-  }
-}
-
-.emotion-17 {
-  display: none;
-}
-
-@supports (filter: blur(15px)) {
-  .emotion-17 {
-    display: block;
-    z-index: 1;
-    position: absolute;
-    bottom: 0;
-    top: -15px;
-    left: 0;
-    right: 0;
-    background-color: #202224;
-    background-repeat: no-repeat;
-    -webkit-background-size: cover;
-    background-size: cover;
-    -webkit-background-position: bottom;
-    background-position: bottom;
-    -webkit-transform: scaleX(1.15) scaleY(-1.15);
-    -moz-transform: scaleX(1.15) scaleY(-1.15);
-    -ms-transform: scaleX(1.15) scaleY(-1.15);
-    transform: scaleX(1.15) scaleY(-1.15);
-    -webkit-filter: blur(15px);
-    filter: blur(15px);
   }
 }
 
@@ -620,32 +474,28 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
       <noscript />
     </div>
     <div
-      class="emotion-6 emotion-7"
+      class="lazyload-wrapper "
     >
       <div
-        class="emotion-8 emotion-9"
+        class="emotion-6 emotion-7"
       >
         <h3
-          class="emotion-10 emotion-11"
+          class="emotion-8 emotion-9"
         >
           <a
-            class="emotion-12 emotion-13"
+            class="emotion-10 emotion-11"
             href="https://www.bbc.com/pidgin/sport-51434980"
           >
             Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
           </a>
         </h3>
         <time
-          class="emotion-14 emotion-15 emotion-16"
+          class="emotion-12 emotion-13 emotion-14"
           datetime="2020-02-17"
         >
           17 febrero 2020
         </time>
       </div>
-      <div
-        class="emotion-17 emotion-18"
-        style="background-image: url(https://ichef.bbci.co.uk/news/400/cpsdevpb/C105/test/_63731494__110870927_climategrief5.jpg.webp);"
-      />
     </div>
   </div>
 </div>

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -2,10 +2,12 @@ import React, { useContext } from 'react';
 import { shape, node, string, number } from 'prop-types';
 import styled from '@emotion/styled';
 import pick from 'ramda/src/pick';
+import Lazyload from 'react-lazyload';
 
 import { getSerifRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
+import { C_WHITE, C_GREY_8 } from '@bbc/psammead-styles/colours';
 
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -15,6 +17,8 @@ import FrostedGlassPanel from './FrostedGlassPanel';
 import ImageWithPlaceholder from '../../containers/ImageWithPlaceholder';
 
 import withData from './withData';
+
+const PANEL_OFFSET = 250;
 
 const Wrapper = styled.div`
   position: relative;
@@ -66,6 +70,11 @@ const A = styled.a`
   }
 `;
 
+const LazyloadPlaceholder = styled.div`
+  background-color: ${({ isAmp }) => (isAmp ? C_WHITE : C_GREY_8)};
+  height: 100px;
+`;
+
 const FrostedGlassPromo = ({
   image,
   children,
@@ -86,6 +95,23 @@ const FrostedGlassPromo = ({
   });
 
   const onClick = eventTrackingData ? clickTracker : () => {};
+
+  const promoText = (
+    <>
+      <H3>
+        <A
+          script={script}
+          service={service}
+          href={url}
+          onClick={onClick}
+          isAmp={isAmp}
+        >
+          {children}
+        </A>
+      </H3>
+      {footer}
+    </>
+  );
 
   // The ClickableArea component is an anchor ("a") element
   // Anchors cannot be self-closing under the HTML spec
@@ -117,24 +143,21 @@ const FrostedGlassPromo = ({
           image,
         )}
       />
-      <FrostedGlassPanel
-        image={image.src}
-        minimumContrast={minimumContrast}
-        paletteSize={paletteSize}
+      <Lazyload
+        offset={PANEL_OFFSET}
+        once
+        placeholder={
+          <LazyloadPlaceholder isAmp={isAmp}>{promoText}</LazyloadPlaceholder>
+        }
       >
-        <H3>
-          <A
-            script={script}
-            service={service}
-            href={url}
-            onClick={onClick}
-            isAmp={isAmp}
-          >
-            {children}
-          </A>
-        </H3>
-        {footer}
-      </FrostedGlassPanel>
+        <FrostedGlassPanel
+          image={image.src}
+          minimumContrast={minimumContrast}
+          paletteSize={paletteSize}
+        >
+          {promoText}
+        </FrostedGlassPanel>
+      </Lazyload>
     </Wrapper>
   );
 };

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -147,7 +147,12 @@ const FrostedGlassPromo = ({
         offset={PANEL_OFFSET}
         once
         placeholder={
-          <LazyloadPlaceholder isAmp={isAmp}>{promoText}</LazyloadPlaceholder>
+          <LazyloadPlaceholder
+            data-testid="frosted-glass-lazyload-placeholder"
+            isAmp={isAmp}
+          >
+            {promoText}
+          </LazyloadPlaceholder>
         }
       >
         <FrostedGlassPanel

--- a/src/app/components/FrostedGlassPromo/index.test.jsx
+++ b/src/app/components/FrostedGlassPromo/index.test.jsx
@@ -89,4 +89,14 @@ describe('Frosted Glass Promo', () => {
       url: cpsPromoFixture.item.locators.assetUri,
     });
   });
+
+  it('should render lazyload component for frosted glass section', () => {
+    const { container, getByTestId } = render(
+      <Component {...linkPromoFixture} service="pidgin" />,
+    );
+    expect(container.querySelector('noscript')).toBeInTheDocument();
+    expect(
+      getByTestId('frosted-glass-lazyload-placeholder'),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Adds lazyloading to the frosted glass section of the high impact promos to prevent rendering when offscreen.

**Code changes:**
- Adds `react-lazyload` wrapper around the `FrostedGlassPanel` component, so that it doesn't trigger rendering of the frosted glass effect and image downloads when not on screen

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
