### PR TITLE
Add dir conditional to padding

### DIFF
--- a/src/app/components/Promo/index.jsx
+++ b/src/app/components/Promo/index.jsx
@@ -4,6 +4,7 @@ import { arrayOf, element } from 'prop-types';
 import partition from 'ramda/src/partition';
 
 import { GEL_GROUP_2_SCREEN_WIDTH_MAX } from '#legacy/gel-foundations/src/breakpoints';
+import { GEL_SPACING } from '#legacy/gel-foundations/src/spacings';
 
 import { ServiceContext } from '#contexts/ServiceContext';
 
@@ -36,7 +37,10 @@ const Left = styled.div`
 `;
 const Right = styled.div`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    padding-left: 0.5rem;
+    ${({ dir }) =>
+      dir === 'ltr'
+        ? `padding-left: ${GEL_SPACING}`
+        : `padding-right: ${GEL_SPACING};`}
     width: 67%;
     display: inline-block;
     vertical-align: top;
@@ -44,7 +48,7 @@ const Right = styled.div`
 `;
 
 const Promo = ({ children }) => {
-  const { script, service } = useContext(ServiceContext);
+  const { script, service, dir } = useContext(ServiceContext);
 
   // Image components are moved to a left column on mobile
   const [leftChildren, rightChildren] = partition(
@@ -55,7 +59,7 @@ const Promo = ({ children }) => {
     <Wrapper>
       <PromoContext.Provider value={{ script, service }}>
         {leftChildren && <Left>{leftChildren}</Left>}
-        {rightChildren && <Right>{rightChildren}</Right>}
+        {rightChildren && <Right dir={dir}>{rightChildren}</Right>}
       </PromoContext.Provider>
     </Wrapper>
   );

--- a/src/app/components/Promo/index.jsx
+++ b/src/app/components/Promo/index.jsx
@@ -37,10 +37,7 @@ const Left = styled.div`
 `;
 const Right = styled.div`
   @media (max-width: ${GEL_GROUP_2_SCREEN_WIDTH_MAX}) {
-    ${({ dir }) =>
-      dir === 'ltr'
-        ? `padding-left: ${GEL_SPACING}`
-        : `padding-right: ${GEL_SPACING};`}
+    padding-inline-start: ${GEL_SPACING};
     width: 67%;
     display: inline-block;
     vertical-align: top;
@@ -48,7 +45,7 @@ const Right = styled.div`
 `;
 
 const Promo = ({ children }) => {
-  const { script, service, dir } = useContext(ServiceContext);
+  const { script, service } = useContext(ServiceContext);
 
   // Image components are moved to a left column on mobile
   const [leftChildren, rightChildren] = partition(
@@ -59,7 +56,7 @@ const Promo = ({ children }) => {
     <Wrapper>
       <PromoContext.Provider value={{ script, service }}>
         {leftChildren && <Left>{leftChildren}</Left>}
-        {rightChildren && <Right dir={dir}>{rightChildren}</Right>}
+        {rightChildren && <Right>{rightChildren}</Right>}
       </PromoContext.Provider>
     </Wrapper>
   );


### PR DESCRIPTION
Resolves WSTEAMA-78

**Overall change:**
Replaces padding with inline padding so that a space is in between image and text on rtl topics.

**Code changes:**

- Uses padding-inline-start to add padding to left or right of text in a promo
- Add gel spacings

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
