### PR TITLE
Fix: most read for optimo articles

### DIFF
--- a/src/app/containers/MostRead/Amp/index.jsx
+++ b/src/app/containers/MostRead/Amp/index.jsx
@@ -29,8 +29,13 @@ const rankTranslationScript = (endpoint, service) => {
         throw new Error("Empty records from mostread endpoint");
       }
 
-      data.records.forEach((item, index) => 
-        item.rankTranslation = translations[index+1]);    
+      data.records.forEach((item, index) => {
+        item.rankTranslation = translations[index+1];
+
+        if (!item.promo.headlines.shortHeadline) {
+          item.promo.headlines.shortHeadline = item.promo.headlines.seoHeadline;
+        }
+      });
 
       return data;
     } catch(error){


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAM1-73

**Overall change:**
Most read on optimo articles does not render correctly (no headline title), this fix add key shortheadline to each item in the array.

**Code changes:**

- Add key `shortheadline` if it is missing and assign value of `seoHeadline`.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Since unit tests are not possible in JUnit, a follow-up PR will address the testing gap.

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
