### PR TITLE
check most read list has hrefs

### DIFF
--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -120,7 +120,25 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
             });
           });
         });
-
+        it(`Most read list should contain hrefs`, () => {
+          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
+            const mostReadRecords = mostReadJson.totalRecords;
+            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
+              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
+              cy.log(
+                `Most read container toggle enabled? ${mostReadIsEnabled}`,
+              );
+              if (mostReadIsEnabled && mostReadRecords >= 5) {
+                cy.get('[data-e2e="most-read"]').scrollIntoView();
+                cy.get('[data-e2e="most-read"] > amp-list div')
+                  .next()
+                  .within(() => {
+                    cy.get('a').should('have.attr', 'href');
+                  });
+              }
+            });
+          });
+        });
         it('should not show most read list when data fetch fails', () => {
           cy.intercept(
             {

--- a/cypress/integration/pages/storyPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/storyPage/testsForAMPOnly.js
@@ -123,6 +123,26 @@ export const testsThatAlwaysRunForAMPOnly = ({
           });
         });
 
+        it(`Most read list should contain hrefs`, () => {
+          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
+            const mostReadRecords = mostReadJson.totalRecords;
+            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
+              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
+              cy.log(
+                `Most read container toggle enabled? ${mostReadIsEnabled}`,
+              );
+              if (mostReadIsEnabled && mostReadRecords >= 5) {
+                cy.get('[data-e2e="most-read"]').scrollIntoView();
+                cy.get('[data-e2e="most-read"] > amp-list div')
+                  .next()
+                  .within(() => {
+                    cy.get('a').should('have.attr', 'href');
+                  });
+              }
+            });
+          });
+        });
+
         it('should not show most read list when data fetch fails', () => {
           cy.intercept(
             {


### PR DESCRIPTION
On Kyrgyz, most read was showing with the container and the numerals, but had all the actual links missing. This tests that the links are present.

(Kyrgyz was disabled until a fix for Optimo articles appearing in most read breaking it)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Passes on test and live
