### PR TITLE
High impact promo placeholder padding fix

### DIFF
--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -61,6 +61,7 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 .emotion-6 {
   background-color: #202224;
   min-height: 100px;
+  padding-bottom: 1rem;
 }
 
 .emotion-8 {
@@ -203,6 +204,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 .emotion-6 {
   background-color: #202224;
   min-height: 100px;
+  padding-bottom: 1rem;
 }
 
 .emotion-8 {
@@ -384,6 +386,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 .emotion-6 {
   background-color: #202224;
   min-height: 100px;
+  padding-bottom: 1rem;
 }
 
 .emotion-8 {

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -73,6 +73,7 @@ const A = styled.a`
 const LazyloadPlaceholder = styled.div`
   background-color: ${({ isAmp }) => (isAmp ? C_WHITE : C_GREY_8)};
   min-height: 100px;
+  padding-bottom: ${GEL_SPACING_DBL};
 `;
 
 const FrostedGlassPromo = ({


### PR DESCRIPTION
**Overall change:**
Small fix for the padding of the lazy-load placeholder element when the promo title is over 2 lines

**Code changes:**
- Adds `padding-bottom` to the lazy-load placeholder element. The timestamp sat too close to the edge of the promo card if the title is over 2 lines long 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
