### PR TITLE
Fix SVG high contrast bug across multiple pages

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -263,6 +263,16 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   }
 }
 
+.emotion-19 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-19 svg {
+    fill: linkText;
+  }
+}
+
 .emotion-21 {
   position: relative;
   display: -webkit-box;
@@ -751,6 +761,16 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   .emotion-144 {
     min-height: 3.25rem;
     padding: 0 1rem;
+  }
+}
+
+.emotion-144 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-144 svg {
+    fill: linkText;
   }
 }
 

--- a/src/app/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -199,6 +199,12 @@ exports[`ProgramCard should render correctly for live 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-22>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-24 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -483,6 +489,12 @@ exports[`ProgramCard should render correctly for next 1`] = `
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-20>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-22 {
@@ -776,6 +788,12 @@ exports[`ProgramCard should render correctly for onDemand 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-20>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-22 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1066,6 +1084,12 @@ exports[`ProgramCard should render correctly in RTL 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-20>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-22 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1338,6 +1362,12 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-20>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-22 {

--- a/src/app/components/RadioSchedule/ProgramCard/index.jsx
+++ b/src/app/components/RadioSchedule/ProgramCard/index.jsx
@@ -67,6 +67,9 @@ const IconWrapper = styled.span`
     width: 1.0625rem;
     height: 0.75rem;
     margin: 0;
+    @media screen and (forced-colors: active) {
+      fill: canvasText;
+    }
   }
 `;
 

--- a/src/app/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
@@ -30,6 +30,13 @@ exports[`StartTime should render LTR correctly 1`] = `
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-2>svg {
+    padding-right: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-4 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -177,6 +184,13 @@ exports[`StartTime should render RTL correctly 1`] = `
   color: #5A5A5A;
   margin: 0;
   overflow: visible;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2>svg {
+    padding-left: 0.25rem;
+    fill: canvasText;
+  }
 }
 
 .emotion-4 {

--- a/src/app/components/RadioSchedule/StartTime/index.jsx
+++ b/src/app/components/RadioSchedule/StartTime/index.jsx
@@ -26,6 +26,9 @@ const StyledClock = styled.span`
     color: ${C_RHINO};
     margin: 0;
     overflow: visible;
+    @media screen and (forced-colors: active) {
+      fill: canvasText;
+    }
   }
 `;
 

--- a/src/app/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -244,6 +244,13 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-10>svg {
+    padding-right: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-12 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -521,6 +528,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-40>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-42 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -681,6 +694,12 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-163>svg {
+    fill: canvasText;
+  }
 }
 
 <div>
@@ -1469,6 +1488,13 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-10>svg {
+    padding-left: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-12 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1746,6 +1772,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-40>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-42 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1906,6 +1938,12 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-163>svg {
+    fill: canvasText;
+  }
 }
 
 <div>

--- a/src/app/containers/Brand/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Brand/__snapshots__/index.test.jsx.snap
@@ -17,6 +17,16 @@ exports[`BrandContainer should render correctly 1`] = `
   }
 }
 
+.emotion-1 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-1 svg {
+    fill: linkText;
+  }
+}
+
 .emotion-3 {
   position: relative;
   display: -webkit-box;

--- a/src/app/containers/Brand/index.jsx
+++ b/src/app/containers/Brand/index.jsx
@@ -7,6 +7,11 @@ import { ServiceContext } from '#contexts/ServiceContext';
 const StyledBrand = styled(Brand)`
   position: relative;
   z-index: 1;
+  svg {
+    fill: currentColor;
+    @media screen and (forced-colors: active) {
+      fill: linkText;
+    }
 `;
 
 const BrandContainer = ({ skipLink, scriptLink, brandRef, ...props }) => {

--- a/src/app/containers/EpisodeList/Image.jsx
+++ b/src/app/containers/EpisodeList/Image.jsx
@@ -47,6 +47,9 @@ const PlayWrapper = withEpisodeContext(styled.div`
     height: 0.6rem;
     width: 0.7rem;
     color: ${C_WHITE};
+    @media screen and (forced-colors: active) {
+      fill: canvasText;
+    }
   }
 
   @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {

--- a/src/app/containers/EpisodeList/Image.jsx
+++ b/src/app/containers/EpisodeList/Image.jsx
@@ -48,7 +48,7 @@ const PlayWrapper = withEpisodeContext(styled.div`
     width: 0.7rem;
     color: ${C_WHITE};
     @media screen and (forced-colors: active) {
-      fill: canvasText;
+      fill: linkText;
     }
   }
 

--- a/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -258,6 +258,12 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   color: #FFFFFF;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-27 svg {
+    fill: linkText;
+  }
+}
+
 @media (min-width: 25rem) {
   .emotion-27 {
     position: absolute;

--- a/src/app/containers/Footer/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Footer/__snapshots__/index.test.jsx.snap
@@ -47,6 +47,16 @@ exports[`FooterContainer should render correctly 1`] = `
   }
 }
 
+.emotion-3 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-3 svg {
+    fill: linkText;
+  }
+}
+
 .emotion-5 {
   position: relative;
   display: -webkit-box;

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -248,6 +248,16 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   }
 }
 
+.emotion-17 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-17 svg {
+    fill: linkText;
+  }
+}
+
 .emotion-19 {
   position: relative;
   display: -webkit-box;
@@ -1348,6 +1358,16 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   }
 }
 
