### PR TITLE
New tests scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "test:lint": "eslint --ext .js,jsx,json ./src ./data ./cypress ./.storybook ./webpack** && stylelint 'src/**/*.js' 'src/**/*.jsx'",
     "test:puppeteer": "jest --ci --env=jsdom --colors ./puppeteer",
     "test:unit": "test -z $CI && jest --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\" || jest --ci --runInBand --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\"",
+    "test:unit:simorgh": "test -z $CI && jest --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\" \"src/app/legacy\" || jest --ci --runInBand --env=jsdom --coverage --colors --testPathIgnorePatterns=\"src/integration\" \"puppeteer\" \"src/app/legacy\"",
+    "test:unit:legacy": "jest --ci --env=jsdom --colors ./src/app/legacy",
     "test:unit:watch": "yarn test:unit -- --watch",
     "test:integration": "node src/integration/utils/runTests/index.js",
     "test:integration:ci": "JEST_SILENT_REPORTER_DOTS=true yarn test:integration -- --ci --onlyRunTests --reporters=jest-silent-reporter",


### PR DESCRIPTION
Resolves No PR, just let me know what you guys think about this 😄 

**Overall change:**
Adds two new test scripts cmd in package.json to run unit tests only on the legacy folder (psammead) or only on simorgh.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
