### PR TITLE
Hide script switch button if there is no variant page

### DIFF
--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -31,6 +31,7 @@ const PageWrapper = ({ children, pageData, status }) => {
 
   const isDarkMode = pathOr(false, ['darkMode'], pageData);
   const scriptSwitchId = pathOr('', ['scriptSwitchId'], pageData);
+  const renderScriptSwitch = pathOr(true, ['renderScriptSwitch'], pageData);
   const isErrorPage = [404, 500].includes(status);
   const pageType = isErrorPage
     ? 'WS-ERROR-PAGE'
@@ -43,7 +44,10 @@ const PageWrapper = ({ children, pageData, status }) => {
       <ManifestContainer />
       <WebVitals pageType={pageType} />
       <Wrapper id="main-wrapper" darkMode={isDarkMode}>
-        <HeaderContainer scriptSwitchId={scriptSwitchId} />
+        <HeaderContainer
+          scriptSwitchId={scriptSwitchId}
+          renderScriptSwitch={renderScriptSwitch}
+        />
         <Content>{children}</Content>
         <FooterContainer />
       </Wrapper>

--- a/src/app/containers/Header/index.jsx
+++ b/src/app/containers/Header/index.jsx
@@ -3,7 +3,7 @@ import SkipLink from '#legacy/psammead-brand/src/SkipLink';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { RequestContext } from '#contexts/RequestContext';
 import useToggle from '#hooks/useToggle';
-import { string } from 'prop-types';
+import { string, bool } from 'prop-types';
 import useOperaMiniDetection from '#hooks/useOperaMiniDetection';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import ScriptLink from './ScriptLink';
@@ -91,10 +91,12 @@ const HeaderContainer = ({ scriptSwitchId, renderScriptSwitch }) => {
 
 HeaderContainer.propTypes = {
   scriptSwitchId: string,
+  renderScriptSwitch: bool,
 };
 
 HeaderContainer.defaultProps = {
   scriptSwitchId: '',
+  renderScriptSwitch: true,
 };
 
 export default HeaderContainer;

--- a/src/app/containers/Header/index.jsx
+++ b/src/app/containers/Header/index.jsx
@@ -28,7 +28,7 @@ const Header = ({ brandRef, borderBottom, skipLink, scriptLink, linkId }) => {
   );
 };
 
-const HeaderContainer = ({ scriptSwitchId }) => {
+const HeaderContainer = ({ scriptSwitchId, renderScriptSwitch }) => {
   const { pageType, isAmp } = useContext(RequestContext);
   const { service, script, translations, dir, scriptLink, lang, serviceLang } =
     useContext(ServiceContext);
@@ -59,6 +59,8 @@ const HeaderContainer = ({ scriptSwitchId }) => {
     </SkipLink>
   );
 
+  const shouldRenderScriptSwitch = scriptLink && renderScriptSwitch;
+
   return (
     <header role="banner" lang={serviceLang}>
       {isAmp ? (
@@ -66,7 +68,9 @@ const HeaderContainer = ({ scriptSwitchId }) => {
           linkId="brandLink"
           skipLink={skipLink}
           scriptLink={
-            scriptLink && <ScriptLink scriptSwitchId={scriptSwitchId} />
+            shouldRenderScriptSwitch && (
+              <ScriptLink scriptSwitchId={scriptSwitchId} />
+            )
           }
         />
       ) : (
@@ -74,7 +78,9 @@ const HeaderContainer = ({ scriptSwitchId }) => {
           brandRef={brandRef}
           skipLink={skipLink}
           scriptLink={
-            scriptLink && <ScriptLink scriptSwitchId={scriptSwitchId} />
+            shouldRenderScriptSwitch && (
+              <ScriptLink scriptSwitchId={scriptSwitchId} />
+            )
           }
         />
       )}

--- a/src/app/containers/Header/index.test.jsx
+++ b/src/app/containers/Header/index.test.jsx
@@ -14,6 +14,7 @@ import {
   FRONT_PAGE,
   MEDIA_PAGE,
   MEDIA_ASSET_PAGE,
+  TOPIC_PAGE,
 } from '#app/routes/utils/pageTypes';
 import { shouldMatchSnapshot } from '#legacy/psammead-test-helpers/src';
 import HeaderContainer from './index';
@@ -40,6 +41,7 @@ const HeaderContainerWithContext = ({
   bbcOrigin = 'https://www.test.bbc.com',
   variant = 'default',
   isAmp = false,
+  renderScriptSwitch = true,
 }) => (
   <ToggleContext.Provider
     value={{
@@ -58,7 +60,7 @@ const HeaderContainerWithContext = ({
         variant={variant}
       >
         <UserContextProvider>
-          <HeaderContainer />
+          <HeaderContainer renderScriptSwitch={renderScriptSwitch} />
         </UserContextProvider>
       </RequestContextProvider>
     </ServiceContext.Provider>
@@ -139,6 +141,23 @@ describe(`Header`, () => {
       );
 
       expect(container.querySelectorAll(scriptLinkSelector).length).toBe(1);
+    });
+
+    it('should not render script link on Topic page when missing variant topic ID', () => {
+      const { container } = render(
+        HeaderContainerWithContext({
+          pageType: TOPIC_PAGE,
+          service: 'serbian',
+          serviceContext: serbianServiceConfig,
+          variant: 'cyr',
+          renderScriptSwitch: false,
+        }),
+        {
+          wrapper: MemoryRouter,
+        },
+      );
+
+      expect(container.querySelectorAll(scriptLinkSelector).length).toBe(0);
     });
 
     it('should render header with lang when serviceLang is defined', () => {

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -41,7 +41,6 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
       : data.summaries;
 
     const scriptSwitchId = data.variantTopicId;
-    const renderScriptSwitch = Boolean(scriptSwitchId);
 
     return {
       status,
@@ -52,7 +51,7 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
         activePage: data.activePage || 1,
         pageCount: data.pageCount,
         scriptSwitchId,
-        renderScriptSwitch,
+        renderScriptSwitch: Boolean(scriptSwitchId),
         metadata: {
           type: 'Topic',
         },

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -41,7 +41,7 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
       : data.summaries;
 
     const scriptSwitchId = data.variantTopicId;
-    const renderScriptSwitch = !!scriptSwitchId;
+    const renderScriptSwitch = Boolean(scriptSwitchId);
 
     return {
       status,

--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -40,6 +40,9 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
       ? data.curations[0].summaries
       : data.summaries;
 
+    const scriptSwitchId = data.variantTopicId;
+    const renderScriptSwitch = !!scriptSwitchId;
+
     return {
       status,
       pageData: {
@@ -48,7 +51,8 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
         promos,
         activePage: data.activePage || 1,
         pageCount: data.pageCount,
-        scriptSwitchId: data.variantTopicId,
+        scriptSwitchId,
+        renderScriptSwitch,
         metadata: {
           type: 'Topic',
         },


### PR DESCRIPTION
Resolves [WSTEAMA-94](https://jira.dev.bbc.co.uk/browse/WSTEAMA-94)

**Overall change:**
Do not show the script switch button on a Topic page when there is no variant page. Currently the link returns a 500. The ticket says to return a 404 but hiding the button is more appropriate.

**Code changes:**

- Add new boolean `renderScriptSwitch` to Topic `pageData` object, based on value of `variantTopicId`
- Pass `renderScriptSwitch` to HeaderContainer component

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Testing on local Simorgh:
/zhongwen/simp/topics/c0dg90z8nqxt should not show the script switch button as there is not a trad asset
/serbian/cyr/topics/c7zp707dy8yt should show the script switch button