+.emotion-17 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-17 svg {
+    fill: linkText;
+  }
+}
+
 .emotion-19 {
   position: relative;
   display: -webkit-box;
@@ -2445,6 +2465,16 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   .emotion-17 {
     min-height: 3.25rem;
     padding: 0 1rem;
+  }
+}
+
+.emotion-17 svg {
+  fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-17 svg {
+    fill: linkText;
   }
 }
 

--- a/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastPromo/__snapshots__/index.test.jsx.snap
@@ -118,6 +118,12 @@ exports[`Inline Should render correctly 1`] = `
   right: 0.1875rem;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-11>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-13 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -387,6 +393,12 @@ exports[`Inline Should render correctly 1`] = `
   right: 0.1875rem;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-29>svg {
+    fill: canvasText;
+  }
+}
+
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
   .emotion-29 {
     font-size: 0.875rem;
@@ -650,6 +662,12 @@ exports[`SecondaryColumn Should render correctly 1`] = `
   right: 0.1875rem;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-6>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-8 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -879,6 +897,12 @@ exports[`SecondaryColumn Should render correctly 1`] = `
   position: relative;
   bottom: 0.125rem;
   right: 0.1875rem;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-24>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-26 {

--- a/src/app/containers/PodcastPromo/components/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/PodcastPromo/components/__snapshots__/index.test.jsx.snap
@@ -99,6 +99,12 @@ exports[`Podcast Promo Card Episodes Text should match snapshot 1`] = `
   right: 0.1875rem;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-0>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-2 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -330,6 +336,12 @@ exports[`Podcast Promo Title should match snapshot 1`] = `
   position: relative;
   bottom: 0.3125rem;
   right: 0.1875rem;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-4 {

--- a/src/app/containers/PodcastPromo/components/card-episodes-text.jsx
+++ b/src/app/containers/PodcastPromo/components/card-episodes-text.jsx
@@ -20,6 +20,9 @@ const EpisodesText = styled.p`
     position: relative;
     bottom: 0.125rem;
     ${({ dir }) => (dir === 'ltr' ? `right: 0.1875rem;` : `left: 0.1875rem;`)}
+    @media screen and (forced-colors: active) {
+      fill: canvasText;
+    }
   }
 `;
 

--- a/src/app/containers/PodcastPromo/components/title.jsx
+++ b/src/app/containers/PodcastPromo/components/title.jsx
@@ -21,6 +21,9 @@ const Heading = styled.h2`
     position: relative;
     bottom: 0.3125rem;
     ${({ dir }) => (dir === 'ltr' ? `right: 0.1875rem;` : `left: 0.1875rem;`)}
+    @media screen and (forced-colors: active) {
+      fill: canvasText;
+    }
   }
 `;
 

--- a/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -435,6 +435,13 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-27>svg {
+    padding-left: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-29 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -688,6 +695,12 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-55>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-57 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -830,6 +843,12 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-96>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-184 {
@@ -1876,6 +1895,13 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-27>svg {
+    padding-left: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-29 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -2129,6 +2155,12 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-55>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-57 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -2271,6 +2303,12 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-96>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-184 {

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -1509,6 +1509,13 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-269>svg {
+    padding-left: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-271 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1727,6 +1734,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-297>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-299 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1869,6 +1882,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-338>svg {
+    fill: canvasText;
+  }
 }
 
 .emotion-560 {

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -1211,6 +1211,13 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   overflow: visible;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-49>svg {
+    padding-right: 0.25rem;
+    fill: canvasText;
+  }
+}
+
 .emotion-51 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1479,6 +1486,12 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   margin: 0;
 }
 
+@media screen and (forced-colors: active) {
+  .emotion-77>svg {
+    fill: canvasText;
+  }
+}
+
 .emotion-79 {
   vertical-align: middle;
   margin: 0 0.25rem;
@@ -1606,6 +1619,12 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   width: 1.0625rem;
   height: 0.75rem;
   margin: 0;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-200>svg {
+    fill: canvasText;
+  }
 }
 
 <div>


### PR DESCRIPTION
Resolves [WSTEAMA-53](https://jira.dev.bbc.co.uk/browse/WSTEAMA-53)

**Overall change:**
Adds forced colour changing to SVGs when in high contrast mode using system colours.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
