### PR TITLE
Update russian disclaimer to promote newsletter

### DIFF
--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -308,25 +308,13 @@ export const service = {
       },
     },
     disclaimer: {
-      para1: 'Приложение Русской службы BBC News доступно для ',
+      para1: 'Подпишитесь на нашу рассылку ”',
       para2: {
-        text: 'IOS',
-        url: 'https://apps.apple.com/us/app/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id504278066',
+        text: 'Контекст',
+        url: 'https://www.bbc.com/russian/resources/idt-b34bb7dd-f094-4722-92eb-cf7aff8cc1bc',
         isExternal: true,
       },
-      para3: ' и ',
-      para4: {
-        text: 'Android',
-        url: 'https://play.google.com/store/apps/details?id=uk.co.bbc.russian',
-        isExternal: true,
-      },
-      para5: '. Вы можете также подписаться на наш канал в ',
-      para6: {
-        text: 'Telegram',
-        url: 'https://t.me/bbcrussian',
-        isExternal: true,
-      },
-      para7: '.',
+      para3: '”: она поможет вам разобраться в происходящем.',
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -312,7 +312,7 @@ export const service = {
       para2: {
         text: 'Контекст',
         url: 'https://www.bbc.com/russian/resources/idt-b34bb7dd-f094-4722-92eb-cf7aff8cc1bc',
-        isExternal: true,
+        isExternal: false,
       },
       para3: '”: она поможет вам разобраться в происходящем.',
     },

--- a/src/app/lib/config/services/russian.js
+++ b/src/app/lib/config/services/russian.js
@@ -314,7 +314,7 @@ export const service = {
         url: 'https://www.bbc.com/russian/resources/idt-b34bb7dd-f094-4722-92eb-cf7aff8cc1bc',
         isExternal: false,
       },
-      para3: '”: она поможет вам разобраться в происходящем.',
+      para3: '”: она поможет вам разобраться в событиях.',
     },
     radioSchedule: {
       hasRadioSchedule: false,


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Replace the text on the Russian page-top disclaimer to promote their new newsletter and link to the newsletter sign-up page

**Code changes:**

- Update disclaimer text and link in /Users/martij05/localsimorgh/simorgh/src/app/lib/config/services/russian.js







---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
