### PR TITLE
Fix for height of lazyload wrapper on High Impact Promo

### DIFF
--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -63,16 +63,20 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 .emotion-6 {
+  height: 100%;
+}
+
+.emotion-8 {
   background-color: #202224;
   min-height: 100px;
   padding-bottom: 1rem;
 }
 
-.emotion-8 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -86,18 +90,18 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-10 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #e6e8ea;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -128,17 +132,17 @@ exports[`Frosted Glass Promo when given props directly 1`] = `
       <noscript />
     </div>
     <div
-      class="lazyload-wrapper "
+      class="lazyload-wrapper  emotion-6 emotion-7"
     >
       <div
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             href="/mundo/internacional-23038380"
           >
             Además de sus decenas de museos tradicionales, Ciudad de México es una galería al aire libre de arte callejero, en la que exponen artistas nacionales y extranjeros. Lo invitamos a un recorrido.
@@ -214,16 +218,20 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 .emotion-6 {
+  height: 100%;
+}
+
+.emotion-8 {
   background-color: #202224;
   min-height: 100px;
   padding-bottom: 1rem;
 }
 
-.emotion-8 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -237,23 +245,23 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-10 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #e6e8ea;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-13 {
+.emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -267,21 +275,21 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
   }
@@ -313,24 +321,24 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
       <noscript />
     </div>
     <div
-      class="lazyload-wrapper "
+      class="lazyload-wrapper  emotion-6 emotion-7"
     >
       <div
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             href="/mundo/internacional-23038380"
           >
             El colorido encanto del arte callejero chilango 17
           </a>
         </h3>
         <time
-          class="emotion-12 emotion-13 emotion-14"
+          class="emotion-14 emotion-15 emotion-16"
           datetime="2016-05-05"
         >
           5 mayo 2016
@@ -404,16 +412,20 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 .emotion-6 {
+  height: 100%;
+}
+
+.emotion-8 {
   background-color: #202224;
   min-height: 100px;
   padding-bottom: 1rem;
 }
 
-.emotion-8 {
+.emotion-10 {
   margin: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -427,23 +439,23 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-10 {
+  .emotion-12 {
     font-size: 1rem;
     line-height: 1.25;
     margin: 0.875rem 1rem 0 1rem;
   }
 }
 
-.emotion-10:visited {
+.emotion-12:visited {
   color: #e6e8ea;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-13 {
+.emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #6E6E73;
@@ -457,21 +469,21 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-13 {
+  .emotion-15 {
     font-size: 0.875rem;
     padding: 0.75rem 1rem 0 1rem;
   }
@@ -503,24 +515,24 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
       <noscript />
     </div>
     <div
-      class="lazyload-wrapper "
+      class="lazyload-wrapper  emotion-6 emotion-7"
     >
       <div
-        class="emotion-6 emotion-7"
+        class="emotion-8 emotion-9"
         data-testid="frosted-glass-lazyload-placeholder"
       >
         <h3
-          class="emotion-8 emotion-9"
+          class="emotion-10 emotion-11"
         >
           <a
-            class="emotion-10 emotion-11"
+            class="emotion-12 emotion-13"
             href="https://www.bbc.com/pidgin/sport-51434980"
           >
             Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
           </a>
         </h3>
         <time
-          class="emotion-12 emotion-13 emotion-14"
+          class="emotion-14 emotion-15 emotion-16"
           datetime="2020-02-17"
         >
           17 febrero 2020

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -83,6 +83,10 @@ const LazyloadPlaceholder = styled.div`
   padding-bottom: ${GEL_SPACING_DBL};
 `;
 
+const LazyloadWrapper = styled(Lazyload)`
+  height: 100%;
+`;
+
 const FrostedGlassPromo = ({
   image,
   children,
@@ -151,7 +155,7 @@ const FrostedGlassPromo = ({
           image,
         )}
       />
-      <Lazyload
+      <LazyloadWrapper
         offset={PANEL_OFFSET}
         once
         placeholder={
@@ -171,7 +175,7 @@ const FrostedGlassPromo = ({
         >
           {promoText}
         </FrostedGlassPanel>
-      </Lazyload>
+      </LazyloadWrapper>
     </Wrapper>
   );
 };


### PR DESCRIPTION
**Overall change:**
Fixes a bug with the height of the high impact promo text component, making the height the same across each of the promos when in tablet view

**Code changes:**
- Adds a `height: 100%` to the wrapping `<Lazyload />` component. This styling was present before the lazy-load logic was added. When the lazy-load component was introduced, it created an extra parent `<div />` element, which in turn caused the promo heights to become uneven again

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
