### PR TITLE
Remove amp link from Live Radio, OD Audi, OD TV and MAPs

### DIFF
--- a/src/app/containers/CpsMetadata/index.jsx
+++ b/src/app/containers/CpsMetadata/index.jsx
@@ -70,7 +70,7 @@ CpsMetadata.defaultProps = {
   imageAltText: null,
   aboutTags: [],
   hasAppleItunesAppBanner: false,
-  hasAmpPage: false,
+  hasAmpPage: true,
 };
 
 export default CpsMetadata;

--- a/src/app/containers/CpsMetadata/index.jsx
+++ b/src/app/containers/CpsMetadata/index.jsx
@@ -15,6 +15,7 @@ const CpsMetadata = ({
   imageAltText,
   aboutTags,
   hasAppleItunesAppBanner,
+  hasAmpPage,
 }) => {
   const { service, articleAuthor } = useContext(ServiceContext);
   const brandedImage = imageLocator
@@ -31,6 +32,7 @@ const CpsMetadata = ({
       imageAltText={imageAltText}
       aboutTags={aboutTags}
       hasAppleItunesAppBanner={hasAppleItunesAppBanner}
+      hasAmpPage={hasAmpPage}
     >
       <meta name="article:author" content={articleAuthor} />
       <meta name="article:published_time" content={firstPublished} />
@@ -60,6 +62,7 @@ CpsMetadata.propTypes = {
   imageAltText: string,
   aboutTags: arrayOf(tagPropTypes),
   hasAppleItunesAppBanner: bool,
+  hasAmpPage: bool,
 };
 
 CpsMetadata.defaultProps = {
@@ -67,6 +70,7 @@ CpsMetadata.defaultProps = {
   imageAltText: null,
   aboutTags: [],
   hasAppleItunesAppBanner: false,
+  hasAmpPage: false,
 };
 
 export default CpsMetadata;

--- a/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
+++ b/src/app/pages/LiveRadioPage/LiveRadioPage.jsx
@@ -66,6 +66,7 @@ const LiveRadioPage = ({ pageData }) => {
         lang={language}
         description={summary}
         openGraphType="website"
+        hasAmpPage={false}
       />
       <LinkedData type="RadioChannel" seoTitle={name} />
 

--- a/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
+++ b/src/app/pages/MediaAssetPage/MediaAssetPage.jsx
@@ -191,6 +191,7 @@ const MediaAssetPage = ({ pageData }) => {
         imageAltText={indexImageAltText}
         aboutTags={aboutTags}
         hasAppleItunesAppBanner
+        hasAmpPage={false}
       />
       <LinkedData
         type="Article"

--- a/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
+++ b/src/app/pages/OnDemandAudioPage/OnDemandAudioPage.jsx
@@ -160,6 +160,7 @@ const OnDemandAudioPage = ({ pageData, mediaIsAvailable, MediaError }) => {
         title={metadataTitle}
         description={shortSynopsis}
         {...metadataImageProps}
+        hasAmpPage={false}
       />
 
       <GelPageGrid

--- a/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
+++ b/src/app/pages/OnDemandTvPage/OnDemandTvPage.jsx
@@ -127,6 +127,7 @@ const OnDemandTvPage = ({ pageData, mediaIsAvailable, MediaError }) => {
         lang={language}
         description={shortSynopsis}
         openGraphType="website"
+        hasAmpPage={false}
       />
       <LinkedData
         type="WebPage"


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
We are trialling not supporting AMP for Live Radio, OD Audio, OD TV and MAPs. This PR removes the amp page link from these pages.

**Code changes:**

- JoRo has already added a `hasAmpPage` prop to the `Metadata` component. This PR sets `hasAmpPage` to false for the 4 pages listed above.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
