### PR TITLE
Adds moment timezone plugin to cypress alias fix

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const envConfig = require('../support/config/envs');
 const { webpackDirAlias } = require('../../dirAlias');
+const MomentTimezoneInclude = require('../../src/app/legacy/moment-timezone-include/src');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolvePath = relativePath => path.resolve(appDirectory, relativePath);
@@ -47,6 +48,7 @@ module.exports = (on, config) => {
           },
         ],
       },
+      plugins: [new MomentTimezoneInclude({ startYear: 2010, endYear: 2025 })],
     },
   };
 


### PR DESCRIPTION
Resolves #N/A

**Overall change:**
Potential fix for Cypress tests that run on AWS, that can't resolve the tz folder that our timezone include package generates.

**Code changes:**

- Adds the tz folder webpack plugin to cypresses resolver, so it can generate the tz folder

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
