### PR TITLE
Preroll ads test change to Mundo (from Russian)

### DIFF
--- a/cypress/integration/specialFeatures/prerollAds/config.js
+++ b/cypress/integration/specialFeatures/prerollAds/config.js
@@ -38,9 +38,9 @@ export const mapsWithPreroll = {
       ],
     },
     {
-      service: 'russian',
+      service: 'mundo',
       paths: [
-        'https://www.bbc.com/russian/media-52728860', // CPS Video, advertising enabled, preroll enabled for russian service
+        'https://www.bbc.com/mundo/media-41174775', // CPS Video, advertising enabled, preroll enabled for mundo service
       ],
     },
   ],


### PR DESCRIPTION
Preroll ads are turned off on Russian now, so this changes it to a services that still has ads: Mundo.


---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

Passes on live, but will need to see how it runs in AWS outside the UK