### PR TITLE
Cloudwatch RUM connect CSP

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -120,6 +120,7 @@ const directives = {
       'https://cdn.optimizely.com/',
       'https://logx.optimizely.com/',
       'https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net', // Web-Vitals monitoring
+      'https://cognito-identity.eu-west-1.amazonaws.com/',
       ...advertisingDirectives.connectSrc,
       "'self'",
     ],

--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -120,7 +120,7 @@ const directives = {
       'https://cdn.optimizely.com/',
       'https://logx.optimizely.com/',
       'https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net', // Web-Vitals monitoring
-      'https://cognito-identity.eu-west-1.amazonaws.com/',
+      'https://cognito-identity.eu-west-1.amazonaws.com/', // CloudWatch RUM
       ...advertisingDirectives.connectSrc,
       "'self'",
     ],

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -359,6 +359,7 @@ describe('cspHeader', () => {
         'https://cdn.optimizely.com/',
         'https://logx.optimizely.com/',
         'https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net',
+        'https://cognito-identity.eu-west-1.amazonaws.com/',
         'https://csi.gstatic.com',
         'https://pagead2.googlesyndication.com',
         'https://*.g.doubleclick.net',
@@ -371,7 +372,6 @@ describe('cspHeader', () => {
         'https://fundingchoicesmessages.google.com',
         'https://secure-dcr-cert.imrworldwide.com',
         'https://*.safeframe.googlesyndication.com',
-        'https://cognito-identity.eu-west-1.amazonaws.com/',
         "'self'",
       ],
       defaultSrcExpectation: [

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -371,6 +371,7 @@ describe('cspHeader', () => {
         'https://fundingchoicesmessages.google.com',
         'https://secure-dcr-cert.imrworldwide.com',
         'https://*.safeframe.googlesyndication.com',
+        'https://cognito-identity.eu-west-1.amazonaws.com/',
         "'self'",
       ],
       defaultSrcExpectation: [


### PR DESCRIPTION
Fix issue where CSP prevents events being sent to cloudwatch rum

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
