### PR TITLE
fix error with no content in live topics

### DIFF
--- a/src/app/pages/TopicPage/TopicGrid/index.jsx
+++ b/src/app/pages/TopicPage/TopicGrid/index.jsx
@@ -60,6 +60,10 @@ const TopicGrid = ({ promos }) => {
   const { dir } = useContext(ServiceContext);
   const hasMultiplePromos = promos.length > 1;
   const firstPromo = promos[0];
+
+  if (promos.length === 0) {
+    return null;
+  }
   return (
     <Wrapper>
       {hasMultiplePromos ? (


### PR DESCRIPTION
Resolves WSTEAMA-57

**Overall change:**
A topic with no content shows a broken page: https://www.bbc.com/pidgin/topics/c7zp5zk5xy8t
![image](https://user-images.githubusercontent.com/9645462/165949918-37aa22e5-941d-4596-99fa-74c29d849827.png)

This PR is a quick fix to show a title with no content in this scenario:
![image](https://user-images.githubusercontent.com/9645462/165949808-af8002a3-1636-4aac-9136-1a8b474010ec.png)

A follow-up ticket will investigate longer term if this acceptable.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
