### PR TITLE
Topics test fix (access data in new structure)

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -33,8 +33,9 @@ export default ({ service, pageType, variant }) => {
         topicTitle = body.data.title;
         variantTopicId = body.data.variantTopicId;
         pageCount = body.data.pageCount;
-        numberOfItems = body.data.summaries.length;
-        firstItemHeadline = body.data.summaries[0].title;
+        firstItemHeadline = body.data.curations[0].summaries[0].title;
+        numberOfItems = body.data.curations[0].summaries.length;
+        firstItemHeadline = body.data.curations[0].summaries[0].title;
       });
       cy.log(`topic id ${topicId}`);
     });

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -33,7 +33,6 @@ export default ({ service, pageType, variant }) => {
         topicTitle = body.data.title;
         variantTopicId = body.data.variantTopicId;
         pageCount = body.data.pageCount;
-        firstItemHeadline = body.data.curations[0].summaries[0].title;
         numberOfItems = body.data.curations[0].summaries.length;
         firstItemHeadline = body.data.curations[0].summaries[0].title;
       });


### PR DESCRIPTION
The data being accessed (length of summaries array and summaries item titles) was now nested within curations and another block, so needed to change the code.

**Code changes:**
e.g numberOfItems = body.data.curations[0].summaries.length;

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Passes on test and live