### PR TITLE
colour for fancy promo's visited link

### DIFF
--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -7,7 +7,7 @@ import Lazyload from 'react-lazyload';
 import { getSerifRegular } from '@bbc/psammead-styles/font-styles';
 import { GEL_GROUP_2_SCREEN_WIDTH_MIN } from '@bbc/gel-foundations/breakpoints';
 import { GEL_SPACING, GEL_SPACING_DBL } from '@bbc/gel-foundations/spacings';
-import { C_WHITE, C_GREY_8 } from '@bbc/psammead-styles/colours';
+import { C_WHITE, C_GREY_8, C_METAL } from '@bbc/psammead-styles/colours';
 
 import useClickTrackerHandler from '#hooks/useClickTrackerHandler';
 import { ServiceContext } from '#contexts/ServiceContext';
@@ -70,7 +70,7 @@ const A = styled.a`
     margin: 0.875rem ${GEL_SPACING_DBL} 0 ${GEL_SPACING_DBL};
   }
   &:visited {
-    color: #e6e8ea;
+    color: ${({ isAmp }) => (isAmp ? C_METAL : '#e6e8ea')};
   }
   &:focus {
     text-decoration: underline;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Using C_METAL for fancy promo's visited link in AMP pages.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
