### PR TITLE
Remove `new_articles` route check

### DIFF
--- a/src/app/routes/utils/fetchPageData/index.js
+++ b/src/app/routes/utils/fetchPageData/index.js
@@ -13,7 +13,6 @@ import {
 } from '#lib/statusCodes.const';
 import { PRIMARY_DATA_TIMEOUT } from '#app/lib/utilities/getFetchTimeouts';
 import onClient from '#lib/utilities/onClient';
-import isLive from '#lib/utilities/isLive';
 import getErrorStatusCode from './utils/getErrorStatusCode';
 import getUrl from './utils/getUrl';
 
@@ -37,10 +36,7 @@ const fetchPageData = async ({
   optHeaders,
   ...loggerArgs
 }) => {
-  const urlPath = path.startsWith('http') ? path : getUrl(path);
-
-  // TODO: Remove this once testing of routing Article pages through Belfrage is complete
-  const url = isLive() ? urlPath : urlPath.replace('new_articles', 'articles');
+  const url = path.startsWith('http') ? path : getUrl(path);
 
   const effectiveTimeout = timeout || PRIMARY_DATA_TIMEOUT;
   const fetchOptions = {

--- a/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
+++ b/src/app/routes/utils/regex/utils/__snapshots__/index.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`regex utils snapshots should create expected regex from getAfricaEyeTVPageRegex 1`] = `"/worldservice/tv/africa_eye/:episodeId([a-z0-9]+)?"`;
 
-exports[`regex utils snapshots should create expected regex from getArticleManifestRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|new_articles|erthyglau|sgeulachdan)/manifest.json"`;
+exports[`regex utils snapshots should create expected regex from getArticleManifestRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|erthyglau|sgeulachdan)/manifest.json"`;
 
-exports[`regex utils snapshots should create expected regex from getArticleRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|new_articles|erthyglau|sgeulachdan)/:id(c[a-zA-Z0-9]{10}o):variant(/simp|/trad|/cyr|/lat)?:amp(.amp)?"`;
+exports[`regex utils snapshots should create expected regex from getArticleRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|erthyglau|sgeulachdan)/:id(c[a-zA-Z0-9]{10}o):variant(/simp|/trad|/cyr|/lat)?:amp(.amp)?"`;
 
-exports[`regex utils snapshots should create expected regex from getArticleSwRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|new_articles|erthyglau|sgeulachdan)/sw.js"`;
+exports[`regex utils snapshots should create expected regex from getArticleSwRegex 1`] = `"/:service(news|persian|igbo)/:local(articles|erthyglau|sgeulachdan)/sw.js"`;
 
 exports[`regex utils snapshots should create expected regex from getCpsAssetRegex 1`] = `"/:service(news|persian|igbo):variant(/simp|/trad|/cyr|/lat)?/:assetUri([a-z0-9-_]{0,}[0-9]{8,}):amp(.amp)?"`;
 

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -3,8 +3,7 @@ const ampRegex = '.amp';
 const assetUriRegex = '[a-z0-9-_]{0,}[0-9]{8,}';
 const legacyAssetUriRegex = '[a-z0-9-_]{1,}/[a-z0-9-_/]{1,}';
 const variantRegex = '/simp|/trad|/cyr|/lat';
-// TODO: Remove 'new_articles' once testing of routing Article pages through Belfrage is complete
-const articleLocalRegex = 'articles|new_articles|erthyglau|sgeulachdan';
+const articleLocalRegex = 'articles|erthyglau|sgeulachdan';
 const mediaIdRegex = '[a-z0-9]+';
 const topicIdRegex = '[a-z0-9]+';
 const radioMasterBrandRegex = 'bbc_[a-z]+_radio';


### PR DESCRIPTION
**Overall change:**
Removes the `new_articles` route that was used for testing Belfrage routing for Optimo articles. This is no longer needed, as we are beginning the rollout to Live article pages, starting with the Kyrgyz service.

**Code changes:**
- Removes checks for `new_articles` from the Ares page data fetch, as well as the route regex matching

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
