### PR TITLE
Fix topics page test - data structure different for cps and optimo articles

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -202,8 +202,25 @@ export default ({ service, pageType, variant }) => {
                   .then(url => {
                     // Check the page navigated to has the short headline that was on the topic item
                     cy.request(`${url}.json`).then(({ body }) => {
-                      const { shortHeadline } = body.promo.headlines;
-                      expect(shortHeadline).to.equal(firstItemHeadline);
+                      if (body.metadata.locators.cpsUrn) {
+                        cy.log('cps article');
+                        const { shortHeadline } = body.promo.headlines;
+                        expect(shortHeadline).to.equal(firstItemHeadline);
+                      }
+                      if (body.promo.locators.optimoUrn) {
+                        cy.log('optimo article');
+                        cy.window().then(win => {
+                          const jsonData = win.SIMORGH_DATA.pageData;
+                          const headline =
+                            jsonData.promo.headlines.promoHeadline.blocks[0]
+                              .model.blocks[0].model.text;
+                          cy.log(
+                            jsonData.promo.headlines.promoHeadline.blocks[0]
+                              .model.blocks[0].model.text,
+                          );
+                          expect(headline).to.equal(firstItemHeadline);
+                        });
+                      }
                     });
                   });
               });


### PR DESCRIPTION
**Overall change:**

Some tests are failing when they go to an article with a different data structure as the headline isn't in the same place in the data for CPS and Optimo articles. Hopefully there aren't more structure types that will make this fail again in the future...

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Passes on test where it was failing before