### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -9,8 +9,14 @@ on:
   push:
     branches:
       - latest
+permissions:
+  contents: read
+
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: ubuntu-latest
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,15 @@ on:
   schedule:
     - cron: '0 8 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - latest
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - latest
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - latest
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - latest
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
