### PR TITLE
Topic Page Script Switch

### DIFF
--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -30,6 +30,7 @@ const PageWrapper = ({ children, pageData, status }) => {
   const fonts = fontFunctions.map(getFonts => getFonts());
 
   const isDarkMode = pathOr(false, ['darkMode'], pageData);
+  const scriptSwitchId = pathOr('', ['scriptSwitchId'], pageData);
   const isErrorPage = [404, 500].includes(status);
   const pageType = isErrorPage
     ? 'WS-ERROR-PAGE'
@@ -42,7 +43,7 @@ const PageWrapper = ({ children, pageData, status }) => {
       <ManifestContainer />
       <WebVitals pageType={pageType} />
       <Wrapper id="main-wrapper" darkMode={isDarkMode}>
-        <HeaderContainer />
+        <HeaderContainer scriptSwitchId={scriptSwitchId} />
         <Content>{children}</Content>
         <FooterContainer />
       </Wrapper>

--- a/src/app/containers/Header/ScriptLink/index.jsx
+++ b/src/app/containers/Header/ScriptLink/index.jsx
@@ -22,15 +22,15 @@ export const getVariantHref = ({
     return fallback;
   }
 
-  const queryParams = clone(params);
+  const pathParams = clone(params);
   if (scriptSwitchId) {
-    queryParams.id = scriptSwitchId;
+    pathParams.id = scriptSwitchId;
   }
 
   try {
     return compile(path)(
       {
-        ...queryParams,
+        ...pathParams,
         variant: `/${variant}`,
         amp: undefined, // we don't want to link to AMP pages directly
       },

--- a/src/app/containers/Header/ScriptLink/index.jsx
+++ b/src/app/containers/Header/ScriptLink/index.jsx
@@ -1,12 +1,19 @@
 import React, { useContext } from 'react';
 import { compile } from 'path-to-regexp';
+import clone from 'ramda/src/clone';
 import { useRouteMatch } from 'react-router-dom';
 import ScriptLink from '@bbc/psammead-script-link';
 import { UserContext } from '#contexts/UserContext';
 import { ServiceContext } from '#contexts/ServiceContext';
 import useToggle from '#hooks/useToggle';
 
-export const getVariantHref = ({ path, params, service, variant }) => {
+export const getVariantHref = ({
+  path,
+  params,
+  service,
+  variant,
+  scriptSwitchId,
+}) => {
   const fallback = `/${service}/${variant}`;
 
   // On error pages, we may not be on a path defined in router config.
@@ -15,10 +22,15 @@ export const getVariantHref = ({ path, params, service, variant }) => {
     return fallback;
   }
 
+  const queryParams = clone(params);
+  if (scriptSwitchId) {
+    queryParams.id = scriptSwitchId;
+  }
+
   try {
     return compile(path)(
       {
-        ...params,
+        ...queryParams,
         variant: `/${variant}`,
         amp: undefined, // we don't want to link to AMP pages directly
       },
@@ -31,7 +43,7 @@ export const getVariantHref = ({ path, params, service, variant }) => {
   }
 };
 
-const ScriptLinkContainer = () => {
+const ScriptLinkContainer = ({ scriptSwitchId }) => {
   const { setPreferredVariantCookie } = useContext(UserContext);
   const { service, script, scriptLink } = useContext(ServiceContext);
   const { enabled: scriptLinkEnabled } = useToggle('scriptLink');
@@ -53,6 +65,7 @@ const ScriptLinkContainer = () => {
         params,
         service,
         variant,
+        scriptSwitchId,
       })}
       variant={variant}
       onClick={() => {

--- a/src/app/containers/Header/ScriptLink/index.jsx
+++ b/src/app/containers/Header/ScriptLink/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { compile } from 'path-to-regexp';
 import clone from 'ramda/src/clone';
+import { string } from 'prop-types';
 import { useRouteMatch } from 'react-router-dom';
 import ScriptLink from '@bbc/psammead-script-link';
 import { UserContext } from '#contexts/UserContext';
@@ -77,6 +78,14 @@ const ScriptLinkContainer = ({ scriptSwitchId }) => {
       {text}
     </ScriptLink>
   );
+};
+
+ScriptLinkContainer.propTypes = {
+  scriptSwitchId: string,
+};
+
+ScriptLinkContainer.defaultProps = {
+  scriptSwitchId: '',
 };
 
 export default ScriptLinkContainer;

--- a/src/app/containers/Header/ScriptLink/index.test.jsx
+++ b/src/app/containers/Header/ScriptLink/index.test.jsx
@@ -16,6 +16,7 @@ import {
   errorPagePath,
   frontPagePath,
   legacyAssetPagePath,
+  topicPath,
 } from '#app/routes/utils/regex';
 import ScriptLinkContainer, { getVariantHref } from '.';
 
@@ -70,12 +71,13 @@ const ScriptLinkContainerWithContext = ({
   serviceContext = serbianServiceConfig.lat,
   requestContext = requestContextMock,
   toggleContext = toggleContextMock,
+  ...props
 }) => (
   <ToggleContext.Provider value={toggleContext}>
     <ServiceContext.Provider value={serviceContext}>
       <UserContext.Provider value={userContextMock}>
         <RequestContext.Provider value={requestContext}>
-          <ScriptLinkContainer />
+          <ScriptLinkContainer {...props} />
         </RequestContext.Provider>
       </UserContext.Provider>
     </ServiceContext.Provider>
@@ -158,6 +160,24 @@ describe(`Script Link`, () => {
 
           expect(scriptLink.getAttribute('href')).toBe(variantPath);
         });
+      });
+      it(`Script Link should contain link to other variant when on topic page`, () => {
+        const matchPath = topicPath;
+        const path = '/serbian/lat/topics/c06g871g3knt';
+        const variantPath = '/serbian/cyr/topics/c7zp707dy8yt';
+        const otherVariant = 'cyr';
+
+        const { container } = withRouter(
+          <ScriptLinkContainerWithContext scriptSwitchId="c7zp707dy8yt" />,
+          matchPath,
+          path,
+        );
+
+        const scriptLink = container.querySelector(
+          `a[data-variant="${otherVariant}"]`,
+        );
+
+        expect(scriptLink.getAttribute('href')).toBe(variantPath);
       });
     });
 

--- a/src/app/containers/Header/index.jsx
+++ b/src/app/containers/Header/index.jsx
@@ -3,6 +3,7 @@ import SkipLink from '@bbc/psammead-brand/skip-link';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#contexts/RequestContext';
 import useToggle from '#hooks/useToggle';
+import { string } from 'prop-types';
 import useOperaMiniDetection from '#hooks/useOperaMiniDetection';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import ScriptLink from './ScriptLink';
@@ -27,7 +28,7 @@ const Header = ({ brandRef, borderBottom, skipLink, scriptLink, linkId }) => {
   );
 };
 
-const HeaderContainer = () => {
+const HeaderContainer = ({ scriptSwitchId }) => {
   const { pageType, isAmp } = useContext(RequestContext);
   const { service, script, translations, dir, scriptLink, lang, serviceLang } =
     useContext(ServiceContext);
@@ -64,18 +65,30 @@ const HeaderContainer = () => {
         <Header
           linkId="brandLink"
           skipLink={skipLink}
-          scriptLink={scriptLink && <ScriptLink />}
+          scriptLink={
+            scriptLink && <ScriptLink scriptSwitchId={scriptSwitchId} />
+          }
         />
       ) : (
         <Header
           brandRef={brandRef}
           skipLink={skipLink}
-          scriptLink={scriptLink && <ScriptLink />}
+          scriptLink={
+            scriptLink && <ScriptLink scriptSwitchId={scriptSwitchId} />
+          }
         />
       )}
       {showNav && <NavigationContainer />}
     </header>
   );
+};
+
+HeaderContainer.propTypes = {
+  scriptSwitchId: string,
+};
+
+HeaderContainer.defaultProps = {
+  scriptSwitchId: '',
 };
 
 export default HeaderContainer;

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -44,6 +44,7 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
         promos: data.summaries,
         activePage: data.activePage || 1,
         pageCount: data.pageCount,
+        scriptSwitchId: data.variantTopicId,
         metadata: {
           type: 'Topic',
         },

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -19,6 +19,9 @@ const topicJSON = {
         id: '54321',
       },
     ],
+    activePage: 1,
+    pageCount: 14,
+    variantTopicId: null,
   },
 };
 
@@ -50,6 +53,9 @@ describe('get initial data for topic', () => {
     expect(pageData.promos[0].link).toEqual('mock-link');
     expect(pageData.promos[0].imageAlt).toEqual('mock-image-alt');
     expect(pageData.promos[0].id).toEqual('54321');
+    expect(pageData.scriptSwitchId).toBeNull();
+    expect(pageData.activePage).toEqual(1);
+    expect(pageData.pageCount).toEqual(14);
   });
 
   it('should use the title as description if description is empty', async () => {
@@ -91,11 +97,11 @@ describe('get initial data for topic', () => {
       path: 'serbian/cyr/topics/54321',
       getAgent,
       service: 'serbian',
-      variant: 'sr-cyrl',
+      variant: 'cyr',
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=serbian&variant=sr-cyrl',
+      path: 'https://mock-bff-path/?id=54321&service=serbian&variant=cyr',
       agent,
       optHeaders,
     });


### PR DESCRIPTION
Resolves [#1602](https://github.com/bbc/simorgh-infrastructure/issues/1602)

**Overall change:**
Use the variant topic ID returned by the BFF for the Topic page script switch button

**Code changes:**

Passes the script switch ID from the BFF response to the script switch component

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
