### PR TITLE
Removes Confusing and Unnecessary Routes Utilities dirAlias

### DIFF
--- a/dirAlias.js
+++ b/dirAlias.js
@@ -32,7 +32,6 @@ module.exports = {
     '^#pages(.*)$': '<rootDir>/src/app/pages$1',
     '^#testHelpers(.*)$': '<rootDir>/src/testHelpers$1',
     '^#server(.*)$': '<rootDir>/src/server$1',
-    '^#utils(.*)$': '<rootDir>/src/app/routes/utils$1',
   },
   eslintDirAlias: {
     map: [
@@ -48,7 +47,6 @@ module.exports = {
       ['#pages', './src/app/pages'],
       ['#testHelpers', './src/testHelpers'],
       ['#server', './src/server'],
-      ['#utils', './src/app/routes/utils'],
     ],
     extensions: ['.js', '.jsx', '.json'],
   },

--- a/dirAlias.js
+++ b/dirAlias.js
@@ -18,7 +18,6 @@ module.exports = {
     '#pages': resolvePath('src/app/pages/'),
     '#testHelpers': resolvePath('src/testHelpers/'),
     '#server': resolvePath('src/server/'),
-    '#utils': resolvePath('src/app/routes/utils/'),
   },
   jestDirAlias: {
     '^#app(.*)$': '<rootDir>/src/app$1',

--- a/src/app/routes/article/index.js
+++ b/src/app/routes/article/index.js
@@ -1,6 +1,6 @@
 import { ArticlePage } from '#pages';
-import { articlePath } from '#utils/regex';
-import { ARTICLE_PAGE } from '#utils/pageTypes';
+import { articlePath } from '#app/routes/utils/regex';
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/getImageBlock/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/convertToOptimoBlocks/blocks/include/getImageBlock/index.js
@@ -1,4 +1,4 @@
-import htmlUnescape from '#utils/htmlUnescape';
+import htmlUnescape from '#app/routes/utils/htmlUnescape';
 
 const getImageBlock = (type, blockData, isAmp) => {
   const supportedImageTypes = ['idt2'];

--- a/src/app/routes/error/index.js
+++ b/src/app/routes/error/index.js
@@ -1,6 +1,6 @@
 import { ErrorPage } from '#pages';
-import { errorPagePath } from '#utils/regex';
-import { ERROR_PAGE } from '#utils/pageTypes';
+import { errorPagePath } from '#app/routes/utils/regex';
+import { ERROR_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/errorNoRouteMatch/index.js
+++ b/src/app/routes/errorNoRouteMatch/index.js
@@ -1,5 +1,5 @@
 import { ErrorPage } from '#pages';
-import { ERROR_PAGE } from '#utils/pageTypes';
+import { ERROR_PAGE } from '#app/routes/utils/pageTypes';
 
 export default {
   component: ErrorPage,

--- a/src/app/routes/home/index.js
+++ b/src/app/routes/home/index.js
@@ -1,6 +1,6 @@
 import { FrontPage } from '#pages';
-import { frontPagePath } from '#utils/regex';
-import { FRONT_PAGE } from '#utils/pageTypes';
+import { frontPagePath } from '#app/routes/utils/regex';
+import { FRONT_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/idx/index.js
+++ b/src/app/routes/idx/index.js
@@ -1,6 +1,6 @@
 import { IdxPage } from '#pages';
-import { IdxPagePath } from '#utils/regex';
-import { INDEX_PAGE } from '#utils/pageTypes';
+import { IdxPagePath } from '#app/routes/utils/regex';
+import { INDEX_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/liveRadio/index.js
+++ b/src/app/routes/liveRadio/index.js
@@ -1,6 +1,6 @@
 import { LiveRadioPage } from '#pages';
-import { liveRadioPath } from '#utils/regex';
-import { MEDIA_PAGE } from '#utils/pageTypes';
+import { liveRadioPath } from '#app/routes/utils/regex';
+import { MEDIA_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/mostRead/index.js
+++ b/src/app/routes/mostRead/index.js
@@ -1,6 +1,6 @@
 import { MostReadPage } from '#pages';
-import { mostReadPagePath } from '#utils/regex';
-import { MOST_READ_PAGE } from '#utils/pageTypes';
+import { mostReadPagePath } from '#app/routes/utils/regex';
+import { MOST_READ_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/mostWatched/index.js
+++ b/src/app/routes/mostWatched/index.js
@@ -1,6 +1,6 @@
 import { MostWatchedPage } from '#pages';
-import { mostWatchedPagePath } from '#utils/regex';
-import { MOST_WATCHED_PAGE } from '#utils/pageTypes';
+import { mostWatchedPagePath } from '#app/routes/utils/regex';
+import { MOST_WATCHED_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/onDemandRadio/index.js
+++ b/src/app/routes/onDemandRadio/index.js
@@ -1,6 +1,6 @@
 import { OnDemandAudioPage } from '#pages';
-import { onDemandRadioPath } from '#utils/regex';
-import { MEDIA_PAGE } from '#utils/pageTypes';
+import { onDemandRadioPath } from '#app/routes/utils/regex';
+import { MEDIA_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from '../onDemandAudio/getInitialData';
 
 export default {

--- a/src/app/routes/onDemandTV/index.js
+++ b/src/app/routes/onDemandTV/index.js
@@ -1,6 +1,6 @@
 import { OnDemandTvPage } from '#pages';
-import { onDemandTvPath } from '#utils/regex';
-import { MEDIA_PAGE } from '#utils/pageTypes';
+import { onDemandTvPath } from '#app/routes/utils/regex';
+import { MEDIA_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {

--- a/src/app/routes/podcast/index.js
+++ b/src/app/routes/podcast/index.js
@@ -1,6 +1,6 @@
 import { OnDemandAudioPage } from '#pages';
-import { podcastEpisodePath, podcastBrandPath } from '#utils/regex';
-import { MEDIA_PAGE } from '#utils/pageTypes';
+import { podcastEpisodePath, podcastBrandPath } from '#app/routes/utils/regex';
+import { MEDIA_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from '../onDemandAudio/getInitialData';
 
 export default {

--- a/src/app/routes/topic/index.js
+++ b/src/app/routes/topic/index.js
@@ -1,6 +1,6 @@
 import { TopicPage } from '#pages';
-import { temporaryTopicPath, topicPath } from '#utils/regex';
-import { TOPIC_PAGE } from '#utils/pageTypes';
+import { temporaryTopicPath, topicPath } from '#app/routes/utils/regex';
+import { TOPIC_PAGE } from '#app/routes/utils/pageTypes';
 import getInitialData from './getInitialData';
 
 export default {


### PR DESCRIPTION
Resolves N/A

**Overall change:**
Replaces the routes utility directory alias, as it's confusing as the directory makes it seem like it's a general utility directory, when in fact it's only related to routes.

**Code changes:**

- Removes the `#utils` directory alias which mapped to `src/app/routes/utils/`
- Replaces the `#utils` imports used in `routes` with `#app/routes/utils/`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
