### PR TITLE
Remove divider between nav and banner

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -432,13 +432,6 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 .emotion-31 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-31 {
-    border-top: none;
-  }
 }
 
 .emotion-31::after {

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -417,13 +417,6 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 .emotion-29 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-29 {
-    border-top: none;
-  }
 }
 
 .emotion-29::after {
@@ -1542,13 +1535,6 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 .emotion-29 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-29 {
-    border-top: none;
-  }
 }
 
 .emotion-29::after {
@@ -2667,13 +2653,6 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 .emotion-29 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-29 {
-    border-top: none;
-  }
 }
 
 .emotion-29::after {

--- a/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
@@ -4,18 +4,11 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
   .emotion-0.si-nav-open {
     background-color: #222222;
-  }
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
   }
 }
 

--- a/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
@@ -4,13 +4,6 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {

--- a/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -4,18 +4,11 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
   .emotion-0.si-nav-open {
     background-color: #222222;
-  }
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
   }
 }
 
@@ -801,18 +794,11 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
   .emotion-0.si-nav-open {
     background-color: #222222;
-  }
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
   }
 }
 
@@ -1508,18 +1494,11 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
   .emotion-0.si-nav-open {
     background-color: #222222;
-  }
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
   }
 }
 
@@ -2215,13 +2194,6 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {
@@ -2986,13 +2958,6 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {
@@ -3667,13 +3632,6 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {

--- a/src/app/legacy/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -4,13 +4,6 @@ exports[`Navigation should render correctly 1`] = `
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {
@@ -287,18 +280,11 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
 .emotion-0 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
   .emotion-0.is-open {
     background-color: #222222;
-  }
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
   }
 }
 
@@ -576,13 +562,6 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
 .emotion-0 {
   position: relative;
   background-color: #222222;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-0 {
-    border-top: none;
-  }
 }
 
 .emotion-0::after {
@@ -898,13 +877,6 @@ exports[`Scrollable Navigation should render correctly 1`] = `
 .emotion-2 {
   position: relative;
   background-color: #FFFFFF;
-  border-top: 0.0625rem solid #FFFFFF;
-}
-
-@media (max-width: 25rem) {
-  .emotion-2 {
-    border-top: none;
-  }
 }
 
 .emotion-2::after {

--- a/src/app/legacy/psammead-navigation/src/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/index.jsx
@@ -260,10 +260,7 @@ const StyledNav = styled.nav`
         }
       }
     `}
-    border-top: 0.0625rem solid ${C_WHITE};
-  @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) {
-    border-top: none;
-  }
+  
 
   &::after {
     content: '';

--- a/src/app/legacy/psammead-navigation/src/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/index.jsx
@@ -16,7 +16,6 @@ import {
 } from '#legacy/gel-foundations/src/spacings';
 import {
   GEL_GROUP_2_SCREEN_WIDTH_MAX,
-  GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_3_SCREEN_WIDTH_MIN,
   GEL_GROUP_5_SCREEN_WIDTH_MIN,
 } from '#legacy/gel-foundations/src/breakpoints';


### PR DESCRIPTION


**Overall change:**
Removes white divider between nav and banner at all breakpoints.
to fully meet designs here https://zpl.io/3XkPxK1  

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
