### PR TITLE
[WSTEAM1-86] Switch recommendations endpoint

### DIFF
--- a/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.js
+++ b/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.js
@@ -1,5 +1,5 @@
 export default ({ assetUri }) =>
-  `https://onward-journeys.api.bbci.co.uk/api/recommendations${assetUri}`;
+  `${process.env.RECOMMENDATIONS_ENDPOINT}/recommendations${assetUri}`;
 
 export const portugueseRecommendationsExperimentEndpoint = ({
   assetUri,

--- a/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.js
+++ b/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.js
@@ -1,7 +1,5 @@
-export default ({ assetUri, variant }) =>
-  variant
-    ? `${assetUri}/recommendations/${variant}`
-    : `${assetUri}/recommendations`;
+export default ({ assetUri }) =>
+  `https://onward-journeys.api.bbci.co.uk/api/recommendations${assetUri}`;
 
 export const portugueseRecommendationsExperimentEndpoint = ({
   assetUri,

--- a/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
+++ b/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
@@ -8,15 +8,6 @@ describe('getRecommendationsUrl', () => {
       'https://onward-journeys.api.bbci.co.uk/api/recommendations/mundo/123456',
     );
   });
-  it('should return endpoint when passed assetUri with a variant', () => {
-    expect(
-      getRecommendationsUrl({
-        assetUri: '/zhongwen/trad/123456',
-      }),
-    ).toBe(
-      'https://onward-journeys.api.bbci.co.uk/api/recommendations/zhongwen/trad/123456',
-    );
-  });
 
   describe('Optimizely Experiments', () => {
     describe('004_brasil_recommendations_experiment', () => {

--- a/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
+++ b/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
@@ -3,18 +3,19 @@ import getRecommendationsUrl, {
 } from '.';
 
 describe('getRecommendationsUrl', () => {
-  it('should return endpoint when passed service and assetUri', () => {
+  it('should return endpoint when passed assetUri', () => {
     expect(getRecommendationsUrl({ assetUri: '/mundo/123456' })).toBe(
-      '/mundo/123456/recommendations',
+      'https://onward-journeys.api.bbci.co.uk/api/recommendations/mundo/123456',
     );
   });
-  it('should return endpoint when passed service variant and assetUri', () => {
+  it('should return endpoint when passed assetUri with a variant', () => {
     expect(
       getRecommendationsUrl({
-        variant: 'trad',
-        assetUri: '/zhongwen/123456',
+        assetUri: '/zhongwen/trad/123456',
       }),
-    ).toBe('/zhongwen/123456/recommendations/trad');
+    ).toBe(
+      'https://onward-journeys.api.bbci.co.uk/api/recommendations/zhongwen/trad/123456',
+    );
   });
 
   describe('Optimizely Experiments', () => {

--- a/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
+++ b/src/app/lib/utilities/getUrlHelpers/getRecommendationsUrl/index.test.js
@@ -3,22 +3,20 @@ import getRecommendationsUrl, {
 } from '.';
 
 describe('getRecommendationsUrl', () => {
+  beforeEach(() => {
+    process.env.RECOMMENDATIONS_ENDPOINT = 'http://mock-recommendations-path';
+  });
+  afterEach(() => {
+    delete process.env.RECOMMENDATIONS_ENDPOINT;
+  });
   it('should return endpoint when passed assetUri', () => {
     expect(getRecommendationsUrl({ assetUri: '/mundo/123456' })).toBe(
-      'https://onward-journeys.api.bbci.co.uk/api/recommendations/mundo/123456',
+      'http://mock-recommendations-path/recommendations/mundo/123456',
     );
   });
 
   describe('Optimizely Experiments', () => {
     describe('004_brasil_recommendations_experiment', () => {
-      beforeEach(() => {
-        process.env.RECOMMENDATIONS_ENDPOINT =
-          'http://mock-recommendations-path';
-      });
-
-      afterEach(() => {
-        delete process.env.RECOMMENDATIONS_ENDPOINT;
-      });
       it('should return portuguese experimentation endpoint with engine', () => {
         expect(
           portugueseRecommendationsExperimentEndpoint({

--- a/src/app/pages/StoryPage/index.test.jsx
+++ b/src/app/pages/StoryPage/index.test.jsx
@@ -250,6 +250,7 @@ describe('Story Page', () => {
   const appEnv = process.env.SIMORGH_APP_ENV;
   beforeEach(() => {
     process.env.SIMORGH_ICHEF_BASE_URL = 'https://ichef.test.bbci.co.uk';
+    process.env.RECOMMENDATIONS_ENDPOINT = 'http://mock-recommendations-path';
     // 004_brasil_recommendations_experiment
     OptimizelyExperiment.mockImplementation(props => {
       const { children } = props;
@@ -1096,7 +1097,7 @@ describe('Story Page', () => {
               mundoPageData,
             );
             fetchMock.mock(
-              'http://localhost/mundo/noticias-56669604/recommendations.json',
+              'http://mock-recommendations-path/recommendations/mundo/noticias-56669604',
               mundoRecommendationsData,
             );
             const { pageData } = await getInitialData({
@@ -1140,7 +1141,7 @@ describe('Story Page', () => {
               mundoPageData,
             );
             fetchMock.mock(
-              'http://localhost/mundo/noticias-56669604/recommendations.json',
+              'http://mock-recommendations-path/recommendations/mundo/noticias-56669604',
               mundoRecommendationsData,
             );
             const { pageData } = await getInitialData({
@@ -1417,7 +1418,7 @@ describe('Story Page', () => {
               mundoPageData,
             );
             fetchMock.mock(
-              'http://localhost/mundo/noticias-56669604/recommendations.json',
+              'http://mock-recommendations-path/recommendations/mundo/noticias-56669604',
               mundoRecommendationsData,
             );
             const { pageData } = await getInitialData({
@@ -1479,7 +1480,7 @@ describe('Story Page', () => {
         };
 
         const recommendationsEndpoint =
-          'http://localhost/mundo/noticias-56669604/recommendations.json';
+          'http://mock-recommendations-path/recommendations/mundo/noticias-56669604';
 
         fetchMock.mock(
           'http://localhost/some-cps-sty-path.json',

--- a/src/app/pages/StoryPage/index.test.jsx
+++ b/src/app/pages/StoryPage/index.test.jsx
@@ -268,6 +268,7 @@ describe('Story Page', () => {
   afterEach(() => {
     fetchMock.restore();
     delete process.env.SIMORGH_ICHEF_BASE_URL;
+    delete process.env.RECOMMENDATIONS_ENDPOINT;
     process.env.SIMORGH_APP_ENV = appEnv;
   });
 
@@ -781,6 +782,7 @@ describe('Story Page', () => {
         process.env.RECOMMENDATIONS_ENDPOINT =
           'http://mock-recommendations-path';
       });
+
       afterEach(() => {
         delete process.env.RECOMMENDATIONS_ENDPOINT;
         jest.clearAllMocks();
@@ -805,6 +807,10 @@ describe('Story Page', () => {
 
             return null;
           });
+        });
+
+        afterEach(() => {
+          delete process.env.RECOMMENDATIONS_ENDPOINT;
         });
 
         it('should fetch and render recommendations from current endpoint when variation is control and service is portuguese', async () => {
@@ -867,6 +873,10 @@ describe('Story Page', () => {
 
             return null;
           });
+        });
+
+        afterEach(() => {
+          delete process.env.RECOMMENDATIONS_ENDPOINT;
         });
 
         it('should fetch and render recommendations from content variant endpoint when variation is content_recs and service is portuguese', async () => {
@@ -932,6 +942,10 @@ describe('Story Page', () => {
           });
         });
 
+        afterEach(() => {
+          delete process.env.RECOMMENDATIONS_ENDPOINT;
+        });
+
         it('should fetch and render recommendations from datalab hybrid variant endpoint when variation is hybrid_recs and service is portuguese', async () => {
           const toggles = {
             cpsRecommendations: {
@@ -983,6 +997,11 @@ describe('Story Page', () => {
           process.env.RECOMMENDATIONS_ENDPOINT =
             'http://mock-recommendations-path';
         });
+
+        afterEach(() => {
+          delete process.env.RECOMMENDATIONS_ENDPOINT;
+        });
+
         describe('View Tracking', () => {
           it('should send ATI and Optimizely view tracking event when recommendations render', async () => {
             const toggles = {

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.js
@@ -25,12 +25,12 @@ const noop = () => {};
 const logger = nodeLogger(__filename);
 
 // 004_brasil_recommendations_experiment
-const getRecommendations = (service, variant, assetUri) => {
+const getRecommendations = (service, assetUri) => {
   if (service !== 'portuguese' || isLive()) {
     return [
       {
         name: 'recommendations',
-        path: getRecommendationsUrl({ assetUri, variant }),
+        path: getRecommendationsUrl({ assetUri }),
         assetUri,
         api: 'recommendations',
         apiContext: 'secondary_data',
@@ -112,7 +112,7 @@ const pageTypeUrls = async (
         },
         // 004_brasil_recommendations_experiment
         ...((await hasRecommendations(service, variant, pageData))
-          ? getRecommendations(service, variant, assetUri)
+          ? getRecommendations(service, assetUri)
           : []),
       ].filter(i => i);
     case MEDIA_ASSET_PAGE:

--- a/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
+++ b/src/app/routes/cpsAsset/utils/getAdditionalPageData.test.js
@@ -24,7 +24,11 @@ jest.mock('./hasRecommendations', () => jest.fn());
 jest.mock('#server/utilities/getAgent/index');
 
 describe('getAdditionalPageData', () => {
+  beforeEach(() => {
+    process.env.RECOMMENDATIONS_ENDPOINT = 'http://mock-recommendations-path';
+  });
   afterEach(() => {
+    delete process.env.RECOMMENDATIONS_ENDPOINT;
     fetchMock.restore();
   });
 
@@ -49,7 +53,7 @@ describe('getAdditionalPageData', () => {
       secondaryColumnJson,
     );
     fetchMock.mock(
-      'http://localhost/mundo/23263889/recommendations.json',
+      'http://mock-recommendations-path/recommendations/mundo/23263889',
       recommendationsJson,
     );
     hasRecommendations.mockImplementationOnce(() => true);
@@ -89,7 +93,10 @@ describe('getAdditionalPageData', () => {
   it('should return an empty object when a data fetch fails', async () => {
     fetchMock.mock('http://localhost/mundo/mostread.json', 404);
     fetchMock.mock('http://localhost/mundo/sty-secondary-column.json', 404);
-    fetchMock.mock('http://localhost/mundo/23263889/recommendations.json', 404);
+    fetchMock.mock(
+      'http://mock-recommendations-path/recommendations/mundo/23263889',
+      404,
+    );
     const additionalPageData = await getAdditionalPageData({
       pageData: styJson,
       service: 'mundo',
@@ -119,15 +126,6 @@ describe('getAdditionalPageData', () => {
 
   describe('Optimizely Experiments', () => {
     describe('004_brasil_recommendations_experiment', () => {
-      beforeEach(() => {
-        process.env.RECOMMENDATIONS_ENDPOINT =
-          'http://mock-recommendations-path';
-      });
-
-      afterEach(() => {
-        delete process.env.RECOMMENDATIONS_ENDPOINT;
-      });
-
       it('should recommendations data from camino, unirecs content and unirecs hybrid engine', async () => {
         const expectedOutput = {
           recommendations: recommendationsJson,
@@ -160,7 +158,7 @@ describe('getAdditionalPageData', () => {
 
       it('should not get recommendations data when hasRecommendations is false', async () => {
         fetchMock.mock(
-          'http://localhost/portuguese/brasil-59057279/recommendations.json',
+          'http://mock-recommendations-path/recommendations/portuguese/brasil-59057279',
           recommendationsJson,
         );
         fetchMock.mock(
@@ -180,14 +178,14 @@ describe('getAdditionalPageData', () => {
         expect(additionalPageData).toEqual({});
       });
 
-      it('should get recommendations from public deimos endpoint on live environment', async () => {
+      it('should get recommendations from private recommendation endpoint on live environment', async () => {
         process.env.SIMORGH_APP_ENV = 'live';
         const expectedOutput = {
           recommendations: recommendationsJson,
         };
         hasRecommendations.mockImplementationOnce(() => true);
         fetchMock.mock(
-          'http://localhost/portuguese/brasil-59057279/recommendations.json',
+          'http://mock-recommendations-path/recommendations/portuguese/brasil-59057279',
           recommendationsJson,
         );
 


### PR DESCRIPTION
Resolves #[WSTEAM1-86](https://jira.dev.bbc.co.uk/browse/WSTEAM1-86)

**Overall change:**
Switching from a public to a private recommendations endpoint

**Code changes:**

- Update `getRecommendationsUrl` with new private endpoint
- Remove `variant` from `getRecommendationsUrl`
- Update tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
