### PR TITLE
Update Arabic and Hindi podcast promos

### DIFF
--- a/src/app/lib/config/services/arabic.js
+++ b/src/app/lib/config/services/arabic.js
@@ -65,16 +65,15 @@ export const service = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'البودكاست',
-      brandTitle: 'مراهقتي (Morahakaty)',
-      brandDescription:
-        'تابوهات المراهقة، من تقديم كريمة كواح و إعداد ميس باقي.',
+      brandTitle: 'تغيير بسيط (A Simple Change)',
+      brandDescription: 'تغيير بسيط: ما علاقة سلة مشترياتك بتغير المناخ؟',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0b3x87s.jpg',
-        alt: 'مراهقتي (Morahakaty)',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0c9wp5c.jpg',
+        alt: 'تغيير بسيط',
       },
       linkLabel: {
         text: 'الحلقات',
-        href: 'https://www.bbc.com/arabic/podcasts/p0b3xdrj',
+        href: 'https://www.bbc.com/arabic/podcasts/p0c9wp0l',
       },
       skipLink: {
         text: 'تخطى %title% وواصل القراءة',

--- a/src/app/lib/config/services/hindi.js
+++ b/src/app/lib/config/services/hindi.js
@@ -61,16 +61,16 @@ export const service = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'पॉडकास्ट',
-      brandTitle: 'ड्रामा क्वीन',
+      brandTitle: 'दिन भर',
       brandDescription:
-        'बातें उन मुश्किलों की जो हमें किसी के साथ बांटने नहीं दी जातीं...',
+        'वो राष्ट्रीय और अंतरराष्ट्रीय ख़बरें जो दिनभर सुर्खियां बनीं.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/448xn/p0c04wcm.jpg',
-        alt: 'पॉडकास्ट',
+        src: 'https://ichef.bbci.co.uk/images/ic/448xn/p09ds7cb.jpg',
+        alt: 'दिन भर',
       },
       linkLabel: {
         text: 'ड्रामा क्वीन',
-        href: 'https://www.bbc.com/hindi/podcasts/p0c0530h',
+        href: 'https://www.bbc.com/hindi/podcasts/p09ds7zx',
       },
       skipLink: {
         text: 'छोड़कर %title% आगे बढ़ें',


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Update in-article podcast promos for Arabic and Hindi

**Code changes:**

- Updated, brand title, brand description, image URL and alt text, and link in podcastPromo in  src/app/lib/config/services/arabic.js

- Updated, brand title, brand description, image URL and alt text, and link in podcastPromo in  src/app/lib/config/services/hindi.js


<img width="333" alt="Screenshot 2022-06-07 at 16 08 27" src="https://user-images.githubusercontent.com/10046386/172427075-3dcd1b4a-b7b9-4186-aa0f-fe8216775df9.png">


<img width="349" alt="Screenshot 2022-06-07 at 16 22 32" src="https://user-images.githubusercontent.com/10046386/172427185-156bd333-3847-426c-8c08-f23ade610078.png">






---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing

