### PR TITLE
Display visited state on high impact promos

### DIFF
--- a/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
+++ b/src/app/components/FrostedGlassPromo/TimestampFooter.jsx
@@ -12,7 +12,7 @@ import PromoTimestamp from '#components/Promo/timestamp';
 
 const StyledTimestamp = styled(PromoTimestamp)`
   ${({ service }) => service && getSansRegular(service)}
-  color: ${({ isAmp }) => (isAmp ? 'black' : 'white')};
+  color: ${({ isAmp }) => (isAmp ? 'black' : '#e6e8ea')};
 
   font-size: 0.8125rem;
   padding: ${GEL_SPACING_HLF_TRPL} ${GEL_SPACING} 0 ${GEL_SPACING};

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -21,6 +21,10 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
   text-decoration: underline;
 }
 
+.emotion-0:visited a {
+  color: #e6e8ea;
+}
+
 .emotion-2 {
   position: absolute;
   top: 0;
@@ -86,6 +90,10 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
+}
+
+.emotion-10:visited {
+  color: #e6e8ea;
 }
 
 .emotion-10:focus {
@@ -163,6 +171,10 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   text-decoration: underline;
 }
 
+.emotion-0:visited a {
+  color: #e6e8ea;
+}
+
 .emotion-2 {
   position: absolute;
   top: 0;
@@ -230,6 +242,10 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   }
 }
 
+.emotion-10:visited {
+  color: #e6e8ea;
+}
+
 .emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -243,7 +259,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: white;
+  color: #e6e8ea;
   font-size: 0.8125rem;
   padding: 0.75rem 0.5rem 0 0.5rem;
 }
@@ -344,6 +360,10 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   text-decoration: underline;
 }
 
+.emotion-0:visited a {
+  color: #e6e8ea;
+}
+
 .emotion-2 {
   position: absolute;
   top: 0;
@@ -411,6 +431,10 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   }
 }
 
+.emotion-10:visited {
+  color: #e6e8ea;
+}
+
 .emotion-10:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -424,7 +448,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: white;
+  color: #e6e8ea;
   font-size: 0.8125rem;
   padding: 0.75rem 0.5rem 0 0.5rem;
 }

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -26,11 +26,15 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-
   text-decoration: none;
   &:hover {
     a {
       text-decoration: underline;
+    }
+  }
+  &:visited {
+    a {
+      color: #e6e8ea;
     }
   }
 `;
@@ -64,6 +68,9 @@ const A = styled.a`
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
+  }
+  &:visited {
+    color: #e6e8ea;
   }
   &:focus {
     text-decoration: underline;


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAM1-28

**Overall change:**
Updated to match the visited state designs here:
https://zpl.io/wqBkomK

Visited state colour is now #e6e8ea
Timestamp colour is now #e6e8ea


---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
