### PR TITLE
Fix height of placeholder for high impact promo

### DIFF
--- a/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
+++ b/src/app/components/FrostedGlassPromo/FrostedGlassPanel.jsx
@@ -1,15 +1,13 @@
-import React, { useContext } from 'react';
-import { RequestContext } from '#contexts/RequestContext';
+import React from 'react';
 import styled from '@emotion/styled';
 import { node, number, string } from 'prop-types';
 
 import { GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
-import { C_WHITE, C_GREY_8 } from '@bbc/psammead-styles/colours';
+import { C_GREY_8 } from '@bbc/psammead-styles/colours';
 import useImageColour from '../../hooks/useImageColour';
 
 const BLUR_RADIUS = 15;
 const FALLBACK_COLOUR = C_GREY_8;
-const FALLBACK_COLOUR_AMP = C_WHITE;
 
 const Wrapper = styled.div`
   position: relative;
@@ -65,16 +63,12 @@ const FrostedGlassPanel = ({
   minimumContrast,
   paletteSize,
 }) => {
-  const { isAmp } = useContext(RequestContext);
-
   const { isLoading, colour } = useImageColour(image, {
-    fallbackColour: isAmp ? FALLBACK_COLOUR_AMP : FALLBACK_COLOUR,
+    fallbackColour: FALLBACK_COLOUR,
     minimumContrast,
     contrastColour: '#ffffff',
     paletteSize,
   });
-
-  const isCanonical = !isAmp;
 
   const backgroundImageStyle = {
     backgroundImage: `url('${image}')`,
@@ -85,7 +79,7 @@ const FrostedGlassPanel = ({
       <Children colour={colour.rgb} isLoading={isLoading}>
         {children}
       </Children>
-      {isCanonical && <Background style={backgroundImageStyle} />}
+      <Background style={backgroundImageStyle} />
     </Wrapper>
   );
 };

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -60,7 +60,7 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 
 .emotion-6 {
   background-color: #202224;
-  height: 100px;
+  min-height: 100px;
 }
 
 .emotion-8 {
@@ -202,7 +202,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 
 .emotion-6 {
   background-color: #202224;
-  height: 100px;
+  min-height: 100px;
 }
 
 .emotion-8 {
@@ -383,7 +383,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 
 .emotion-6 {
   background-color: #202224;
-  height: 100px;
+  min-height: 100px;
 }
 
 .emotion-8 {

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -147,6 +147,7 @@ const FrostedGlassPromo = ({
         offset={PANEL_OFFSET}
         once
         placeholder={
+          // Placeholder always gets rendered on AMP
           <LazyloadPlaceholder
             data-testid="frosted-glass-lazyload-placeholder"
             isAmp={isAmp}

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -72,7 +72,7 @@ const A = styled.a`
 
 const LazyloadPlaceholder = styled.div`
   background-color: ${({ isAmp }) => (isAmp ? C_WHITE : C_GREY_8)};
-  height: 100px;
+  min-height: 100px;
 `;
 
 const FrostedGlassPromo = ({


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Fixes a bug with the height of the high impact promo which caused text content to get cut off

**Code changes:**
- Changes `height` to `min-height` for the lazy-load placeholder.
- Removes AMP logic from the `FrostedGlassPanel` component, as AMP will now always render the lazy-load placeholder

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
