### PR TITLE
Fix pagination arrows direction on rtl services

### DIFF
--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -210,7 +210,7 @@ const getTranslations = translations => ({
 });
 
 const Pagination = ({ activePage, pageCount }) => {
-  const { service, translations } = useContext(ServiceContext);
+  const { service, translations, dir } = useContext(ServiceContext);
   const blocks = buildBlocks(activePage, pageCount);
   if (!blocks) return null;
 
@@ -226,8 +226,8 @@ const Pagination = ({ activePage, pageCount }) => {
 
   const showLeftArrow = activePage > 1;
   const showRightArrow = activePage < pageCount;
-
-  return (
+  console.log("DIRECTION= "+ dir);
+  return dir === 'ltr' ? (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
       {showLeftArrow && (
         <LeftArrow activePage={activePage}>{previousPage}</LeftArrow>
@@ -245,6 +245,26 @@ const Pagination = ({ activePage, pageCount }) => {
       </StyledUnorderedList>
       {showRightArrow && (
         <RightArrow activePage={activePage}>{nextPage}</RightArrow>
+      )}
+    </Nav>
+  ) : (
+    <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
+      {showRightArrow && (
+        <RightArrow activePage={activePage}>{nextPage}</RightArrow>
+      )}
+      <TextSummary
+        service={service}
+        data-testid="topic-pagination-summary"
+        // eslint-disable-next-line jsx-a11y/aria-role
+        role="text"
+      >
+        {tokens}
+      </TextSummary>
+      <StyledUnorderedList role="list">
+        {blocks.map(block => renderBlock({ ...block, activePage, service }))}
+      </StyledUnorderedList>
+      {showLeftArrow && (
+        <LeftArrow activePage={activePage}>{previousPage}</LeftArrow>
       )}
     </Nav>
   );

--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -226,7 +226,7 @@ const Pagination = ({ activePage, pageCount }) => {
 
   const showLeftArrow = activePage > 1;
   const showRightArrow = activePage < pageCount;
-  console.log("DIRECTION= "+ dir);
+
   return dir === 'ltr' ? (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
       {showLeftArrow && (

--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -139,35 +139,21 @@ const LinkComponent = ({ children, pageNumber, isActive, ...rest }) => (
   </A>
 );
 
-const LeftArrowLTR = ({ activePage, children }) => (
+const PreviousArrow = ({ activePage, children, dir }) => (
   <Block as="span" visibility={VISIBILITY.ALL}>
     <LinkComponent
       pageNumber={activePage - 1}
       aria-labelledby="pagination-previous-page"
     >
       <span id="pagination-previous-page">
-        <LeftChevron />
+        {dir === 'ltr' ? <LeftChevron /> : <RightChevron />}
         <VisuallyHiddenText>{children}</VisuallyHiddenText>
       </span>
     </LinkComponent>
   </Block>
 );
 
-const LeftArrowRTL = ({ activePage, children }) => (
-  <Block as="span" visibility={VISIBILITY.ALL}>
-    <LinkComponent
-      pageNumber={activePage + 1}
-      aria-labelledby="pagination-next-page"
-    >
-      <span id="pagination-next-page">
-        <LeftChevron />
-        <VisuallyHiddenText>{children}</VisuallyHiddenText>
-      </span>
-    </LinkComponent>
-  </Block>
-);
-
-const RightArrowLTR = ({ activePage, children }) => (
+const NextArrow = ({ activePage, children, dir }) => (
   <Block as="span" visibility={VISIBILITY.ALL}>
     <LinkComponent
       pageNumber={activePage + 1}
@@ -175,21 +161,7 @@ const RightArrowLTR = ({ activePage, children }) => (
     >
       <span id="pagination-next-page">
         <VisuallyHiddenText>{children}</VisuallyHiddenText>
-        <RightChevron />
-      </span>
-    </LinkComponent>
-  </Block>
-);
-
-const RightArrowRTL = ({ activePage, children }) => (
-  <Block as="span" visibility={VISIBILITY.ALL}>
-    <LinkComponent
-      pageNumber={activePage - 1}
-      aria-labelledby="pagination-previous-page"
-    >
-      <span id="pagination-previous-page">
-        <VisuallyHiddenText>{children}</VisuallyHiddenText>
-        <RightChevron />
+        {dir === 'ltr' ? <RightChevron /> : <LeftChevron />}
       </span>
     </LinkComponent>
   </Block>
@@ -252,13 +224,15 @@ const Pagination = ({ activePage, pageCount }) => {
     }[token] || <span key={key}>{token}</span>);
   const tokens = pageXOfY.split(/(\{.\})/).map(tokenMapper);
 
-  const showLeftArrow = activePage > 1;
-  const showRightArrow = activePage < pageCount;
+  const showPreviousArrow = activePage > 1;
+  const showNextArrow = activePage < pageCount;
 
-  return dir === 'ltr' ? (
+  return (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
-      {showLeftArrow && (
-        <LeftArrowLTR activePage={activePage}>{previousPage}</LeftArrowLTR>
+      {showPreviousArrow && (
+        <PreviousArrow activePage={activePage} dir={dir}>
+          {previousPage}
+        </PreviousArrow>
       )}
       <TextSummary
         service={service}
@@ -271,28 +245,8 @@ const Pagination = ({ activePage, pageCount }) => {
       <StyledUnorderedList role="list">
         {blocks.map(block => renderBlock({ ...block, activePage, service }))}
       </StyledUnorderedList>
-      {showRightArrow && (
-        <RightArrowLTR activePage={activePage}>{nextPage}</RightArrowLTR>
-      )}
-    </Nav>
-  ) : (
-    <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
-      {showLeftArrow && (
-        <RightArrowRTL activePage={activePage}>{previousPage}</RightArrowRTL>
-      )}
-      <TextSummary
-        service={service}
-        data-testid="topic-pagination-summary"
-        // eslint-disable-next-line jsx-a11y/aria-role
-        role="text"
-      >
-        {tokens}
-      </TextSummary>
-      <StyledUnorderedList role="list">
-        {blocks.map(block => renderBlock({ ...block, activePage, service }))}
-      </StyledUnorderedList>
-      {showRightArrow && (
-        <LeftArrowRTL activePage={activePage}>{nextPage}</LeftArrowRTL>
+      {showNextArrow && (
+        <NextArrow activePage={activePage}>{nextPage}</NextArrow>
       )}
     </Nav>
   );

--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -246,7 +246,9 @@ const Pagination = ({ activePage, pageCount }) => {
         {blocks.map(block => renderBlock({ ...block, activePage, service }))}
       </StyledUnorderedList>
       {showNextArrow && (
-        <NextArrow activePage={activePage}>{nextPage}</NextArrow>
+        <NextArrow activePage={activePage} dir={dir}>
+          {nextPage}
+        </NextArrow>
       )}
     </Nav>
   );

--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -139,7 +139,7 @@ const LinkComponent = ({ children, pageNumber, isActive, ...rest }) => (
   </A>
 );
 
-const LeftArrow = ({ activePage, children }) => (
+const LeftArrowLTR = ({ activePage, children }) => (
   <Block as="span" visibility={VISIBILITY.ALL}>
     <LinkComponent
       pageNumber={activePage - 1}
@@ -153,13 +153,41 @@ const LeftArrow = ({ activePage, children }) => (
   </Block>
 );
 
-const RightArrow = ({ activePage, children }) => (
+const LeftArrowRTL = ({ activePage, children }) => (
   <Block as="span" visibility={VISIBILITY.ALL}>
     <LinkComponent
       pageNumber={activePage + 1}
       aria-labelledby="pagination-next-page"
     >
       <span id="pagination-next-page">
+        <LeftChevron />
+        <VisuallyHiddenText>{children}</VisuallyHiddenText>
+      </span>
+    </LinkComponent>
+  </Block>
+);
+
+const RightArrowLTR = ({ activePage, children }) => (
+  <Block as="span" visibility={VISIBILITY.ALL}>
+    <LinkComponent
+      pageNumber={activePage + 1}
+      aria-labelledby="pagination-next-page"
+    >
+      <span id="pagination-next-page">
+        <VisuallyHiddenText>{children}</VisuallyHiddenText>
+        <RightChevron />
+      </span>
+    </LinkComponent>
+  </Block>
+);
+
+const RightArrowRTL = ({ activePage, children }) => (
+  <Block as="span" visibility={VISIBILITY.ALL}>
+    <LinkComponent
+      pageNumber={activePage - 1}
+      aria-labelledby="pagination-previous-page"
+    >
+      <span id="pagination-previous-page">
         <VisuallyHiddenText>{children}</VisuallyHiddenText>
         <RightChevron />
       </span>
@@ -230,7 +258,7 @@ const Pagination = ({ activePage, pageCount }) => {
   return dir === 'ltr' ? (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
       {showLeftArrow && (
-        <LeftArrow activePage={activePage}>{previousPage}</LeftArrow>
+        <LeftArrowLTR activePage={activePage}>{previousPage}</LeftArrowLTR>
       )}
       <TextSummary
         service={service}
@@ -244,13 +272,13 @@ const Pagination = ({ activePage, pageCount }) => {
         {blocks.map(block => renderBlock({ ...block, activePage, service }))}
       </StyledUnorderedList>
       {showRightArrow && (
-        <RightArrow activePage={activePage}>{nextPage}</RightArrow>
+        <RightArrowLTR activePage={activePage}>{nextPage}</RightArrowLTR>
       )}
     </Nav>
   ) : (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
-      {showRightArrow && (
-        <RightArrow activePage={activePage}>{previousPage}</RightArrow>
+      {showLeftArrow && (
+        <RightArrowRTL activePage={activePage}>{previousPage}</RightArrowRTL>
       )}
       <TextSummary
         service={service}
@@ -263,8 +291,8 @@ const Pagination = ({ activePage, pageCount }) => {
       <StyledUnorderedList role="list">
         {blocks.map(block => renderBlock({ ...block, activePage, service }))}
       </StyledUnorderedList>
-      {showLeftArrow && (
-        <LeftArrow activePage={activePage}>{nextPage}</LeftArrow>
+      {showRightArrow && (
+        <LeftArrowRTL activePage={activePage}>{nextPage}</LeftArrowRTL>
       )}
     </Nav>
   );

--- a/src/app/pages/TopicPage/Pagination/index.jsx
+++ b/src/app/pages/TopicPage/Pagination/index.jsx
@@ -250,7 +250,7 @@ const Pagination = ({ activePage, pageCount }) => {
   ) : (
     <Nav role="navigation" aria-label={page} data-testid="topic-pagination">
       {showRightArrow && (
-        <RightArrow activePage={activePage}>{nextPage}</RightArrow>
+        <RightArrow activePage={activePage}>{previousPage}</RightArrow>
       )}
       <TextSummary
         service={service}
@@ -264,7 +264,7 @@ const Pagination = ({ activePage, pageCount }) => {
         {blocks.map(block => renderBlock({ ...block, activePage, service }))}
       </StyledUnorderedList>
       {showLeftArrow && (
-        <LeftArrow activePage={activePage}>{previousPage}</LeftArrow>
+        <LeftArrow activePage={activePage}>{nextPage}</LeftArrow>
       )}
     </Nav>
   );


### PR DESCRIPTION
Resolves WSTEAMA-60

**Overall change:**
Renders arrows in correct direction

**Code changes:**
added a tertiary so they render depending on "dir"

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
