### PR TITLE
[NEWSWORLDSERVICE-1499] Redact sensitive HTTP headers from logs

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -40,9 +40,8 @@ logger.debug(
   `Application outputting logs to directory '${process.env.LOG_DIR}'`,
 );
 
-const removeSensitiveHeaders = omit(
-  (process.env.SENSITIVE_HTTP_HEADERS || '').split(','),
-);
+const removeSensitiveHeaders = headers =>
+  omit((process.env.SENSITIVE_HTTP_HEADERS || '').split(','), headers);
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["write"] }] */
 class LoggerStream {

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -1,6 +1,7 @@
 import express from 'express';
 import compression from 'compression';
 import ramdaPath from 'ramda/src/path';
+import omit from 'ramda/src/omit';
 // not part of react-helmet
 import helmet from 'helmet';
 import gnuTP from 'gnu-terry-pratchett';
@@ -37,6 +38,10 @@ const logger = nodeLogger(__filename);
 
 logger.debug(
   `Application outputting logs to directory '${process.env.LOG_DIR}'`,
+);
+
+const removeSensitiveHeaders = omit(
+  (process.env.SENSITIVE_HTTP_HEADERS || '').split(','),
 );
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["write"] }] */
@@ -133,7 +138,7 @@ server.get(
   async ({ url, query, headers, path: urlPath }, res) => {
     logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
       url,
-      headers,
+      headers: removeSensitiveHeaders(headers),
     });
 
     let derivedPageType = 'Unknown';
@@ -205,7 +210,7 @@ server.get(
           status,
           message,
           url,
-          headers,
+          headers: removeSensitiveHeaders(headers),
         });
 
         result = await renderDocument({
@@ -248,7 +253,7 @@ server.get(
         status,
         message,
         url,
-        headers,
+        headers: removeSensitiveHeaders(headers),
       });
 
       res.status(500).send(message);


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1499

**Overall change:**
_Remove HTTP headers from logging, based on a comma-separated list specified in a `SENSITIVE_HTTP_HEADERS environment variable._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
