### PR TITLE
[WSTEAM1-99] - Enable Optimo article adverts on Live

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -6,7 +6,6 @@ import last from 'ramda/src/last';
 import styled from '@emotion/styled';
 import { string, node } from 'prop-types';
 import useToggle from '#hooks/useToggle';
-import isLive from '#lib/utilities/isLive';
 
 import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
@@ -122,7 +121,6 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const { enabled: adsEnabled } = useToggle('ads');
 
   const isAdsEnabled = [
-    !isLive(), // TODO: Remove `isLive` when editorial are happy with the ads display
     path(['metadata', 'allowAdvertising'], pageData),
     adsEnabled,
     showAdsBasedOnLocation,

--- a/src/app/pages/ArticlePage/fixtureData.js
+++ b/src/app/pages/ArticlePage/fixtureData.js
@@ -15,6 +15,7 @@ const articleDataBuilder = (
   promoHeadline,
   summary,
   things,
+  allowAdvertising = false,
 ) => ({
   metadata: {
     id: `urn:bbc:ares::article:${id}`,
@@ -37,6 +38,7 @@ const articleDataBuilder = (
       genre: null,
     },
     tags: things,
+    allowAdvertising,
   },
   content: {
     model: {
@@ -144,4 +146,18 @@ export const articleDataPidgin = articleDataBuilder(
   'Article Headline for Promo in Pidgin',
   'Article summary in Pidgin',
   emptyThings,
+);
+
+export const articleDataPidginWithAds = articleDataBuilder(
+  'cwl08rd38l6o',
+  'Pidgin',
+  'pcm',
+  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
+  'Article Headline in Pidgin',
+  'A paragraph in Pidgin.',
+  'Article Headline for SEO in Pidgin',
+  'Article Headline for Promo in Pidgin',
+  'Article summary in Pidgin',
+  emptyThings,
+  true,
 );

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -1,4 +1,6 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { render, waitFor } from '@testing-library/react';
 import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { RequestContextProvider } from '#contexts/RequestContext';
@@ -8,6 +10,7 @@ import {
   articleDataNews,
   articleDataPersian,
   articleDataPidgin,
+  articleDataPidginWithAds,
 } from '#pages/ArticlePage/fixtureData';
 import newsMostReadData from '#data/news/mostRead';
 import persianMostReadData from '#data/persian/mostRead';
@@ -20,10 +23,6 @@ import {
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import ArticlePage from './ArticlePage';
 
-// temporary: will be removed with https://github.com/bbc/simorgh/issues/836
-const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
-articleDataNewsNoHeadline.content.model.blocks.shift();
-
 jest.mock('#containers/ChartbeatAnalytics', () => {
   const ChartbeatAnalytics = () => <div>chartbeat</div>;
   return ChartbeatAnalytics;
@@ -34,10 +33,24 @@ jest.mock('#containers/OptimizelyPageViewTracking', () => {
   return OptimizelyPageViewTracking;
 });
 
-// eslint-disable-next-line react/prop-types
-const Context = ({ service, children }) => (
-  <ToggleContextProvider>
-    <ServiceContextProvider service={service}>
+const Context = ({
+  service = 'pidgin',
+  children,
+  adsToggledOn = false,
+  mostReadToggledOn = true,
+  showAdsBasedOnLocation = false,
+} = {}) => (
+  <BrowserRouter>
+    <ToggleContextProvider
+      toggles={{
+        mostRead: {
+          enabled: mostReadToggledOn,
+        },
+        ads: {
+          enabled: adsToggledOn,
+        },
+      }}
+    >
       <RequestContextProvider
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
@@ -46,11 +59,14 @@ const Context = ({ service, children }) => (
         pathname="/pathname"
         service={service}
         statusCode={200}
+        showAdsBasedOnLocation={showAdsBasedOnLocation}
       >
-        {children}
+        <ServiceContextProvider service={service}>
+          {children}
+        </ServiceContextProvider>
       </RequestContextProvider>
-    </ServiceContextProvider>
-  </ToggleContextProvider>
+    </ToggleContextProvider>
+  </BrowserRouter>
 );
 
 beforeEach(() => {
@@ -208,6 +224,7 @@ it('should render a rtl article (persian) with most read correctly', async () =>
   );
 
   await waitFor(() => container.querySelector('#Most-Read'));
+
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();
@@ -224,6 +241,7 @@ it('should render a ltr article (pidgin) with most read correctly', async () => 
   );
 
   await waitFor(() => container.querySelector('#Most-Read'));
+
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();
@@ -319,4 +337,31 @@ it('should render the top stories and features when passed', async () => {
 
   expect(getByTestId('top-stories')).toBeInTheDocument();
   expect(getByTestId('features')).toBeInTheDocument();
+});
+
+it('should show ads when enabled', async () => {
+  [
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ].forEach(([adsToggledOn, showAdsBasedOnLocation]) => {
+    const { container } = render(
+      <Context
+        service="pidgin"
+        adsToggledOn={adsToggledOn}
+        showAdsBasedOnLocation={showAdsBasedOnLocation}
+      >
+        <ArticlePage pageData={articleDataPidginWithAds} />
+      </Context>,
+    );
+
+    const shouldShowAds = adsToggledOn && showAdsBasedOnLocation;
+    const adElement = container.querySelector('[data-e2e="advertisement"]');
+    if (shouldShowAds) {
+      expect(adElement).toBeInTheDocument();
+    } else {
+      expect(adElement).not.toBeInTheDocument();
+    }
+  });
 });

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.js
@@ -3,7 +3,6 @@ import splitAt from 'ramda/src/splitAt';
 import flatten from 'ramda/src/flatten';
 import clone from 'ramda/src/clone';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
-import isLive from '#app/lib/utilities/isLive';
 
 const mpuBlock = {
   type: 'mpu',
@@ -92,9 +91,7 @@ const addMpuBlock = json => {
   const { allowAdvertising } = path(['metadata'], json);
   const pageType = path(['metadata', 'type'], json);
 
-  /* TODO: Remove `isLive` checks when editorial are happy with the ads display */
-  if (isLive() || (!isLive() && !allowAdvertising) || pageType !== ARTICLE_PAGE)
-    return json;
+  if (!allowAdvertising || pageType !== ARTICLE_PAGE) return json;
 
   const pageData = clone(json);
 

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
@@ -266,32 +266,23 @@ describe('addMpuBlock', () => {
     expect(addMpuBlock(input)).toEqual(expected);
   });
 
-  it('should return input if `isLive` is true', async () => {
+  it('should return input if page type is not Article', async () => {
     const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'live';
+    input.metadata.type = 'STY';
 
     expect(addMpuBlock(input)).toEqual(input);
   });
 
-  it('should return input if `isLive` is true and `allowAdvertising` is true', async () => {
+  it('should return input if "allowAdvertising" is "false"', async () => {
     const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'live';
-    input.metadata.allowAdvertising = true;
-
-    expect(addMpuBlock(input)).toEqual(input);
-  });
-
-  it('should return input if `isLive` is false and `allowAdvertising` is false', async () => {
-    const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'test';
     input.metadata.allowAdvertising = false;
 
     expect(addMpuBlock(input)).toEqual(input);
   });
 
-  it('should return input if page type is not Article', async () => {
+  it('should return input if "allowAdvertising" is "undefined"', async () => {
     const input = clone(styInput);
-    input.metadata.type = 'STY';
+    delete input.metadata.allowAdvertising;
 
     expect(addMpuBlock(input)).toEqual(input);
   });


### PR DESCRIPTION
Resolves WSTEAM1-99

**Overall change:**
Enables adverts on Optimo article pages on Live. This change was implemented previously in https://github.com/bbc/simorgh/pull/10150, so this is more or less a revert of that PR.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
