### PR TITLE
Re-add ads rendering to Article pages on Test

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -16,6 +16,7 @@ import {
   SERVER_STATUS_ENDPOINT_ERROR,
 } from '#lib/logger.const';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
+import isLive from '#lib/utilities/isLive';
 import { OK } from '#lib/statusCodes.const';
 import injectCspHeader from './utilities/cspHeader';
 import logResponseTime from './utilities/logResponseTime';
@@ -165,7 +166,11 @@ server.get(
       data.toggles = toggles;
       data.path = urlPath;
       data.timeOnServer = Date.now();
-      data.showAdsBasedOnLocation = headers['bbc-adverts'] === 'true';
+
+      // TODO: Remove isLive and article page check after testing Ads on Article pages
+      data.showAdsBasedOnLocation =
+        (!isLive() && derivedPageType === 'article') ||
+        headers['bbc-adverts'] === 'true';
 
       const { status } = data;
       // Set derivedPageType based on returned page data


### PR DESCRIPTION
**Overall change:**
This reverts commit a282de6c01ccad90ba093a3c238284bbeea367e6 and re-adds the temporary logic to display ads on Article pages on **Test only**.

Work is being done in Belfrage/Mozart to properly support the `bbc-adverts` header, so this logic is added back to allow us to continue UX work on ads in Article pages.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
