### PR TITLE
Support old and new topic contract

### DIFF
--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -36,12 +36,16 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
     });
     const { data } = json;
 
+    const promos = data.curations
+      ? data.curations[0].summaries
+      : data.summaries;
+
     return {
       status,
       pageData: {
         title: data.title,
         description: data.description || data.title,
-        promos: data.summaries,
+        promos,
         activePage: data.activePage || 1,
         pageCount: data.pageCount,
         scriptSwitchId: data.variantTopicId,


### PR DESCRIPTION
Resolves [WSTEAMA-68](https://jira.dev.bbc.co.uk/browse/WSTEAMA-68)

**Overall change:**
We have made a breaking change to the FABL response object - simorgh-bff now returns an array of curations that each contain their own array of promo summaries. Previously, we only returned an array of summaries from the first curation.

Supporting both until the FABL PR is merged and we can drop support for the array of summaries.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
