### PR TITLE
Render error page for page errors

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -216,7 +216,6 @@ server.get(
           url,
           variant,
         });
-        res.status(status).send(result.html);
       }
 
       logger.info(ROUTING_INFORMATION, {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -167,7 +167,7 @@ server.get(
       data.timeOnServer = Date.now();
       data.showAdsBasedOnLocation = headers['bbc-adverts'] === 'true';
 
-      const { status } = data;
+      let { status } = data;
       // Set derivedPageType based on returned page data
       if (status === OK) {
         derivedPageType = ramdaPath(['pageData', 'metadata', 'type'], data);
@@ -193,15 +193,16 @@ server.get(
           variant,
         });
       } catch ({ message }) {
+        status = 500;
         sendCustomMetric({
           metricName: NON_200_RESPONSE,
-          statusCode: 500,
+          statusCode: status,
           pageType: derivedPageType,
           requestUrl: url,
         });
 
         logger.error(SERVER_SIDE_REQUEST_FAILED, {
-          status: 500,
+          status,
           message,
           url,
           headers,
@@ -209,7 +210,7 @@ server.get(
 
         result = await renderDocument({
           bbcOrigin,
-          data: { error: true, status: 500 },
+          data: { error: true, status },
           isAmp,
           routes,
           service,

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -251,7 +251,6 @@ server.get(
         headers,
       });
 
-      // Return an internal server error for any uncaught errors
       res.status(500).send(message);
     }
   },

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -192,16 +192,31 @@ server.get(
           url,
           variant,
         });
-      } catch {
+      } catch ({ message }) {
+        sendCustomMetric({
+          metricName: NON_200_RESPONSE,
+          statusCode: 500,
+          pageType: derivedPageType,
+          requestUrl: url,
+        });
+
+        logger.error(SERVER_SIDE_REQUEST_FAILED, {
+          status: 500,
+          message,
+          url,
+          headers,
+        });
+
         result = await renderDocument({
           bbcOrigin,
-          data: { error: true },
+          data: { error: true, status: 500 },
           isAmp,
           routes,
           service,
           url,
           variant,
         });
+        res.status(status).send(result.html);
       }
 
       logger.info(ROUTING_INFORMATION, {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -181,15 +181,28 @@ server.get(
       }
 
       const bbcOrigin = headers['bbc-origin'];
-      const result = await renderDocument({
-        bbcOrigin,
-        data,
-        isAmp,
-        routes,
-        service,
-        url,
-        variant,
-      });
+      let result;
+      try {
+        result = await renderDocument({
+          bbcOrigin,
+          data,
+          isAmp,
+          routes,
+          service,
+          url,
+          variant,
+        });
+      } catch {
+        result = await renderDocument({
+          bbcOrigin,
+          data: { error: true },
+          isAmp,
+          routes,
+          service,
+          url,
+          variant,
+        });
+      }
 
       logger.info(ROUTING_INFORMATION, {
         url,


### PR DESCRIPTION
Resolves [WSTEAMA-104](https://jira.dev.bbc.co.uk/browse/WSTEAMA-104)

**Overall change:**
If renderDocument throws an error, call again with error set to true and status set to 500. This returns the error page to the user.

Currently, any error thrown results in the error message being shown to the user, as per this line - https://github.com/bbc/simorgh/blob/latest/src/server/index.jsx#L227

**Code changes:**

- Wrap renderDocument in a try catch block. Log error and call renderDocument again, this time with status set to 500 and error set to true. Our withError page handler then returns our ErrorPage component.
- Remove unnecessary comment

Long term, we'd like to:

- Refactor `getRouteProps` so that it can be moved outside the try block, thus allowing us to access `service` within the existing catch block. This in turn would allow us to remove the nested try catch statement added in this PR and move the second call to `renderDocument` to the existing catch block.
- Create a `renderErrorPage` function that can be called from the existing catch in place of the second call to `renderDocument`. This would require refactoring server/Document.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
