### PR TITLE
Add condition to skip testing for sport and newsround service

### DIFF
--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -72,11 +72,13 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         cy.getToggles(config[service].name);
       });
 
+      const skipServices = ['scotland', 'sport', 'newsround'];
+
       const serviceVariant = variant === 'default' ? '' : `/${variant}`;
 
       const mostReadPath = `/${config[service].name}/mostread${serviceVariant}.json`;
 
-      if (service !== 'scotland') {
+      if (!skipServices.includes(service)) {
         it(`should show the correct number of items for ${service}\`s ${pageType}`, () => {
           cy.request(mostReadPath).then(({ body: mostReadJson }) => {
             const mostReadRecords = mostReadJson.totalRecords;

--- a/cypress/integration/pages/storyPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/storyPage/testsForAMPOnly.js
@@ -74,79 +74,90 @@ export const testsThatAlwaysRunForAMPOnly = ({
         cy.getToggles(config[service].name);
       });
 
+      const skipServices = ['scotland', 'sport', 'newsround'];
+
       const serviceVariant = variant === 'default' ? '' : `/${variant}`;
 
       const mostReadPath = `/${config[service].name}/mostread${serviceVariant}.json`;
 
-      it(`should show the correct number of items for ${service}\`s ${pageType}`, () => {
-        cy.request(mostReadPath).then(({ body: mostReadJson }) => {
-          const mostReadRecords = mostReadJson.totalRecords;
-          cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
-            const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
-            cy.log(`Most read container toggle enabled? ${mostReadIsEnabled}`);
-            if (
-              Cypress.env('APP_ENV') !== 'live' &&
-              mostReadIsEnabled &&
-              mostReadRecords >= 5
-            ) {
-              const expectedMostReadItems =
-                appConfig[config[service].name][variant].mostRead.numberOfItems;
-              cy.get('[data-e2e="most-read"]').scrollIntoView();
-              cy.get('[data-e2e="most-read"] > amp-list div')
-                .children('li')
-                .should('have.length', expectedMostReadItems);
-            }
+      if (!skipServices.includes(service)) {
+        it(`should show the correct number of items for ${service}\`s ${pageType}`, () => {
+          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
+            const mostReadRecords = mostReadJson.totalRecords;
+            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
+              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
+              cy.log(
+                `Most read container toggle enabled? ${mostReadIsEnabled}`,
+              );
+              if (
+                Cypress.env('APP_ENV') !== 'live' &&
+                mostReadIsEnabled &&
+                mostReadRecords >= 5
+              ) {
+                const expectedMostReadItems =
+                  appConfig[config[service].name][variant].mostRead
+                    .numberOfItems;
+                cy.get('[data-e2e="most-read"]').scrollIntoView();
+                cy.get('[data-e2e="most-read"] > amp-list div')
+                  .children('li')
+                  .should('have.length', expectedMostReadItems);
+              }
+            });
           });
         });
-      });
 
-      it(`should show numerals used for the corresponding ${service} service`, () => {
-        cy.request(mostReadPath).then(({ body: mostReadJson }) => {
-          const mostReadRecords = mostReadJson.totalRecords;
-          cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
-            const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
-            cy.log(`Most read container toggle enabled? ${mostReadIsEnabled}`);
-            if (
-              Cypress.env('APP_ENV') !== 'live' &&
-              mostReadIsEnabled &&
-              mostReadRecords >= 5
-            ) {
-              const expectedMostReadRank = serviceNumerals(service);
-              cy.get('[data-e2e="most-read"]').scrollIntoView();
-              cy.get('[data-e2e="most-read"] > amp-list div')
-                .find('li span')
-                .each(($el, index) => {
-                  expect($el.text()).equal(expectedMostReadRank[index + 1]);
-                });
-            }
+        it(`should show numerals used for the corresponding ${service} service`, () => {
+          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
+            const mostReadRecords = mostReadJson.totalRecords;
+            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
+              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
+              cy.log(
+                `Most read container toggle enabled? ${mostReadIsEnabled}`,
+              );
+              if (
+                Cypress.env('APP_ENV') !== 'live' &&
+                mostReadIsEnabled &&
+                mostReadRecords >= 5
+              ) {
+                const expectedMostReadRank = serviceNumerals(service);
+                cy.get('[data-e2e="most-read"]').scrollIntoView();
+                cy.get('[data-e2e="most-read"] > amp-list div')
+                  .find('li span')
+                  .each(($el, index) => {
+                    expect($el.text()).equal(expectedMostReadRank[index + 1]);
+                  });
+              }
+            });
           });
         });
-      });
 
-      it('should not show most read list when data fetch fails', () => {
-        cy.intercept(
-          {
-            method: 'GET',
-            pathname: mostReadPath,
-          },
-          { status: '404' },
-        );
-        cy.reload();
-        cy.request(mostReadPath).then(({ body: mostReadJson }) => {
-          const mostReadRecords = mostReadJson.totalRecords;
-          cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
-            const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
-            cy.log(`Most read container toggle enabled? ${mostReadIsEnabled}`);
-            if (
-              Cypress.env('APP_ENV') !== 'live' &&
-              mostReadIsEnabled &&
-              mostReadRecords >= 5
-            ) {
-              cy.get('amp-script > div').should('not.exist');
-            }
+        it('should not show most read list when data fetch fails', () => {
+          cy.intercept(
+            {
+              method: 'GET',
+              pathname: mostReadPath,
+            },
+            { status: '404' },
+          );
+          cy.reload();
+          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
+            const mostReadRecords = mostReadJson.totalRecords;
+            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
+              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
+              cy.log(
+                `Most read container toggle enabled? ${mostReadIsEnabled}`,
+              );
+              if (
+                Cypress.env('APP_ENV') !== 'live' &&
+                mostReadIsEnabled &&
+                mostReadRecords >= 5
+              ) {
+                cy.get('amp-script > div').should('not.exist');
+              }
+            });
           });
         });
-      });
+      }
     });
   });
 };


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
E2E are failing because there is no most read data for sport and newsround services. Add check to skip if the service is one of these.

**Code changes:**

- Add array of services to skip.
- Add condition to skip request/tests if service is one of sport, newsround or scotland.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
