### PR TITLE
[WSTEAMA-29] Put topic ads live

### DIFF
--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -17,7 +17,6 @@ import CanonicalAdBootstrapJs from '#containers/Ad/Canonical/CanonicalAdBootstra
 import useToggle from '#hooks/useToggle';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#contexts/RequestContext';
-import isLive from '#lib/utilities/isLive';
 import TopicTitle from './TopicTitle';
 import TopicGrid from './TopicGrid';
 import Pagination from './Pagination';
@@ -38,9 +37,6 @@ const TopicPage = ({ pageData }) => {
 
   const { enabled: adsEnabled } = useToggle('ads');
   const { showAdsBasedOnLocation } = useContext(RequestContext);
-  const showAds = [!isLive(), adsEnabled, showAdsBasedOnLocation].every(
-    Boolean,
-  );
 
   const promoEntities = promos.map(promo => ({
     '@type': 'Article',
@@ -65,36 +61,43 @@ const TopicPage = ({ pageData }) => {
   const pageTitle = `${title}, ${translatedPage}`;
 
   return (
-    <Wrapper role="main">
-      {showAds && <CanonicalAdBootstrapJs />}
-      <ATIAnalytics data={pageData} />
-      <ChartbeatAnalytics data={pageData} />
-      <MetadataContainer
-        title={activePage >= 2 ? pageTitle : title}
-        socialHeadline={title}
-        lang={lang}
-        description={description}
-        openGraphType="website"
-        hasAmpPage={false}
-      />
-      <LinkedData
-        type="CollectionPage"
-        seoTitle={title}
-        headline={title}
-        entities={promoEntities}
-      />
-      {showAds && <AdContainer slotType="leaderboard" />}
-      <TopicTitle>{title}</TopicTitle>
-      <TopicGrid promos={promos} />
-      <Pagination
-        activePage={activePage}
-        pageCount={pageCount}
-        pageXOfY={pageXOfY}
-        previousPage={previousPage}
-        nextPage={nextPage}
-        page={page}
-      />
-    </Wrapper>
+    <>
+      {adsEnabled && showAdsBasedOnLocation && (
+        <>
+          <CanonicalAdBootstrapJs />
+          <AdContainer slotType="leaderboard" />
+        </>
+      )}
+      <Wrapper role="main">
+        <ATIAnalytics data={pageData} />
+        <ChartbeatAnalytics data={pageData} />
+        <MetadataContainer
+          title={activePage >= 2 ? pageTitle : title}
+          socialHeadline={title}
+          lang={lang}
+          description={description}
+          openGraphType="website"
+          hasAmpPage={false}
+        />
+        <LinkedData
+          type="CollectionPage"
+          seoTitle={title}
+          headline={title}
+          entities={promoEntities}
+        />
+
+        <TopicTitle>{title}</TopicTitle>
+        <TopicGrid promos={promos} />
+        <Pagination
+          activePage={activePage}
+          pageCount={pageCount}
+          pageXOfY={pageXOfY}
+          previousPage={previousPage}
+          nextPage={nextPage}
+          page={page}
+        />
+      </Wrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAMA-29

**Overall change:**
_Putting topic ads live, and moving the leaderboard out of the wrapper so it extends the full width of the page._

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
