### PR TITLE
Update external links for Hindi and Urdu podcasts

### DIFF
--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
@@ -153,6 +153,17 @@ const externalLinks = {
           'https://www.saavn.com/s/show/ड्रामा-क्वीन-drama-queen/1/dZOptt08D4A_',
       },
     ],
+    p0clc83k: [
+      {
+        linkText: 'Spotify',
+        linkUrl: 'https://open.spotify.com/show/0sgucaqSDSOg30tyDdq960',
+      },
+      {
+        linkText: 'Apple Podcasts',
+        linkUrl:
+          'https://podcasts.apple.com/gb/podcast/%E0%A4%AC-%E0%A4%A4-%E0%A4%B8%E0%A4%B0%E0%A4%B9%E0%A4%A6-%E0%A4%AA-%E0%A4%B0/id1634185584',
+      },
+    ],
   },
 };
 

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/urdu.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/urdu.js
@@ -20,6 +20,17 @@ const externalLinks = {
       },
     ],
   },
+  p0clc9zw: [
+    {
+      linkText: 'Spotify',
+      linkUrl: 'https://open.spotify.com/show/7iOhf64Hu8wBCZDQSm0Dod',
+    },
+    {
+      linkText: 'Apple Podcasts',
+      linkUrl:
+        'https://podcasts.apple.com/gb/podcast/%D8%A8%D8%A7%D8%AA-%D8%B3%D8%B1%D8%AD%D8%AF-%D9%BE%D8%A7%D8%B1/id1634186835',
+    },
+  ],
 };
 
 export default externalLinks;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Adds Spotify and Apple Podcast external links to two new Urdu and Hindi podcast brands. 
**Code changes:**

Adds relevant key/value pairs to src\app\routes\onDemandAudio\tempData\podcastExternalLinks\urdu.js and src\app\routes\onDemandAudio\tempData\podcastExternalLinks\hindi.js

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
