### PR TITLE
Update CSP reporting endpoint in Simorgh

### DIFF
--- a/envConfig/live.env
+++ b/envConfig/live.env
@@ -27,6 +27,6 @@ AWS_EMF_ENVIRONMENT=EC2
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-prod-4591.cloudfunctions.net/report-endpoint
 SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=20
 
-SIMORGH_CSP_REPORTING_ENDPOINT=https://reporting-endpoint-live-7piyvnsc3a-nw.a.run.app/report-endpoint
+SIMORGH_CSP_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint
 
 SIMORGH_OPTIMIZELY_SDK_KEY=4Rje1JY7YY1FhaiHJ88Zi

--- a/envConfig/local.env
+++ b/envConfig/local.env
@@ -27,6 +27,6 @@ AWS_EMF_ENVIRONMENT=Local
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net/report-endpoint
 SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=100
 
-SIMORGH_CSP_REPORTING_ENDPOINT=https://reporting-endpoint-live-7piyvnsc3a-nw.a.run.app/report-endpoint
+SIMORGH_CSP_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint
 
 SIMORGH_OPTIMIZELY_SDK_KEY=LptPKDnHyAFu9V12s5xCz

--- a/envConfig/test.env
+++ b/envConfig/test.env
@@ -27,6 +27,6 @@ AWS_EMF_ENVIRONMENT=EC2
 SIMORGH_WEBVITALS_REPORTING_ENDPOINT=https://europe-west1-bbc-otg-traf-mgr-bq-dev-4105.cloudfunctions.net/report-endpoint
 SIMORGH_WEBVITALS_DEFAULT_SAMPLING_RATE=100
 
-SIMORGH_CSP_REPORTING_ENDPOINT=https://reporting-endpoint-live-7piyvnsc3a-nw.a.run.app/report-endpoint
+SIMORGH_CSP_REPORTING_ENDPOINT=https://ws.bbc-reporting-api.app/report-endpoint
 
 SIMORGH_OPTIMIZELY_SDK_KEY=LptPKDnHyAFu9V12s5xCz


### PR DESCRIPTION
Resolves [NEWSWORLDSERVICE-1535](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1535)

**Overall change:**
Update CSP reporting endpoint in Simorgh from https://reporting-endpoint-live-7piyvnsc3a-nw.a.run.app/report-endpoint  to https://ws.bbc-reporting-api.app/report-endpoint

**Code changes:**

- Update `SIMORGH_CSP_REPORTING_ENDPOINT` field in: `envConfig/live.env`, `envConfig/local.env`, `envConfig/test.env`

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
