### PR TITLE
Revert "[WSTEAM1-55] - Article page `allowAdvertising` flag (#10150)"

### DIFF
--- a/data/kyrgyz/articles/c88ld5g4xxxo.json
+++ b/data/kyrgyz/articles/c88ld5g4xxxo.json
@@ -314,8 +314,7 @@
         "types": ["tagging:TagConcept", "core:Thing", "core:Theme"],
         "home": "http://www.bbc.co.uk/ontologies/passport/home/Kyrgyz"
       }
-    ],
-    "allowAdvertising": true
+    ]
   },
   "content": {
     "model": {

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -6,6 +6,7 @@ import last from 'ramda/src/last';
 import styled from '@emotion/styled';
 import { string, node } from 'prop-types';
 import useToggle from '#hooks/useToggle';
+import isLive from '#lib/utilities/isLive';
 
 import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
@@ -120,11 +121,10 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const { enabled: preloadLeadImageToggle } = useToggle('preloadLeadImage');
   const { enabled: adsEnabled } = useToggle('ads');
 
-  const isAdsEnabled = [
-    path(['metadata', 'allowAdvertising'], pageData),
-    adsEnabled,
-    showAdsBasedOnLocation,
-  ].every(Boolean);
+  /* TODO: Remove `isLive` and replace with `allowAdvertisng` or similar when available in Ares */
+  const isAdsEnabled = [!isLive(), adsEnabled, showAdsBasedOnLocation].every(
+    Boolean,
+  );
 
   const adcampaign = path(['metadata', 'adCampaignKeyword'], pageData);
 

--- a/src/app/pages/ArticlePage/fixtureData.js
+++ b/src/app/pages/ArticlePage/fixtureData.js
@@ -15,7 +15,6 @@ const articleDataBuilder = (
   promoHeadline,
   summary,
   things,
-  allowAdvertising = false,
 ) => ({
   metadata: {
     id: `urn:bbc:ares::article:${id}`,
@@ -38,7 +37,6 @@ const articleDataBuilder = (
       genre: null,
     },
     tags: things,
-    allowAdvertising,
   },
   content: {
     model: {
@@ -146,18 +144,4 @@ export const articleDataPidgin = articleDataBuilder(
   'Article Headline for Promo in Pidgin',
   'Article summary in Pidgin',
   emptyThings,
-);
-
-export const articleDataPidginWithAds = articleDataBuilder(
-  'cwl08rd38l6o',
-  'Pidgin',
-  'pcm',
-  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
-  'Article Headline in Pidgin',
-  'A paragraph in Pidgin.',
-  'Article Headline for SEO in Pidgin',
-  'Article Headline for Promo in Pidgin',
-  'Article summary in Pidgin',
-  emptyThings,
-  true,
 );

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.js
@@ -3,6 +3,7 @@ import splitAt from 'ramda/src/splitAt';
 import flatten from 'ramda/src/flatten';
 import clone from 'ramda/src/clone';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+import isLive from '#app/lib/utilities/isLive';
 
 const mpuBlock = {
   type: 'mpu',
@@ -88,10 +89,11 @@ export const insertMpuBlock = (blocks, insertIndex) => {
 };
 
 const addMpuBlock = json => {
-  const { allowAdvertising } = path(['metadata'], json);
+  // const { allowAdvertising } = path(['metadata', 'options'], json);
   const pageType = path(['metadata', 'type'], json);
 
-  if (!allowAdvertising || pageType !== ARTICLE_PAGE) return json;
+  /* TODO: Remove `isLive` and replace with `allowAdvertisng` or similar when available in Ares */
+  if (isLive() || pageType !== ARTICLE_PAGE) return json;
 
   const pageData = clone(json);
 

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
@@ -4,7 +4,9 @@ import addMpuBlock, { insertMpuBlock } from '.';
 const styInput = {
   metadata: {
     type: 'article',
-    allowAdvertising: true,
+    options: {
+      allowAdvertising: true,
+    },
     locators: {
       assetUri: '/news/media-333256',
     },
@@ -137,7 +139,9 @@ describe('addMpuBlock', () => {
     const expected = {
       metadata: {
         type: 'article',
-        allowAdvertising: true,
+        options: {
+          allowAdvertising: true,
+        },
         locators: {
           assetUri: '/news/media-333256',
         },
@@ -266,23 +270,16 @@ describe('addMpuBlock', () => {
     expect(addMpuBlock(input)).toEqual(expected);
   });
 
+  it('should return input if `isLive` is true', async () => {
+    const input = clone(styInput);
+    process.env.SIMORGH_APP_ENV = 'live';
+
+    expect(addMpuBlock(input)).toEqual(input);
+  });
+
   it('should return input if page type is not Article', async () => {
     const input = clone(styInput);
     input.metadata.type = 'STY';
-
-    expect(addMpuBlock(input)).toEqual(input);
-  });
-
-  it('should return input if "allowAdvertising" is "false"', async () => {
-    const input = clone(styInput);
-    input.metadata.allowAdvertising = false;
-
-    expect(addMpuBlock(input)).toEqual(input);
-  });
-
-  it('should return input if "allowAdvertising" is "undefined"', async () => {
-    const input = clone(styInput);
-    delete input.metadata.allowAdvertising;
 
     expect(addMpuBlock(input)).toEqual(input);
   });
@@ -482,7 +479,9 @@ describe('addMpuBlock', () => {
     const pageData = {
       metadata: {
         type: 'article',
-        allowAdvertising: true,
+        options: {
+          allowAdvertising: true,
+        },
         locators: {
           assetUri: '/news/media-333256',
         },
@@ -501,7 +500,9 @@ describe('addMpuBlock', () => {
     const pageData = {
       metadata: {
         type: 'article',
-        allowAdvertising: true,
+        options: {
+          allowAdvertising: true,
+        },
         locators: {
           assetUri: '/news/media-333256',
         },


### PR DESCRIPTION
**Overall change:**
Reverts the Optimo adverts on Live so that they can be tested fully by editorial and GNL

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
