### PR TITLE
Fix topic promos on storybook

### DIFF
--- a/src/app/components/Promo/media-icon.jsx
+++ b/src/app/components/Promo/media-icon.jsx
@@ -42,7 +42,7 @@ const MediaIcon = ({ script, service, children, type }) => {
   if (!type) return null;
   return (
     <Wrapper script={script} service={service}>
-      {mediaIcons[TYPES[type]]}
+      {mediaIcons[type]}
       {formatChildren(children)}
     </Wrapper>
   );
@@ -51,7 +51,7 @@ const MediaIcon = ({ script, service, children, type }) => {
 MediaIcon.propTypes = {
   script: shape(scriptPropType).isRequired,
   service: string.isRequired,
-  type: oneOf(Object.keys(TYPES)),
+  type: oneOf(Object.values(TYPES)),
   children: number,
 };
 

--- a/src/app/pages/TopicPage/TopicPromo/index.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.jsx
@@ -34,7 +34,7 @@ TopicPromo.propTypes = {
   imageAlt: string.isRequired,
   lazy: bool,
   link: string.isRequired,
-  mediaType: oneOf(Object.keys(MEDIA_TYPES)),
+  mediaType: oneOf(Object.values(MEDIA_TYPES)),
   mediaDuration: number,
 };
 

--- a/src/app/pages/TopicPage/TopicPromo/index.stories.jsx
+++ b/src/app/pages/TopicPage/TopicPromo/index.stories.jsx
@@ -1,14 +1,38 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import { withServicesKnob } from '#legacy/psammead-storybook-helpers/src';
 import { withKnobs } from '@storybook/addon-knobs';
+import fixture from '#data/pidgin/topics/c95y35941vrt.json';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
+import { MEDIA_TYPES } from '#components/Promo';
 import TopicPromo from '.';
+
+const Wrapper = styled.div`
+  max-width: 30rem;
+`;
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ service, variant }) => {
   return (
     <ServiceContextProvider service={service} variant={variant}>
-      <TopicPromo />
+      <Wrapper>
+        <TopicPromo {...fixture.data.summaries[0]} />
+      </Wrapper>
+    </ServiceContextProvider>
+  );
+};
+
+// eslint-disable-next-line react/prop-types
+const WithMediaIndicator = ({ service, variant }) => {
+  return (
+    <ServiceContextProvider service={service} variant={variant}>
+      <Wrapper>
+        <TopicPromo
+          {...fixture.data.summaries[0]}
+          mediaType={MEDIA_TYPES.VIDEO}
+          mediaDuration={123}
+        />
+      </Wrapper>
     </ServiceContextProvider>
   );
 };
@@ -21,3 +45,4 @@ export default {
 };
 
 export const Example = Component;
+export const Media = WithMediaIndicator;


### PR DESCRIPTION
Resolves [No Issue]

**Overall change:**
Fix a storybook exception on the topic promo story.

Also update the api around media icons, and add an example for media indicators on the promo.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
