### PR TITLE
Converts Absolute URL's to Relative in Frosted Glass Promos

### DIFF
--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -497,7 +497,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
     <a
       aria-hidden="true"
       class="emotion-2 emotion-3"
-      href="https://www.bbc.com/pidgin/sport-51434980"
+      href="/pidgin/sport-51434980"
       tabindex="-1"
     />
     <div
@@ -526,7 +526,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
         >
           <a
             class="emotion-12 emotion-13"
-            href="https://www.bbc.com/pidgin/sport-51434980"
+            href="/pidgin/sport-51434980"
           >
             Man City vs West Ham: Bad weather force Premier League to cancel Sunday match
           </a>

--- a/src/app/components/FrostedGlassPromo/index.jsx
+++ b/src/app/components/FrostedGlassPromo/index.jsx
@@ -18,6 +18,7 @@ import {
   C_GREY_8,
   C_METAL,
 } from '#legacy/psammead-styles/src/colours';
+import makeRelativeUrlPath from '#lib/utilities/makeRelativeUrlPath';
 
 import FrostedGlassPanel from './FrostedGlassPanel';
 
@@ -107,10 +108,11 @@ const FrostedGlassPromo = ({
   const { script, service } = useContext(ServiceContext);
   const { isAmp } = useContext(RequestContext);
   const isCanonical = !isAmp;
+  const relativeUrl = makeRelativeUrlPath(url);
 
   const clickTracker = useClickTrackerHandler({
     ...(eventTrackingData || {}),
-    url,
+    url: relativeUrl,
   });
 
   const onClick = eventTrackingData ? clickTracker : () => {};
@@ -121,7 +123,7 @@ const FrostedGlassPromo = ({
         <A
           script={script}
           service={service}
-          href={url}
+          href={relativeUrl}
           onClick={onClick}
           isAmp={isAmp}
         >
@@ -138,7 +140,7 @@ const FrostedGlassPromo = ({
   return (
     <Wrapper data-testid={`frosted-promo-${index}`}>
       <ClickableArea
-        href={url}
+        href={relativeUrl}
         onClick={onClick}
         aria-hidden="true"
         tabIndex="-1"

--- a/src/app/components/FrostedGlassPromo/index.test.jsx
+++ b/src/app/components/FrostedGlassPromo/index.test.jsx
@@ -9,12 +9,7 @@ import * as clickTracking from '#hooks/useClickTrackerHandler';
 import { ToggleContextProvider } from '#app/contexts/ToggleContext';
 
 import { STORY_PAGE } from '#app/routes/utils/pageTypes';
-import {
-  promoProps,
-  cpsPromoFixture,
-  optimoPromoFixture,
-  linkPromoFixture,
-} from './fixtures';
+import { promoProps, cpsPromoFixture, linkPromoFixture } from './fixtures';
 
 import Promo from '.';
 

--- a/src/app/components/FrostedGlassPromo/index.test.jsx
+++ b/src/app/components/FrostedGlassPromo/index.test.jsx
@@ -9,7 +9,12 @@ import * as clickTracking from '#hooks/useClickTrackerHandler';
 import { ToggleContextProvider } from '#app/contexts/ToggleContext';
 
 import { STORY_PAGE } from '#app/routes/utils/pageTypes';
-import { promoProps, cpsPromoFixture, linkPromoFixture } from './fixtures';
+import {
+  promoProps,
+  cpsPromoFixture,
+  optimoPromoFixture,
+  linkPromoFixture,
+} from './fixtures';
 
 import Promo from '.';
 
@@ -74,7 +79,7 @@ describe('Frosted Glass Promo', () => {
     // Main image is lazy-loaded
     expect(container.querySelector('noscript')).toBeInTheDocument();
     expect(
-      container.querySelector(`a[href="${linkPromoFixture.item.uri}"]`),
+      container.querySelector('a[href="/pidgin/sport-51434980"]'),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Resolves NEWSWORLDSERVICE-1560

**Overall change:**
Converts absolute URL's to relative in frosted glass promos

**Code changes:**

- Uses `makeRelativeUrlPath` function in frosted glass promos to convert URL's to a relative path
- Updates unit tests

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
