### PR TITLE
Add external links to Kyrgyz podcast

### DIFF
--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/kyrgyz.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/kyrgyz.js
@@ -11,6 +11,17 @@ const externalLinks = {
           'https://podcasts.apple.com/us/podcast/25-%D0%B6%D1%8B%D0%BB-%D0%BE%D0%B1%D0%BE%D0%B4%D0%BE/id1568103058',
       },
     ],
+    p0c80v81: [
+      {
+        linkText: 'Spotify',
+        linkUrl: 'https://open.spotify.com/show/7nYFDxTuJnmWtS5lhxtjmB',
+      },
+      {
+        linkText: 'Apple',
+        linkUrl:
+          'https://podcasts.apple.com/us/podcast/би-би-си-дүрбүсүндө/id1625319429',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Add external links to Kyrgyz podcast

**Code changes:**

Adds a new external links entry to /Development/simorgh/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/kyrgyz.js

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
