### PR TITLE
Clean up `audit-ci.json` allowlist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,4 @@
 {
   "low": true,
-  "allowlist": [1556, 1615, 1002475, 1002522]
+  "allowlist": []
 }


### PR DESCRIPTION
**Overall change:**
The format for the `audit-ci.json` `allowlist` has changed from the numerical npm-identifier to the string github-identifiers. Running the audit script highlights that we don't need the identifiers we currently have in the `allowlist`, so these have been removed. 

**Code changes:**
- Removes the old npm-identifier values from the audit-ci `allowlist`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
