### PR TITLE
Make /japanese report-only for CSP rules

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -409,7 +409,7 @@ const helmetCsp = ({ isAmp, isLive, reportOnlyOnLive }) => ({
 });
 
 const injectCspHeader = (req, res, next) => {
-  const { isAmp } = getRouteProps(req.url);
+  const { isAmp, service } = getRouteProps(req.url);
 
   res.setHeader(
     'report-to',
@@ -430,7 +430,7 @@ const injectCspHeader = (req, res, next) => {
     helmetCsp({
       isAmp,
       isLive: isLiveEnv(),
-      reportOnlyOnLive: req.url === '/japanese',
+      reportOnlyOnLive: service === 'japanese',
     }),
   );
   middleware(req, res, next);

--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -389,7 +389,7 @@ export const generatePrefetchSrc = ({ isAmp, isLive }) => {
   return directives.prefetchSrc.canonicalLive;
 };
 
-const helmetCsp = ({ isAmp, isLive }) => ({
+const helmetCsp = ({ isAmp, isLive, reportOnlyOnLive }) => ({
   directives: {
     'default-src': generateDefaultSrc(),
     'child-src': generateChildSrc({ isAmp }),
@@ -405,6 +405,7 @@ const helmetCsp = ({ isAmp, isLive }) => ({
     'report-to': 'worldsvc',
     'upgrade-insecure-requests': [],
   },
+  reportOnly: reportOnlyOnLive,
 });
 
 const injectCspHeader = (req, res, next) => {
@@ -425,7 +426,13 @@ const injectCspHeader = (req, res, next) => {
     }),
   );
 
-  const middleware = csp(helmetCsp({ isAmp, isLive: isLiveEnv() }));
+  const middleware = csp(
+    helmetCsp({
+      isAmp,
+      isLive: isLiveEnv(),
+      reportOnlyOnLive: req.url === '/japanese',
+    }),
+  );
   middleware(req, res, next);
 };
 


### PR DESCRIPTION
Resolves[ #GNADTECH-2760](https://jira.dev.bbc.co.uk/browse/GNADTECH-2760)

**Overall change:**
Make /japanese report-only for CSP rules


- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
