### PR TITLE
Increase link touch size on dropdown menu

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -678,12 +678,11 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 .emotion-95 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-95:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -696,6 +695,8 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -663,12 +663,11 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 .emotion-81 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -681,6 +680,8 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1781,12 +1782,11 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 .emotion-81 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -1799,6 +1799,8 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2899,12 +2901,11 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 .emotion-81 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -2917,6 +2918,8 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -120,12 +120,11 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 }
 
 .emotion-16 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -138,6 +137,8 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -910,12 +911,11 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 }
 
 .emotion-16 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -928,6 +928,8 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1610,12 +1612,11 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 }
 
 .emotion-16 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -1628,6 +1629,8 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2516,12 +2519,11 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 }
 
 .emotion-68 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-68:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -2534,6 +2536,8 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -3215,12 +3219,11 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 .emotion-64 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -3233,6 +3236,8 @@ exports[`Navigation Container should correctly render canonical navigation on no
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -3889,12 +3894,11 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 .emotion-64 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -3907,6 +3911,8 @@ exports[`Navigation Container should correctly render canonical navigation on no
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/legacy/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -672,12 +672,11 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
 }
 
 .emotion-4 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -690,6 +689,8 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -931,12 +932,11 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
 }
 
 .emotion-4 {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4:last-child {
-  padding-bottom: 1rem;
+  padding-bottom: 0.25rem;
   border: 0;
 }
 
@@ -949,6 +949,8 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
   color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
+  padding: 0.75rem 0;
+  display: inline-block;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {

--- a/src/app/legacy/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -12,7 +12,7 @@ import {
 import {
   GEL_SPACING_HLF,
   GEL_SPACING,
-  GEL_SPACING_DBL,
+  GEL_SPACING_HLF_TRPL,
 } from '#legacy/gel-foundations/src/spacings';
 import { Helmet } from 'react-helmet';
 import {
@@ -97,11 +97,10 @@ DropdownUl.defaultProps = {
 };
 
 const StyledDropdownLi = styled.li`
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid ${C_GREY_3};
 
   &:last-child {
-    padding-bottom: ${GEL_SPACING_DBL};
+    padding-bottom: ${GEL_SPACING_HLF};
     border: 0;
   }
 `;
@@ -111,6 +110,8 @@ const StyledDropdownLink = styled.a`
   ${({ service }) => service && getSansRegular(service)}
   color: ${C_GREY_10};
   text-decoration: none;
+  padding: ${GEL_SPACING_HLF_TRPL} 0;
+  display: inline-block;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Resolves WSTEAMA-116

**Overall change:**
Moves padding into link to increase touch size

**Code changes:**

- Adds padding to a tag instead of li
- Adjust padding of last child to compensate for moving of padding into a tag

**Needs to be tested on:**

- [x] Android TalkBack
- [x] iPhone VoiceOver

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
