### PR TITLE
Render secondary column on CSP pages

### DIFF
--- a/src/app/containers/MostRead/index.jsx
+++ b/src/app/containers/MostRead/index.jsx
@@ -12,7 +12,7 @@ const blockLevelEventTrackingData = {
   componentName: 'most-read',
 };
 
-const showMostReadPageTypes = ['STY', 'article'];
+const mostReadAmpPageTypes = ['STY', 'CSP', 'article'];
 
 const MostReadContainer = ({
   mostReadEndpointOverride,
@@ -39,9 +39,9 @@ const MostReadContainer = ({
     return null;
   }
 
-  // We render amp on ONLY STY and ART pages using amp-list.
+  // We render amp on ONLY STY, CSP and ARTICLE pages using amp-list.
   // We also want to render most read on AMP for the "/popular/read" pages
-  if (isAmp && !serverRenderOnAmp && showMostReadPageTypes.includes(pageType)) {
+  if (isAmp && !serverRenderOnAmp && mostReadAmpPageTypes.includes(pageType)) {
     const mostReadUrl = `${process.env.SIMORGH_MOST_READ_CDN_URL}${endpoint}`;
     return <AmpMostRead endpoint={mostReadUrl} size={size} wrapper={wrapper} />;
   }

--- a/src/app/containers/MostRead/index.test.jsx
+++ b/src/app/containers/MostRead/index.test.jsx
@@ -11,6 +11,7 @@ import {
   FRONT_PAGE,
   STORY_PAGE,
   ARTICLE_PAGE,
+  CORRESPONDENT_STORY_PAGE,
 } from '#app/routes/utils/pageTypes';
 import MostReadContainer from '.';
 import { setFreshPromoTimestamp } from './utilities/testHelpers';
@@ -193,6 +194,15 @@ describe('MostReadContainerCanonical Assertion', () => {
         variant: null,
         renderExpectation: shouldRenderMostReadAmp,
         pageType: ARTICLE_PAGE,
+      },
+      {
+        description: 'should render most read amp on CSP page for PS news',
+        service: 'news',
+        mostReadToggle: true,
+        isAmp: true,
+        variant: null,
+        renderExpectation: shouldRenderMostReadAmp,
+        pageType: CORRESPONDENT_STORY_PAGE,
       },
       {
         description: 'should not render most read amp on front page',

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -1,5 +1,9 @@
 import isEmpty from 'ramda/src/isEmpty';
-import { STORY_PAGE, MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
+import {
+  STORY_PAGE,
+  CORRESPONDENT_STORY_PAGE,
+  MEDIA_ASSET_PAGE,
+} from '#app/routes/utils/pageTypes';
 import { getMostReadEndpoint } from '#lib/utilities/getUrlHelpers/getMostReadUrls';
 import getMostWatchedEndpoint from '#lib/utilities/getUrlHelpers/getMostWatchedUrl';
 import getSecondaryColumnUrl from '#lib/utilities/getUrlHelpers/getSecondaryColumnUrl';
@@ -23,6 +27,7 @@ const pageTypeUrls = async (
 ) => {
   switch (assetType) {
     case STORY_PAGE:
+    case CORRESPONDENT_STORY_PAGE:
       return [
         (await hasMostRead(service, variant))
           ? {

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
@@ -6,10 +6,13 @@ import fetchMock from 'fetch-mock';
 // mock data
 import mapJson from '#data/pidgin/cpsAssets/media-23256549.json';
 import styJson from '#data/mundo/cpsAssets/23263889.json';
+import cspJson from '#data/news/cpsAssets/business-55345826.json';
 import noRecommendationsStyJson from '#data/pidgin/cpsAssets/world-23252817.json';
 import mostReadJson from '#data/mundo/mostRead/index.json';
+import cspMostReadJson from '#data/news/mostRead/index.json';
 import mostWatchedJson from '#data/pidgin/mostWatched/index.json';
 import secondaryColumnJson from '#data/mundo/secondaryColumn/index.json';
+import cspSecondaryColumnJson from '#data/news/secondaryColumn/index.json';
 import recommendationsJson from '#data/mundo/recommendations/index.json';
 import hasRecommendations from './hasRecommendations';
 import getAdditionalPageData from './getAdditionalPageData';
@@ -91,5 +94,24 @@ describe('getAdditionalPageData', () => {
     });
 
     expect(additionalPageData).toEqual({});
+  });
+
+  it('should return additional data for a CSP asset', async () => {
+    fetchMock.mock('http://localhost/news/mostread.json', cspMostReadJson);
+    fetchMock.mock(
+      'http://localhost/news/sty-secondary-column.json',
+      cspSecondaryColumnJson,
+    );
+    const additionalPageData = await getAdditionalPageData({
+      pageData: cspJson,
+      service: 'news',
+      env: 'local',
+    });
+
+    const expectedOutput = {
+      mostRead: cspMostReadJson,
+      secondaryColumn: cspSecondaryColumnJson,
+    };
+    expect(additionalPageData).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
**Overall change:**
Renders the secondary column on `CSP` page types. Includes a fix to render the MostRead component on AMP on CSP pages.

**Code changes:**
- Updates the `getAdditionalPageData` fetch to check for the `CSP` page type
- Updates the page types we show the AMP MostRead component on to include the `CSP` page type

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
