### PR TITLE
Replace Translations For Recommendation Title

### DIFF
--- a/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
@@ -521,7 +521,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           class="emotion-6 emotion-7"
           href="#end-of-recommendations"
         >
-          Saltar Quizás también te interese y continuar leyendo
+          Saltar Recomendamos y continuar leyendo
         </a>
         <div
           class="emotion-8 emotion-9 emotion-10"
@@ -543,7 +543,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
                   dir="ltr"
                   id="recommendations-heading"
                 >
-                  Quizás también te interese
+                  Recomendamos
                 </span>
               </span>
             </span>
@@ -595,7 +595,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           id="end-of-recommendations"
           tabindex="-1"
         >
-          Final de Quizás también te interese
+          Final de Recomendamos
         </p>
       </div>
     </section>
@@ -1235,7 +1235,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           class="emotion-6 emotion-7"
           href="#end-of-recommendations"
         >
-          Saltar Quizás también te interese y continuar leyendo
+          Saltar Recomendamos y continuar leyendo
         </a>
         <div
           class="emotion-8 emotion-9 emotion-10"
@@ -1257,7 +1257,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
                   dir="ltr"
                   id="recommendations-heading"
                 >
-                  Quizás también te interese
+                  Recomendamos
                 </span>
               </span>
             </span>
@@ -1462,7 +1462,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           id="end-of-recommendations"
           tabindex="-1"
         >
-          Final de Quizás también te interese
+          Final de Recomendamos
         </p>
       </div>
     </section>
@@ -2102,7 +2102,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           class="emotion-6 emotion-7"
           href="#end-of-recommendations"
         >
-          تخطى مواضيع قد تهمك وواصل القراءة
+          تخطى قصص مقترحة وواصل القراءة
         </a>
         <div
           class="emotion-8 emotion-9 emotion-10"
@@ -2124,7 +2124,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
                   dir="rtl"
                   id="recommendations-heading"
                 >
-                  مواضيع قد تهمك
+                  قصص مقترحة
                 </span>
               </span>
             </span>
@@ -2329,7 +2329,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
           id="end-of-recommendations"
           tabindex="-1"
         >
-          مواضيع قد تهمك نهاية
+          قصص مقترحة نهاية
         </p>
       </div>
     </section>

--- a/src/app/containers/CpsRecommendations/index.test.jsx
+++ b/src/app/containers/CpsRecommendations/index.test.jsx
@@ -96,7 +96,7 @@ describe('CpsRecommendations', () => {
 
     expect(skipLink.getAttribute('href')).toEqual('#end-of-recommendations');
     expect(skipLink.textContent).toEqual(
-      'Saltar Quizás también te interese y continuar leyendo',
+      'Saltar Recomendamos y continuar leyendo',
     );
   });
 

--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -91,7 +91,8 @@ export const service = {
       ads: {
         advertisementLabel: 'إعلان',
       },
-      recommendationTitle: 'مواضيع قد تهمك',
+      recommendationTitle: 'قصص مقترحة',
+      splitRecommendationTitle: 'مزيد من القصص المقترحة',
       seeAll: 'المزيد',
       home: 'الرئيسية',
       currentPage: 'الصفحة الحالية',

--- a/src/app/lib/config/services/indonesia.js
+++ b/src/app/lib/config/services/indonesia.js
@@ -86,6 +86,8 @@ export const service = {
       ads: {
         advertisementLabel: 'Iklan',
       },
+      recommendationTitle: 'Artikel-artikel yang direkomendasikan',
+      splitRecommendationTitle: 'Artikel-artikel lainnya yang direkomendasikan',
       seeAll: 'Lihat semua',
       home: 'Berita',
       currentPage: 'Halaman saat ini',

--- a/src/app/lib/config/services/mundo.js
+++ b/src/app/lib/config/services/mundo.js
@@ -78,7 +78,8 @@ export const service = {
       ads: {
         advertisementLabel: 'Publicidad',
       },
-      recommendationTitle: 'Quizás también te interese',
+      recommendationTitle: 'Recomendamos',
+      splitRecommendationTitle: 'Más recomendaciones',
       seeAll: 'Ver todo',
       home: 'Página de inicio',
       currentPage: 'Página actual',

--- a/src/app/lib/config/services/persian.js
+++ b/src/app/lib/config/services/persian.js
@@ -92,6 +92,8 @@ export const service = {
       ads: {
         advertisementLabel: 'آگهی',
       },
+      recommendationTitle: 'مطالب پیشنهادی',
+      splitRecommendationTitle: 'مطالب پیشنهادی دیگر',
       seeAll: 'بیشتر',
       home: 'صفحه اول',
       currentPage: 'صفحه فعلی',

--- a/src/app/lib/config/services/portuguese.js
+++ b/src/app/lib/config/services/portuguese.js
@@ -98,7 +98,8 @@ export const service = {
       ads: {
         advertisementLabel: 'Publicidade',
       },
-      recommendationTitle: 'Talvez também te interesse',
+      recommendationTitle: 'Matérias recomendadas',
+      splitRecommendationTitle: 'Mais matérias recomendadas',
       seeAll: 'Ver todos',
       home: 'Início',
       currentPage: 'Página atual',

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -130,6 +130,8 @@ export const mainTranslations = {
   ads: {
     advertisementLabel: 'Реклама',
   },
+  recommendationTitle: 'По теме',
+  splitRecommendationTitle: 'Другие статьи',
   seeAll: 'Посмотреть все',
   skipLinkText: 'Перейти к содержанию',
   relatedContent: 'Читайте также',

--- a/src/app/lib/config/services/thai.js
+++ b/src/app/lib/config/services/thai.js
@@ -67,6 +67,8 @@ export const service = {
       ads: {
         advertisementLabel: 'โฆษณา',
       },
+      recommendationTitle: 'เรื่องแนะนำ',
+      splitRecommendationTitle: 'เรื่่องแนะนำอื่น ๆ',
       seeAll: 'ดูทั้งหมด',
       home: 'หน้าแรก',
       currentPage: 'หน้าปัจจุบัน',

--- a/src/app/lib/config/services/turkce.js
+++ b/src/app/lib/config/services/turkce.js
@@ -76,7 +76,8 @@ export const service = {
       ads: {
         advertisementLabel: 'Reklam',
       },
-      recommendationTitle: 'Bunlar da ilginizi çekebilir',
+      recommendationTitle: 'Önerilen hikayeler',
+      splitRecommendationTitle: 'Daha fazla önerilen hikaye',
       seeAll: 'Hepsini görüntüle',
       home: 'Ana sayfa',
       currentPage: 'Bulunduğunuz sayfa',


### PR DESCRIPTION
Resolves WSTEAM1-49

**Overall change:**
Replace translations for recommendation titles in:

- Mundo
- Brazil
- Turkish
- Arabic

Adds recommendation titles' translation in:

- Russian
- Indonesian
- Persian
- Thai


**Code changes:**

- Updated service files

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
