### PR TITLE
Update time stamp prefix for Arabic

### DIFF
--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -18,7 +18,7 @@ export const service = {
   default: {
     lang: 'ar',
     articleAuthor: 'https://www.facebook.com/bbcnews',
-    articleTimestampPrefix: 'جدّد في',
+    articleTimestampPrefix: 'آخر تحديث',
     articleTimestampSuffix: '',
     atiAnalyticsAppName: 'news-arabic',
     atiAnalyticsProducerId: '5',


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Replace the time stamp prefix used to create the "Last updated' time stamp for article updates on Arabic.

**Code changes:**

- Updated _articleTimestampPrefix_ in   src/app/lib/config/services/arabic.js  

The last updated time stamp with the new prefix has been reviewed and approved by Arabic's deputy digital editor:


<img width="372" alt="Screenshot 2022-05-17 at 10 10 56" src="https://user-images.githubusercontent.com/10046386/168815693-cf3fef93-39ca-4190-8bd0-bc9182c15df9.png">


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
