### PR TITLE
Unrevert things

### DIFF
--- a/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
+++ b/src/app/Layouts/__snapshots__/defaultPageWrapper.test.jsx.snap
@@ -431,8 +431,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 
 .emotion-31 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-31::after {
@@ -441,7 +440,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-31 .emotion-48::after {
@@ -452,6 +451,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-35 {
@@ -483,7 +483,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -505,8 +505,14 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 }
 
 .emotion-39 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-39 {
+    fill: linkText;
+  }
 }
 
 @media (max-width: 37.4375rem) {
@@ -535,8 +541,8 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -579,7 +585,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -591,6 +597,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -624,7 +631,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-49:focus::after {
@@ -633,13 +640,13 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-91 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -667,12 +674,12 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-95 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-95:last-child {
@@ -686,7 +693,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -711,6 +718,7 @@ exports[`defaultPageWrapper should render default page wrapper with children 1`]
 .emotion-97:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 .emotion-139 {

--- a/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/ErrorMain/__snapshots__/index.test.jsx.snap
@@ -231,7 +231,7 @@ exports[`ErrorMain should correctly render for an error page for News 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -557,7 +557,7 @@ exports[`ErrorMain should correctly render for an error page for arabic 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -883,7 +883,7 @@ exports[`ErrorMain should correctly render for an error page for pashto 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -1209,7 +1209,7 @@ exports[`ErrorMain should correctly render for an error page for persian 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -1535,7 +1535,7 @@ exports[`ErrorMain should correctly render for an error page for urdu 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;

--- a/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/FrostedGlassPromo/__snapshots__/index.test.jsx.snap
@@ -264,7 +264,7 @@ exports[`Frosted Glass Promo when given props for a CPS promo 1`] = `
 .emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -458,7 +458,7 @@ exports[`Frosted Glass Promo when given props for a Link promo 1`] = `
 .emotion-15 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/RadioSchedule/StartTime/__snapshots__/index.test.jsx.snap
@@ -95,7 +95,7 @@ exports[`StartTime should render LTR correctly 1`] = `
 .emotion-8 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -251,7 +251,7 @@ exports[`StartTime should render RTL correctly 1`] = `
 .emotion-8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;

--- a/src/app/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -309,7 +309,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 .emotion-16 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1553,7 +1553,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 .emotion-16 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;

--- a/src/app/containers/ArticleRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleRelatedContent/__snapshots__/index.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 .emotion-4 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -44,50 +44,11 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 .emotion-6 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-6 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-8 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-8 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    display: none;
-  }
-}
-
-.emotion-10 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-12 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -97,7 +58,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   flex-direction: column;
 }
 
-.emotion-14 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -117,7 +78,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -125,11 +86,11 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F6F6F6;
   margin: 1rem 0;
@@ -145,45 +106,45 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-18 {
+  .emotion-14 {
     padding-top: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-18 {
+  .emotion-14 {
     padding-bottom: 1.5rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-20 {
+  .emotion-16 {
     display: grid;
     position: initial;
     width: initial;
@@ -191,7 +152,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -199,7 +160,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -207,7 +168,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -215,7 +176,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -223,7 +184,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
       grid-column-gap: 1rem;
@@ -231,7 +192,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-20 {
+    .emotion-16 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
       grid-column-gap: 1rem;
@@ -239,31 +200,31 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 }
 
-.emotion-22 {
+.emotion-18 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-22 {
+  .emotion-18 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-22 {
+    .emotion-18 {
       display: block;
     }
   }
 }
 
-.emotion-24 {
+.emotion-20 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -271,24 +232,24 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 63rem) {
-  .emotion-24 {
+  .emotion-20 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
+  .emotion-20 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-26 {
+.emotion-22 {
   position: relative;
 }
 
-.emotion-28 {
+.emotion-24 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -303,39 +264,39 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-30 {
+  .emotion-26 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-30>* {
+.emotion-26>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-30>* {
+  .emotion-26>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-32 {
+.emotion-28 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -343,13 +304,13 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-32 {
+  .emotion-28 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-32 {
+  .emotion-28 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -357,7 +318,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-32 {
+  .emotion-28 {
     display: block;
     width: initial;
     padding: initial;
@@ -365,13 +326,13 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   }
 
   @media (min-width: 63rem) {
-    .emotion-32 {
+    .emotion-28 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-34 {
+.emotion-30 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -383,20 +344,20 @@ exports[`ArticleRelatedContent should render related content 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-34 {
+  .emotion-30 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-34 {
+  .emotion-30 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-36 {
+.emotion-32 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -405,7 +366,7 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   overflow-wrap: anywhere;
 }
 
-.emotion-36:before {
+.emotion-32:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -417,13 +378,13 @@ exports[`ArticleRelatedContent should render related content 1`] = `
   z-index: 1;
 }
 
-.emotion-36:hover,
-.emotion-36:focus {
+.emotion-32:hover,
+.emotion-32:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-36:visited {
+.emotion-32:visited {
   color: #6E6E73;
 }
 
@@ -437,23 +398,17 @@ exports[`ArticleRelatedContent should render related content 1`] = `
     <div
       class="emotion-3 emotion-4 emotion-5"
     >
-      <div
-        class="emotion-6 emotion-7"
-      />
-      <div
-        class="emotion-8 emotion-9"
-      />
       <h2
-        class="emotion-10 emotion-11"
+        class="emotion-6 emotion-7"
       >
         <span
-          class="emotion-12 emotion-13"
+          class="emotion-8 emotion-9"
         >
           <span
-            class="emotion-14 emotion-15"
+            class="emotion-10 emotion-11"
           >
             <span
-              class="emotion-16 emotion-17"
+              class="emotion-12 emotion-13"
               dir="ltr"
               id="related-content-heading"
             >
@@ -464,25 +419,25 @@ exports[`ArticleRelatedContent should render related content 1`] = `
       </h2>
     </div>
     <div
-      class="emotion-18 emotion-19"
+      class="emotion-14 emotion-15"
     >
       <div
-        class="emotion-20 emotion-21"
+        class="emotion-16 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-22 emotion-23"
+          class="emotion-18 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-24 emotion-25"
+            class="emotion-20 emotion-21"
             dir="ltr"
           >
             <div
-              class="emotion-26 emotion-27"
+              class="emotion-22 emotion-23"
             >
               <div
-                class="emotion-28 emotion-29"
+                class="emotion-24 emotion-25"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25625625625625%;"
               >
@@ -495,20 +450,20 @@ exports[`ArticleRelatedContent should render related content 1`] = `
                 </div>
               </div>
               <div
-                class="emotion-30 emotion-31"
+                class="emotion-26 emotion-27"
               />
             </div>
           </div>
           <div
-            class="emotion-32 emotion-33"
+            class="emotion-28 emotion-29"
             dir="ltr"
           >
             <div
-              class="emotion-34 emotion-35"
+              class="emotion-30 emotion-31"
             >
               <a
                 aria-labelledby="promo-news-1"
-                class="emotion-36 emotion-37"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk/news"
               >
                 <span

--- a/src/app/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/ArticleTimestamp/__snapshots__/index.test.jsx.snap
@@ -114,7 +114,7 @@ exports[`ArticleTimestamp should render a 'created' Timestamp correctly 1`] = `
 .emotion-3 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -269,7 +269,7 @@ exports[`ArticleTimestamp should render both a 'created' and an 'updated' Timest
 .emotion-3 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -432,7 +432,7 @@ exports[`ArticleTimestamp should render with a prefix 1`] = `
 .emotion-3 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -595,7 +595,7 @@ exports[`ArticleTimestamp should render with a suffix 1`] = `
 .emotion-3 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -758,7 +758,7 @@ exports[`ArticleTimestamp should render with no suffix or prefix 1`] = `
 .emotion-3 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsOnwardJourney/__snapshots__/index.test.jsx.snap
@@ -679,7 +679,7 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
   margin: 0;
@@ -710,50 +710,11 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -763,7 +724,7 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -783,7 +744,7 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -791,11 +752,11 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -811,27 +772,27 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
@@ -851,23 +812,17 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <strong
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="heading-label"
               >
@@ -878,7 +833,7 @@ exports[`CpsOnwardJourney renders section label with element as strong 1`] = `
         </strong>
       </div>
       <div
-        class="emotion-21 emotion-22"
+        class="emotion-17 emotion-18"
       >
         <div
           dir="ltr"
@@ -1098,7 +1053,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
   margin: 0;
@@ -1129,50 +1084,11 @@ exports[`CpsOnwardJourney renders section label with with alternative background
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1182,7 +1098,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1202,7 +1118,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1210,11 +1126,11 @@ exports[`CpsOnwardJourney renders section label with with alternative background
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #222222;
   margin: 1rem 0;
@@ -1230,27 +1146,27 @@ exports[`CpsOnwardJourney renders section label with with alternative background
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
@@ -1270,23 +1186,17 @@ exports[`CpsOnwardJourney renders section label with with alternative background
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <h2
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="heading-label"
               >
@@ -1297,7 +1207,7 @@ exports[`CpsOnwardJourney renders section label with with alternative background
         </h2>
       </div>
       <div
-        class="emotion-21 emotion-22"
+        class="emotion-17 emotion-18"
       >
         <div
           dir="ltr"
@@ -1517,7 +1427,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
   margin: 0;
@@ -1548,28 +1458,11 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: none;
-  }
-}
-
-.emotion-11 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-13 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1579,7 +1472,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
   flex-direction: column;
 }
 
-.emotion-15 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1599,7 +1492,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1607,11 +1500,11 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
   }
 }
 
-.emotion-17 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1627,27 +1520,27 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-17 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
@@ -1667,20 +1560,17 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
         <h2
-          class="emotion-11 emotion-12"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-13 emotion-14"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-15 emotion-16"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-17 emotion-18"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="heading-label"
               >
@@ -1691,7 +1581,7 @@ exports[`CpsOnwardJourney renders section label with without bar under section l
         </h2>
       </div>
       <div
-        class="emotion-19 emotion-20"
+        class="emotion-17 emotion-18"
       >
         <div
           dir="ltr"
@@ -1958,7 +1848,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
 .emotion-11 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
   margin: 0;
@@ -1989,50 +1879,11 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
 }
 
 .emotion-13 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-13 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-13 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-15 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-15 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-15 {
-    display: none;
-  }
-}
-
-.emotion-17 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-19 {
+.emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2042,7 +1893,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
   flex-direction: column;
 }
 
-.emotion-21 {
+.emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2062,7 +1913,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-21 {
+  .emotion-17 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2070,11 +1921,11 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
   }
 }
 
-.emotion-23 {
+.emotion-19 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2090,32 +1941,32 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-23 {
+  .emotion-19 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     padding-right: 1rem;
   }
 }
 
-.emotion-25 {
+.emotion-21 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -2150,23 +2001,17 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
         <div
           class="emotion-10 emotion-11 emotion-12"
         >
-          <div
-            class="emotion-13 emotion-14"
-          />
-          <div
-            class="emotion-15 emotion-16"
-          />
           <h2
-            class="emotion-17 emotion-18"
+            class="emotion-13 emotion-14"
           >
             <span
-              class="emotion-19 emotion-20"
+              class="emotion-15 emotion-16"
             >
               <span
-                class="emotion-21 emotion-22"
+                class="emotion-17 emotion-18"
               >
                 <span
-                  class="emotion-23 emotion-24"
+                  class="emotion-19 emotion-20"
                   dir="ltr"
                   id="heading-label"
                 >
@@ -2206,7 +2051,7 @@ exports[`CpsOnwardJourney renders skip link with multiple promos 1`] = `
           </li>
         </ul>
         <p
-          class="emotion-25 emotion-26"
+          class="emotion-21 emotion-22"
           id="end-of-the-foo-section"
           tabindex="-1"
         >
@@ -2468,7 +2313,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
 .emotion-11 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
   margin: 0;
@@ -2499,50 +2344,11 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
 }
 
 .emotion-13 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-13 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-13 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-15 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-15 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-15 {
-    display: none;
-  }
-}
-
-.emotion-17 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-19 {
+.emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2552,7 +2358,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
   flex-direction: column;
 }
 
-.emotion-21 {
+.emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2572,7 +2378,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-21 {
+  .emotion-17 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2580,11 +2386,11 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
   }
 }
 
-.emotion-23 {
+.emotion-19 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2600,32 +2406,32 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-23 {
+  .emotion-19 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     padding-right: 1rem;
   }
 }
 
-.emotion-27 {
+.emotion-23 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -2660,23 +2466,17 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
         <div
           class="emotion-10 emotion-11 emotion-12"
         >
-          <div
-            class="emotion-13 emotion-14"
-          />
-          <div
-            class="emotion-15 emotion-16"
-          />
           <h2
-            class="emotion-17 emotion-18"
+            class="emotion-13 emotion-14"
           >
             <span
-              class="emotion-19 emotion-20"
+              class="emotion-15 emotion-16"
             >
               <span
-                class="emotion-21 emotion-22"
+                class="emotion-17 emotion-18"
               >
                 <span
-                  class="emotion-23 emotion-24"
+                  class="emotion-19 emotion-20"
                   dir="ltr"
                   id="heading-label"
                 >
@@ -2687,7 +2487,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
           </h2>
         </div>
         <div
-          class="emotion-25 emotion-26"
+          class="emotion-21 emotion-22"
         >
           <div
             dir="ltr"
@@ -2700,7 +2500,7 @@ exports[`CpsOnwardJourney renders skip link with single promo 1`] = `
           </div>
         </div>
         <p
-          class="emotion-27 emotion-28"
+          class="emotion-23 emotion-24"
           id="end-of-the-foo-section"
           tabindex="-1"
         >

--- a/src/app/containers/CpsRecommendations/RecommendationsPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRecommendations/RecommendationsPromo/__snapshots__/index.test.jsx.snap
@@ -138,7 +138,7 @@ exports[`RecommendationsPromo it renders a Story Promo wrapped in a Grid compone
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #222222;
+  color: #141414;
   margin: 0;
   height: 100%;
   display: -webkit-box;
@@ -167,7 +167,7 @@ exports[`RecommendationsPromo it renders a Story Promo wrapped in a Grid compone
 
 .emotion-12 {
   position: static;
-  color: #222222;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow-wrap: break-word;

--- a/src/app/containers/CpsRecommendations/RecommendationsPromo/index.jsx
+++ b/src/app/containers/CpsRecommendations/RecommendationsPromo/index.jsx
@@ -12,7 +12,11 @@ import {
 } from '#legacy/gel-foundations/src/breakpoints';
 import { getSerifMedium } from '#legacy/psammead-styles/src/font-styles';
 import { getPica } from '#legacy/gel-foundations/src/typography';
-import { C_EBON, C_METAL, C_GREY_2 } from '#legacy/psammead-styles/src/colours';
+import {
+  C_METAL,
+  C_GREY_2,
+  C_GREY_10,
+} from '#legacy/psammead-styles/src/colours';
 import { shape, string, oneOfType } from 'prop-types';
 import { ServiceContext } from '#contexts/ServiceContext';
 import { storyItem } from '#models/propTypes/storyItem';
@@ -60,7 +64,7 @@ const TextWrapper = styled.div`
 
 const Link = styled.a`
   position: static;
-  color: ${C_EBON};
+  color: ${C_GREY_10};
   text-decoration: none;
   overflow-wrap: break-word;
 
@@ -89,7 +93,7 @@ const Link = styled.a`
 const StyledHeadline = styled.div`
   ${({ service }) => getSerifMedium(service)}
   ${({ script }) => getPica(script)}
-  color: ${C_EBON};
+  color: ${C_GREY_10};
   margin: 0;
   height: 100%;
   display: flex;

--- a/src/app/containers/CpsRecommendations/RecommendationsPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRecommendations/RecommendationsPromoList/__snapshots__/index.test.jsx.snap
@@ -255,7 +255,7 @@ exports[`RecommendationsPromoList it renders a list of Story Promos wrapped in G
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #222222;
+  color: #141414;
   margin: 0;
   height: 100%;
   display: -webkit-box;
@@ -284,7 +284,7 @@ exports[`RecommendationsPromoList it renders a list of Story Promos wrapped in G
 
 .emotion-18 {
   position: static;
-  color: #222222;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow-wrap: break-word;

--- a/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRecommendations/__snapshots__/index.test.jsx.snap
@@ -169,7 +169,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 .emotion-9 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0;
   padding: 0;
@@ -240,7 +240,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -418,7 +418,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #222222;
+  color: #141414;
   margin: 0;
   height: 100%;
   display: -webkit-box;
@@ -447,7 +447,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 
 .emotion-31 {
   position: static;
-  color: #222222;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow-wrap: break-word;
@@ -746,7 +746,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 .emotion-9 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0;
   padding: 0;
@@ -817,7 +817,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1112,7 +1112,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #222222;
+  color: #141414;
   margin: 0;
   height: 100%;
   display: -webkit-box;
@@ -1141,7 +1141,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 
 .emotion-37 {
   position: static;
-  color: #222222;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow-wrap: break-word;
@@ -1593,7 +1593,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 .emotion-9 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0;
   padding: 0;
@@ -1664,7 +1664,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1959,7 +1959,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #222222;
+  color: #141414;
   margin: 0;
   height: 100%;
   display: -webkit-box;
@@ -1988,7 +1988,7 @@ exports[`CpsRecommendations should render when cpsRecommendations toggle is enab
 
 .emotion-37 {
   position: static;
-  color: #222222;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow-wrap: break-word;

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromo/__snapshots__/index.test.jsx.snap
@@ -288,7 +288,7 @@ exports[`RelatedContentPromo it renders a Story Promo wrapped in a Grid componen
 .emotion-20 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/RelatedContentPromoList/__snapshots__/index.test.jsx.snap
@@ -358,7 +358,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for MAP pages
 .emotion-23 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -921,7 +921,7 @@ exports[`RelatedContentPromoList it renders a list of Story Promos for STY pages
 .emotion-22 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsRelatedContent/__snapshots__/index.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -228,50 +228,11 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -281,7 +242,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -301,7 +262,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -309,11 +270,11 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -329,39 +290,39 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
 
-.emotion-22 {
+.emotion-18 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-22 {
+  .emotion-18 {
     display: grid;
     position: initial;
     width: initial;
@@ -369,7 +330,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -377,7 +338,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -385,7 +346,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -393,7 +354,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -401,7 +362,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -409,7 +370,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 80rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -417,121 +378,121 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 }
 
-.emotion-25 {
+.emotion-21 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-25 {
+  .emotion-21 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-25:last-child {
+.emotion-21:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-25 {
+  .emotion-21 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-25 {
+  .emotion-21 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-25:first-child {
+.emotion-21:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-25:first-child {
+  .emotion-21:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-25:last-child {
+.emotion-21:last-child {
   padding-bottom: 0;
 }
 
 @supports (display: grid) {
-  .emotion-25 {
+  .emotion-21 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-27 {
+.emotion-23 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-27 {
+  .emotion-23 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-27 {
+    .emotion-23 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-27 {
+    .emotion-23 {
       display: block;
     }
   }
 }
 
-.emotion-29 {
+.emotion-25 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -539,24 +500,24 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 63rem) {
-  .emotion-29 {
+  .emotion-25 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-29 {
+  .emotion-25 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-31 {
+.emotion-27 {
   position: relative;
 }
 
-.emotion-33 {
+.emotion-29 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -571,39 +532,39 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 25rem) {
-  .emotion-33 {
+  .emotion-29 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-33 {
+  .emotion-29 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-35 {
+  .emotion-31 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-35>* {
+.emotion-31>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-35>* {
+  .emotion-31>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-37 {
+.emotion-33 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -611,13 +572,13 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-33 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-33 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -625,7 +586,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-37 {
+  .emotion-33 {
     display: block;
     width: initial;
     padding: initial;
@@ -633,13 +594,13 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   }
 
   @media (min-width: 63rem) {
-    .emotion-37 {
+    .emotion-33 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -651,20 +612,20 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-41 {
+.emotion-37 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -673,7 +634,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   overflow-wrap: anywhere;
 }
 
-.emotion-41:before {
+.emotion-37:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -685,20 +646,20 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
   z-index: 1;
 }
 
-.emotion-41:hover,
-.emotion-41:focus {
+.emotion-37:hover,
+.emotion-37:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-41:visited {
+.emotion-37:visited {
   color: #6E6E73;
 }
 
-.emotion-43 {
+.emotion-39 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -706,14 +667,14 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -733,23 +694,17 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <h2
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -760,27 +715,27 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
         </h2>
       </div>
       <ul
-        class="emotion-2 emotion-22 emotion-23"
+        class="emotion-2 emotion-18 emotion-19"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-2 emotion-25 emotion-26"
+          class="emotion-2 emotion-21 emotion-22"
           dir="ltr"
         >
           <div
-            class="emotion-27 emotion-28"
+            class="emotion-23 emotion-24"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-29 emotion-30"
+              class="emotion-25 emotion-26"
               dir="ltr"
             >
               <div
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
               >
                 <div
-                  class="emotion-33 emotion-34"
+                  class="emotion-29 emotion-30"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
@@ -793,20 +748,20 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   </div>
                 </div>
                 <div
-                  class="emotion-35 emotion-36"
+                  class="emotion-31 emotion-32"
                 />
               </div>
             </div>
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-33 emotion-34"
               dir="ltr"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-35 emotion-36"
               >
                 <a
                   aria-labelledby="promo-rel-content-pidgin44508901-1"
-                  class="emotion-41 emotion-42"
+                  class="emotion-37 emotion-38"
                   href="/pidgin/44508901"
                 >
                   <span
@@ -820,7 +775,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 </a>
               </h3>
               <time
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
                 datetime="1970-01-18"
               >
                 18th January 1970
@@ -829,22 +784,22 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
           </div>
         </li>
         <li
-          class="emotion-2 emotion-25 emotion-26"
+          class="emotion-2 emotion-21 emotion-22"
           dir="ltr"
         >
           <div
-            class="emotion-27 emotion-28"
+            class="emotion-23 emotion-24"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-29 emotion-30"
+              class="emotion-25 emotion-26"
               dir="ltr"
             >
               <div
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
               >
                 <div
-                  class="emotion-33 emotion-34"
+                  class="emotion-29 emotion-30"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
@@ -857,20 +812,20 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   </div>
                 </div>
                 <div
-                  class="emotion-35 emotion-36"
+                  class="emotion-31 emotion-32"
                 />
               </div>
             </div>
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-33 emotion-34"
               dir="ltr"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-35 emotion-36"
               >
                 <a
                   aria-labelledby="promo-rel-content-pidgintori46975713-2"
-                  class="emotion-41 emotion-42"
+                  class="emotion-37 emotion-38"
                   href="/pidgin/tori-46975713"
                 >
                   <span
@@ -881,7 +836,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 </a>
               </h3>
               <time
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
                 datetime="1970-01-18"
               >
                 18th January 1970
@@ -890,22 +845,22 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
           </div>
         </li>
         <li
-          class="emotion-2 emotion-25 emotion-26"
+          class="emotion-2 emotion-21 emotion-22"
           dir="ltr"
         >
           <div
-            class="emotion-27 emotion-28"
+            class="emotion-23 emotion-24"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-29 emotion-30"
+              class="emotion-25 emotion-26"
               dir="ltr"
             >
               <div
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
               >
                 <div
-                  class="emotion-33 emotion-34"
+                  class="emotion-29 emotion-30"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
@@ -918,20 +873,20 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                   </div>
                 </div>
                 <div
-                  class="emotion-35 emotion-36"
+                  class="emotion-31 emotion-32"
                 />
               </div>
             </div>
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-33 emotion-34"
               dir="ltr"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-35 emotion-36"
               >
                 <a
                   aria-labelledby="promo-rel-content-pidgintori42494678-3"
-                  class="emotion-41 emotion-42"
+                  class="emotion-37 emotion-38"
                   href="/pidgin/tori-42494678"
                 >
                   <span
@@ -942,7 +897,7 @@ exports[`CpsRelatedContent should render Story Promo components when given appro
                 </a>
               </h3>
               <time
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
                 datetime="1970-01-18"
               >
                 18th January 1970
@@ -1160,7 +1115,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -1184,50 +1139,11 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1237,7 +1153,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1257,7 +1173,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1265,11 +1181,11 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1285,45 +1201,45 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-21 {
+  .emotion-17 {
     padding-top: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-21 {
+  .emotion-17 {
     padding-bottom: 1.5rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-23 {
+  .emotion-19 {
     display: grid;
     position: initial;
     width: initial;
@@ -1331,7 +1247,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -1339,7 +1255,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -1347,7 +1263,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 0.5rem;
@@ -1355,7 +1271,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -1363,7 +1279,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
       grid-column-gap: 1rem;
@@ -1371,7 +1287,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 80rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
       grid-column-gap: 1rem;
@@ -1379,31 +1295,31 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 }
 
-.emotion-25 {
+.emotion-21 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-25 {
+  .emotion-21 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-25 {
+    .emotion-21 {
       display: block;
     }
   }
 }
 
-.emotion-27 {
+.emotion-23 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -1411,24 +1327,24 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 63rem) {
-  .emotion-27 {
+  .emotion-23 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-27 {
+  .emotion-23 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-29 {
+.emotion-25 {
   position: relative;
 }
 
-.emotion-31 {
+.emotion-27 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -1443,39 +1359,39 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 25rem) {
-  .emotion-31 {
+  .emotion-27 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-31 {
+  .emotion-27 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-33 {
+  .emotion-29 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-33>* {
+.emotion-29>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-33>* {
+  .emotion-29>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-35 {
+.emotion-31 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -1483,13 +1399,13 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-35 {
+  .emotion-31 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-35 {
+  .emotion-31 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -1497,7 +1413,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-35 {
+  .emotion-31 {
     display: block;
     width: initial;
     padding: initial;
@@ -1505,13 +1421,13 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   }
 
   @media (min-width: 63rem) {
-    .emotion-35 {
+    .emotion-31 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-37 {
+.emotion-33 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -1523,20 +1439,20 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-37 {
+  .emotion-33 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-33 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1545,7 +1461,7 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   overflow-wrap: anywhere;
 }
 
-.emotion-39:before {
+.emotion-35:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1557,17 +1473,17 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
   z-index: 1;
 }
 
-.emotion-39:hover,
-.emotion-39:focus {
+.emotion-35:hover,
+.emotion-35:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-39:visited {
+.emotion-35:visited {
   color: #6E6E73;
 }
 
-.emotion-41 {
+.emotion-37 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1579,37 +1495,37 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-41 {
+  .emotion-37 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-41 {
+  .emotion-37 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-41 {
+  .emotion-37 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-41 {
+  .emotion-37 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-43 {
+.emotion-39 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1617,14 +1533,14 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -1644,23 +1560,17 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <h2
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="related-content-heading"
               >
@@ -1671,25 +1581,25 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
         </h2>
       </div>
       <div
-        class="emotion-21 emotion-22"
+        class="emotion-17 emotion-18"
       >
         <div
-          class="emotion-23 emotion-2"
+          class="emotion-19 emotion-2"
           dir="ltr"
         >
           <div
-            class="emotion-25 emotion-26"
+            class="emotion-21 emotion-22"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <div
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
               >
                 <div
-                  class="emotion-31 emotion-32"
+                  class="emotion-27 emotion-28"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
@@ -1702,20 +1612,20 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                   </div>
                 </div>
                 <div
-                  class="emotion-33 emotion-34"
+                  class="emotion-29 emotion-30"
                 />
               </div>
             </div>
             <div
-              class="emotion-35 emotion-36"
+              class="emotion-31 emotion-32"
               dir="ltr"
             >
               <h3
-                class="emotion-37 emotion-38"
+                class="emotion-33 emotion-34"
               >
                 <a
                   aria-labelledby="promo-pidgin44508901-1"
-                  class="emotion-39 emotion-40"
+                  class="emotion-35 emotion-36"
                   href="/pidgin/44508901"
                 >
                   <span
@@ -1729,12 +1639,12 @@ exports[`CpsRelatedContent should render Story Promo components without <ul> whe
                 </a>
               </h3>
               <p
-                class="emotion-41 emotion-42"
+                class="emotion-37 emotion-38"
               >
                 James den Kwesi Ansah want convert most of Ghana's cassava waste into cheap electricity supply for schools, hospitals den villages.
               </p>
               <time
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
                 datetime="1970-01-18"
               >
                 18th January 1970

--- a/src/app/containers/CpsTable/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTable/__snapshots__/index.test.jsx.snap
@@ -142,7 +142,7 @@ exports[`CpsTable should match snapshot - fixture 0 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -470,7 +470,7 @@ exports[`CpsTable should match snapshot - fixture 1 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -798,7 +798,7 @@ exports[`CpsTable should match snapshot - fixture 2 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/CpsTopStories/__snapshots__/index.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -228,50 +228,11 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -281,7 +242,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -301,7 +262,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -309,11 +270,11 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -329,102 +290,102 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
 
-.emotion-21 {
+.emotion-17 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.emotion-23 {
+.emotion-19 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-23 {
+  .emotion-19 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-23:last-child {
+.emotion-19:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-23 {
+  .emotion-19 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-23 {
+  .emotion-19 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-23:first-child {
+.emotion-19:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-23:first-child {
+  .emotion-19:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-23:last-child {
+.emotion-19:last-child {
   padding-bottom: 0;
 }
 
-.emotion-25 {
+.emotion-21 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-25 {
+  .emotion-21 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-25 {
+    .emotion-21 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-25 {
+    .emotion-21 {
       display: block;
     }
   }
 }
 
-.emotion-27 {
+.emotion-23 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -433,25 +394,25 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-27 {
+  .emotion-23 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-27 {
+  .emotion-23 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
   }
 }
 
-.emotion-27>div {
+.emotion-23>div {
   vertical-align: middle;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-27 {
+  .emotion-23 {
     display: block;
     width: initial;
     padding: initial;
@@ -460,22 +421,22 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   }
 
   @media (min-width: 63rem) {
-    .emotion-27 {
+    .emotion-23 {
       padding-top: 0;
     }
   }
 }
 
-.emotion-27>div {
+.emotion-23>div {
   display: inline-block;
   vertical-align: initial;
 }
 
-.emotion-27 svg {
+.emotion-23 svg {
   margin: 0;
 }
 
-.emotion-29 {
+.emotion-25 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -488,20 +449,20 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-29 {
+  .emotion-25 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-29 {
+  .emotion-25 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-31 {
+.emotion-27 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -510,7 +471,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   overflow-wrap: anywhere;
 }
 
-.emotion-31:before {
+.emotion-27:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -522,20 +483,20 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
   z-index: 1;
 }
 
-.emotion-31:hover,
-.emotion-31:focus {
+.emotion-27:hover,
+.emotion-27:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-31:visited {
+.emotion-27:visited {
   color: #6E6E73;
 }
 
-.emotion-33 {
+.emotion-29 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -543,14 +504,14 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -570,23 +531,17 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <h2
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="top-stories-heading"
               >
@@ -597,26 +552,26 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
         </h2>
       </div>
       <ul
-        class="emotion-21 emotion-22"
+        class="emotion-17 emotion-18"
         role="list"
       >
         <li
-          class="emotion-23 emotion-24"
+          class="emotion-19 emotion-20"
         >
           <div
-            class="emotion-25 emotion-26"
+            class="emotion-21 emotion-22"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <h3
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
               >
                 <a
                   aria-labelledby="top-stories-promo-mundonoticiasinternacional51939501-1"
-                  class="emotion-31 emotion-32"
+                  class="emotion-27 emotion-28"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
@@ -627,7 +582,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 </a>
               </h3>
               <time
-                class="emotion-33 emotion-34"
+                class="emotion-29 emotion-30"
                 datetime="2020-02-03"
               >
                 3rd February 2020
@@ -636,22 +591,22 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
           </div>
         </li>
         <li
-          class="emotion-23 emotion-24"
+          class="emotion-19 emotion-20"
         >
           <div
-            class="emotion-25 emotion-26"
+            class="emotion-21 emotion-22"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <h3
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
               >
                 <a
                   aria-labelledby="top-stories-promo-pidgintori51945757-1"
-                  class="emotion-31 emotion-32"
+                  class="emotion-27 emotion-28"
                   href="/pidgin/tori-51945757"
                 >
                   <span
@@ -662,7 +617,7 @@ exports[`CpsRelatedContent should render Top Stories components when given appro
                 </a>
               </h3>
               <time
-                class="emotion-33 emotion-34"
+                class="emotion-29 emotion-30"
                 datetime="2020-02-03"
               >
                 3rd February 2020
@@ -880,7 +835,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 .emotion-7 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -904,50 +859,11 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 .emotion-9 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-9 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-9 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-11 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-11 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-11 {
-    display: none;
-  }
-}
-
-.emotion-13 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-15 {
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -957,7 +873,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
   flex-direction: column;
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -977,7 +893,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-17 {
+  .emotion-13 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -985,11 +901,11 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
   }
 }
 
-.emotion-19 {
+.emotion-15 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1005,68 +921,68 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-21 {
+  .emotion-17 {
     padding-top: 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-21 {
+  .emotion-17 {
     padding-bottom: 1.5rem;
   }
 }
 
-.emotion-23 {
+.emotion-19 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-23 {
+  .emotion-19 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-23 {
+    .emotion-19 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-23 {
+    .emotion-19 {
       display: block;
     }
   }
 }
 
-.emotion-25 {
+.emotion-21 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -1075,25 +991,25 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-25 {
+  .emotion-21 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-25 {
+  .emotion-21 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
   }
 }
 
-.emotion-25>div {
+.emotion-21>div {
   vertical-align: middle;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-25 {
+  .emotion-21 {
     display: block;
     width: initial;
     padding: initial;
@@ -1102,22 +1018,22 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
   }
 
   @media (min-width: 63rem) {
-    .emotion-25 {
+    .emotion-21 {
       padding-top: 0;
     }
   }
 }
 
-.emotion-25>div {
+.emotion-21>div {
   display: inline-block;
   vertical-align: initial;
 }
 
-.emotion-25 svg {
+.emotion-21 svg {
   margin: 0;
 }
 
-.emotion-27 {
+.emotion-23 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -1130,20 +1046,20 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-27 {
+  .emotion-23 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-27 {
+  .emotion-23 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-29 {
+.emotion-25 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1152,7 +1068,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
   overflow-wrap: anywhere;
 }
 
-.emotion-29:before {
+.emotion-25:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1164,20 +1080,20 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
   z-index: 1;
 }
 
-.emotion-29:hover,
-.emotion-29:focus {
+.emotion-25:hover,
+.emotion-25:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-29:visited {
+.emotion-25:visited {
   color: #6E6E73;
 }
 
-.emotion-31 {
+.emotion-27 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1185,14 +1101,14 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-31 {
+  .emotion-27 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31 {
+  .emotion-27 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -1212,23 +1128,17 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
       <div
         class="emotion-6 emotion-7 emotion-8"
       >
-        <div
-          class="emotion-9 emotion-10"
-        />
-        <div
-          class="emotion-11 emotion-12"
-        />
         <h2
-          class="emotion-13 emotion-14"
+          class="emotion-9 emotion-10"
         >
           <span
-            class="emotion-15 emotion-16"
+            class="emotion-11 emotion-12"
           >
             <span
-              class="emotion-17 emotion-18"
+              class="emotion-13 emotion-14"
             >
               <span
-                class="emotion-19 emotion-20"
+                class="emotion-15 emotion-16"
                 dir="ltr"
                 id="top-stories-heading"
               >
@@ -1239,23 +1149,23 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
         </h2>
       </div>
       <div
-        class="emotion-21 emotion-22"
+        class="emotion-17 emotion-18"
       >
         <div>
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-19 emotion-20"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-21 emotion-22"
               dir="ltr"
             >
               <h3
-                class="emotion-27 emotion-28"
+                class="emotion-23 emotion-24"
               >
                 <a
                   aria-labelledby="top-stories-promo-mundonoticiasinternacional51939501-1"
-                  class="emotion-29 emotion-30"
+                  class="emotion-25 emotion-26"
                   href="/mundo/noticias-internacional-51939501"
                 >
                   <span
@@ -1266,7 +1176,7 @@ exports[`CpsRelatedContent should render Top Stories components when without <ul
                 </a>
               </h3>
               <time
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
                 datetime="2020-02-03"
               >
                 3rd February 2020

--- a/src/app/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/EpisodeList/RecentAudioEpisodes/__snapshots__/index.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 .emotion-3 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-bottom: 0;
 }
@@ -39,28 +39,11 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 .emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: none;
-  }
-}
-
-.emotion-7 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-9 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -70,7 +53,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   flex-direction: column;
 }
 
-.emotion-11 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,7 +73,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-11 {
+  .emotion-9 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -98,11 +81,11 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   }
 }
 
-.emotion-13 {
+.emotion-11 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -118,66 +101,66 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     padding-right: 1rem;
   }
 }
 
-.emotion-15 {
+.emotion-13 {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.emotion-17 {
+.emotion-15 {
   padding: 1rem 0;
   line-height: 0;
 }
 
-.emotion-17:first-child {
+.emotion-15:first-child {
   padding-top: 0;
 }
 
-.emotion-17:last-child {
+.emotion-15:last-child {
   padding-bottom: 0;
 }
 
-.emotion-17:not(:last-child) {
+.emotion-15:not(:last-child) {
   border-bottom: 1px #BABABA solid;
 }
 
-.emotion-19 {
+.emotion-17 {
   position: relative;
   padding-left: 4rem;
 }
 
-.emotion-21 {
+.emotion-19 {
   line-height: 0;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-21:before {
+.emotion-19:before {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -188,47 +171,47 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-21 .rounded-play-button__ring,
-.emotion-21 .rounded-play-button__triangle {
+.emotion-19 .rounded-play-button__ring,
+.emotion-19 .rounded-play-button__triangle {
   color: #000;
 }
 
-.emotion-21:focus [class*='--hover'],
-.emotion-21:hover [class*='--hover'] {
+.emotion-19:focus [class*='--hover'],
+.emotion-19:hover [class*='--hover'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-21:focus .rounded-play-button__ring,
-.emotion-21:hover .rounded-play-button__ring,
-.emotion-21:focus .rounded-play-button__inner,
-.emotion-21:hover .rounded-play-button__inner {
+.emotion-19:focus .rounded-play-button__ring,
+.emotion-19:hover .rounded-play-button__ring,
+.emotion-19:focus .rounded-play-button__inner,
+.emotion-19:hover .rounded-play-button__inner {
   fill: currentColor;
   color: #B80000;
 }
 
-.emotion-21:focus .rounded-play-button__triangle,
-.emotion-21:hover .rounded-play-button__triangle {
+.emotion-19:focus .rounded-play-button__triangle,
+.emotion-19:hover .rounded-play-button__triangle {
   fill: transparent;
 }
 
-.emotion-21:visited [class*='--visited'] {
+.emotion-19:visited [class*='--visited'] {
   color: #6E6E73;
 }
 
-.emotion-23 {
+.emotion-21 {
   position: absolute;
   left: 0.5rem;
   top: 0;
 }
 
-.emotion-25 {
+.emotion-23 {
   display: inline-block;
   width: 2.5rem;
   height: 2.5rem;
 }
 
-.emotion-27 {
+.emotion-25 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -239,7 +222,7 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
   margin: 0;
 }
 
-.emotion-29 {
+.emotion-27 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -252,20 +235,20 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-29 {
+  .emotion-27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-29 {
+  .emotion-27 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-33 {
+.emotion-31 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -278,20 +261,20 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-39 {
+.emotion-37 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -301,27 +284,27 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-41 {
+.emotion-39 {
   display: inline;
 }
 
-.emotion-45 {
+.emotion-43 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -339,28 +322,28 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-43 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-43 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-43 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-43 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -375,20 +358,17 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
     <div
       class="emotion-2 emotion-3 emotion-4"
     >
-      <div
-        class="emotion-5 emotion-6"
-      />
       <h2
-        class="emotion-7 emotion-8"
+        class="emotion-5 emotion-6"
       >
         <span
-          class="emotion-9 emotion-10"
+          class="emotion-7 emotion-8"
         >
           <span
-            class="emotion-11 emotion-12"
+            class="emotion-9 emotion-10"
           >
             <span
-              class="emotion-13 emotion-14"
+              class="emotion-11 emotion-12"
               dir="ltr"
               id="recent-episodes"
             >
@@ -399,31 +379,31 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
       </h2>
     </div>
     <ul
-      class="emotion-15 emotion-16"
+      class="emotion-13 emotion-14"
       data-e2e="recent-episodes-list"
       role="list"
     >
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-15 emotion-16"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-17 emotion-18"
           dir="ltr"
         >
           <a
             aria-labelledby="episodeLinkIndex-0"
-            class="emotion-21 emotion-22"
+            class="emotion-19 emotion-20"
             href="/indonesia/bbc_indonesian_radio/w172xnm8j4tz686"
           >
             <div
               aria-hidden="true"
-              class="emotion-23 emotion-24"
+              class="emotion-21 emotion-22"
               dir="ltr"
             >
               <div
                 aria-hidden="true"
-                class="emotion-25 emotion-26"
+                class="emotion-23 emotion-24"
               >
                 
       
@@ -469,39 +449,39 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
               role="text"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 Audio, 
               </span>
               <span
-                class="episode-list__title--hover episode-list__title--visited emotion-29 emotion-30"
+                class="episode-list__title--hover episode-list__title--visited emotion-27 emotion-28"
                 dir="ltr"
               >
                 Dunia Pagi Ini
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="episode-list__description--hover episode-list__description--visited emotion-33 emotion-34"
+                class="episode-list__description--hover episode-list__description--visited emotion-31 emotion-32"
                 dir="ltr"
               >
                 BBC Indonesia, Kamis 18 Februari 2021
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                  Durasi 15,30 
               </span>
               <span
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
                 dir="ltr"
               >
                 <span
@@ -513,10 +493,10 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
             </span>
           </a>
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-39 emotion-40"
           >
             <time
-              class="emotion-40 emotion-44 emotion-45 emotion-46"
+              class="emotion-38 emotion-42 emotion-43 emotion-44"
               datetime="2020-11-17"
             >
               17 November 2020
@@ -525,26 +505,26 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
         </div>
       </li>
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-15 emotion-16"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-17 emotion-18"
           dir="ltr"
         >
           <a
             aria-labelledby="episodeLinkIndex-1"
-            class="emotion-21 emotion-22"
+            class="emotion-19 emotion-20"
             href="/indonesia/bbc_indonesian_radio/w172xnm84wjrkv2"
           >
             <div
               aria-hidden="true"
-              class="emotion-23 emotion-24"
+              class="emotion-21 emotion-22"
               dir="ltr"
             >
               <div
                 aria-hidden="true"
-                class="emotion-25 emotion-26"
+                class="emotion-23 emotion-24"
               >
                 
       
@@ -590,39 +570,39 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
               role="text"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 Audio, 
               </span>
               <span
-                class="episode-list__title--hover episode-list__title--visited emotion-29 emotion-30"
+                class="episode-list__title--hover episode-list__title--visited emotion-27 emotion-28"
                 dir="ltr"
               >
                 Dunia Pagi Ini
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="episode-list__description--hover episode-list__description--visited emotion-33 emotion-34"
+                class="episode-list__description--hover episode-list__description--visited emotion-31 emotion-32"
                 dir="ltr"
               >
                 16 November 2020
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                  Durasi 15,30 
               </span>
               <span
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
                 dir="ltr"
               >
                 <span
@@ -636,26 +616,26 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
         </div>
       </li>
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-15 emotion-16"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-17 emotion-18"
           dir="ltr"
         >
           <a
             aria-labelledby="episodeLinkIndex-2"
-            class="emotion-21 emotion-22"
+            class="emotion-19 emotion-20"
             href="/indonesia/bbc_indonesian_radio/w172xnm84wjrg2y"
           >
             <div
               aria-hidden="true"
-              class="emotion-23 emotion-24"
+              class="emotion-21 emotion-22"
               dir="ltr"
             >
               <div
                 aria-hidden="true"
-                class="emotion-25 emotion-26"
+                class="emotion-23 emotion-24"
               >
                 
       
@@ -701,39 +681,39 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
               role="text"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 Audio, 
               </span>
               <span
-                class="episode-list__title--hover episode-list__title--visited emotion-29 emotion-30"
+                class="episode-list__title--hover episode-list__title--visited emotion-27 emotion-28"
                 dir="ltr"
               >
                 Dunia Pagi Ini
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="episode-list__description--hover episode-list__description--visited emotion-33 emotion-34"
+                class="episode-list__description--hover episode-list__description--visited emotion-31 emotion-32"
                 dir="ltr"
               >
                 16 November 2020
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                  Durasi 15,30 
               </span>
               <span
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
                 dir="ltr"
               >
                 <span
@@ -747,26 +727,26 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
         </div>
       </li>
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-15 emotion-16"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-17 emotion-18"
           dir="ltr"
         >
           <a
             aria-labelledby="episodeLinkIndex-3"
-            class="emotion-21 emotion-22"
+            class="emotion-19 emotion-20"
             href="/indonesia/bbc_indonesian_radio/w172xnm84wjgw3s"
           >
             <div
               aria-hidden="true"
-              class="emotion-23 emotion-24"
+              class="emotion-21 emotion-22"
               dir="ltr"
             >
               <div
                 aria-hidden="true"
-                class="emotion-25 emotion-26"
+                class="emotion-23 emotion-24"
               >
                 
       
@@ -812,39 +792,39 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
               role="text"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 Audio, 
               </span>
               <span
-                class="episode-list__title--hover episode-list__title--visited emotion-29 emotion-30"
+                class="episode-list__title--hover episode-list__title--visited emotion-27 emotion-28"
                 dir="ltr"
               >
                 Dunia Pagi Ini
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="episode-list__description--hover episode-list__description--visited emotion-33 emotion-34"
+                class="episode-list__description--hover episode-list__description--visited emotion-31 emotion-32"
                 dir="ltr"
               >
                 Wednesday Evening
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                 , 
               </span>
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
               >
                  Durasi 15,30 
               </span>
               <span
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
                 dir="ltr"
               >
                 <span
@@ -856,10 +836,10 @@ exports[`RecentAudioEpisodes should render audio episodes correctly 1`] = `
             </span>
           </a>
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-39 emotion-40"
           >
             <time
-              class="emotion-40 emotion-44 emotion-45 emotion-46"
+              class="emotion-38 emotion-42 emotion-43 emotion-44"
               datetime="2020-11-13"
             >
               13 November 2020

--- a/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/EpisodeList/RecentVideoEpisodes/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 .emotion-1 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   color: #FFFFFF;
   margin-bottom: 0;
@@ -35,50 +35,11 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 .emotion-3 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-3 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-3 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: none;
-  }
-}
-
-.emotion-7 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-9 {
+.emotion-5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -88,7 +49,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   flex-direction: column;
 }
 
-.emotion-11 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +69,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-11 {
+  .emotion-7 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -116,11 +77,11 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   }
 }
 
-.emotion-13 {
+.emotion-9 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #121212;
   margin: 1rem 0;
@@ -136,59 +97,59 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-9 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-9 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-9 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-9 {
     padding-right: 1rem;
   }
 }
 
-.emotion-15 {
+.emotion-11 {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.emotion-17 {
+.emotion-13 {
   padding: 1rem 0;
   line-height: 0;
 }
 
-.emotion-17:first-child {
+.emotion-13:first-child {
   padding-top: 0;
 }
 
-.emotion-17:last-child {
+.emotion-13:last-child {
   padding-bottom: 0;
 }
 
-.emotion-17:not(:last-child) {
+.emotion-13:not(:last-child) {
   border-bottom: 1px #BABABA solid;
 }
 
-.emotion-19 {
+.emotion-15 {
   position: relative;
 }
 
-.emotion-21 {
+.emotion-17 {
   display: inline-block;
   position: relative;
   width: 4.375rem;
@@ -196,19 +157,19 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-21 {
+  .emotion-17 {
     width: 7.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-21 {
+  .emotion-17 {
     margin-right: 1rem;
     width: 14.375rem;
   }
 }
 
-.emotion-23 {
+.emotion-19 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -223,35 +184,35 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-23 {
+  .emotion-19 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-23 {
+  .emotion-19 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
-.emotion-25 {
+.emotion-21 {
   width: 100%;
 }
 
-.emotion-27 {
+.emotion-23 {
   background-color: #222222;
   padding: 0.25rem;
 }
 
 @media (min-width: 25rem) {
-  .emotion-27 {
+  .emotion-23 {
     padding: 0.5rem;
   }
 }
 
-.emotion-27 svg {
+.emotion-23 svg {
   margin: 0 0 1px 0;
   height: 0.6rem;
   width: 0.7rem;
@@ -259,19 +220,19 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-27 svg {
+  .emotion-23 svg {
     fill: linkText;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-27 {
+  .emotion-23 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-29 {
+.emotion-25 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -280,7 +241,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   height: 0.75rem;
 }
 
-.emotion-31 {
+.emotion-27 {
   font-size: 0.75rem;
   line-height: 1rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -291,44 +252,44 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-31 {
+  .emotion-27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31 {
+  .emotion-27 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
-.emotion-33 {
+.emotion-29 {
   display: inline-block;
   max-width: calc(100% - 4.375rem - 1rem);
   vertical-align: top;
 }
 
 @media (min-width: 25rem) {
-  .emotion-33 {
+  .emotion-29 {
     max-width: calc(100% - 7.5rem - 1rem);
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     max-width: calc(100% - 14.375rem - 1rem);
   }
 }
 
-.emotion-35 {
+.emotion-31 {
   line-height: 0;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-35:before {
+.emotion-31:before {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -339,35 +300,35 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   z-index: 1;
 }
 
-.emotion-35 .rounded-play-button__ring,
-.emotion-35 .rounded-play-button__triangle {
+.emotion-31 .rounded-play-button__ring,
+.emotion-31 .rounded-play-button__triangle {
   color: #000;
 }
 
-.emotion-35:focus [class*='--hover'],
-.emotion-35:hover [class*='--hover'] {
+.emotion-31:focus [class*='--hover'],
+.emotion-31:hover [class*='--hover'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-35:focus .rounded-play-button__ring,
-.emotion-35:hover .rounded-play-button__ring,
-.emotion-35:focus .rounded-play-button__inner,
-.emotion-35:hover .rounded-play-button__inner {
+.emotion-31:focus .rounded-play-button__ring,
+.emotion-31:hover .rounded-play-button__ring,
+.emotion-31:focus .rounded-play-button__inner,
+.emotion-31:hover .rounded-play-button__inner {
   fill: currentColor;
   color: #B80000;
 }
 
-.emotion-35:focus .rounded-play-button__triangle,
-.emotion-35:hover .rounded-play-button__triangle {
+.emotion-31:focus .rounded-play-button__triangle,
+.emotion-31:hover .rounded-play-button__triangle {
   fill: transparent;
 }
 
-.emotion-35:visited [class*='--visited'] {
+.emotion-31:visited [class*='--visited'] {
   color: #D5D0CD;
 }
 
-.emotion-37 {
+.emotion-33 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -378,7 +339,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
   margin: 0;
 }
 
-.emotion-39 {
+.emotion-35 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -391,20 +352,20 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-43 {
+.emotion-39 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -417,27 +378,27 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.9375rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-107 {
+.emotion-103 {
   display: inline;
 }
 
-.emotion-110 {
+.emotion-106 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -451,28 +412,28 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-110 {
+  .emotion-106 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-110 {
+  .emotion-106 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-110 {
+  .emotion-106 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-110 {
+  .emotion-106 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -486,23 +447,17 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
     <div
       class="emotion-0 emotion-1 emotion-2"
     >
-      <div
-        class="emotion-3 emotion-4"
-      />
-      <div
-        class="emotion-5 emotion-6"
-      />
       <h2
-        class="emotion-7 emotion-8"
+        class="emotion-3 emotion-4"
       >
         <span
-          class="emotion-9 emotion-10"
+          class="emotion-5 emotion-6"
         >
           <span
-            class="emotion-11 emotion-12"
+            class="emotion-7 emotion-8"
           >
             <span
-              class="emotion-13 emotion-14"
+              class="emotion-9 emotion-10"
               dir="ltr"
               id="recent-episodes"
             >
@@ -513,42 +468,42 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
       </h2>
     </div>
     <ul
-      class="emotion-15 emotion-16"
+      class="emotion-11 emotion-12"
       data-e2e="recent-episodes-list"
       role="list"
     >
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-13 emotion-14"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-15 emotion-16"
           dir="ltr"
         >
           <div
-            class="emotion-21 emotion-22"
+            class="emotion-17 emotion-18"
             dir="ltr"
           >
             <div
-              class="emotion-23 emotion-24"
+              class="emotion-19 emotion-20"
               data-e2e="image-placeholder"
               style="padding-bottom: 56.25%;"
             >
               <img
                 alt="BBC Info"
-                class="emotion-25 emotion-26"
+                class="emotion-21 emotion-22"
                 dir="ltr"
                 src="//ichef.bbci.co.uk/images/ic/768x432/p08b22y1.png"
               />
             </div>
             <div
               aria-hidden="true"
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <svg
                 aria-hidden="true"
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
                 focusable="false"
                 height="12px"
                 viewBox="0 0 32 32"
@@ -559,7 +514,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 />
               </svg>
               <span
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
                 dir="ltr"
               >
                 15:00
@@ -567,11 +522,11 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
             </div>
           </div>
           <div
-            class="emotion-33 emotion-34"
+            class="emotion-29 emotion-30"
           >
             <a
               aria-labelledby="episodeLinkIndex-0"
-              class="emotion-35 emotion-36"
+              class="emotion-31 emotion-32"
               href="/afrique/bbc_afrique_tv/tv/w172xc9xq2gllfk"
             >
               <span
@@ -579,29 +534,29 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 role="text"
               >
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   Vidéo, 
                 </span>
                 <span
-                  class="episode-list__title--hover episode-list__title--visited emotion-39 emotion-40"
+                  class="episode-list__title--hover episode-list__title--visited emotion-35 emotion-36"
                   dir="ltr"
                 >
                   BBC Info
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , 
                 </span>
                 <span
-                  class="episode-list__description--hover episode-list__description--visited emotion-43 emotion-44"
+                  class="episode-list__description--hover episode-list__description--visited emotion-39 emotion-40"
                   dir="ltr"
                 >
                   13 novembre 2020
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , Durée 15,00 
                 </span>
@@ -611,37 +566,37 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
         </div>
       </li>
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-13 emotion-14"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-15 emotion-16"
           dir="ltr"
         >
           <div
-            class="emotion-21 emotion-22"
+            class="emotion-17 emotion-18"
             dir="ltr"
           >
             <div
-              class="emotion-23 emotion-24"
+              class="emotion-19 emotion-20"
               data-e2e="image-placeholder"
               style="padding-bottom: 56.25%;"
             >
               <img
                 alt="BBC Info"
-                class="emotion-25 emotion-26"
+                class="emotion-21 emotion-22"
                 dir="ltr"
                 src="//ichef.bbci.co.uk/images/ic/768x432/p08b22y1.png"
               />
             </div>
             <div
               aria-hidden="true"
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <svg
                 aria-hidden="true"
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
                 focusable="false"
                 height="12px"
                 viewBox="0 0 32 32"
@@ -652,7 +607,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 />
               </svg>
               <span
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
                 dir="ltr"
               >
                 15:00
@@ -660,11 +615,11 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
             </div>
           </div>
           <div
-            class="emotion-33 emotion-34"
+            class="emotion-29 emotion-30"
           >
             <a
               aria-labelledby="episodeLinkIndex-1"
-              class="emotion-35 emotion-36"
+              class="emotion-31 emotion-32"
               href="/afrique/bbc_afrique_tv/tv/w172xc9xq2ghpjg"
             >
               <span
@@ -672,29 +627,29 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 role="text"
               >
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   Vidéo, 
                 </span>
                 <span
-                  class="episode-list__title--hover episode-list__title--visited emotion-39 emotion-40"
+                  class="episode-list__title--hover episode-list__title--visited emotion-35 emotion-36"
                   dir="ltr"
                 >
                   BBC Info
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , 
                 </span>
                 <span
-                  class="episode-list__description--hover episode-list__description--visited emotion-43 emotion-44"
+                  class="episode-list__description--hover episode-list__description--visited emotion-39 emotion-40"
                   dir="ltr"
                 >
                   12 novembre 2020
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , Durée 15,00 
                 </span>
@@ -704,37 +659,37 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
         </div>
       </li>
       <li
-        class="emotion-17 emotion-18"
+        class="emotion-13 emotion-14"
         data-e2e="recent-episodes-list-item"
       >
         <div
-          class="emotion-19 emotion-20"
+          class="emotion-15 emotion-16"
           dir="ltr"
         >
           <div
-            class="emotion-21 emotion-22"
+            class="emotion-17 emotion-18"
             dir="ltr"
           >
             <div
-              class="emotion-23 emotion-24"
+              class="emotion-19 emotion-20"
               data-e2e="image-placeholder"
               style="padding-bottom: 56.25%;"
             >
               <img
                 alt="BBC Info"
-                class="emotion-25 emotion-26"
+                class="emotion-21 emotion-22"
                 dir="ltr"
                 src="//ichef.bbci.co.uk/images/ic/768x432/p08b22y1.png"
               />
             </div>
             <div
               aria-hidden="true"
-              class="emotion-27 emotion-28"
+              class="emotion-23 emotion-24"
               dir="ltr"
             >
               <svg
                 aria-hidden="true"
-                class="emotion-29 emotion-30"
+                class="emotion-25 emotion-26"
                 focusable="false"
                 height="12px"
                 viewBox="0 0 32 32"
@@ -745,7 +700,7 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 />
               </svg>
               <span
-                class="emotion-31 emotion-32"
+                class="emotion-27 emotion-28"
                 dir="ltr"
               >
                 15:00
@@ -753,11 +708,11 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
             </div>
           </div>
           <div
-            class="emotion-33 emotion-34"
+            class="emotion-29 emotion-30"
           >
             <a
               aria-labelledby="episodeLinkIndex-2"
-              class="emotion-35 emotion-36"
+              class="emotion-31 emotion-32"
               href="/afrique/bbc_afrique_tv/tv/w172xc9xq2gdsmc"
             >
               <span
@@ -765,39 +720,39 @@ exports[`Recent Video Episodes should render video episodes correctly 1`] = `
                 role="text"
               >
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   Vidéo, 
                 </span>
                 <span
-                  class="episode-list__title--hover episode-list__title--visited emotion-39 emotion-40"
+                  class="episode-list__title--hover episode-list__title--visited emotion-35 emotion-36"
                   dir="ltr"
                 >
                   BBC Info
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , 
                 </span>
                 <span
-                  class="episode-list__description--hover episode-list__description--visited emotion-43 emotion-44"
+                  class="episode-list__description--hover episode-list__description--visited emotion-39 emotion-40"
                   dir="ltr"
                 >
                   Oui, je suis le chef
                 </span>
                 <span
-                  class="emotion-37 emotion-38"
+                  class="emotion-33 emotion-34"
                 >
                   , Durée 15,00 
                 </span>
               </span>
             </a>
             <div
-              class="emotion-107 emotion-108"
+              class="emotion-103 emotion-104"
             >
               <time
-                class="emotion-109 emotion-110 emotion-111"
+                class="emotion-105 emotion-106 emotion-107"
                 datetime="2020-11-11"
               >
                 11 novembre 2020

--- a/src/app/containers/FauxHeadline/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FauxHeadline/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`FauxHeadline with headline data should render correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -266,7 +266,7 @@ exports[`FauxHeadline with plain text headline should render <strong> containing
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;

--- a/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/FrontPageStoryRows/__snapshots__/index.test.jsx.snap
@@ -707,7 +707,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow - rtl 1`] = `
 .emotion-52 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -1129,7 +1129,7 @@ exports[`FrontPageStoryRows Container - snapshots LeadingRow 1`] = `
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2310,7 +2310,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images - rtl 1
 .emotion-52 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -2927,7 +2927,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow with images 1`] = `
 .emotion-19 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -3865,7 +3865,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images - rt
 .emotion-42 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -4419,7 +4419,7 @@ exports[`FrontPageStoryRows Container - snapshots RegularRow without images 1`] 
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5496,7 +5496,7 @@ exports[`FrontPageStoryRows Container - snapshots TopRow 1`] = `
 .emotion-19 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/Header/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Header/__snapshots__/index.test.jsx.snap
@@ -416,8 +416,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 
 .emotion-29 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-29::after {
@@ -426,7 +425,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-29 .emotion-46::after {
@@ -437,6 +436,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-33 {
@@ -468,7 +468,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -490,8 +490,14 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 }
 
 .emotion-37 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-37 {
+    fill: linkText;
+  }
 }
 
 @media (max-width: 37.4375rem) {
@@ -520,8 +526,8 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -564,7 +570,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -576,6 +582,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -609,7 +616,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-47:focus::after {
@@ -618,13 +625,13 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-77 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -652,12 +659,12 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
@@ -671,7 +678,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -696,6 +703,7 @@ exports[`Header Snapshots should render correctly for WS frontPage 1`] = `
 .emotion-83:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 <div>
@@ -1528,8 +1536,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 
 .emotion-29 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-29::after {
@@ -1538,7 +1545,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-29 .emotion-46::after {
@@ -1549,6 +1556,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-33 {
@@ -1580,7 +1588,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -1602,8 +1610,14 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 }
 
 .emotion-37 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-37 {
+    fill: linkText;
+  }
 }
 
 @media (max-width: 37.4375rem) {
@@ -1632,8 +1646,8 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -1676,7 +1690,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -1688,6 +1702,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1721,7 +1736,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-47:focus::after {
@@ -1730,13 +1745,13 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-77 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -1764,12 +1779,12 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
@@ -1783,7 +1798,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -1808,6 +1823,7 @@ exports[`Header Snapshots should render correctly for WS radio page 1`] = `
 .emotion-83:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 <div>
@@ -2640,8 +2656,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 
 .emotion-29 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-29::after {
@@ -2650,7 +2665,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-29 .emotion-46::after {
@@ -2661,6 +2676,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-33 {
@@ -2692,7 +2708,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -2714,8 +2730,14 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 }
 
 .emotion-37 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-37 {
+    fill: linkText;
+  }
 }
 
 @media (max-width: 37.4375rem) {
@@ -2744,8 +2766,8 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -2788,7 +2810,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -2800,6 +2822,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2833,7 +2856,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-47:focus::after {
@@ -2842,13 +2865,13 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-77 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -2876,12 +2899,12 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-81:last-child {
@@ -2895,7 +2918,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -2920,6 +2943,7 @@ exports[`Header Snapshots should render correctly for news article 1`] = `
 .emotion-83:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 <div>

--- a/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Headings/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`Headings in the middle of articles should render correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -259,7 +259,7 @@ exports[`Headings with headline data should render correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -413,7 +413,7 @@ exports[`Headings with plain text headline should render h1 containing correct t
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -567,7 +567,7 @@ exports[`Headings with plain text subheadline should render h2 containing correc
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -715,7 +715,7 @@ exports[`Headings with rich text headline with bold text should render h1 with <
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -871,7 +871,7 @@ exports[`Headings with rich text headline with italic text should render h1 with
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1037,7 +1037,7 @@ exports[`Headings with rich text should render headline with bold & italic text 
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1205,7 +1205,7 @@ exports[`Headings with rich text should render headline with italic & bold text 
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1373,7 +1373,7 @@ exports[`Headings with rich text with different attributes should render headlin
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1541,7 +1541,7 @@ exports[`Headings with subheadline data should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }

--- a/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/IndexPageSection/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,7 @@ HTMLCollection [
 .emotion-2 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -42,33 +42,11 @@ HTMLCollection [
 }
 
 .emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,7 +56,7 @@ HTMLCollection [
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,7 +76,7 @@ HTMLCollection [
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -106,11 +84,11 @@ HTMLCollection [
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -126,4333 +104,40 @@ HTMLCollection [
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-top: 0.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-top: 2rem;
-  }
-}
-
-.emotion-17 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-@supports (display: grid) {
-  .emotion-17 {
-    display: grid;
-    position: initial;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-}
-
-.emotion-20 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-20 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-20:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-20 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-20 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-20:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-20:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-20:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-20 {
-    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-20 {
-    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-20 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-    }
-  }
-}
-
-.emotion-22 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-22 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-22 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(12, 1fr);
-    }
-  }
-}
-
-.emotion-24 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  margin-bottom: 0.5rem;
-  width: 100%;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-24 {
-    width: calc(50% - 0.5rem);
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-24 {
-    width: calc(50% - 0.5rem);
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
-    width: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
-    .emotion-24 {
-      grid-column: 1/span 3;
-    }
-  }
-}
-
-.emotion-26 {
-  position: relative;
-}
-
-.emotion-28 {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  background-color: #F2F2F2;
-  -webkit-background-position: center center;
-  background-position: center center;
-  background-repeat: no-repeat;
-  -webkit-background-size: 60px 17px;
-  background-size: 60px 17px;
-  width: 100%;
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
-}
-
-@media (min-width: 25rem) {
-  .emotion-28 {
-    -webkit-background-size: 77px 22px;
-    background-size: 77px 22px;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-28 {
-    -webkit-background-size: 93px 27px;
-    background-size: 93px 27px;
-  }
-}
-
-.emotion-30 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-33 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-35 {
-  position: absolute;
-  bottom: 0;
-}
-
-.emotion-35>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-.emotion-37 {
-  display: inline-block;
-  vertical-align: top;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-37 {
-    width: 50%;
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-37 {
-    width: 50%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-37 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-37 {
-      grid-column: 4/span 3;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-37 {
-      grid-column: 7/span 6;
-    }
-  }
-}
-
-.emotion-39 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
-    font-size: 1.375rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-39 {
-    font-size: 1.75rem;
-    line-height: 2rem;
-  }
-}
-
-.emotion-41 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-
-.emotion-41:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.emotion-41:hover,
-.emotion-41:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-41:visited {
-  color: #6E6E73;
-}
-
-.emotion-43 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-43 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-.emotion-45 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-45 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-.emotion-48 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-48 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-48:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-48 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-48 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-48:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-48:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-48:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-48 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-48 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-48 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-48 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-48 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-48 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-48 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-48 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-}
-
-.emotion-50 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-50 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-50 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-50 {
-      display: block;
-    }
-  }
-}
-
-.emotion-52 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-52 {
-    display: block;
-    width: 100%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-52 {
-    width: initial;
-    grid-column: 1/span 2;
-  }
-}
-
-@media (min-width: 25rem) {
-  .emotion-58 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-.emotion-58>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-@media (max-width: 24.9375rem) {
-  .emotion-58>* {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-.emotion-60 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-60 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-60 {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 0;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-60 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3/span 4;
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-60 {
-      padding-top: 0.5rem;
-    }
-  }
-}
-
-.emotion-62 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 700;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-62 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-62 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-.emotion-66 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-66 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-66 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width: 37.4375rem) {
-  .emotion-66 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-66 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-<section
-    aria-labelledby="Top-Stories"
-    class="emotion-0 emotion-1"
-    role="region"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      />
-      <h2
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-          >
-            <span
-              class="emotion-12 emotion-13"
-              dir="ltr"
-              id="Top-Stories"
-            >
-              Top Stories
-            </span>
-          </span>
-        </span>
-      </h2>
-    </div>
-    <div
-      class="emotion-14 emotion-15"
-    >
-      <ul
-        class="emotion-16 emotion-17 emotion-18"
-        dir="ltr"
-        role="list"
-      >
-        <li
-          class="emotion-16 emotion-20 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-22 emotion-23"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-24 emotion-25"
-              dir="ltr"
-            >
-              <div
-                class="emotion-26 emotion-27"
-              >
-                <div
-                  class="emotion-28 emotion-29"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <picture
-                    class="emotion-30 emotion-31"
-                  >
-                    <source
-                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg.webp 660w"
-                      type="image/webp"
-                    />
-                    <source
-                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg 660w"
-                      type="image/jpeg"
-                    />
-                    <img
-                      alt="Image Alt text 1"
-                      class="emotion-32 emotion-33 emotion-34"
-                      height="1152"
-                      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg"
-                      width="2048"
-                    />
-                  </picture>
-                </div>
-                <div
-                  class="emotion-35 emotion-36"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-37 emotion-38"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-39 emotion-40"
-              >
-                <a
-                  aria-labelledby="promo-1"
-                  class="emotion-41 emotion-42"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-1"
-                  >
-                    Top Story 1 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-43 emotion-44"
-              >
-                Summary text 1
-              </p>
-              <time
-                class="emotion-45 emotion-46"
-                datetime="1970-01-19"
-              >
-                19 Jenụwarị 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-16 emotion-48 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-50 emotion-23"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-52 emotion-25"
-              dir="ltr"
-            >
-              <div
-                class="emotion-26 emotion-27"
-              >
-                <div
-                  class="emotion-28 emotion-29"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-58 emotion-36"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-60 emotion-38"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-62 emotion-40"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-1"
-                  class="emotion-41 emotion-42"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-1"
-                  >
-                    Top Story 2 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-66 emotion-44"
-              >
-                Summary text 2
-              </p>
-              <time
-                class="emotion-45 emotion-46"
-                datetime="1970-01-19"
-              >
-                19 Jenụwarị 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-16 emotion-48 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-50 emotion-23"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-52 emotion-25"
-              dir="ltr"
-            >
-              <div
-                class="emotion-26 emotion-27"
-              >
-                <div
-                  class="emotion-28 emotion-29"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-58 emotion-36"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-60 emotion-38"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-62 emotion-40"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-2"
-                  class="emotion-41 emotion-42"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-2"
-                  >
-                    Top Story 3 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-66 emotion-44"
-              >
-                Summary text 3
-              </p>
-              <time
-                class="emotion-45 emotion-46"
-                datetime="1970-01-19"
-              >
-                19 Jenụwarị 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-16 emotion-48 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-50 emotion-23"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-52 emotion-25"
-              dir="ltr"
-            >
-              <div
-                class="emotion-26 emotion-27"
-              >
-                <div
-                  class="emotion-28 emotion-29"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-58 emotion-36"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-60 emotion-38"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-62 emotion-40"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-3"
-                  class="emotion-41 emotion-42"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-3"
-                  >
-                    Top Story 4 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-66 emotion-44"
-              >
-                Summary text 4
-              </p>
-              <time
-                class="emotion-45 emotion-46"
-                datetime="1970-01-19"
-              >
-                19 Jenụwarị 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-16 emotion-48 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-50 emotion-23"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-52 emotion-25"
-              dir="ltr"
-            >
-              <div
-                class="emotion-26 emotion-27"
-              >
-                <div
-                  class="emotion-28 emotion-29"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-58 emotion-36"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-60 emotion-38"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-62 emotion-40"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-4"
-                  class="emotion-41 emotion-42"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-4"
-                  >
-                    Top Story 5 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-66 emotion-44"
-              >
-                Summary text 5
-              </p>
-              <time
-                class="emotion-45 emotion-46"
-                datetime="1970-01-19"
-              >
-                19 Jenụwarị 1970
-              </time>
-            </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </section>,
-]
-`;
-
-exports[`IndexPageSection Container snapshots should render correctly for canonical 1`] = `
-.emotion-0 {
-  margin: 0 auto;
-  width: 100%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    max-width: 63rem;
-  }
-}
-
-.emotion-2 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-2 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-6 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-6 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    display: none;
-  }
-}
-
-.emotion-8 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-14 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    padding-right: 1rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-16 {
-    margin-top: 0.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-16 {
-    margin-top: 2rem;
-  }
-}
-
-.emotion-19 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-@supports (display: grid) {
-  .emotion-19 {
-    display: grid;
-    position: initial;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-19 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-}
-
-.emotion-22 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-22 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-22:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-22 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-22 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-22:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-22:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-22:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-22 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-22 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-22 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-22 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-22 {
-    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-22 {
-    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-22 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-22 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-    }
-  }
-}
-
-.emotion-24 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-24 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-24 {
-      grid-template-columns: repeat(12, 1fr);
-    }
-  }
-}
-
-.emotion-26 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  margin-bottom: 0.5rem;
-  width: 100%;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-26 {
-    width: calc(50% - 0.5rem);
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-26 {
-    width: calc(50% - 0.5rem);
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-26 {
-    width: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
-    .emotion-26 {
-      grid-column: 1/span 3;
-    }
-  }
-}
-
-.emotion-28 {
-  position: relative;
-}
-
-.emotion-30 {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  background-color: #F2F2F2;
-  -webkit-background-position: center center;
-  background-position: center center;
-  background-repeat: no-repeat;
-  -webkit-background-size: 60px 17px;
-  background-size: 60px 17px;
-  width: 100%;
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
-}
-
-@media (min-width: 25rem) {
-  .emotion-30 {
-    -webkit-background-size: 77px 22px;
-    background-size: 77px 22px;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-30 {
-    -webkit-background-size: 93px 27px;
-    background-size: 93px 27px;
-  }
-}
-
-.emotion-32 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-35 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-37 {
-  position: absolute;
-  bottom: 0;
-}
-
-.emotion-37>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-.emotion-39 {
-  display: inline-block;
-  vertical-align: top;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-39 {
-    width: 50%;
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-39 {
-    width: 50%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-39 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-39 {
-      grid-column: 4/span 3;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-39 {
-      grid-column: 7/span 6;
-    }
-  }
-}
-
-.emotion-41 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-41 {
-    font-size: 1.375rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-41 {
-    font-size: 1.75rem;
-    line-height: 2rem;
-  }
-}
-
-.emotion-43 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-
-.emotion-43:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.emotion-43:hover,
-.emotion-43:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-43:visited {
-  color: #6E6E73;
-}
-
-.emotion-45 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-45 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-45 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-.emotion-47 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-47 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-47 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-.emotion-50 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-50 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-50:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-50 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-50 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-50:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-50:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-50:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-50 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-50 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-50 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-50 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-50 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-50 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-50 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-50 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-}
-
-.emotion-52 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-52 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-52 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-52 {
-      display: block;
-    }
-  }
-}
-
-.emotion-54 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-54 {
-    display: block;
-    width: 100%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-54 {
-    width: initial;
-    grid-column: 1/span 2;
-  }
-}
-
-@media (min-width: 25rem) {
-  .emotion-60 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-.emotion-60>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-@media (max-width: 24.9375rem) {
-  .emotion-60>* {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-.emotion-62 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-62 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-62 {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 0;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-62 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3/span 4;
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-62 {
-      padding-top: 0.5rem;
-    }
-  }
-}
-
-.emotion-64 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-64 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-64 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-.emotion-68 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-68 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-68 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width: 37.4375rem) {
-  .emotion-68 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-68 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-<div>
-  <section
-    aria-labelledby="Top-Stories"
-    class="emotion-0 emotion-1"
-    role="region"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      />
-      <div
-        class="emotion-6 emotion-7"
-      />
-      <h2
-        class="emotion-8 emotion-9"
-      >
-        <span
-          class="emotion-10 emotion-11"
-        >
-          <span
-            class="emotion-12 emotion-13"
-          >
-            <span
-              class="emotion-14 emotion-15"
-              dir="ltr"
-              id="Top-Stories"
-            >
-              Top Stories
-            </span>
-          </span>
-        </span>
-      </h2>
-    </div>
-    <div
-      class="emotion-16 emotion-17"
-    >
-      <ul
-        class="emotion-18 emotion-19 emotion-20"
-        dir="ltr"
-        role="list"
-      >
-        <li
-          class="emotion-18 emotion-22 emotion-23"
-          dir="ltr"
-        >
-          <div
-            class="emotion-24 emotion-25"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-26 emotion-27"
-              dir="ltr"
-            >
-              <div
-                class="emotion-28 emotion-29"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <picture
-                    class="emotion-32 emotion-33"
-                  >
-                    <source
-                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg.webp 660w"
-                      type="image/webp"
-                    />
-                    <source
-                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg 660w"
-                      type="image/jpeg"
-                    />
-                    <img
-                      alt="Image Alt text 1"
-                      class="emotion-34 emotion-35 emotion-36"
-                      height="1152"
-                      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg"
-                      width="2048"
-                    />
-                  </picture>
-                </div>
-                <div
-                  class="emotion-37 emotion-38"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-39 emotion-40"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-41 emotion-42"
-              >
-                <a
-                  aria-labelledby="promo-1"
-                  class="emotion-43 emotion-44"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-1"
-                  >
-                    Top Story 1 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-45 emotion-46"
-              >
-                Summary text 1
-              </p>
-              <time
-                class="emotion-47 emotion-48"
-                datetime="1970-01-19"
-              >
-                19 January 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-50 emotion-23"
-          dir="ltr"
-        >
-          <div
-            class="emotion-52 emotion-25"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-54 emotion-27"
-              dir="ltr"
-            >
-              <div
-                class="emotion-28 emotion-29"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-60 emotion-38"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-62 emotion-40"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-64 emotion-42"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-1"
-                  class="emotion-43 emotion-44"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-1"
-                  >
-                    Top Story 2 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-68 emotion-46"
-              >
-                Summary text 2
-              </p>
-              <time
-                class="emotion-47 emotion-48"
-                datetime="1970-01-19"
-              >
-                19 January 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-50 emotion-23"
-          dir="ltr"
-        >
-          <div
-            class="emotion-52 emotion-25"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-54 emotion-27"
-              dir="ltr"
-            >
-              <div
-                class="emotion-28 emotion-29"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-60 emotion-38"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-62 emotion-40"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-64 emotion-42"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-2"
-                  class="emotion-43 emotion-44"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-2"
-                  >
-                    Top Story 3 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-68 emotion-46"
-              >
-                Summary text 3
-              </p>
-              <time
-                class="emotion-47 emotion-48"
-                datetime="1970-01-19"
-              >
-                19 January 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-50 emotion-23"
-          dir="ltr"
-        >
-          <div
-            class="emotion-52 emotion-25"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-54 emotion-27"
-              dir="ltr"
-            >
-              <div
-                class="emotion-28 emotion-29"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-60 emotion-38"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-62 emotion-40"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-64 emotion-42"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-3"
-                  class="emotion-43 emotion-44"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-3"
-                  >
-                    Top Story 4 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-68 emotion-46"
-              >
-                Summary text 4
-              </p>
-              <time
-                class="emotion-47 emotion-48"
-                datetime="1970-01-19"
-              >
-                19 January 1970
-              </time>
-            </div>
-          </div>
-        </li>
-        <li
-          class="emotion-18 emotion-50 emotion-23"
-          dir="ltr"
-        >
-          <div
-            class="emotion-52 emotion-25"
-            data-e2e="story-promo"
-          >
-            <div
-              class="emotion-54 emotion-27"
-              dir="ltr"
-            >
-              <div
-                class="emotion-28 emotion-29"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                  data-e2e="image-placeholder"
-                  style="padding-bottom: 56.25%;"
-                >
-                  <div
-                    class="lazyload-wrapper "
-                  >
-                    <div
-                      class="lazyload-placeholder"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="emotion-60 emotion-38"
-                />
-              </div>
-            </div>
-            <div
-              class="emotion-62 emotion-40"
-              dir="ltr"
-            >
-              <h3
-                class="emotion-64 emotion-42"
-              >
-                <a
-                  aria-labelledby="promo-top-stories-4"
-                  class="emotion-43 emotion-44"
-                  href="https://www.bbc.co.uk"
-                >
-                  <span
-                    id="promo-top-stories-4"
-                  >
-                    Top Story 5 headline
-                  </span>
-                </a>
-              </h3>
-              <p
-                class="emotion-68 emotion-46"
-              >
-                Summary text 5
-              </p>
-              <time
-                class="emotion-47 emotion-48"
-                datetime="1970-01-19"
-              >
-                19 January 1970
-              </time>
-            </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </section>
-</div>
-`;
-
-exports[`IndexPageSection Container snapshots should render correctly with a linking strapline 1`] = `
-.emotion-0 {
-  margin: 0 auto;
-  width: 100%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    max-width: 63rem;
-  }
-}
-
-.emotion-2 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-2 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-6 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-6 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    display: none;
-  }
-}
-
-.emotion-8 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-14 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    padding-right: 1rem;
-  }
-}
-
-.emotion-17 {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-@supports (display: grid) {
-  .emotion-17 {
-    display: grid;
-    position: initial;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 0.5rem;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-17 {
-      grid-template-columns: repeat(8, 1fr);
-      grid-column-end: span 8;
-      grid-column-gap: 1rem;
-    }
-  }
-}
-
-.emotion-20 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-20 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-20:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-20 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-20 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-20:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-20:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-20:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-20 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-20 {
-    width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-20 {
-    width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-20 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-20 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-}
-
-.emotion-22 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-22 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-22 {
-      grid-column-gap: 1rem;
-    }
-  }
-}
-
-.emotion-24 {
-  display: inline-block;
-  vertical-align: top;
-  width: 100%;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-24 {
-    padding-right: 0.5rem;
-    width: 50%;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-24 {
-    width: 33.33%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
-    display: block;
-    width: initial;
-    padding: initial;
-    padding: 0;
-    width: 100%;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-end: span 6;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-24 {
-      grid-template-columns: repeat(3, 1fr);
-      grid-column-end: span 3;
-    }
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-24 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-24>time {
-    padding-bottom: 0.5rem;
-  }
-}
-
-.emotion-26 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-26 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-26 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-.emotion-28 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-
-.emotion-28:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.emotion-28:hover,
-.emotion-28:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-28:visited {
-  color: #6E6E73;
-}
-
-.emotion-30 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-30 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-30 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (max-width: 37.4375rem) {
-  .emotion-30 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-30 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-.emotion-32 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-32 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-32 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-.emotion-34 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 100%;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-34 {
-    padding-right: 0.5rem;
-    width: 50%;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-34 {
-    width: 66.67%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-34 {
-    width: initial;
-    padding: 0;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-end: span 6;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-34 {
-      grid-template-columns: repeat(3, 1fr);
-      grid-column-end: span 3;
-    }
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-34 {
-      grid-template-columns: repeat(4, 1fr);
-      grid-column-end: span 4;
-    }
-  }
-}
-
-.emotion-36 {
-  position: relative;
-}
-
-.emotion-38 {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  background-color: #F2F2F2;
-  -webkit-background-position: center center;
-  background-position: center center;
-  background-repeat: no-repeat;
-  -webkit-background-size: 60px 17px;
-  background-size: 60px 17px;
-  width: 100%;
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
-}
-
-@media (min-width: 25rem) {
-  .emotion-38 {
-    -webkit-background-size: 77px 22px;
-    background-size: 77px 22px;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-38 {
-    -webkit-background-size: 93px 27px;
-    background-size: 93px 27px;
-  }
-}
-
-.emotion-40 {
-  position: absolute;
-  bottom: 0;
-}
-
-.emotion-40>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-.emotion-43 {
-  padding: 0.5rem 0 1rem;
-}
-
-@media (max-width: 62.9375rem) {
-  .emotion-43 {
-    border-bottom: 0.0625rem solid #F2F2F2;
-  }
-}
-
-.emotion-43:last-child {
-  border: none;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-43 {
-    padding: 1rem 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-43 {
-    padding: 0 0 1.5rem;
-  }
-}
-
-.emotion-43:first-child {
-  padding-top: 0;
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43:first-child {
-    padding-top: 1rem;
-  }
-}
-
-.emotion-43:last-child {
-  padding-bottom: 0;
-}
-
-@media (max-width: 14.9375rem) {
-  .emotion-43 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-43 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
-    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
-    margin: 0 0.25rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
-    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-43 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-43 {
-    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
-    margin: 0 0.5rem;
-    display: inline-block;
-    vertical-align: top;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-43 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-43 {
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-end: span 2;
-    }
-  }
-}
-
-.emotion-45 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-45 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-45 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-45 {
-      display: block;
-    }
-  }
-}
-
-.emotion-47 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  width: 33.33%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-47 {
-    display: block;
-    width: 100%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-47 {
-    width: initial;
-    grid-column: 1/span 2;
-  }
-}
-
-@media (min-width: 25rem) {
-  .emotion-53 {
-    position: absolute;
-    bottom: 0;
-  }
-}
-
-.emotion-53>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-@media (max-width: 24.9375rem) {
-  .emotion-53>* {
-    height: 1.25rem;
-    padding: 0.25rem 0.25rem 0;
-  }
-}
-
-.emotion-55 {
-  display: inline-block;
-  vertical-align: top;
-  width: 66.67%;
-  padding: 0 0.5rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-55 {
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-55 {
-    display: block;
-    width: 100%;
-    padding: 0.5rem 0;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-55 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 3/span 4;
-  }
-
-  @media (min-width: 63rem) {
-    .emotion-55 {
-      padding-top: 0.5rem;
-    }
-  }
-}
-
-.emotion-57 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-57 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-57 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-<div>
-  <section
-    aria-labelledby="Top-Stories"
-    class="emotion-0 emotion-1"
-    role="region"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      />
-      <div
-        class="emotion-6 emotion-7"
-      />
-      <h2
-        class="emotion-8 emotion-9"
-      >
-        <span
-          class="emotion-10 emotion-11"
-        >
-          <span
-            class="emotion-12 emotion-13"
-          >
-            <span
-              class="emotion-14 emotion-15"
-              dir="ltr"
-              id="Top-Stories"
-            >
-              Top Stories
-            </span>
-          </span>
-        </span>
-      </h2>
-    </div>
-    <ul
-      class="emotion-16 emotion-17 emotion-18"
-      dir="ltr"
-      role="list"
-    >
-      <li
-        class="emotion-16 emotion-20 emotion-21"
-        dir="ltr"
-      >
-        <div
-          class="emotion-22 emotion-23"
-          data-e2e="story-promo"
-        >
-          <div
-            class="emotion-24 emotion-25"
-            dir="ltr"
-          >
-            <h3
-              class="emotion-26 emotion-27"
-            >
-              <a
-                aria-labelledby="promo-top-stories-1"
-                class="emotion-28 emotion-29"
-                href="https://www.bbc.co.uk"
-              >
-                <span
-                  id="promo-top-stories-1"
-                >
-                  Top Story 1 headline
-                </span>
-              </a>
-            </h3>
-            <p
-              class="emotion-30 emotion-31"
-            >
-              Summary text 1
-            </p>
-            <time
-              class="emotion-32 emotion-33"
-              datetime="1970-01-19"
-            >
-              19 January 1970
-            </time>
-          </div>
-          <div
-            class="emotion-34 emotion-35"
-            dir="ltr"
-          >
-            <div
-              class="emotion-36 emotion-37"
-            >
-              <div
-                class="emotion-38 emotion-39"
-                data-e2e="image-placeholder"
-                style="padding-bottom: 56.25%;"
-              >
-                <div
-                  class="lazyload-wrapper "
-                >
-                  <div
-                    class="lazyload-placeholder"
-                  />
-                </div>
-              </div>
-              <div
-                class="emotion-40 emotion-41"
-              />
-            </div>
-          </div>
-        </div>
-      </li>
-      <li
-        class="emotion-16 emotion-43 emotion-21"
-        dir="ltr"
-      >
-        <div
-          class="emotion-45 emotion-23"
-          data-e2e="story-promo"
-        >
-          <div
-            class="emotion-47 emotion-35"
-            dir="ltr"
-          >
-            <div
-              class="emotion-36 emotion-37"
-            >
-              <div
-                class="emotion-38 emotion-39"
-                data-e2e="image-placeholder"
-                style="padding-bottom: 56.25%;"
-              >
-                <div
-                  class="lazyload-wrapper "
-                >
-                  <div
-                    class="lazyload-placeholder"
-                  />
-                </div>
-              </div>
-              <div
-                class="emotion-53 emotion-41"
-              />
-            </div>
-          </div>
-          <div
-            class="emotion-55 emotion-25"
-            dir="ltr"
-          >
-            <h3
-              class="emotion-57 emotion-27"
-            >
-              <a
-                aria-labelledby="promo-1"
-                class="emotion-28 emotion-29"
-                href="https://www.bbc.co.uk"
-              >
-                <span
-                  id="promo-1"
-                >
-                  Top Story 2 headline
-                </span>
-              </a>
-            </h3>
-            <p
-              class="emotion-30 emotion-31"
-            >
-              Summary text 2
-            </p>
-            <time
-              class="emotion-32 emotion-33"
-              datetime="1970-01-19"
-            >
-              19 January 1970
-            </time>
-          </div>
-        </div>
-      </li>
-    </ul>
-  </section>
-</div>
-`;
-
-exports[`IndexPageSection Container snapshots should render with only one item 1`] = `
-.emotion-0 {
-  margin: 0 auto;
-  width: 100%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    max-width: 63rem;
-  }
-}
-
-.emotion-2 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-2 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-6 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-6 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-6 {
-    display: none;
-  }
-}
-
-.emotion-8 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-14 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-14 {
-    padding-right: 1rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-16 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-16 {
-    margin-top: 2rem;
-  }
-}
-
-.emotion-18 {
-  position: relative;
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-18 {
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: 0.5rem;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-18 {
-      grid-column-gap: 1rem;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-18 {
-      grid-template-columns: repeat(12, 1fr);
-    }
-  }
-}
-
-.emotion-20 {
-  display: inline-block;
-  vertical-align: top;
-  position: relative;
-  margin-bottom: 0.5rem;
-  width: 100%;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-20 {
-    width: calc(50% - 0.5rem);
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-20 {
-    width: calc(50% - 0.5rem);
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-20 {
-    width: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
-    .emotion-20 {
-      grid-column: 1/span 3;
-    }
-  }
-}
-
-.emotion-22 {
-  position: relative;
-}
-
-.emotion-24 {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  background-color: #F2F2F2;
-  -webkit-background-position: center center;
-  background-position: center center;
-  background-repeat: no-repeat;
-  -webkit-background-size: 60px 17px;
-  background-size: 60px 17px;
-  width: 100%;
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
-}
-
-@media (min-width: 25rem) {
-  .emotion-24 {
-    -webkit-background-size: 77px 22px;
-    background-size: 77px 22px;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-24 {
-    -webkit-background-size: 93px 27px;
-    background-size: 93px 27px;
-  }
-}
-
-.emotion-26 {
-  display: block;
-  width: 100%;
-  visibility: visible;
-}
-
-.emotion-29 {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.emotion-31 {
-  position: absolute;
-  bottom: 0;
-}
-
-.emotion-31>* {
-  height: 2rem;
-  padding: 0.5rem 0.25rem;
-}
-
-.emotion-33 {
-  display: inline-block;
-  vertical-align: top;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-33 {
-    width: 50%;
-    padding: 0 1rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-33 {
-    width: 50%;
-  }
-}
-
-@supports (grid-template-columns: fit-content(200px)) {
-  .emotion-33 {
-    display: block;
-    width: initial;
-    padding: initial;
-    grid-column: 1/span 6;
-  }
-
-  @media (min-width: 37.5rem) {
-    .emotion-33 {
-      grid-column: 4/span 3;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-33 {
-      grid-column: 7/span 6;
-    }
-  }
-}
-
-.emotion-35 {
-  color: #222222;
-  margin: 0;
-  padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-35 {
-    font-size: 1.375rem;
-    line-height: 1.625rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-35 {
-    font-size: 1.75rem;
-    line-height: 2rem;
-  }
-}
-
-.emotion-37 {
-  position: static;
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-
-.emotion-37:before {
-  bottom: 0;
-  content: '';
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.emotion-37:hover,
-.emotion-37:focus {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-37:visited {
-  color: #6E6E73;
-}
-
-.emotion-39 {
-  font-size: 0.9375rem;
-  line-height: 1.125rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  color: #3F3F42;
-  margin: 0;
-  padding-bottom: 0.5rem;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
-    font-size: 0.9375rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-39 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-39 {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-.emotion-41 {
-  font-size: 0.875rem;
-  line-height: 1.125rem;
-  color: #6E6E73;
-  display: block;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-41 {
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-41 {
-    font-size: 0.8125rem;
-    line-height: 1rem;
-  }
-}
-
-<div>
-  <section
-    aria-labelledby="Top-Stories"
-    class="emotion-0 emotion-1"
-    role="region"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      />
-      <div
-        class="emotion-6 emotion-7"
-      />
-      <h2
-        class="emotion-8 emotion-9"
-      >
-        <span
-          class="emotion-10 emotion-11"
-        >
-          <span
-            class="emotion-12 emotion-13"
-          >
-            <span
-              class="emotion-14 emotion-15"
-              dir="ltr"
-              id="Top-Stories"
-            >
-              Top Stories
-            </span>
-          </span>
-        </span>
-      </h2>
-    </div>
-    <div
-      class="emotion-16 emotion-17"
-    >
-      <div
-        class="emotion-18 emotion-19"
-        data-e2e="story-promo"
-      >
-        <div
-          class="emotion-20 emotion-21"
-          dir="ltr"
-        >
-          <div
-            class="emotion-22 emotion-23"
-          >
-            <div
-              class="emotion-24 emotion-25"
-              data-e2e="image-placeholder"
-              style="padding-bottom: 56.25%;"
-            >
-              <picture
-                class="emotion-26 emotion-27"
-              >
-                <source
-                  sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                  srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg.webp 660w"
-                  type="image/webp"
-                />
-                <source
-                  sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
-                  srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg 660w"
-                  type="image/jpeg"
-                />
-                <img
-                  alt="Image Alt text 1"
-                  class="emotion-28 emotion-29 emotion-30"
-                  height="1152"
-                  src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg"
-                  width="2048"
-                />
-              </picture>
-            </div>
-            <div
-              class="emotion-31 emotion-32"
-            />
-          </div>
-        </div>
-        <div
-          class="emotion-33 emotion-34"
-          dir="ltr"
-        >
-          <h3
-            class="emotion-35 emotion-36"
-          >
-            <a
-              aria-labelledby="promo-1"
-              class="emotion-37 emotion-38"
-              href="https://www.bbc.co.uk"
-            >
-              <span
-                id="promo-1"
-              >
-                Top Story 1 headline
-              </span>
-            </a>
-          </h3>
-          <p
-            class="emotion-39 emotion-40"
-          >
-            Summary text 1
-          </p>
-          <time
-            class="emotion-41 emotion-42"
-            datetime="1970-01-19"
-          >
-            19 January 1970
-          </time>
-        </div>
-      </div>
-    </div>
-  </section>
-</div>
-`;
-
-exports[`IndexPageSection Container snapshots should render without a bar 1`] = `
-.emotion-0 {
-  margin: 0 auto;
-  width: 100%;
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    max-width: 63rem;
-  }
-}
-
-.emotion-2 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-2 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
-  }
-}
-
-.emotion-12 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    padding-right: 1rem;
   }
 }
 
@@ -4754,35 +439,47 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 .emotion-28 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-31 {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.emotion-33 {
   position: absolute;
   bottom: 0;
 }
 
-.emotion-28>* {
+.emotion-33>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.emotion-30 {
+.emotion-35 {
   display: inline-block;
   vertical-align: top;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-30 {
+  .emotion-35 {
     width: 50%;
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-30 {
+  .emotion-35 {
     width: 50%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-30 {
+  .emotion-35 {
     display: block;
     width: initial;
     padding: initial;
@@ -4790,44 +487,44 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-30 {
+    .emotion-35 {
       grid-column: 4/span 3;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-30 {
+    .emotion-35 {
       grid-column: 7/span 6;
     }
   }
 }
 
-.emotion-32 {
+.emotion-37 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
   font-style: normal;
   font-size: 1.25rem;
   line-height: 1.5rem;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-32 {
+  .emotion-37 {
     font-size: 1.375rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-32 {
+  .emotion-37 {
     font-size: 1.75rem;
     line-height: 2rem;
   }
 }
 
-.emotion-34 {
+.emotion-39 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -4836,7 +533,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   overflow-wrap: anywhere;
 }
 
-.emotion-34:before {
+.emotion-39:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -4848,17 +545,1319 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   z-index: 1;
 }
 
-.emotion-34:hover,
-.emotion-34:focus {
+.emotion-39:hover,
+.emotion-39:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-34:visited {
+.emotion-39:visited {
   color: #6E6E73;
 }
 
-.emotion-36 {
+.emotion-41 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-41 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-41 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-41 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+.emotion-43 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #545658;
+  display: block;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-43 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-43 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+.emotion-46 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-46 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-46:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-46 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-46 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-46:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-46:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-46:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-46 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-46 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-46 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-46 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-46 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+}
+
+.emotion-48 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-48 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-48 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-48 {
+      display: block;
+    }
+  }
+}
+
+.emotion-50 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-50 {
+    display: block;
+    width: 100%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-50 {
+    width: initial;
+    grid-column: 1/span 2;
+  }
+}
+
+@media (min-width: 25rem) {
+  .emotion-56 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+.emotion-56>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-56>* {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+.emotion-58 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-58 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-58 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-58 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3/span 4;
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-58 {
+      padding-top: 0.5rem;
+    }
+  }
+}
+
+.emotion-60 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-60 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-60 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+.emotion-64 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-64 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-64 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width: 37.4375rem) {
+  .emotion-64 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-64 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+<section
+    aria-labelledby="Top-Stories"
+    class="emotion-0 emotion-1"
+    role="region"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <h2
+        class="emotion-4 emotion-5"
+      >
+        <span
+          class="emotion-6 emotion-7"
+        >
+          <span
+            class="emotion-8 emotion-9"
+          >
+            <span
+              class="emotion-10 emotion-11"
+              dir="ltr"
+              id="Top-Stories"
+            >
+              Top Stories
+            </span>
+          </span>
+        </span>
+      </h2>
+    </div>
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <ul
+        class="emotion-14 emotion-15 emotion-16"
+        dir="ltr"
+        role="list"
+      >
+        <li
+          class="emotion-14 emotion-18 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-20 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-22 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <picture
+                    class="emotion-28 emotion-29"
+                  >
+                    <source
+                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg.webp 660w"
+                      type="image/webp"
+                    />
+                    <source
+                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg 660w"
+                      type="image/jpeg"
+                    />
+                    <img
+                      alt="Image Alt text 1"
+                      class="emotion-30 emotion-31 emotion-32"
+                      height="1152"
+                      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg"
+                      width="2048"
+                    />
+                  </picture>
+                </div>
+                <div
+                  class="emotion-33 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-35 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-37 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-1"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-1"
+                  >
+                    Top Story 1 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-41 emotion-42"
+              >
+                Summary text 1
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 Jenụwarị 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-1"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-1"
+                  >
+                    Top Story 2 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 2
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 Jenụwarị 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-2"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-2"
+                  >
+                    Top Story 3 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 3
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 Jenụwarị 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-3"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-3"
+                  >
+                    Top Story 4 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 4
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 Jenụwarị 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-4"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-4"
+                  >
+                    Top Story 5 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 5
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 Jenụwarị 1970
+              </time>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>,
+]
+`;
+
+exports[`IndexPageSection Container snapshots should render correctly for canonical 1`] = `
+.emotion-0 {
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    max-width: 63rem;
+  }
+}
+
+.emotion-2 {
+  position: relative;
+  z-index: 0;
+  color: #141414;
+  margin-top: 2rem;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-2 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin-top: 0.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-12 {
+    margin-top: 2rem;
+  }
+}
+
+.emotion-15 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+@supports (display: grid) {
+  .emotion-15 {
+    display: grid;
+    position: initial;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-15 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+}
+
+.emotion-18 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-18 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-18:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-18 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-18 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-18:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-18:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-18:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-18 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-18 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-18 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-18 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-18 {
+    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-18 {
+    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-18 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+    }
+  }
+}
+
+.emotion-20 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-20 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-20 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-20 {
+      grid-template-columns: repeat(12, 1fr);
+    }
+  }
+}
+
+.emotion-22 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-22 {
+    width: calc(50% - 0.5rem);
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-22 {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-22 {
+    width: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
+    .emotion-22 {
+      grid-column: 1/span 3;
+    }
+  }
+}
+
+.emotion-24 {
+  position: relative;
+}
+
+.emotion-26 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #F2F2F2;
+  -webkit-background-position: center center;
+  background-position: center center;
+  background-repeat: no-repeat;
+  -webkit-background-size: 60px 17px;
+  background-size: 60px 17px;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+@media (min-width: 25rem) {
+  .emotion-26 {
+    -webkit-background-size: 77px 22px;
+    background-size: 77px 22px;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-26 {
+    -webkit-background-size: 93px 27px;
+    background-size: 93px 27px;
+  }
+}
+
+.emotion-28 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-31 {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.emotion-33 {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-33>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.emotion-35 {
+  display: inline-block;
+  vertical-align: top;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-35 {
+    width: 50%;
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-35 {
+    width: 50%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-35 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-35 {
+      grid-column: 4/span 3;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-35 {
+      grid-column: 7/span 6;
+    }
+  }
+}
+
+.emotion-37 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-37 {
+    font-size: 1.375rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-37 {
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+.emotion-39 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.emotion-39:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-39:hover,
+.emotion-39:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-39:visited {
+  color: #6E6E73;
+}
+
+.emotion-41 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -4870,30 +1869,30 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-36 {
+  .emotion-41 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-36 {
+  .emotion-41 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-36 {
+  .emotion-41 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-38 {
+.emotion-43 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4901,61 +1900,61 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-38 {
+  .emotion-43 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-38 {
+  .emotion-43 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-41 {
+.emotion-46 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-41 {
+  .emotion-46 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-41:last-child {
+.emotion-46:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-41 {
+  .emotion-46 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-41 {
+  .emotion-46 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-41:first-child {
+.emotion-46:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-41:first-child {
+  .emotion-46:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-41:last-child {
+.emotion-46:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -4964,7 +1963,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -4973,7 +1972,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -4982,7 +1981,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -4991,7 +1990,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5000,7 +1999,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 80rem) {
-  .emotion-41 {
+  .emotion-46 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5009,80 +2008,80 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @supports (display: grid) {
-  .emotion-41 {
+  .emotion-46 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-41 {
+    .emotion-46 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 }
 
-.emotion-43 {
+.emotion-48 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-43 {
+  .emotion-48 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-43 {
+    .emotion-48 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-43 {
+    .emotion-48 {
       display: block;
     }
   }
 }
 
-.emotion-45 {
+.emotion-50 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -5090,39 +2089,39 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 63rem) {
-  .emotion-45 {
+  .emotion-50 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-45 {
+  .emotion-50 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-51 {
+  .emotion-56 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-51>* {
+.emotion-56>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-51>* {
+  .emotion-56>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-53 {
+.emotion-58 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -5130,13 +2129,13 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-58 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-53 {
+  .emotion-58 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -5144,7 +2143,7 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-53 {
+  .emotion-58 {
     display: block;
     width: initial;
     padding: initial;
@@ -5152,13 +2151,13 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
   }
 
   @media (min-width: 63rem) {
-    .emotion-53 {
+    .emotion-58 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-55 {
+.emotion-60 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -5170,20 +2169,20 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-55 {
+  .emotion-60 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-55 {
+  .emotion-60 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-59 {
+.emotion-64 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -5195,28 +2194,28 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-59 {
+  .emotion-64 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-59 {
+  .emotion-64 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-59 {
+  .emotion-64 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-59 {
+  .emotion-64 {
     display: none;
     visibility: hidden;
   }
@@ -5231,20 +2230,1272 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
     <div
       class="emotion-2 emotion-3"
     >
-      <div
-        class="emotion-4 emotion-5"
-      />
       <h2
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-10 emotion-11"
+              dir="ltr"
+              id="Top-Stories"
+            >
+              Top Stories
+            </span>
+          </span>
+        </span>
+      </h2>
+    </div>
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <ul
+        class="emotion-14 emotion-15 emotion-16"
+        dir="ltr"
+        role="list"
+      >
+        <li
+          class="emotion-14 emotion-18 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-20 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-22 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <picture
+                    class="emotion-28 emotion-29"
+                  >
+                    <source
+                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg.webp 660w"
+                      type="image/webp"
+                    />
+                    <source
+                      sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                      srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image1.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image1.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image1.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image1.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image1.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image1.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg 660w"
+                      type="image/jpeg"
+                    />
+                    <img
+                      alt="Image Alt text 1"
+                      class="emotion-30 emotion-31 emotion-32"
+                      height="1152"
+                      src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image1.jpg"
+                      width="2048"
+                    />
+                  </picture>
+                </div>
+                <div
+                  class="emotion-33 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-35 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-37 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-1"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-1"
+                  >
+                    Top Story 1 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-41 emotion-42"
+              >
+                Summary text 1
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 January 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-1"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-1"
+                  >
+                    Top Story 2 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 2
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 January 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-2"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-2"
+                  >
+                    Top Story 3 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 3
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 January 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-3"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-3"
+                  >
+                    Top Story 4 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 4
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 January 1970
+              </time>
+            </div>
+          </div>
+        </li>
+        <li
+          class="emotion-14 emotion-46 emotion-19"
+          dir="ltr"
+        >
+          <div
+            class="emotion-48 emotion-21"
+            data-e2e="story-promo"
+          >
+            <div
+              class="emotion-50 emotion-23"
+              dir="ltr"
+            >
+              <div
+                class="emotion-24 emotion-25"
+              >
+                <div
+                  class="emotion-26 emotion-27"
+                  data-e2e="image-placeholder"
+                  style="padding-bottom: 56.25%;"
+                >
+                  <div
+                    class="lazyload-wrapper "
+                  >
+                    <div
+                      class="lazyload-placeholder"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="emotion-56 emotion-34"
+                />
+              </div>
+            </div>
+            <div
+              class="emotion-58 emotion-36"
+              dir="ltr"
+            >
+              <h3
+                class="emotion-60 emotion-38"
+              >
+                <a
+                  aria-labelledby="promo-top-stories-4"
+                  class="emotion-39 emotion-40"
+                  href="https://www.bbc.co.uk"
+                >
+                  <span
+                    id="promo-top-stories-4"
+                  >
+                    Top Story 5 headline
+                  </span>
+                </a>
+              </h3>
+              <p
+                class="emotion-64 emotion-42"
+              >
+                Summary text 5
+              </p>
+              <time
+                class="emotion-43 emotion-44"
+                datetime="1970-01-19"
+              >
+                19 January 1970
+              </time>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`IndexPageSection Container snapshots should render correctly with a linking strapline 1`] = `
+.emotion-0 {
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    max-width: 63rem;
+  }
+}
+
+.emotion-2 {
+  position: relative;
+  z-index: 0;
+  color: #141414;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-2 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+.emotion-13 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+@supports (display: grid) {
+  .emotion-13 {
+    display: grid;
+    position: initial;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+}
+
+.emotion-16 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-16 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-16:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-16 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-16 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-16:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-16:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-16:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-16 {
+    width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-16 {
+    width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-16 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+}
+
+.emotion-18 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-18 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-18 {
+      grid-column-gap: 1rem;
+    }
+  }
+}
+
+.emotion-20 {
+  display: inline-block;
+  vertical-align: top;
+  width: 100%;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-20 {
+    padding-right: 0.5rem;
+    width: 50%;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-20 {
+    width: 33.33%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-20 {
+    display: block;
+    width: initial;
+    padding: initial;
+    padding: 0;
+    width: 100%;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-end: span 6;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-20 {
+      grid-template-columns: repeat(3, 1fr);
+      grid-column-end: span 3;
+    }
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-20 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-20>time {
+    padding-bottom: 0.5rem;
+  }
+}
+
+.emotion-22 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-22 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-22 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+.emotion-24 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.emotion-24:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-24:hover,
+.emotion-24:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-24:visited {
+  color: #6E6E73;
+}
+
+.emotion-26 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-26 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-26 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width: 37.4375rem) {
+  .emotion-26 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-26 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+.emotion-28 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #545658;
+  display: block;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-28 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-28 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+.emotion-30 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-30 {
+    padding-right: 0.5rem;
+    width: 50%;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-30 {
+    width: 66.67%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-30 {
+    width: initial;
+    padding: 0;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-end: span 6;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-30 {
+      grid-template-columns: repeat(3, 1fr);
+      grid-column-end: span 3;
+    }
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-30 {
+      grid-template-columns: repeat(4, 1fr);
+      grid-column-end: span 4;
+    }
+  }
+}
+
+.emotion-32 {
+  position: relative;
+}
+
+.emotion-34 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #F2F2F2;
+  -webkit-background-position: center center;
+  background-position: center center;
+  background-repeat: no-repeat;
+  -webkit-background-size: 60px 17px;
+  background-size: 60px 17px;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+@media (min-width: 25rem) {
+  .emotion-34 {
+    -webkit-background-size: 77px 22px;
+    background-size: 77px 22px;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-34 {
+    -webkit-background-size: 93px 27px;
+    background-size: 93px 27px;
+  }
+}
+
+.emotion-36 {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-36>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.emotion-39 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-39 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-39:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-39 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-39 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-39:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-39:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-39:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-39 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-39 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-39 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+}
+
+.emotion-41 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-41 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-41 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-41 {
+      display: block;
+    }
+  }
+}
+
+.emotion-43 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-43 {
+    display: block;
+    width: 100%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-43 {
+    width: initial;
+    grid-column: 1/span 2;
+  }
+}
+
+@media (min-width: 25rem) {
+  .emotion-49 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+.emotion-49>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-49>* {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+.emotion-51 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-51 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-51 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-51 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3/span 4;
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-51 {
+      padding-top: 0.5rem;
+    }
+  }
+}
+
+.emotion-53 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-53 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-53 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+<div>
+  <section
+    aria-labelledby="Top-Stories"
+    class="emotion-0 emotion-1"
+    role="region"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <h2
+        class="emotion-4 emotion-5"
+      >
+        <span
+          class="emotion-6 emotion-7"
+        >
+          <span
+            class="emotion-8 emotion-9"
+          >
+            <span
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="Top-Stories"
             >
@@ -5255,27 +3506,58 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
       </h2>
     </div>
     <ul
-      class="emotion-14 emotion-15 emotion-16"
+      class="emotion-12 emotion-13 emotion-14"
       dir="ltr"
       role="list"
     >
       <li
-        class="emotion-14 emotion-18 emotion-19"
+        class="emotion-12 emotion-16 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-20 emotion-21"
+          class="emotion-18 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-22 emotion-23"
+            class="emotion-20 emotion-21"
+            dir="ltr"
+          >
+            <h3
+              class="emotion-22 emotion-23"
+            >
+              <a
+                aria-labelledby="promo-top-stories-1"
+                class="emotion-24 emotion-25"
+                href="https://www.bbc.co.uk"
+              >
+                <span
+                  id="promo-top-stories-1"
+                >
+                  Top Story 1 headline
+                </span>
+              </a>
+            </h3>
+            <p
+              class="emotion-26 emotion-27"
+            >
+              Summary text 1
+            </p>
+            <time
+              class="emotion-28 emotion-29"
+              datetime="1970-01-19"
+            >
+              19 January 1970
+            </time>
+          </div>
+          <div
+            class="emotion-30 emotion-31"
             dir="ltr"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-32 emotion-33"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-34 emotion-35"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25%;"
               >
@@ -5288,20 +3570,1558 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
                 </div>
               </div>
               <div
-                class="emotion-28 emotion-29"
+                class="emotion-36 emotion-37"
+              />
+            </div>
+          </div>
+        </div>
+      </li>
+      <li
+        class="emotion-12 emotion-39 emotion-17"
+        dir="ltr"
+      >
+        <div
+          class="emotion-41 emotion-19"
+          data-e2e="story-promo"
+        >
+          <div
+            class="emotion-43 emotion-31"
+            dir="ltr"
+          >
+            <div
+              class="emotion-32 emotion-33"
+            >
+              <div
+                class="emotion-34 emotion-35"
+                data-e2e="image-placeholder"
+                style="padding-bottom: 56.25%;"
+              >
+                <div
+                  class="lazyload-wrapper "
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+              </div>
+              <div
+                class="emotion-49 emotion-37"
               />
             </div>
           </div>
           <div
-            class="emotion-30 emotion-31"
+            class="emotion-51 emotion-21"
             dir="ltr"
           >
             <h3
-              class="emotion-32 emotion-33"
+              class="emotion-53 emotion-23"
             >
               <a
                 aria-labelledby="promo-1"
-                class="emotion-34 emotion-35"
+                class="emotion-24 emotion-25"
+                href="https://www.bbc.co.uk"
+              >
+                <span
+                  id="promo-1"
+                >
+                  Top Story 2 headline
+                </span>
+              </a>
+            </h3>
+            <p
+              class="emotion-26 emotion-27"
+            >
+              Summary text 2
+            </p>
+            <time
+              class="emotion-28 emotion-29"
+              datetime="1970-01-19"
+            >
+              19 January 1970
+            </time>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </section>
+</div>
+`;
+
+exports[`IndexPageSection Container snapshots should render with only one item 1`] = `
+.emotion-0 {
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    max-width: 63rem;
+  }
+}
+
+.emotion-2 {
+  position: relative;
+  z-index: 0;
+  color: #141414;
+  margin-top: 2rem;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-2 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-12 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-12 {
+    margin-top: 2rem;
+  }
+}
+
+.emotion-14 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-14 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-14 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-14 {
+      grid-template-columns: repeat(12, 1fr);
+    }
+  }
+}
+
+.emotion-16 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-16 {
+    width: calc(50% - 0.5rem);
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-16 {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-16 {
+    width: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
+    .emotion-16 {
+      grid-column: 1/span 3;
+    }
+  }
+}
+
+.emotion-18 {
+  position: relative;
+}
+
+.emotion-20 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #F2F2F2;
+  -webkit-background-position: center center;
+  background-position: center center;
+  background-repeat: no-repeat;
+  -webkit-background-size: 60px 17px;
+  background-size: 60px 17px;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+@media (min-width: 25rem) {
+  .emotion-20 {
+    -webkit-background-size: 77px 22px;
+    background-size: 77px 22px;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-20 {
+    -webkit-background-size: 93px 27px;
+    background-size: 93px 27px;
+  }
+}
+
+.emotion-22 {
+  display: block;
+  width: 100%;
+  visibility: visible;
+}
+
+.emotion-25 {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.emotion-27 {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-27>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.emotion-29 {
+  display: inline-block;
+  vertical-align: top;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-29 {
+    width: 50%;
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-29 {
+    width: 50%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-29 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-29 {
+      grid-column: 4/span 3;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-29 {
+      grid-column: 7/span 6;
+    }
+  }
+}
+
+.emotion-31 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-31 {
+    font-size: 1.375rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-31 {
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+.emotion-33 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.emotion-33:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-33:hover,
+.emotion-33:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-33:visited {
+  color: #6E6E73;
+}
+
+.emotion-35 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-35 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-35 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-35 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+.emotion-37 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #545658;
+  display: block;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-37 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-37 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+<div>
+  <section
+    aria-labelledby="Top-Stories"
+    class="emotion-0 emotion-1"
+    role="region"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <h2
+        class="emotion-4 emotion-5"
+      >
+        <span
+          class="emotion-6 emotion-7"
+        >
+          <span
+            class="emotion-8 emotion-9"
+          >
+            <span
+              class="emotion-10 emotion-11"
+              dir="ltr"
+              id="Top-Stories"
+            >
+              Top Stories
+            </span>
+          </span>
+        </span>
+      </h2>
+    </div>
+    <div
+      class="emotion-12 emotion-13"
+    >
+      <div
+        class="emotion-14 emotion-15"
+        data-e2e="story-promo"
+      >
+        <div
+          class="emotion-16 emotion-17"
+          dir="ltr"
+        >
+          <div
+            class="emotion-18 emotion-19"
+          >
+            <div
+              class="emotion-20 emotion-21"
+              data-e2e="image-placeholder"
+              style="padding-bottom: 56.25%;"
+            >
+              <picture
+                class="emotion-22 emotion-23"
+              >
+                <source
+                  sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                  srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image.jpg.webp 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image.jpg.webp 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image.jpg.webp 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image.jpg.webp 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image.jpg.webp 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image.jpg.webp 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg.webp 660w"
+                  type="image/webp"
+                />
+                <source
+                  sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
+                  srcset="https://ichef.bbci.co.uk/news/70/cpsprodpb/0A06/production/image.jpg 70w, https://ichef.bbci.co.uk/news/95/cpsprodpb/0A06/production/image.jpg 95w, https://ichef.bbci.co.uk/news/144/cpsprodpb/0A06/production/image.jpg 144w, https://ichef.bbci.co.uk/news/183/cpsprodpb/0A06/production/image.jpg 183w, https://ichef.bbci.co.uk/news/240/cpsprodpb/0A06/production/image.jpg 240w, https://ichef.bbci.co.uk/news/320/cpsprodpb/0A06/production/image.jpg 320w, https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg 660w"
+                  type="image/jpeg"
+                />
+                <img
+                  alt="Image Alt text 1"
+                  class="emotion-24 emotion-25 emotion-26"
+                  height="1152"
+                  src="https://ichef.bbci.co.uk/news/660/cpsprodpb/0A06/production/image.jpg"
+                  width="2048"
+                />
+              </picture>
+            </div>
+            <div
+              class="emotion-27 emotion-28"
+            />
+          </div>
+        </div>
+        <div
+          class="emotion-29 emotion-30"
+          dir="ltr"
+        >
+          <h3
+            class="emotion-31 emotion-32"
+          >
+            <a
+              aria-labelledby="promo-1"
+              class="emotion-33 emotion-34"
+              href="https://www.bbc.co.uk"
+            >
+              <span
+                id="promo-1"
+              >
+                Top Story 1 headline
+              </span>
+            </a>
+          </h3>
+          <p
+            class="emotion-35 emotion-36"
+          >
+            Summary text 1
+          </p>
+          <time
+            class="emotion-37 emotion-38"
+            datetime="1970-01-19"
+          >
+            19 January 1970
+          </time>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`IndexPageSection Container snapshots should render without a bar 1`] = `
+.emotion-0 {
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    max-width: 63rem;
+  }
+}
+
+.emotion-2 {
+  position: relative;
+  z-index: 0;
+  color: #141414;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-2 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-4 {
+  margin: 0;
+  padding: 0;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-10 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-10 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-10 {
+    padding-right: 1rem;
+  }
+}
+
+.emotion-13 {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+@supports (display: grid) {
+  .emotion-13 {
+    display: grid;
+    position: initial;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 0.5rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-13 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+      grid-column-gap: 1rem;
+    }
+  }
+}
+
+.emotion-16 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-16 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-16:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-16 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-16 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-16:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-16:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-16:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-16 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-16 {
+    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-16 {
+    width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-16 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-16 {
+      grid-template-columns: repeat(8, 1fr);
+      grid-column-end: span 8;
+    }
+  }
+}
+
+.emotion-18 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-18 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-18 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-18 {
+      grid-template-columns: repeat(12, 1fr);
+    }
+  }
+}
+
+.emotion-20 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-20 {
+    width: calc(50% - 0.5rem);
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-20 {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-20 {
+    width: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
+    .emotion-20 {
+      grid-column: 1/span 3;
+    }
+  }
+}
+
+.emotion-22 {
+  position: relative;
+}
+
+.emotion-24 {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  background-color: #F2F2F2;
+  -webkit-background-position: center center;
+  background-position: center center;
+  background-repeat: no-repeat;
+  -webkit-background-size: 60px 17px;
+  background-size: 60px 17px;
+  width: 100%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSI0NzkiIGhlaWdodD0iMTM2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgZmlsbD0iI0Q1RDBDRCI+PGc+PHBhdGggZD0iTTQ0OS41NTYgOTEuNTUzbC0yLjMxIDEuNDFjLTExLjE2NyA2LjgxOC0yMy4zMTMgMTAuNDc0LTM0LjM0NiAxMC40Ny0yMy42MS0uMDktMzkuMTYzLTE0LjA4My0zOS4yMjctMzQuNDUzLjAzLTE5LjkxOCAxNi4yNy0zNC42NjMgMzguNjMzLTM0LjcxOCAxMS4zODcuMDEgMjEuNzAzIDIuOTU0IDMzLjk2MiA5LjY3MmwyLjI1MSAxLjI0di0xOC4xOWwtLjk2Mi0uMzc3Yy0xMy44MjQtNS40NTgtMjQuNTMtNy44OS0zNS4xMDMtNy44ODQtMTYuMzQ2LS4wMDYtMzAuNTMzIDUuMzk0LTQwLjYzNyAxNC41NTctMTAuMTA1IDkuMTYzLTE2LjEwNiAyMi4xMDItMTYuMDk5IDM2Ljk1My4wMDggMTAuMzQ4IDQuMjc5IDIyLjQ4IDEzLjQyIDMyLjEwNSA5LjEyMSA5LjYyOCAyMy4xNjUgMTYuNjQ4IDQyLjQzIDE2LjYzOWguMDYzYzE1Ljk4IDAgMjcuMDYyLTMuNTYzIDM3LjA3NC04LjQ5MmwuODUxLS40MTRWOTEuNTUzek0zMzQgMTM1LjY5N2gxNDQuMTk1VjBIMzM0djEzNS42OTd6Ii8+PHBhdGggZD0iTTI3Ni45MzcgODkuOTY4Yy4wNDEtMTIuMzMtOC4xNzEtMjEuNjk2LTIxLjMwOC0yNS4zIDMuNTQ0LTEuODA5IDYuMzUtNC4wMjMgOC40MDQtNi43MjcgMi43NS0zLjYyMiA0LjA2MS04LjA2NCA0LjA0Ni0xMy4yMzUuMDE1LTYuMzU5LTIuNDg2LTEyLjgzOS03Ljg1OC0xNy42ODctNS4zNzItNC44NDctMTMuNTI2LTcuOTk3LTI0LjY1NC03Ljk5MUgyMDQuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMTY3IDEzNS42OThoMTQ0LjE5N1YwSDE2N3YxMzUuNjk3eiIvPjxwYXRoIGQ9Ik0xMDkuOTM3IDg5Ljk2OGMuMDQxLTEyLjMzLTguMTcxLTIxLjY5Ni0yMS4zMDgtMjUuMyAzLjU0NC0xLjgwOSA2LjM1LTQuMDIzIDguNDA0LTYuNzI3IDIuNzUtMy42MjIgNC4wNjEtOC4wNjQgNC4wNDYtMTMuMjM1LjAxNS02LjM1OS0yLjQ4Ni0xMi44MzktNy44NTgtMTcuNjg3LTUuMzcyLTQuODQ3LTEzLjUyNi03Ljk5Ny0yNC42NTQtNy45OTFIMzcuODN2OTcuNzI4aDM2LjA3M2MxMi44NyAwIDIxLjkwNi0zLjQ4MiAyNy43MjItOC42NSA1LjgxOC01LjE1NSA4LjMyLTExLjkxIDguMzEyLTE4LjEzOHpNMCAxMzUuNjk4aDE0NC4xOTdWMEgwdjEzNS42OTd6Ii8+PHBhdGggZD0iTTI1OC42NjIgODguMTk4Yy0uMDEzIDMuMjI5LTEuMDA3IDYuNDc1LTMuODk2IDkuMDExLTIuODg0IDIuNTM3LTcuODczIDQuNDYzLTE2LjEzMyA0LjQ2M0gyMjJWNzVoMTUuODkzYzcuNDExIDAgMTIuNjcgMS41MDIgMTUuOTY1IDMuODUgMy4yODkgMi4zNjIgNC43NzYgNS40NjMgNC44MDQgOS4zNDgiLz48cGF0aCBkPSJNOTEuNjYyIDg4LjE5OGMtLjAxMyAzLjIyOS0xLjAwNyA2LjQ3NS0zLjg5NiA5LjAxMS0yLjg4NCAyLjUzNy03Ljg3NCA0LjQ2My0xNi4xMzMgNC40NjNINTVWNzVoMTUuODkyYzcuNDEyIDAgMTIuNjcyIDEuNTAyIDE1Ljk2NiAzLjg1IDMuMjg5IDIuMzYyIDQuNzc2IDUuNDYzIDQuODA0IDkuMzQ4Ii8+PHBhdGggZD0iTTI0NS4xODYgNTUuNzljMy4wOTYtMi4yMzcgNC41OS01LjM4NiA0LjYxMy0xMC4xMjQtLjAxNS0zLjI1LS45NDMtNi4wMzMtMy4yODEtOC4xMTEtMi4zNDYtMi4wNzgtNi4zMy0zLjU1NS0xMi43NTQtMy41NTVIMjIydjI1LjI3NWg4LjA3NmM2Ljk4OC4wMDQgMTEuOTk4LTEuMjQzIDE1LjExLTMuNDg2Ii8+PHBhdGggZD0iTTc4LjE4NiA1NS43OWMzLjA5Ni0yLjIzNyA0LjU5LTUuMzg2IDQuNjEzLTEwLjEyNC0uMDE1LTMuMjUtLjk0My02LjAzMy0zLjI4Mi04LjExMUM3Ny4xNzIgMzUuNDc3IDczLjE4OCAzNCA2Ni43NjQgMzRINTV2MjUuMjc1aDguMDc2YzYuOTg4LjAwNCAxMS45OTgtMS4yNDMgMTUuMTEtMy40ODYiLz48L2c+PC9nPjwvZz48L3N2Zz4K);
+}
+
+@media (min-width: 25rem) {
+  .emotion-24 {
+    -webkit-background-size: 77px 22px;
+    background-size: 77px 22px;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-24 {
+    -webkit-background-size: 93px 27px;
+    background-size: 93px 27px;
+  }
+}
+
+.emotion-26 {
+  position: absolute;
+  bottom: 0;
+}
+
+.emotion-26>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.emotion-28 {
+  display: inline-block;
+  vertical-align: top;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-28 {
+    width: 50%;
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-28 {
+    width: 50%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-28 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 1/span 6;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-28 {
+      grid-column: 4/span 3;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-28 {
+      grid-column: 7/span 6;
+    }
+  }
+}
+
+.emotion-30 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-30 {
+    font-size: 1.375rem;
+    line-height: 1.625rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-30 {
+    font-size: 1.75rem;
+    line-height: 2rem;
+  }
+}
+
+.emotion-32 {
+  position: static;
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.emotion-32:before {
+  bottom: 0;
+  content: '';
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-32:hover,
+.emotion-32:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-32:visited {
+  color: #6E6E73;
+}
+
+.emotion-34 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-34 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-34 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-34 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+.emotion-36 {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  color: #545658;
+  display: block;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-36 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-36 {
+    font-size: 0.8125rem;
+    line-height: 1rem;
+  }
+}
+
+.emotion-39 {
+  padding: 0.5rem 0 1rem;
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-39 {
+    border-bottom: 0.0625rem solid #F2F2F2;
+  }
+}
+
+.emotion-39:last-child {
+  border: none;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-39 {
+    padding: 1rem 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-39 {
+    padding: 0 0 1.5rem;
+  }
+}
+
+.emotion-39:first-child {
+  padding-top: 0;
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-39:first-child {
+    padding-top: 1rem;
+  }
+}
+
+.emotion-39:last-child {
+  padding-bottom: 0;
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
+    margin: 0 0.25rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-39 {
+    width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-39 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-39 {
+    width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
+    margin: 0 0.5rem;
+    display: inline-block;
+    vertical-align: top;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-39 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-39 {
+      grid-template-columns: repeat(2, 1fr);
+      grid-column-end: span 2;
+    }
+  }
+}
+
+.emotion-41 {
+  position: relative;
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-41 {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-column-gap: 0.5rem;
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-41 {
+      grid-column-gap: 1rem;
+    }
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-41 {
+      display: block;
+    }
+  }
+}
+
+.emotion-43 {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  width: 33.33%;
+}
+
+@media (min-width: 63rem) {
+  .emotion-43 {
+    display: block;
+    width: 100%;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-43 {
+    width: initial;
+    grid-column: 1/span 2;
+  }
+}
+
+@media (min-width: 25rem) {
+  .emotion-49 {
+    position: absolute;
+    bottom: 0;
+  }
+}
+
+.emotion-49>* {
+  height: 2rem;
+  padding: 0.5rem 0.25rem;
+}
+
+@media (max-width: 24.9375rem) {
+  .emotion-49>* {
+    height: 1.25rem;
+    padding: 0.25rem 0.25rem 0;
+  }
+}
+
+.emotion-51 {
+  display: inline-block;
+  vertical-align: top;
+  width: 66.67%;
+  padding: 0 0.5rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-51 {
+    padding: 0 1rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-51 {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+}
+
+@supports (grid-template-columns: fit-content(200px)) {
+  .emotion-51 {
+    display: block;
+    width: initial;
+    padding: initial;
+    grid-column: 3/span 4;
+  }
+
+  @media (min-width: 63rem) {
+    .emotion-51 {
+      padding-top: 0.5rem;
+    }
+  }
+}
+
+.emotion-53 {
+  color: #222222;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size: 0.9375rem;
+  line-height: 1.25rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-53 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-53 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+.emotion-57 {
+  font-size: 0.9375rem;
+  line-height: 1.125rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  color: #3F3F42;
+  margin: 0;
+  padding-bottom: 0.5rem;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-57 {
+    font-size: 0.9375rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-57 {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+}
+
+@media (max-width: 37.4375rem) {
+  .emotion-57 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-57 {
+    display: none;
+    visibility: hidden;
+  }
+}
+
+<div>
+  <section
+    aria-labelledby="Top-Stories"
+    class="emotion-0 emotion-1"
+    role="region"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <h2
+        class="emotion-4 emotion-5"
+      >
+        <span
+          class="emotion-6 emotion-7"
+        >
+          <span
+            class="emotion-8 emotion-9"
+          >
+            <span
+              class="emotion-10 emotion-11"
+              dir="ltr"
+              id="Top-Stories"
+            >
+              Top Stories
+            </span>
+          </span>
+        </span>
+      </h2>
+    </div>
+    <ul
+      class="emotion-12 emotion-13 emotion-14"
+      dir="ltr"
+      role="list"
+    >
+      <li
+        class="emotion-12 emotion-16 emotion-17"
+        dir="ltr"
+      >
+        <div
+          class="emotion-18 emotion-19"
+          data-e2e="story-promo"
+        >
+          <div
+            class="emotion-20 emotion-21"
+            dir="ltr"
+          >
+            <div
+              class="emotion-22 emotion-23"
+            >
+              <div
+                class="emotion-24 emotion-25"
+                data-e2e="image-placeholder"
+                style="padding-bottom: 56.25%;"
+              >
+                <div
+                  class="lazyload-wrapper "
+                >
+                  <div
+                    class="lazyload-placeholder"
+                  />
+                </div>
+              </div>
+              <div
+                class="emotion-26 emotion-27"
+              />
+            </div>
+          </div>
+          <div
+            class="emotion-28 emotion-29"
+            dir="ltr"
+          >
+            <h3
+              class="emotion-30 emotion-31"
+            >
+              <a
+                aria-labelledby="promo-1"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk"
               >
                 <span
@@ -5312,12 +5132,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               </a>
             </h3>
             <p
-              class="emotion-36 emotion-37"
+              class="emotion-34 emotion-35"
             >
               Summary text 1
             </p>
             <time
-              class="emotion-38 emotion-39"
+              class="emotion-36 emotion-37"
               datetime="1970-01-19"
             >
               19 January 1970
@@ -5326,22 +5146,22 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
         </div>
       </li>
       <li
-        class="emotion-14 emotion-41 emotion-19"
+        class="emotion-12 emotion-39 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-43 emotion-21"
+          class="emotion-41 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-45 emotion-23"
+            class="emotion-43 emotion-21"
             dir="ltr"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-22 emotion-23"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-24 emotion-25"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25%;"
               >
@@ -5354,20 +5174,20 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
                 </div>
               </div>
               <div
-                class="emotion-51 emotion-29"
+                class="emotion-49 emotion-27"
               />
             </div>
           </div>
           <div
-            class="emotion-53 emotion-31"
+            class="emotion-51 emotion-29"
             dir="ltr"
           >
             <h3
-              class="emotion-55 emotion-33"
+              class="emotion-53 emotion-31"
             >
               <a
                 aria-labelledby="promo-top-stories-1"
-                class="emotion-34 emotion-35"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk"
               >
                 <span
@@ -5378,12 +5198,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               </a>
             </h3>
             <p
-              class="emotion-59 emotion-37"
+              class="emotion-57 emotion-35"
             >
               Summary text 2
             </p>
             <time
-              class="emotion-38 emotion-39"
+              class="emotion-36 emotion-37"
               datetime="1970-01-19"
             >
               19 January 1970
@@ -5392,22 +5212,22 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
         </div>
       </li>
       <li
-        class="emotion-14 emotion-41 emotion-19"
+        class="emotion-12 emotion-39 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-43 emotion-21"
+          class="emotion-41 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-45 emotion-23"
+            class="emotion-43 emotion-21"
             dir="ltr"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-22 emotion-23"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-24 emotion-25"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25%;"
               >
@@ -5420,20 +5240,20 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
                 </div>
               </div>
               <div
-                class="emotion-51 emotion-29"
+                class="emotion-49 emotion-27"
               />
             </div>
           </div>
           <div
-            class="emotion-53 emotion-31"
+            class="emotion-51 emotion-29"
             dir="ltr"
           >
             <h3
-              class="emotion-55 emotion-33"
+              class="emotion-53 emotion-31"
             >
               <a
                 aria-labelledby="promo-top-stories-2"
-                class="emotion-34 emotion-35"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk"
               >
                 <span
@@ -5444,12 +5264,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               </a>
             </h3>
             <p
-              class="emotion-59 emotion-37"
+              class="emotion-57 emotion-35"
             >
               Summary text 3
             </p>
             <time
-              class="emotion-38 emotion-39"
+              class="emotion-36 emotion-37"
               datetime="1970-01-19"
             >
               19 January 1970
@@ -5458,22 +5278,22 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
         </div>
       </li>
       <li
-        class="emotion-14 emotion-41 emotion-19"
+        class="emotion-12 emotion-39 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-43 emotion-21"
+          class="emotion-41 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-45 emotion-23"
+            class="emotion-43 emotion-21"
             dir="ltr"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-22 emotion-23"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-24 emotion-25"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25%;"
               >
@@ -5486,20 +5306,20 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
                 </div>
               </div>
               <div
-                class="emotion-51 emotion-29"
+                class="emotion-49 emotion-27"
               />
             </div>
           </div>
           <div
-            class="emotion-53 emotion-31"
+            class="emotion-51 emotion-29"
             dir="ltr"
           >
             <h3
-              class="emotion-55 emotion-33"
+              class="emotion-53 emotion-31"
             >
               <a
                 aria-labelledby="promo-top-stories-3"
-                class="emotion-34 emotion-35"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk"
               >
                 <span
@@ -5510,12 +5330,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               </a>
             </h3>
             <p
-              class="emotion-59 emotion-37"
+              class="emotion-57 emotion-35"
             >
               Summary text 4
             </p>
             <time
-              class="emotion-38 emotion-39"
+              class="emotion-36 emotion-37"
               datetime="1970-01-19"
             >
               19 January 1970
@@ -5524,22 +5344,22 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
         </div>
       </li>
       <li
-        class="emotion-14 emotion-41 emotion-19"
+        class="emotion-12 emotion-39 emotion-17"
         dir="ltr"
       >
         <div
-          class="emotion-43 emotion-21"
+          class="emotion-41 emotion-19"
           data-e2e="story-promo"
         >
           <div
-            class="emotion-45 emotion-23"
+            class="emotion-43 emotion-21"
             dir="ltr"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-22 emotion-23"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-24 emotion-25"
                 data-e2e="image-placeholder"
                 style="padding-bottom: 56.25%;"
               >
@@ -5552,20 +5372,20 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
                 </div>
               </div>
               <div
-                class="emotion-51 emotion-29"
+                class="emotion-49 emotion-27"
               />
             </div>
           </div>
           <div
-            class="emotion-53 emotion-31"
+            class="emotion-51 emotion-29"
             dir="ltr"
           >
             <h3
-              class="emotion-55 emotion-33"
+              class="emotion-53 emotion-31"
             >
               <a
                 aria-labelledby="promo-top-stories-4"
-                class="emotion-34 emotion-35"
+                class="emotion-32 emotion-33"
                 href="https://www.bbc.co.uk"
               >
                 <span
@@ -5576,12 +5396,12 @@ exports[`IndexPageSection Container snapshots should render without a bar 1`] = 
               </a>
             </h3>
             <p
-              class="emotion-59 emotion-37"
+              class="emotion-57 emotion-35"
             >
               Summary text 5
             </p>
             <time
-              class="emotion-38 emotion-39"
+              class="emotion-36 emotion-37"
               datetime="1970-01-19"
             >
               19 January 1970

--- a/src/app/containers/MostRead/Canonical/Item/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/MostRead/Canonical/Item/__snapshots__/index.test.jsx.snap
@@ -1870,7 +1870,7 @@ exports[`MostReadLink should render with last updated date correctly 1`] = `
 .emotion-6 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/MostRead/Canonical/__snapshots__/LastUpdated.test.jsx.snap
+++ b/src/app/containers/MostRead/Canonical/__snapshots__/LastUpdated.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`MostReadCanonical - LastUpdated should render LastUpdated correctly 1`]
 .emotion-0 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.amp.test.jsx.snap
@@ -3,8 +3,7 @@
 exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
@@ -19,7 +18,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .e1ibkbh72::after {
@@ -30,6 +29,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -57,7 +57,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -79,8 +79,14 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
 }
 
 .emotion-6 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-6 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -95,7 +101,7 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
 }
 
 .emotion-12 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
 }
 
@@ -132,8 +138,8 @@ exports[`AMP Navigation Snapshots should correctly render AMP navigation 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }

--- a/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.canonical.test.jsx.snap
@@ -3,8 +3,7 @@
 exports[`Canonical Navigation snapshots should correctly render Canonical navigation 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-0::after {
@@ -13,7 +12,7 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .e1ibkbh72::after {
@@ -24,6 +23,7 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -55,7 +55,7 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -77,8 +77,14 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
 }
 
 .emotion-8 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-8 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -118,8 +124,8 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -132,7 +138,7 @@ exports[`Canonical Navigation snapshots should correctly render Canonical naviga
 }
 
 .emotion-14 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;

--- a/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Navigation/__snapshots__/index.test.jsx.snap
@@ -3,8 +3,7 @@
 exports[`Navigation Container should correctly render amp navigation 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
@@ -19,7 +18,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-70::after {
@@ -30,6 +29,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -57,7 +57,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -79,8 +79,14 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 }
 
 .emotion-6 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-6 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -95,7 +101,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 }
 
 .emotion-12 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
 }
 
@@ -110,12 +116,12 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
@@ -129,7 +135,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -154,10 +160,11 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 .emotion-18:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 .emotion-20 {
-  border-left: 0.25rem solid #FFFFFF;
+  border-left: 0.25rem solid #B80000;
   padding-left: 0.5rem;
 }
 
@@ -187,8 +194,8 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -238,7 +245,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -250,6 +257,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -283,8 +291,8 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-71:focus::after {
@@ -293,9 +301,9 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-73::after {
@@ -304,7 +312,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-79 {
@@ -314,6 +322,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -347,7 +356,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-79:focus::after {
@@ -356,9 +365,9 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -786,8 +795,7 @@ exports[`Navigation Container should correctly render amp navigation 1`] = `
 exports[`Navigation Container should correctly render amp navigation on non-home navigation page 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
@@ -802,7 +810,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-66::after {
@@ -813,6 +821,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -840,7 +849,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -862,8 +871,14 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 }
 
 .emotion-6 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-6 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -878,7 +893,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 }
 
 .emotion-12 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
 }
 
@@ -893,12 +908,12 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
@@ -912,7 +927,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -937,6 +952,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 .emotion-18:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 @media (max-width: 37.4375rem) {
@@ -965,8 +981,8 @@ exports[`Navigation Container should correctly render amp navigation on non-home
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -1016,7 +1032,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -1028,6 +1044,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1061,7 +1078,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-67:focus::after {
@@ -1070,9 +1087,9 @@ exports[`Navigation Container should correctly render amp navigation on non-home
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -1480,8 +1497,7 @@ exports[`Navigation Container should correctly render amp navigation on non-home
 exports[`Navigation Container should correctly render amp navigation on non-navigation page 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
@@ -1496,7 +1512,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-66::after {
@@ -1507,6 +1523,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -1534,7 +1551,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -1556,8 +1573,14 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 }
 
 .emotion-6 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-6 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -1572,7 +1595,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 }
 
 .emotion-12 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
 }
 
@@ -1587,12 +1610,12 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-16:last-child {
@@ -1606,7 +1629,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -1631,6 +1654,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 .emotion-18:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 @media (max-width: 37.4375rem) {
@@ -1659,8 +1683,8 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -1710,7 +1734,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -1722,6 +1746,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1755,7 +1780,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-67:focus::after {
@@ -1764,9 +1789,9 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -2174,8 +2199,7 @@ exports[`Navigation Container should correctly render amp navigation on non-navi
 exports[`Navigation Container should correctly render canonical navigation 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-0::after {
@@ -2184,7 +2208,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-17::after {
@@ -2195,6 +2219,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -2226,7 +2251,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -2248,8 +2273,14 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 }
 
 .emotion-8 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-8 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -2289,8 +2320,8 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -2333,7 +2364,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -2345,6 +2376,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2378,8 +2410,8 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-18:focus::after {
@@ -2388,9 +2420,9 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-20::after {
@@ -2399,7 +2431,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-26 {
@@ -2409,6 +2441,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2442,7 +2475,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-26:focus::after {
@@ -2451,13 +2484,13 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-64 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -2485,12 +2518,12 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-68 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-68:last-child {
@@ -2504,7 +2537,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -2529,10 +2562,11 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 .emotion-70:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 .emotion-72 {
-  border-left: 0.25rem solid #FFFFFF;
+  border-left: 0.25rem solid #B80000;
   padding-left: 0.5rem;
 }
 
@@ -2931,8 +2965,7 @@ exports[`Navigation Container should correctly render canonical navigation 1`] =
 exports[`Navigation Container should correctly render canonical navigation on non-home navigation page 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-0::after {
@@ -2941,7 +2974,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-17::after {
@@ -2952,6 +2985,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -2983,7 +3017,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -3005,8 +3039,14 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 .emotion-8 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-8 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -3046,8 +3086,8 @@ exports[`Navigation Container should correctly render canonical navigation on no
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -3090,7 +3130,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -3102,6 +3142,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3135,7 +3176,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-18:focus::after {
@@ -3144,13 +3185,13 @@ exports[`Navigation Container should correctly render canonical navigation on no
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-60 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -3178,12 +3219,12 @@ exports[`Navigation Container should correctly render canonical navigation on no
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64:last-child {
@@ -3197,7 +3238,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -3222,6 +3263,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-66:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 <div>
@@ -3599,8 +3641,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
 exports[`Navigation Container should correctly render canonical navigation on non-navigation page 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-0::after {
@@ -3609,7 +3650,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-17::after {
@@ -3620,6 +3661,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -3651,7 +3693,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -3673,8 +3715,14 @@ exports[`Navigation Container should correctly render canonical navigation on no
 }
 
 .emotion-8 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-8 {
+    fill: linkText;
+  }
 }
 
 .emotion-10 {
@@ -3714,8 +3762,8 @@ exports[`Navigation Container should correctly render canonical navigation on no
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -3758,7 +3806,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -3770,6 +3818,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3803,7 +3852,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-18:focus::after {
@@ -3812,13 +3861,13 @@ exports[`Navigation Container should correctly render canonical navigation on no
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-60 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -3846,12 +3895,12 @@ exports[`Navigation Container should correctly render canonical navigation on no
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-64:last-child {
@@ -3865,7 +3914,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -3890,6 +3939,7 @@ exports[`Navigation Container should correctly render canonical navigation on no
 .emotion-66:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 <div>

--- a/src/app/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/OnDemandHeading/__snapshots__/index.test.jsx.snap
@@ -139,7 +139,7 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;

--- a/src/app/containers/OnDemandParagraph/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/OnDemandParagraph/__snapshots__/index.test.jsx.snap
@@ -50,7 +50,7 @@ exports[`MediaPageBlocks Paragraph should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-bottom: 16px;

--- a/src/app/containers/Paragraph/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Paragraph/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`ParagraphContainer should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -295,7 +295,7 @@ exports[`ParagraphContainer should render correctly with inline block 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 .emotion-3 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0 auto;
   width: 100%;
@@ -69,28 +69,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: none;
-  }
-}
-
-.emotion-7 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-9 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,7 +83,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   flex-direction: column;
 }
 
-.emotion-11 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -120,7 +103,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-11 {
+  .emotion-9 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -128,11 +111,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 }
 
-.emotion-13 {
+.emotion-11 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F2F2F2;
   margin: 1rem 0;
@@ -148,75 +131,75 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     padding-left: 1rem;
   }
 }
 
-.emotion-15 {
+.emotion-13 {
   margin: 0 auto;
   width: 100%;
   padding-bottom: 1rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-13 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-15 {
+  .emotion-13 {
     max-width: 63rem;
     padding-bottom: 1.5rem;
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   padding: 0;
   margin: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 1rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-18 {
+  .emotion-16 {
     display: grid;
     position: initial;
     width: initial;
@@ -224,7 +207,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -233,7 +216,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -242,7 +225,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -251,7 +234,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -259,7 +242,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -267,7 +250,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 
   @media (min-width: 80rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -276,18 +259,18 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (max-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0;
   }
 }
 
-.emotion-21 {
+.emotion-19 {
   position: relative;
   padding-bottom: 1rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -296,7 +279,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -305,7 +288,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -314,7 +297,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -323,7 +306,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -332,7 +315,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 80rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -341,49 +324,49 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @supports (display: grid) {
-  .emotion-21 {
+  .emotion-19 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
@@ -391,7 +374,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-21 {
+  .emotion-19 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -402,8 +385,19 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   }
 }
 
-.emotion-23 {
+.emotion-21 {
   padding-bottom: 0.5rem;
+}
+
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .emotion-25 {
@@ -415,34 +409,23 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   padding-left: 0.25rem;
 }
 
-.emotion-27>svg {
+.emotion-25>svg {
   color: #5A5A5A;
   margin: 0;
   overflow: visible;
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-27>svg {
+  .emotion-25>svg {
     padding-left: 0.25rem;
     fill: canvasText;
   }
 }
 
-.emotion-29 {
+.emotion-27 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -451,7 +434,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   height: 0.725rem;
 }
 
-.emotion-31 {
+.emotion-29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -466,7 +449,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   width: 100%;
 }
 
-.emotion-31>time {
+.emotion-29>time {
   color: #5A5A5A;
   font-size: 0.75rem;
   line-height: 1.125rem;
@@ -476,20 +459,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-31>time {
+  .emotion-29>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31>time {
+  .emotion-29>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-31::after {
+.emotion-29::after {
   content: '';
   border-top: 0.0625rem solid #AEAEB5;
   top: 1.0625rem;
@@ -497,10 +480,10 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   width: 100%;
 }
 
-.emotion-33 {
+.emotion-31 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -508,20 +491,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-35 {
+.emotion-33 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -535,7 +518,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   height: 100%;
 }
 
-.emotion-37 {
+.emotion-35 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -543,7 +526,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   flex-grow: 1;
 }
 
-.emotion-39 {
+.emotion-37 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -554,20 +537,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-41 {
+.emotion-39 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -578,7 +561,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   margin: 0;
 }
 
-.emotion-43 {
+.emotion-41 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -590,20 +573,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-41 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-41 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-47 {
+.emotion-45 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
@@ -616,20 +599,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-47 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-47 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-51 {
+.emotion-49 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -641,20 +624,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-51 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-51 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-53 {
+.emotion-51 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -667,27 +650,27 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-51 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-51 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-53 {
+  .emotion-51 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-55>svg {
+.emotion-53>svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -696,12 +679,12 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-55>svg {
+  .emotion-53>svg {
     fill: canvasText;
   }
 }
 
-.emotion-57 {
+.emotion-55 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -710,11 +693,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   height: 0.75rem;
 }
 
-.emotion-59 {
+.emotion-57 {
   padding-right: 0.5rem;
 }
 
-.emotion-80 {
+.emotion-78 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -725,20 +708,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-80 {
+  .emotion-78 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-80 {
+  .emotion-78 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-82 {
+.emotion-80 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -746,7 +729,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   overflow-wrap: break-word;
 }
 
-.emotion-82:before {
+.emotion-80:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -758,27 +741,27 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   z-index: 1;
 }
 
-.emotion-82:hover,
-.emotion-82:focus {
+.emotion-80:hover,
+.emotion-80:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-82:visited {
+.emotion-80:visited {
   color: #6E6E73;
 }
 
-.emotion-82:hover .emotion-48 {
+.emotion-80:hover .emotion-46 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-82:focus .emotion-48 {
+.emotion-80:focus .emotion-46 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-88 {
+.emotion-86 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
@@ -791,20 +774,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-88 {
+  .emotion-86 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-88 {
+  .emotion-86 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-94 {
+.emotion-92 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -817,27 +800,27 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-94 {
+  .emotion-92 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-94 {
+  .emotion-92 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-94 {
+  .emotion-92 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-96>svg {
+.emotion-94>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -846,12 +829,12 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-96>svg {
+  .emotion-94>svg {
     fill: canvasText;
   }
 }
 
-.emotion-184 {
+.emotion-182 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -863,26 +846,26 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-184:hover,
-.emotion-184:focus {
+.emotion-182:hover,
+.emotion-182:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-184:visited {
+.emotion-182:visited {
   color: #6E6E73;
 }
 
@@ -895,20 +878,17 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
     <div
       class="emotion-2 emotion-3 emotion-4"
     >
-      <div
-        class="emotion-5 emotion-6"
-      />
       <h2
-        class="emotion-7 emotion-8"
+        class="emotion-5 emotion-6"
       >
         <span
-          class="emotion-9 emotion-10"
+          class="emotion-7 emotion-8"
         >
           <span
-            class="emotion-11 emotion-12"
+            class="emotion-9 emotion-10"
           >
             <span
-              class="emotion-13 emotion-14"
+              class="emotion-11 emotion-12"
               dir="rtl"
               id="Radio-Schedule"
             >
@@ -919,33 +899,33 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
       </h2>
     </div>
     <div
-      class="emotion-15 emotion-16"
+      class="emotion-13 emotion-14"
       data-e2e="radio-schedule"
     >
       <div
-        class="emotion-17 emotion-18 emotion-19"
+        class="emotion-15 emotion-16 emotion-17"
         dir="rtl"
         role="list"
       >
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="next"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -961,11 +941,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2030-01-01"
                 >
                   09:00
@@ -974,63 +954,63 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
               >
                 <span
                   id="scheduleItem-p086pmsd"
                   role="text"
                 >
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     واصل الاستماع, 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-43 emotion-44"
+                    class="emotion-41 emotion-42"
                     dir="rtl"
                   >
                     لاحق 
                   </span>
                   العالم هذا الصباح
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     , 09:00, 
                   </span>
                   <span
-                    class="emotion-47 emotion-48"
+                    class="emotion-45 emotion-46"
                   >
                     1 يناير/ كانون الثاني 2030
                   </span>
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     , المدة 1،30،30 
                   </span>
                 </span>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
               </p>
             </div>
             <div
-              class="emotion-53 emotion-54"
+              class="emotion-51 emotion-52"
             >
               <span
-                class="emotion-55 emotion-56"
+                class="emotion-53 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1045,7 +1025,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT1H30M30S"
                 dir="rtl"
               >
@@ -1059,24 +1039,24 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -1092,11 +1072,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:59
@@ -1105,17 +1085,17 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpz"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172x9qcpbyctzs"
                 >
                   <span
@@ -1123,23 +1103,23 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     العالم هذا الصباح
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:59, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 2،00،00 
                     </span>
@@ -1147,20 +1127,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1175,7 +1155,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT2H"
                 dir="rtl"
               >
@@ -1189,24 +1169,24 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -1222,11 +1202,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:30
@@ -1235,17 +1215,17 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpx"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172xbf7kbvtt4h"
                 >
                   <span
@@ -1253,23 +1233,23 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     موجز الأنباء
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:30, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 02،00 
                     </span>
@@ -1277,20 +1257,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 نشرة موجزة في دقيقتين لأهم الأنباء الأقليمية والدولية
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1305,7 +1285,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT2M"
                 dir="rtl"
               >
@@ -1319,24 +1299,24 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -1352,11 +1332,11 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:00
@@ -1365,17 +1345,17 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpp"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172xbdf3m84fx2"
                 >
                   <span
@@ -1383,23 +1363,23 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     نشرة الأخبار
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:00, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 06،00 
                     </span>
@@ -1407,20 +1387,20 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 نشرة اخبارية على رأس الساعة تركز على أهم أخبار المنطقة والعالم وتتضمن تصريحات المسؤولين وإفادات مراسلينا
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1435,7 +1415,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT6M"
                 dir="rtl"
               >
@@ -1450,7 +1430,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
         </li>
       </div>
       <a
-        class="emotion-184 emotion-185"
+        class="emotion-182 emotion-183"
         href="/arabic/tv-and-radio-57895092"
       >
         استقبال البث
@@ -1495,7 +1475,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 .emotion-3 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0 auto;
   width: 100%;
@@ -1529,28 +1509,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 .emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: none;
-  }
-}
-
-.emotion-7 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-9 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1560,7 +1523,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   flex-direction: column;
 }
 
-.emotion-11 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1580,7 +1543,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-11 {
+  .emotion-9 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1588,11 +1551,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 }
 
-.emotion-13 {
+.emotion-11 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F2F2F2;
   margin: 1rem 0;
@@ -1608,75 +1571,75 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-11 {
     padding-left: 1rem;
   }
 }
 
-.emotion-15 {
+.emotion-13 {
   margin: 0 auto;
   width: 100%;
   padding-bottom: 1rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-13 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-15 {
+  .emotion-13 {
     max-width: 63rem;
     padding-bottom: 1.5rem;
   }
 }
 
-.emotion-18 {
+.emotion-16 {
   padding: 0;
   margin: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0 1rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-18 {
+  .emotion-16 {
     display: grid;
     position: initial;
     width: initial;
@@ -1684,7 +1647,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1693,7 +1656,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1702,7 +1665,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1711,7 +1674,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -1719,7 +1682,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1727,7 +1690,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 
   @media (min-width: 80rem) {
-    .emotion-18 {
+    .emotion-16 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1736,18 +1699,18 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (max-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-16 {
     padding: 0;
   }
 }
 
-.emotion-21 {
+.emotion-19 {
   position: relative;
   padding-bottom: 1rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1756,7 +1719,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1765,7 +1728,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1774,7 +1737,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1783,7 +1746,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1792,7 +1755,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 80rem) {
-  .emotion-21 {
+  .emotion-19 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1801,49 +1764,49 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @supports (display: grid) {
-  .emotion-21 {
+  .emotion-19 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-21 {
+    .emotion-19 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
@@ -1851,7 +1814,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-21 {
+  .emotion-19 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1862,8 +1825,19 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   }
 }
 
-.emotion-23 {
+.emotion-21 {
   padding-bottom: 0.5rem;
+}
+
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .emotion-25 {
@@ -1875,34 +1849,23 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   padding-left: 0.25rem;
 }
 
-.emotion-27>svg {
+.emotion-25>svg {
   color: #5A5A5A;
   margin: 0;
   overflow: visible;
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-27>svg {
+  .emotion-25>svg {
     padding-left: 0.25rem;
     fill: canvasText;
   }
 }
 
-.emotion-29 {
+.emotion-27 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1911,7 +1874,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   height: 0.725rem;
 }
 
-.emotion-31 {
+.emotion-29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1926,7 +1889,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   width: 100%;
 }
 
-.emotion-31>time {
+.emotion-29>time {
   color: #5A5A5A;
   font-size: 0.75rem;
   line-height: 1.125rem;
@@ -1936,20 +1899,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-31>time {
+  .emotion-29>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31>time {
+  .emotion-29>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-31::after {
+.emotion-29::after {
   content: '';
   border-top: 0.0625rem solid #AEAEB5;
   top: 1.0625rem;
@@ -1957,10 +1920,10 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   width: 100%;
 }
 
-.emotion-33 {
+.emotion-31 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -1968,20 +1931,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-31 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-35 {
+.emotion-33 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -1995,7 +1958,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   height: 100%;
 }
 
-.emotion-37 {
+.emotion-35 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -2003,7 +1966,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   flex-grow: 1;
 }
 
-.emotion-39 {
+.emotion-37 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -2014,20 +1977,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-41 {
+.emotion-39 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -2038,7 +2001,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   margin: 0;
 }
 
-.emotion-43 {
+.emotion-41 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -2050,20 +2013,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-41 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-41 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-47 {
+.emotion-45 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
@@ -2076,20 +2039,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-47 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-47 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-51 {
+.emotion-49 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -2101,20 +2064,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-51 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-51 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-53 {
+.emotion-51 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -2127,27 +2090,27 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-51 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-51 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-53 {
+  .emotion-51 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-55>svg {
+.emotion-53>svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -2156,12 +2119,12 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-55>svg {
+  .emotion-53>svg {
     fill: canvasText;
   }
 }
 
-.emotion-57 {
+.emotion-55 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -2170,11 +2133,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   height: 0.75rem;
 }
 
-.emotion-59 {
+.emotion-57 {
   padding-right: 0.5rem;
 }
 
-.emotion-80 {
+.emotion-78 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -2185,20 +2148,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-80 {
+  .emotion-78 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-80 {
+  .emotion-78 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-82 {
+.emotion-80 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -2206,7 +2169,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   overflow-wrap: break-word;
 }
 
-.emotion-82:before {
+.emotion-80:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -2218,27 +2181,27 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   z-index: 1;
 }
 
-.emotion-82:hover,
-.emotion-82:focus {
+.emotion-80:hover,
+.emotion-80:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-82:visited {
+.emotion-80:visited {
   color: #6E6E73;
 }
 
-.emotion-82:hover .emotion-48 {
+.emotion-80:hover .emotion-46 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-82:focus .emotion-48 {
+.emotion-80:focus .emotion-46 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-88 {
+.emotion-86 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
@@ -2251,20 +2214,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-88 {
+  .emotion-86 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-88 {
+  .emotion-86 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-94 {
+.emotion-92 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -2277,27 +2240,27 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-94 {
+  .emotion-92 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-94 {
+  .emotion-92 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-94 {
+  .emotion-92 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-96>svg {
+.emotion-94>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -2306,12 +2269,12 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-96>svg {
+  .emotion-94>svg {
     fill: canvasText;
   }
 }
 
-.emotion-184 {
+.emotion-182 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2323,26 +2286,26 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-184:hover,
-.emotion-184:focus {
+.emotion-182:hover,
+.emotion-182:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-184:visited {
+.emotion-182:visited {
   color: #6E6E73;
 }
 
@@ -2355,20 +2318,17 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
     <div
       class="emotion-2 emotion-3 emotion-4"
     >
-      <div
-        class="emotion-5 emotion-6"
-      />
       <h2
-        class="emotion-7 emotion-8"
+        class="emotion-5 emotion-6"
       >
         <span
-          class="emotion-9 emotion-10"
+          class="emotion-7 emotion-8"
         >
           <span
-            class="emotion-11 emotion-12"
+            class="emotion-9 emotion-10"
           >
             <span
-              class="emotion-13 emotion-14"
+              class="emotion-11 emotion-12"
               dir="rtl"
               id="Radio-Schedule"
             >
@@ -2379,33 +2339,33 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
       </h2>
     </div>
     <div
-      class="emotion-15 emotion-16"
+      class="emotion-13 emotion-14"
       data-e2e="radio-schedule"
     >
       <div
-        class="emotion-17 emotion-18 emotion-19"
+        class="emotion-15 emotion-16 emotion-17"
         dir="rtl"
         role="list"
       >
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="next"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2421,11 +2381,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2030-01-01"
                 >
                   09:00
@@ -2434,63 +2394,63 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
               >
                 <span
                   id="scheduleItem-p086pmsd"
                   role="text"
                 >
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     واصل الاستماع, 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-43 emotion-44"
+                    class="emotion-41 emotion-42"
                     dir="rtl"
                   >
                     لاحق 
                   </span>
                   العالم هذا الصباح
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     , 09:00, 
                   </span>
                   <span
-                    class="emotion-47 emotion-48"
+                    class="emotion-45 emotion-46"
                   >
                     1 يناير/ كانون الثاني 2030
                   </span>
                   <span
-                    class="emotion-41 emotion-42"
+                    class="emotion-39 emotion-40"
                   >
                     , المدة 1،30،30 
                   </span>
                 </span>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
               </p>
             </div>
             <div
-              class="emotion-53 emotion-54"
+              class="emotion-51 emotion-52"
             >
               <span
-                class="emotion-55 emotion-56"
+                class="emotion-53 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2505,7 +2465,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT1H30M30S"
                 dir="rtl"
               >
@@ -2519,24 +2479,24 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2552,11 +2512,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:59
@@ -2565,17 +2525,17 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpz"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172x9qcpbyctzs"
                 >
                   <span
@@ -2583,23 +2543,23 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     العالم هذا الصباح
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:59, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 2،00،00 
                     </span>
@@ -2607,20 +2567,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 الفترة الإخبارية الرئيسية كل صباح على مدى أربع ساعات وتتناول أهم الأخبار والموضوعات الأقليمية والدولية بالتغطية والتحليل.
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2635,7 +2595,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT2H"
                 dir="rtl"
               >
@@ -2649,24 +2609,24 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2682,11 +2642,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:30
@@ -2695,17 +2655,17 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpx"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172xbf7kbvtt4h"
                 >
                   <span
@@ -2713,23 +2673,23 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     موجز الأنباء
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:30, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 02،00 
                     </span>
@@ -2737,20 +2697,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 نشرة موجزة في دقيقتين لأهم الأنباء الأقليمية والدولية
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2765,7 +2725,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT2M"
                 dir="rtl"
               >
@@ -2779,24 +2739,24 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
           </div>
         </li>
         <li
-          class="emotion-20 emotion-21 emotion-19"
+          class="emotion-18 emotion-19 emotion-17"
           data-e2e="onDemand"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-23 emotion-24"
+            class="emotion-21 emotion-22"
           >
             <div
-              class="emotion-25 emotion-26"
+              class="emotion-23 emotion-24"
             >
               <span
-                class="emotion-27 emotion-28"
+                class="emotion-25 emotion-26"
                 dir="rtl"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-29 emotion-30"
+                  class="emotion-27 emotion-28"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2812,11 +2772,11 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-31 emotion-32"
+                class="emotion-29 emotion-30"
                 dir="rtl"
               >
                 <time
-                  class="emotion-33 emotion-34"
+                  class="emotion-31 emotion-32"
                   datetime="2020-03-26"
                 >
                   02:00
@@ -2825,17 +2785,17 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
             </div>
           </div>
           <div
-            class="emotion-35 emotion-36"
+            class="emotion-33 emotion-34"
           >
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-35 emotion-36"
             >
               <h3
-                class="emotion-80 emotion-40"
+                class="emotion-78 emotion-38"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pjpp"
-                  class="emotion-82 emotion-83"
+                  class="emotion-80 emotion-81"
                   href="/arabic/bbc_arabic_radio/w172xbdf3m84fx2"
                 >
                   <span
@@ -2843,23 +2803,23 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                     role="text"
                   >
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       استمع, 
                     </span>
                     نشرة الأخبار
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , 02:00, 
                     </span>
                     <span
-                      class="emotion-88 emotion-48"
+                      class="emotion-86 emotion-46"
                     >
                       26 مارس/ آذار 2020
                     </span>
                     <span
-                      class="emotion-41 emotion-42"
+                      class="emotion-39 emotion-40"
                     >
                       , المدة 06،00 
                     </span>
@@ -2867,20 +2827,20 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </a>
               </h3>
               <p
-                class="emotion-51 emotion-52"
+                class="emotion-49 emotion-50"
               >
                 نشرة اخبارية على رأس الساعة تركز على أهم أخبار المنطقة والعالم وتتضمن تصريحات المسؤولين وإفادات مراسلينا
               </p>
             </div>
             <div
-              class="emotion-94 emotion-54"
+              class="emotion-92 emotion-52"
             >
               <span
-                class="emotion-96 emotion-56"
+                class="emotion-94 emotion-54"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-57 emotion-58"
+                  class="emotion-55 emotion-56"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2895,7 +2855,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
                 </svg>
               </span>
               <time
-                class="emotion-59 emotion-60"
+                class="emotion-57 emotion-58"
                 datetime="PT6M"
                 dir="rtl"
               >
@@ -2910,7 +2870,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
         </li>
       </div>
       <a
-        class="emotion-184 emotion-185"
+        class="emotion-182 emotion-183"
         href="/arabic/tv-and-radio-57895092"
       >
         استقبال البث

--- a/src/app/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/RelatedTopics/__snapshots__/index.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
 .emotion-3 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -32,50 +32,11 @@ exports[`Expected use should render correctly with a single tag 1`] = `
 }
 
 .emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-7 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-7 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-7 {
-    display: none;
-  }
-}
-
-.emotion-9 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-11 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,7 +46,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   flex-direction: column;
 }
 
-.emotion-13 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,7 +66,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-9 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -113,11 +74,11 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-11 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -133,32 +94,32 @@ exports[`Expected use should render correctly with a single tag 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-15 {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     padding-right: 1rem;
   }
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,7 +135,7 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   padding: 0;
 }
 
-.emotion-19 {
+.emotion-15 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -187,20 +148,20 @@ exports[`Expected use should render correctly with a single tag 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-19 a {
+.emotion-15 a {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -217,13 +178,13 @@ exports[`Expected use should render correctly with a single tag 1`] = `
   color: #222222;
 }
 
-.emotion-19 a:hover,
-.emotion-19 a:focus {
+.emotion-15 a:hover,
+.emotion-15 a:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-19 a:visited {
+.emotion-15 a:visited {
   color: #6E6E73;
 }
 
@@ -236,23 +197,17 @@ exports[`Expected use should render correctly with a single tag 1`] = `
     <div
       class="emotion-2 emotion-3 emotion-4"
     >
-      <div
-        class="emotion-5 emotion-6"
-      />
-      <div
-        class="emotion-7 emotion-8"
-      />
       <h2
-        class="emotion-9 emotion-10"
+        class="emotion-5 emotion-6"
       >
         <span
-          class="emotion-11 emotion-12"
+          class="emotion-7 emotion-8"
         >
           <span
-            class="emotion-13 emotion-14"
+            class="emotion-9 emotion-10"
           >
             <span
-              class="emotion-15 emotion-16"
+              class="emotion-11 emotion-12"
               dir="ltr"
               id="related-topics"
             >
@@ -263,10 +218,10 @@ exports[`Expected use should render correctly with a single tag 1`] = `
       </h2>
     </div>
     <div
-      class="emotion-17 emotion-18"
+      class="emotion-13 emotion-14"
     >
       <div
-        class="emotion-19 emotion-20"
+        class="emotion-15 emotion-16"
       >
         <a
           href="/mundo/topics/123"
@@ -287,7 +242,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 .emotion-3 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -311,50 +266,11 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 }
 
 .emotion-5 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-5 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-5 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-7 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-7 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-7 {
-    display: none;
-  }
-}
-
-.emotion-9 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-11 {
+.emotion-7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -364,7 +280,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
   flex-direction: column;
 }
 
-.emotion-13 {
+.emotion-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -384,7 +300,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-13 {
+  .emotion-9 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -392,11 +308,11 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
   }
 }
 
-.emotion-15 {
+.emotion-11 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -412,32 +328,32 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-15 {
+  .emotion-11 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-15 {
+  .emotion-11 {
     padding-right: 1rem;
   }
 }
 
-.emotion-17 {
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -454,7 +370,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
   list-style-type: none;
 }
 
-.emotion-19 {
+.emotion-15 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -467,20 +383,20 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-15 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-19 a {
+.emotion-15 a {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -497,13 +413,13 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
   color: #222222;
 }
 
-.emotion-19 a:hover,
-.emotion-19 a:focus {
+.emotion-15 a:hover,
+.emotion-15 a:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-19 a:visited {
+.emotion-15 a:visited {
   color: #6E6E73;
 }
 
@@ -516,23 +432,17 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
     <div
       class="emotion-2 emotion-3 emotion-4"
     >
-      <div
-        class="emotion-5 emotion-6"
-      />
-      <div
-        class="emotion-7 emotion-8"
-      />
       <h2
-        class="emotion-9 emotion-10"
+        class="emotion-5 emotion-6"
       >
         <span
-          class="emotion-11 emotion-12"
+          class="emotion-7 emotion-8"
         >
           <span
-            class="emotion-13 emotion-14"
+            class="emotion-9 emotion-10"
           >
             <span
-              class="emotion-15 emotion-16"
+              class="emotion-11 emotion-12"
               dir="ltr"
               id="related-topics"
             >
@@ -543,11 +453,11 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
       </h2>
     </div>
     <ul
-      class="emotion-17 emotion-18"
+      class="emotion-13 emotion-14"
       role="list"
     >
       <li
-        class="emotion-19 emotion-20"
+        class="emotion-15 emotion-16"
       >
         <a
           href="/mundo/topics/1"
@@ -556,7 +466,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
         </a>
       </li>
       <li
-        class="emotion-19 emotion-20"
+        class="emotion-15 emotion-16"
       >
         <a
           href="/mundo/topics/2"
@@ -565,7 +475,7 @@ exports[`Expected use should render correctly with multiple tags 1`] = `
         </a>
       </li>
       <li
-        class="emotion-19 emotion-20"
+        class="emotion-15 emotion-16"
       >
         <a
           href="/mundo/topics/3"

--- a/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/StoryPromo/__snapshots__/index.test.jsx.snap
@@ -292,7 +292,7 @@ exports[`StoryPromo Container should render audio correctly for amp 1`] = `
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -729,7 +729,7 @@ exports[`StoryPromo Container should render audio correctly for canonical 1`] = 
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1040,7 +1040,7 @@ exports[`StoryPromo Container should render audio promoType leading on amp 1`] =
 .emotion-14 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1612,7 +1612,7 @@ exports[`StoryPromo Container should render audio promoType top on amp 1`] = `
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2045,7 +2045,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
 .emotion-26 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2467,7 +2467,7 @@ exports[`StoryPromo Container should render audio with no duration correctly for
 .emotion-26 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2767,7 +2767,7 @@ exports[`StoryPromo Container should render audio with no duration promoType lea
 .emotion-12 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -3320,7 +3320,7 @@ exports[`StoryPromo Container should render audio with no duration promoType top
 .emotion-26 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -3685,7 +3685,7 @@ exports[`StoryPromo Container should render featureLink correctly for amp 1`] = 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4015,7 +4015,7 @@ exports[`StoryPromo Container should render featureLink correctly for canonical 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4269,7 +4269,7 @@ exports[`StoryPromo Container should render featureLink promoType leading on amp
 .emotion-10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4684,7 +4684,7 @@ exports[`StoryPromo Container should render featureLink promoType top on amp 1`]
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5020,7 +5020,7 @@ exports[`StoryPromo Container should render full width promos correctly for amp 
 .emotion-19 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5356,7 +5356,7 @@ exports[`StoryPromo Container should render full width promos correctly for cano
 .emotion-19 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5673,7 +5673,7 @@ exports[`StoryPromo Container should render item without an image correctly for 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5982,7 +5982,7 @@ exports[`StoryPromo Container should render item without an image correctly for 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -6228,7 +6228,7 @@ exports[`StoryPromo Container should render item without an image promoType lead
 .emotion-10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -6622,7 +6622,7 @@ exports[`StoryPromo Container should render item without an image promoType top 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -8212,7 +8212,7 @@ exports[`StoryPromo Container should render multiple Index Alsos correctly for c
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -9870,7 +9870,7 @@ exports[`StoryPromo Container should render standard correctly for amp 1`] = `
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -10200,7 +10200,7 @@ exports[`StoryPromo Container should render standard correctly for canonical 1`]
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -10454,7 +10454,7 @@ exports[`StoryPromo Container should render standard promoType leading on amp 1`
 .emotion-10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -10869,7 +10869,7 @@ exports[`StoryPromo Container should render standard promoType top on amp 1`] = 
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -11199,7 +11199,7 @@ exports[`StoryPromo Container should render standardLink correctly for amp 1`] =
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -11529,7 +11529,7 @@ exports[`StoryPromo Container should render standardLink correctly for canonical
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -11783,7 +11783,7 @@ exports[`StoryPromo Container should render standardLink promoType leading on am
 .emotion-10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -12198,7 +12198,7 @@ exports[`StoryPromo Container should render standardLink promoType top on amp 1`
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -12528,7 +12528,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -12858,7 +12858,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary correctly f
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -13112,7 +13112,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType l
 .emotion-10 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -13527,7 +13527,7 @@ exports[`StoryPromo Container should render standardOvertypedSummary promoType t
 .emotion-18 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -13918,7 +13918,7 @@ exports[`StoryPromo Container should render video correctly for amp 1`] = `
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -14352,7 +14352,7 @@ exports[`StoryPromo Container should render video correctly for canonical 1`] = 
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -14660,7 +14660,7 @@ exports[`StoryPromo Container should render video promoType leading on amp 1`] =
 .emotion-14 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -15229,7 +15229,7 @@ exports[`StoryPromo Container should render video promoType top on amp 1`] = `
 .emotion-30 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/containers/Text/__snapshots__/index.test.jsx.snap
+++ b/src/app/containers/Text/__snapshots__/index.test.jsx.snap
@@ -107,7 +107,7 @@ exports[`TextContainer with data should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/src/app/legacy/psammead-assets/src/svgs/navigationIcons.jsx
+++ b/src/app/legacy/psammead-assets/src/svgs/navigationIcons.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { C_BLACK } from '#legacy/psammead-styles/src/colours';
 
 const svgSize = '2.75rem'; // 44px
 
 const MenuIcon = styled.svg`
-  color: #fff;
+  color: ${C_BLACK};
   fill: currentColor;
+  @media screen and (forced-colors: active) {
+    fill: linkText;
+  }
 `;
 
 const defaultAttrs = {

--- a/src/app/legacy/psammead-grid/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-grid/src/__snapshots__/index.test.jsx.snap
@@ -218,7 +218,7 @@ exports[`Grid component should render Grid with Grid items 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -961,7 +961,7 @@ exports[`Grid component should render Grid with Grid items including nested non-
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/src/app/legacy/psammead-headings/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-headings/src/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`Headline component should render correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -91,7 +91,7 @@ exports[`Headline component should render correctly with arabic script typograph
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -133,7 +133,7 @@ exports[`SubHeading component should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -217,7 +217,7 @@ exports[`SubHeading component should render correctly with an ID 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -260,7 +260,7 @@ exports[`SubHeading component should render correctly with arabic script typogra
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }

--- a/src/app/legacy/psammead-headings/src/index.jsx
+++ b/src/app/legacy/psammead-headings/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { shape, string, bool } from 'prop-types';
-import { C_SHADOW, C_LUNAR } from '#legacy/psammead-styles/src/colours';
+import { C_LUNAR, C_GREY_10 } from '#legacy/psammead-styles/src/colours';
 import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
@@ -17,7 +17,7 @@ import {
 export const Headline = styled.h1`
   ${({ script }) => script && getCanon(script)};
   ${({ service }) => getSerifMedium(service)}
-  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_GREY_10)};
   display: block; /* Explicitly set */
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_QUAD} 0;
@@ -39,7 +39,7 @@ Headline.defaultProps = {
 export const SubHeading = styled.h2`
   ${({ script }) => script && getTrafalgar(script)};
   ${({ service }) => getSansBold(service)}
-  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_GREY_10)};
   margin: 0; /* Reset */
   padding: ${GEL_SPACING_TRPL} 0;
   ${MEDIA_QUERY_TYPOGRAPHY.LAPTOP_AND_LARGER} {

--- a/src/app/legacy/psammead-locales/moment/sr.test.js
+++ b/src/app/legacy/psammead-locales/moment/sr.test.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { format } from 'prettier';
 import './sr';
 
 moment.locale('sr');

--- a/src/app/legacy/psammead-locales/moment/sr.test.js
+++ b/src/app/legacy/psammead-locales/moment/sr.test.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { format } from 'prettier';
 import './sr';
 
 moment.locale('sr');

--- a/src/app/legacy/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-navigation/src/DropdownNavigation/__snapshots__/index.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`AMP Menu Button should render correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -48,8 +48,14 @@ exports[`AMP Menu Button should render correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-6 {
@@ -144,7 +150,7 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -166,8 +172,14 @@ exports[`AMP Menu Button should render rtl correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-6 {
@@ -262,7 +274,7 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -284,8 +296,14 @@ exports[`Canonical Closed menu button should render correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-4 {
@@ -353,7 +371,7 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -375,8 +393,14 @@ exports[`Canonical Closed menu button should render rtl correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-4 {
@@ -444,7 +468,7 @@ exports[`Canonical Open menu button should render correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -466,8 +490,14 @@ exports[`Canonical Open menu button should render correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-4 {
@@ -536,7 +566,7 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 @media (min-width: 37.5rem) {
@@ -558,8 +588,14 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
 }
 
 .emotion-2 {
-  color: #fff;
+  color: #000000;
   fill: currentColor;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-2 {
+    fill: linkText;
+  }
 }
 
 .emotion-4 {
@@ -604,7 +640,7 @@ exports[`Canonical Open menu button should render rtl correctly 1`] = `
 
 exports[`Dropdown navigation should render correctly when closed 1`] = `
 .emotion-0 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -632,12 +668,12 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4:last-child {
@@ -651,7 +687,7 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -676,10 +712,11 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
 .emotion-6:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 .emotion-20 {
-  border-left: 0.25rem solid #FFFFFF;
+  border-left: 0.25rem solid #B80000;
   padding-left: 0.5rem;
 }
 
@@ -863,7 +900,7 @@ exports[`Dropdown navigation should render correctly when closed 1`] = `
 
 exports[`Dropdown navigation should render correctly when open 1`] = `
 .emotion-0 {
-  background-color: #222222;
+  background-color: #FFFFFF;
   clear: both;
   overflow: hidden;
   height: 0;
@@ -892,12 +929,12 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
   list-style-type: none;
   margin: 0;
   padding: 0 0.5rem;
-  border-bottom: 0.125rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4 {
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid #3F3F42;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-4:last-child {
@@ -911,7 +948,7 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #FFFFFF;
+  color: #141414;
   -webkit-text-decoration: none;
   text-decoration: none;
   padding: 0.75rem 0;
@@ -936,10 +973,11 @@ exports[`Dropdown navigation should render correctly when open 1`] = `
 .emotion-6:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+  text-decoration-color: #B80000;
 }
 
 .emotion-20 {
-  border-left: 0.25rem solid #FFFFFF;
+  border-left: 0.25rem solid #B80000;
   padding-left: 0.5rem;
 }
 

--- a/src/app/legacy/psammead-navigation/src/DropdownNavigation/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/DropdownNavigation/index.jsx
@@ -3,7 +3,12 @@ import styled from '@emotion/styled';
 import { shape, string, bool, func, oneOf, node } from 'prop-types';
 import VisuallyHiddenText from '#legacy/psammead-visually-hidden-text/src';
 import { navigationIcons } from '#legacy/psammead-assets/src/svgs';
-import { C_WHITE, C_EBON, C_SHADOW } from '#legacy/psammead-styles/src/colours';
+import {
+  C_WHITE,
+  C_POSTBOX,
+  C_GREY_10,
+  C_GREY_3,
+} from '#legacy/psammead-styles/src/colours';
 import {
   GEL_SPACING_HLF,
   GEL_SPACING,
@@ -22,12 +27,12 @@ export const NAV_BAR_TOP_BOTTOM_SPACING = 0.75; // 12px
 
 const getStyles = dir => {
   const direction = dir === 'ltr' ? 'left' : 'right';
-  return `border-${direction}: ${GEL_SPACING_HLF} solid ${C_WHITE};
+  return `border-${direction}: ${GEL_SPACING_HLF} solid ${C_POSTBOX};
           padding-${direction}: ${GEL_SPACING};`;
 };
 
 const StyledDropdown = styled.div`
-  background-color: ${C_EBON};
+  background-color: ${C_WHITE};
   clear: both;
   overflow: hidden;
 
@@ -71,7 +76,7 @@ CanonicalDropdown.propTypes = {
 };
 
 export const AmpDropdown = styled.div`
-  background-color: ${C_EBON};
+  background-color: ${C_WHITE};
   clear: both;
 
   @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
@@ -84,7 +89,7 @@ export const DropdownUl = styled.ul`
   list-style-type: none;
   margin: 0;
   padding: 0 ${GEL_SPACING};
-  border-bottom: 0.125rem solid ${C_SHADOW};
+  border-bottom: 0.0625rem solid ${C_GREY_3};
 `;
 
 DropdownUl.defaultProps = {
@@ -93,7 +98,7 @@ DropdownUl.defaultProps = {
 
 const StyledDropdownLi = styled.li`
   padding: 0.75rem 0;
-  border-bottom: 0.0625rem solid ${C_SHADOW};
+  border-bottom: 0.0625rem solid ${C_GREY_3};
 
   &:last-child {
     padding-bottom: ${GEL_SPACING_HLF};
@@ -104,7 +109,7 @@ const StyledDropdownLi = styled.li`
 const StyledDropdownLink = styled.a`
   ${({ script }) => script && getPica(script)};
   ${({ service }) => service && getSansRegular(service)}
-  color: ${C_WHITE};
+  color: ${C_GREY_10};
   text-decoration: none;
   padding: ${GEL_SPACING_HLF_TRPL} 0;
   display: inline-block;
@@ -112,6 +117,7 @@ const StyledDropdownLink = styled.a`
   &:hover,
   &:focus {
     text-decoration: underline;
+    text-decoration-color: ${C_POSTBOX};
   }
 `;
 
@@ -182,7 +188,7 @@ const iconBorder = `
   right: 0;
   bottom: 0;
   top: 0;
-  border: ${GEL_SPACING_HLF} solid ${C_WHITE};
+  border: ${GEL_SPACING_HLF} solid ${C_POSTBOX};
 `;
 
 // The sideLength of the button should be

--- a/src/app/legacy/psammead-navigation/src/ScrollableNavigation/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/ScrollableNavigation/index.jsx
@@ -6,6 +6,7 @@ import {
   GEL_GROUP_2_SCREEN_WIDTH_MIN,
   GEL_GROUP_2_SCREEN_WIDTH_MAX,
 } from '#legacy/gel-foundations/src/breakpoints';
+import { C_WHITE } from '#legacy/psammead-styles/src/colours';
 
 // Because IE11 can't handle 8-digit hex, need to convert to rgba
 const hexToRGB = (hex, alpha = 1) => {
@@ -66,7 +67,7 @@ export const ScrollableNavigation = ({
   <StyledScrollableNav
     data-e2e="scrollable-nav"
     dir={dir}
-    brandBackgroundColour={brandBackgroundColour}
+    brandBackgroundColour={C_WHITE}
     brandHighlightColour={brandHighlightColour}
     {...props}
   >

--- a/src/app/legacy/psammead-navigation/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-navigation/src/__snapshots__/index.test.jsx.snap
@@ -3,8 +3,7 @@
 exports[`Navigation should render correctly 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-0::after {
@@ -13,7 +12,7 @@ exports[`Navigation should render correctly 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-7::after {
@@ -24,6 +23,7 @@ exports[`Navigation should render correctly 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -57,7 +57,7 @@ exports[`Navigation should render correctly 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -69,6 +69,7 @@ exports[`Navigation should render correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -102,8 +103,8 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-8:focus::after {
@@ -112,9 +113,9 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-10::after {
@@ -123,7 +124,7 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-12 {
@@ -144,6 +145,7 @@ exports[`Navigation should render correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -177,7 +179,7 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-16:focus::after {
@@ -186,9 +188,9 @@ exports[`Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -277,8 +279,7 @@ exports[`Navigation should render correctly 1`] = `
 exports[`Navigation should render correctly when ampOpenClass prop is provided 1`] = `
 .emotion-0 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 @media (max-width: 37.4375rem) {
@@ -293,7 +294,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-7::after {
@@ -304,6 +305,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -337,7 +339,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -349,6 +351,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -382,8 +385,8 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-8:focus::after {
@@ -392,9 +395,9 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-10::after {
@@ -403,7 +406,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-12 {
@@ -424,6 +427,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -457,7 +461,7 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-16:focus::after {
@@ -466,9 +470,9 @@ exports[`Navigation should render correctly when ampOpenClass prop is provided 1
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -558,7 +562,6 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
 .emotion-0 {
   position: relative;
   background-color: #222222;
-  border-top: 0.0625rem solid #FFFFFF;
 }
 
 .emotion-0::after {
@@ -567,7 +570,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-0 .emotion-7::after {
@@ -578,6 +581,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-4 {
@@ -611,7 +615,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -623,6 +627,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -656,8 +661,8 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-8:focus::after {
@@ -666,9 +671,9 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-10::after {
@@ -677,7 +682,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-12 {
@@ -698,6 +703,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -731,7 +737,7 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-16:focus::after {
@@ -740,9 +746,9 @@ exports[`Navigation should render correctly when isOpen is true 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>
@@ -855,8 +861,8 @@ exports[`Scrollable Navigation should render correctly 1`] = `
     pointer-events: none;
     background: linear-gradient(
             to right,
-            rgba(184, 0, 0, 0) 0%,
-            rgba(184, 0, 0, 1)
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 1)
               100%
           );
   }
@@ -870,8 +876,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
 
 .emotion-2 {
   position: relative;
-  background-color: #B80000;
-  border-top: 0.0625rem solid #FFFFFF;
+  background-color: #FFFFFF;
 }
 
 .emotion-2::after {
@@ -880,7 +885,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   bottom: 0;
   right: 0;
   left: 0;
-  border-bottom: 0.0625rem solid transparent;
+  border-bottom: 0.0625rem solid #E6E8EA;
 }
 
 .emotion-2 .emotion-9::after {
@@ -891,6 +896,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   position: relative;
   max-width: 80rem;
   margin: 0 auto;
+  background-color: #FFFFFF;
 }
 
 .emotion-6 {
@@ -924,7 +930,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
     position: absolute;
     bottom: -1px;
     width: 80rem;
-    border-bottom: 0.0625rem solid #EAB3B3;
+    border-bottom: 0.0625rem solid #E6E8EA;
     z-index: -1;
   }
 }
@@ -936,6 +942,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -969,8 +976,8 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
-  border-bottom: 0.3125rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
+  border-bottom: 0.3125rem solid #B80000;
 }
 
 .emotion-10:focus::after {
@@ -979,9 +986,9 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 .emotion-12::after {
@@ -990,7 +997,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-14 {
@@ -1011,6 +1018,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   font-weight: 400;
   font-style: normal;
   color: #FDFDFD;
+  color: #141414;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1044,7 +1052,7 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
 }
 
 .emotion-18:focus::after {
@@ -1053,9 +1061,9 @@ exports[`Scrollable Navigation should render correctly 1`] = `
   left: 0;
   right: 0;
   bottom: 0;
-  border-bottom: 0.25rem solid #FFFFFF;
+  border-bottom: 0.25rem solid #B80000;
   top: 0;
-  border: 0.25rem solid #FFFFFF;
+  border: 0.25rem solid #B80000;
 }
 
 <div>

--- a/src/app/legacy/psammead-navigation/src/index.jsx
+++ b/src/app/legacy/psammead-navigation/src/index.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { shape, string, node, bool, oneOf } from 'prop-types';
 import VisuallyHiddenText from '#legacy/psammead-visually-hidden-text/src';
-import { C_WHITE, C_EBON } from '#legacy/psammead-styles/src/colours';
+import {
+  C_WHITE,
+  C_EBON,
+  C_GREY_10,
+  C_GREY_3,
+  C_POSTBOX,
+} from '#legacy/psammead-styles/src/colours';
 import {
   GEL_SPACING_HLF,
   GEL_SPACING,
@@ -25,6 +31,7 @@ const NavWrapper = styled.div`
   position: relative;
   max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
   margin: 0 auto;
+  background-color: ${C_WHITE};
 `;
 
 const StyledUnorderedList = styled.ul`
@@ -50,6 +57,7 @@ const StyledLink = styled.a`
   ${({ script }) => script && getPica(script)};
   ${({ service }) => getSansRegular(service)};
   ${({ brandForegroundColour }) => `color: ${brandForegroundColour};`}
+  color: ${C_GREY_10};
   cursor: pointer;
   text-decoration: none;
   display: inline-block;
@@ -178,7 +186,7 @@ export const NavigationLi = ({
       role="listitem"
       brandForegroundColour={brandForegroundColour}
       brandHighlightColour={brandHighlightColour}
-      brandBorderColour={brandBorderColour}
+      brandBorderColour={C_GREY_3}
     >
       {active && currentPageText ? (
         <StyledLink
@@ -187,7 +195,7 @@ export const NavigationLi = ({
           service={service}
           currentLink
           brandForegroundColour={brandForegroundColour}
-          brandHighlightColour={brandHighlightColour}
+          brandHighlightColour={C_POSTBOX}
           // This is a temporary fix for the a11y nested span's bug experienced in TalkBack, refer to the following issue: https://github.com/bbc/simorgh/issues/9652
           aria-labelledby={`NavigationLinks-${link}`}
           {...props}
@@ -196,7 +204,7 @@ export const NavigationLi = ({
             linkId={link}
             script={script}
             currentPageText={currentPageText}
-            brandHighlightColour={brandHighlightColour}
+            brandHighlightColour={C_POSTBOX}
           >
             {link}
           </CurrentLink>
@@ -207,7 +215,7 @@ export const NavigationLi = ({
           script={script}
           service={service}
           brandForegroundColour={brandForegroundColour}
-          brandHighlightColour={brandHighlightColour}
+          brandHighlightColour={C_POSTBOX}
           {...props}
         >
           {link}
@@ -241,8 +249,7 @@ NavigationLi.defaultProps = {
 // color of the Navigation
 const StyledNav = styled.nav`
   position: relative;
-  ${({ isOpen, brandBackgroundColour }) =>
-    `background-color: ${isOpen ? C_EBON : brandBackgroundColour};`}
+  ${({ isOpen }) => `background-color: ${isOpen ? C_EBON : C_WHITE};`}
   ${({ ampOpenClass }) =>
     ampOpenClass &&
     `
@@ -252,7 +259,7 @@ const StyledNav = styled.nav`
         }
       }
     `}
-  border-top: 0.0625rem solid ${C_WHITE};
+  
 
   &::after {
     content: '';
@@ -260,7 +267,7 @@ const StyledNav = styled.nav`
     bottom: 0;
     right: 0;
     left: 0;
-    border-bottom: 0.0625rem solid transparent;
+    border-bottom: 0.0625rem solid ${C_GREY_3};
   }
 
   ${StyledListItem} {

--- a/src/app/legacy/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-paragraph/src/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`Paragraph should render correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -77,7 +77,7 @@ exports[`Paragraph should render correctly with arabic script typography values 
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }

--- a/src/app/legacy/psammead-paragraph/src/index.jsx
+++ b/src/app/legacy/psammead-paragraph/src/index.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { shape, string, bool } from 'prop-types';
-import { C_SHADOW, C_LUNAR } from '#legacy/psammead-styles/src/colours';
+import { C_LUNAR, C_GREY_10 } from '#legacy/psammead-styles/src/colours';
 import { GEL_SPACING_TRPL } from '#legacy/gel-foundations/src/spacings';
 import { getBodyCopy } from '#legacy/gel-foundations/src/typography';
 import { scriptPropType } from '#legacy/gel-foundations/src/prop-types';
@@ -9,7 +9,7 @@ import { getSansRegular } from '#legacy/psammead-styles/src/font-styles';
 const Paragraph = styled.p`
   ${({ script }) => script && getBodyCopy(script)};
   ${({ service }) => getSansRegular(service)}
-  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_SHADOW)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_GREY_10)};
   padding-bottom: ${GEL_SPACING_TRPL};
   margin: 0; /* Reset */
 `;

--- a/src/app/legacy/psammead-section-label/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-section-label/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -28,28 +28,11 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -59,7 +42,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +62,7 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -87,11 +70,11 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -107,27 +90,27 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -136,20 +119,17 @@ exports[`SectionLabel When hideSectionHeader is true should add styling to hide 
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -166,7 +146,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -183,62 +163,23 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-8:focus,
-.emotion-8:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -248,7 +189,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   flex-direction: column;
 }
 
-.emotion-12 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -268,7 +209,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -276,11 +217,11 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   }
 }
 
-.emotion-14 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -296,32 +237,32 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -343,21 +284,21 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -366,28 +307,22 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="test-section-label"
             >
@@ -395,7 +330,7 @@ exports[`SectionLabel With bar With linking title should render correctly 1`] = 
             </span>
             <span
               aria-hidden="true"
-              class="emotion-16 emotion-17"
+              class="emotion-12 emotion-13"
               dir="ltr"
             >
               See All
@@ -412,7 +347,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -429,62 +364,23 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-8:focus,
-.emotion-8:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -494,7 +390,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   flex-direction: column;
 }
 
-.emotion-12 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -514,7 +410,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -522,11 +418,11 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   }
 }
 
-.emotion-14 {
+.emotion-10 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -542,32 +438,32 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     padding-left: 1rem;
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -589,21 +485,21 @@ exports[`SectionLabel With bar With linking title should render correctly with a
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -612,28 +508,22 @@ exports[`SectionLabel With bar With linking title should render correctly with a
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
               dir="rtl"
               id="test-section-label"
             >
@@ -641,7 +531,7 @@ exports[`SectionLabel With bar With linking title should render correctly with a
             </span>
             <span
               aria-hidden="true"
-              class="emotion-16 emotion-17"
+              class="emotion-12 emotion-13"
               dir="rtl"
             >
               See All
@@ -658,7 +548,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -675,62 +565,23 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-8:focus,
-.emotion-8:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -740,7 +591,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   flex-direction: column;
 }
 
-.emotion-12 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -760,7 +611,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -768,11 +619,11 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   }
 }
 
-.emotion-14 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -788,32 +639,32 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -835,21 +686,21 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -858,28 +709,22 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="test-section-label"
             >
@@ -887,7 +732,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
             </span>
             <span
               aria-hidden="true"
-              class="emotion-16 emotion-17"
+              class="emotion-12 emotion-13"
               dir="ltr"
             >
               See All
@@ -904,7 +749,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -921,62 +766,23 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-8:focus,
-.emotion-8:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -986,7 +792,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   flex-direction: column;
 }
 
-.emotion-12 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1006,7 +812,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1014,11 +820,11 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   }
 }
 
-.emotion-14 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1034,32 +840,32 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
 
-.emotion-16 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -1081,21 +887,21 @@ exports[`SectionLabel With bar With linking title should render correctly with e
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -1104,28 +910,22 @@ exports[`SectionLabel With bar With linking title should render correctly with e
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="test-section-label"
             >
@@ -1133,7 +933,7 @@ exports[`SectionLabel With bar With linking title should render correctly with e
             </span>
             <span
               aria-hidden="true"
-              class="emotion-16 emotion-17"
+              class="emotion-12 emotion-13"
               dir="ltr"
             >
               See All
@@ -1150,7 +950,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -1167,50 +967,11 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1220,7 +981,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1240,7 +1001,7 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1248,11 +1009,11 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
   }
 }
 
-.emotion-12 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1268,27 +1029,27 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -1297,23 +1058,17 @@ exports[`SectionLabel With bar With plain title should render correctly 1`] = `
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -1330,7 +1085,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -1347,50 +1102,11 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1400,7 +1116,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1420,7 +1136,7 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1428,11 +1144,11 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   }
 }
 
-.emotion-12 {
+.emotion-8 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1448,27 +1164,27 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     padding-left: 1rem;
   }
 }
@@ -1477,23 +1193,17 @@ exports[`SectionLabel With bar With plain title should render correctly with ara
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             dir="rtl"
             id="test-section-label"
           >
@@ -1510,7 +1220,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -1527,50 +1237,11 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1580,7 +1251,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1600,7 +1271,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1608,11 +1279,11 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   }
 }
 
-.emotion-12 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1628,27 +1299,27 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -1657,23 +1328,17 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -1690,7 +1355,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -1707,50 +1372,11 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-4 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-4 {
-    display: none;
-  }
-}
-
-.emotion-6 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-8 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1760,7 +1386,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1780,7 +1406,7 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1788,11 +1414,11 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   }
 }
 
-.emotion-12 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1808,27 +1434,27 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -1837,23 +1463,17 @@ exports[`SectionLabel With bar With plain title should render correctly with exp
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <div
-      class="emotion-4 emotion-5"
-    />
     <h2
-      class="emotion-6 emotion-7"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-8 emotion-9"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-10 emotion-11"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -1870,7 +1490,7 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -1887,33 +1507,11 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1923,7 +1521,7 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1943,7 +1541,7 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1951,11 +1549,11 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1971,27 +1569,27 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -2000,20 +1598,17 @@ exports[`SectionLabel With bar With plain title should render correctly with mob
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -2030,7 +1625,7 @@ exports[`SectionLabel With heading overriden should render a strong element inst
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -2047,25 +1642,155 @@ exports[`SectionLabel With heading overriden should render a strong element inst
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
+  margin: 0;
+  padding: 0;
 }
 
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 2.75rem;
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-6 {
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+.emotion-8 {
+  font-size: 1.125rem;
+  line-height: 1.375rem;
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  background-color: #FDFDFD;
+  margin: 1rem 0;
+  padding-right: 0.5rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-8 {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
+  .emotion-8 {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
   }
 }
 
-.emotion-4 {
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    margin: 0;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-8 {
+    padding-right: 1rem;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <strong
+      class="emotion-2 emotion-3"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        <span
+          class="emotion-6 emotion-7"
+        >
+          <span
+            class="emotion-8 emotion-9"
+            dir="ltr"
+            id="test-section-label"
+          >
+            This is text in a SectionLabel.
+          </span>
+        </span>
+      </span>
+    </strong>
+  </div>
+</div>
+`;
+
+exports[`SectionLabel Without bar With linking title should render correctly 1`] = `
+.emotion-0 {
+  position: relative;
+  z-index: 0;
+  color: #141414;
+  margin-top: 2rem;
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-0 {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-0 {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.emotion-2 {
   margin: 0;
   padding: 0;
+}
+
+.emotion-4 {
+  color: #222222;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-4:focus,
+.emotion-4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
 }
 
 .emotion-6 {
@@ -2110,7 +1835,7 @@ exports[`SectionLabel With heading overriden should render a strong element inst
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2148,177 +1873,10 @@ exports[`SectionLabel With heading overriden should render a strong element inst
 @media (min-width: 37.5rem) {
   .emotion-10 {
     padding-right: 1rem;
-  }
-}
-
-<div>
-  <div
-    class="emotion-0 emotion-1"
-  >
-    <div
-      class="emotion-2 emotion-3"
-    />
-    <strong
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="emotion-6 emotion-7"
-      >
-        <span
-          class="emotion-8 emotion-9"
-        >
-          <span
-            class="emotion-10 emotion-11"
-            dir="ltr"
-            id="test-section-label"
-          >
-            This is text in a SectionLabel.
-          </span>
-        </span>
-      </span>
-    </strong>
-  </div>
-</div>
-`;
-
-exports[`SectionLabel Without bar With linking title should render correctly 1`] = `
-.emotion-0 {
-  position: relative;
-  z-index: 0;
-  color: #3F3F42;
-  margin-top: 2rem;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-0 {
-    margin-top: 1.5rem;
-  }
-}
-
-@media (min-width: 63rem) {
-  .emotion-0 {
-    margin-bottom: 1.5rem;
-  }
-}
-
-.emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
-  margin: 0;
-  padding: 0;
-}
-
-.emotion-6 {
-  color: #222222;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-6:focus,
-.emotion-6:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 2.75rem;
-  -webkit-align-items: baseline;
-  -webkit-box-align: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    -webkit-align-items: stretch;
-    -webkit-box-align: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
   }
 }
 
 .emotion-12 {
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  background-color: #FDFDFD;
-  margin: 1rem 0;
-  padding-right: 0.5rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    font-size: 1.5rem;
-    line-height: 1.75rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    margin: 0;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    padding-right: 1rem;
-  }
-}
-
-.emotion-14 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -2340,21 +1898,21 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -2363,25 +1921,22 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="test-section-label"
             >
@@ -2389,7 +1944,7 @@ exports[`SectionLabel Without bar With linking title should render correctly 1`]
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
               dir="ltr"
             >
               See All
@@ -2406,7 +1961,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -2423,40 +1978,23 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2466,7 +2004,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2486,7 +2024,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2494,11 +2032,11 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2514,32 +2052,32 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     padding-left: 1rem;
   }
 }
 
-.emotion-14 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2561,21 +2099,21 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -2584,25 +2122,22 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-10 emotion-11"
               dir="rtl"
               id="test-section-label"
             >
@@ -2610,7 +2145,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
               dir="rtl"
             >
               See All
@@ -2627,7 +2162,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -2644,40 +2179,23 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-6:focus,
-.emotion-6:hover {
+.emotion-4:focus,
+.emotion-4:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2687,7 +2205,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   flex-direction: column;
 }
 
-.emotion-10 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2707,7 +2225,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2715,11 +2233,11 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   }
 }
 
-.emotion-12 {
+.emotion-10 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2735,32 +2253,32 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-12 {
+  .emotion-10 {
     padding-right: 1rem;
   }
 }
 
-.emotion-14 {
+.emotion-12 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -2782,21 +2300,21 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin: 0;
   }
 }
@@ -2805,25 +2323,22 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <a
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
         href="/igbo/other-index"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             role="text"
           >
             <span
-              class="emotion-12 emotion-13"
+              class="emotion-10 emotion-11"
               dir="ltr"
               id="test-section-label"
             >
@@ -2831,7 +2346,7 @@ exports[`SectionLabel Without bar With linking title should render correctly wit
             </span>
             <span
               aria-hidden="true"
-              class="emotion-14 emotion-15"
+              class="emotion-12 emotion-13"
               dir="ltr"
             >
               See All
@@ -2848,7 +2363,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -2865,28 +2380,11 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2896,7 +2394,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2916,7 +2414,7 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -2924,11 +2422,11 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -2944,27 +2442,27 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -2973,20 +2471,17 @@ exports[`SectionLabel Without bar With plain title should render correctly 1`] =
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >
@@ -3003,7 +2498,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -3020,28 +2515,11 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3051,7 +2529,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3071,7 +2549,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3079,11 +2557,11 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -3099,27 +2577,27 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-left: 1rem;
   }
 }
@@ -3128,20 +2606,17 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             dir="rtl"
             id="test-section-label"
           >
@@ -3158,7 +2633,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 .emotion-0 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -3175,28 +2650,11 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 .emotion-2 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-2 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-2 {
-    display: none;
-  }
-}
-
-.emotion-4 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-6 {
+.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3206,7 +2664,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   flex-direction: column;
 }
 
-.emotion-8 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3226,7 +2684,7 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-8 {
+  .emotion-6 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3234,11 +2692,11 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   }
 }
 
-.emotion-10 {
+.emotion-8 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -3254,27 +2712,27 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-10 {
+  .emotion-8 {
     padding-right: 1rem;
   }
 }
@@ -3283,20 +2741,17 @@ exports[`SectionLabel Without bar With plain title should render correctly with 
   <div
     class="emotion-0 emotion-1"
   >
-    <div
-      class="emotion-2 emotion-3"
-    />
     <h2
-      class="emotion-4 emotion-5"
+      class="emotion-2 emotion-3"
     >
       <span
-        class="emotion-6 emotion-7"
+        class="emotion-4 emotion-5"
       >
         <span
-          class="emotion-8 emotion-9"
+          class="emotion-6 emotion-7"
         >
           <span
-            class="emotion-10 emotion-11"
+            class="emotion-8 emotion-9"
             dir="ltr"
             id="test-section-label"
           >

--- a/src/app/legacy/psammead-section-label/src/index.jsx
+++ b/src/app/legacy/psammead-section-label/src/index.jsx
@@ -10,46 +10,13 @@ import {
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
 } from '#legacy/gel-foundations/src/spacings';
-import {
-  C_PEBBLE,
-  C_GHOST,
-  C_SHADOW,
-} from '#legacy/psammead-styles/src/colours';
+import { C_GHOST, C_GREY_10 } from '#legacy/psammead-styles/src/colours';
 import { PlainTitle, LinkTitle } from './titles';
-
-const Bar = styled.div`
-  border-top: 0.0625rem solid ${C_PEBBLE};
-  z-index: -1;
-
-  @media screen and (-ms-high-contrast: active) {
-    border-color: windowText;
-  }
-`;
-
-const DesktopBar = styled(Bar)`
-  display: none;
-
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-
-    /* Placing bar at the vertical midpoint of the section title */
-    top: ${({ script }) => 0.5 + script.doublePica.groupD.lineHeight / 32}rem;
-  }
-`;
-
-const MobileBar = styled(Bar)`
-  @media (min-width: ${GEL_GROUP_3_SCREEN_WIDTH_MIN}) {
-    display: none;
-  }
-`;
 
 const SectionLabelWrapper = styled.div`
   position: relative;
   z-index: 0;
-  color: ${C_SHADOW};
+  color: ${C_GREY_10};
 
   margin-top: ${GEL_SPACING_QUAD};
 
@@ -77,15 +44,13 @@ SectionLabelWrapper.propTypes = {
   visuallyHidden: bool.isRequired,
 };
 
-const Heading = styled.h2`
+export const Heading = styled.h2`
   /* reset default margins */
   margin: 0;
   padding: 0;
 `;
 
 const SectionLabel = ({
-  bar,
-  mobileDivider,
   children: title,
   dir,
   href,
@@ -99,8 +64,6 @@ const SectionLabel = ({
   ...props
 }) => (
   <SectionLabelWrapper visuallyHidden={visuallyHidden} {...props}>
-    {bar && <DesktopBar script={script} />}
-    {mobileDivider && <MobileBar />}
     <Heading as={overrideHeadingAs}>
       {linkText && href ? (
         <LinkTitle
@@ -130,8 +93,6 @@ const SectionLabel = ({
 );
 
 SectionLabel.defaultProps = {
-  bar: true,
-  mobileDivider: true,
   dir: 'ltr',
   href: null,
   linkText: null,
@@ -141,8 +102,6 @@ SectionLabel.defaultProps = {
 };
 
 SectionLabel.propTypes = {
-  bar: bool,
-  mobileDivider: bool,
   children: string.isRequired,
   dir: oneOf(['ltr', 'rtl']),
   href: string,

--- a/src/app/legacy/psammead-section-label/src/titles.jsx
+++ b/src/app/legacy/psammead-section-label/src/titles.jsx
@@ -17,10 +17,7 @@ import {
   getDoublePica,
 } from '#legacy/gel-foundations/src/typography';
 import { C_EBON, C_GHOST } from '#legacy/psammead-styles/src/colours';
-import {
-  getSansBold,
-  getSansRegular,
-} from '#legacy/psammead-styles/src/font-styles';
+import { getSansBold } from '#legacy/psammead-styles/src/font-styles';
 
 const minClickableHeightPx = 44;
 const minClickableHeightRem = minClickableHeightPx / 16;
@@ -75,7 +72,7 @@ const titleMargins = `
 
 const Title = styled.span`
   ${({ script }) => script && getDoublePica(script)};
-  ${({ service }) => getSansRegular(service)}
+  ${({ service }) => getSansBold(service)}
   background-color: ${props => props.backgroundColor};
   ${titleMargins};
   ${paddingDir}: ${GEL_SPACING};

--- a/src/app/legacy/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-timestamp-container/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Timestamp should add prefix and suffix 1`] = `
 .emotion-0 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -44,7 +44,7 @@ exports[`Timestamp should render correctly 1`] = `
 .emotion-0 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -84,7 +84,7 @@ exports[`Timestamp should render without a leading zero on the day 1`] = `
 .emotion-0 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;

--- a/src/app/legacy/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead-timestamp/src/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Timestamp should render Timestamp correctly 1`] = `
 .emotion-0 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -44,7 +44,7 @@ exports[`Timestamp should render Timestamp with a prefix 1`] = `
 .emotion-0 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -84,7 +84,7 @@ exports[`Timestamp should render Timestamp without padding 1`] = `
 .emotion-0 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -159,7 +159,7 @@ exports[`Timestamp should render with the correct typography style applied 1`] =
 .emotion-0 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/legacy/psammead-timestamp/src/index.jsx
+++ b/src/app/legacy/psammead-timestamp/src/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '#legacy/gel-foundations/src/spacings';
 import { getBrevier } from '#legacy/gel-foundations/src/typography';
 import { scriptPropType } from '#legacy/gel-foundations/src/prop-types';
-import { C_LUNAR, C_METAL } from '#legacy/psammead-styles/src/colours';
+import { C_LUNAR, C_GREY_6 } from '#legacy/psammead-styles/src/colours';
 import { getSansRegular } from '#legacy/psammead-styles/src/font-styles';
 
 const PADDING = `
@@ -20,7 +20,7 @@ const PADDING = `
 const StyledTimestamp = styled.time`
   ${({ script, typographyFunc }) =>
     script && typographyFunc && typographyFunc(script)}
-  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_METAL)};
+  color: ${({ darkMode }) => (darkMode ? C_LUNAR : C_GREY_6)};
   display: block;
   ${({ service }) => getSansRegular(service)}
   ${props => props.padding && PADDING}

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -6,7 +6,6 @@ import last from 'ramda/src/last';
 import styled from '@emotion/styled';
 import { string, node } from 'prop-types';
 import useToggle from '#hooks/useToggle';
-import isLive from '#lib/utilities/isLive';
 
 import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
@@ -122,7 +121,6 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const { enabled: adsEnabled } = useToggle('ads');
 
   const isAdsEnabled = [
-    !isLive(), // TODO: Remove `isLive` when editorial are happy with the ads display
     path(['metadata', 'allowAdvertising'], pageData),
     adsEnabled,
     showAdsBasedOnLocation,

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -307,7 +307,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -444,7 +444,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -502,7 +502,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 .emotion-21 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -525,50 +525,11 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 .emotion-23 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-23 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-23 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-25 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-25 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-25 {
-    display: none;
-  }
-}
-
-.emotion-27 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-29 {
+.emotion-25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -578,7 +539,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   flex-direction: column;
 }
 
-.emotion-31 {
+.emotion-27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -598,7 +559,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31 {
+  .emotion-27 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -606,11 +567,11 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 }
 
-.emotion-33 {
+.emotion-29 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F6F6F6;
   margin: 1rem 0;
@@ -626,32 +587,32 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     padding-right: 1rem;
   }
 }
 
-.emotion-36 {
+.emotion-32 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -660,7 +621,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-36 {
+  .emotion-32 {
     display: grid;
     position: initial;
     width: initial;
@@ -668,7 +629,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -676,7 +637,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -684,7 +645,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -692,7 +653,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -700,7 +661,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -708,7 +669,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(20, 1fr);
       grid-column-end: span 20;
       grid-column-gap: 1rem;
@@ -717,7 +678,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-36 {
+  .emotion-32 {
     grid-template-rows: repeat(
           5,
           auto
@@ -726,18 +687,18 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 80rem) {
-  .emotion-36 {
+  .emotion-32 {
     grid-auto-flow: row;
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -745,7 +706,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -753,7 +714,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -761,7 +722,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -769,7 +730,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -777,7 +738,7 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 80rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(20%);
     display: inline-block;
     vertical-align: top;
@@ -785,56 +746,56 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-39 {
+  .emotion-35 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-41 {
+.emotion-37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -847,50 +808,50 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-43 {
+    .emotion-39 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 2rem;
   }
 }
 
-.emotion-45 {
+.emotion-41 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -903,32 +864,32 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
-.emotion-47 {
+.emotion-43 {
   padding-top: 0.375rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-47 {
+  .emotion-43 {
     padding-right: 0;
   }
 }
 
-.emotion-49 {
+.emotion-45 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -942,26 +903,26 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-49:hover,
-.emotion-49:focus {
+.emotion-45:hover,
+.emotion-45:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-49:before {
+.emotion-45:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -974,34 +935,34 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 
   @media (min-width: 20rem) and (max-width: 37.4375rem) {
-    .emotion-49 {
+    .emotion-45 {
       font-size: 1.125rem;
       line-height: 1.375rem;
     }
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-49 {
+    .emotion-45 {
       font-size: 1.25rem;
       line-height: 1.5rem;
     }
   }
 }
 
-.emotion-51 {
+.emotion-47 {
   padding-top: 0.5rem;
 }
 
-.emotion-53 {
+.emotion-49 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1009,235 +970,235 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 4rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-60 {
+    .emotion-56 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 2rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-111 {
+    .emotion-107 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 4rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 4rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-128 {
+    .emotion-124 {
       min-width: 4rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 2rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-145 {
+    .emotion-141 {
       min-width: 4rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 2rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 2.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 4rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 4rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-196 {
+    .emotion-192 {
       min-width: 4rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 4rem;
   }
 }
@@ -1297,23 +1258,17 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
       <div
         class="emotion-20 emotion-21 emotion-22"
       >
-        <div
-          class="emotion-23 emotion-24"
-        />
-        <div
-          class="emotion-25 emotion-26"
-        />
         <h2
-          class="emotion-27 emotion-28"
+          class="emotion-23 emotion-24"
         >
           <span
-            class="emotion-29 emotion-30"
+            class="emotion-25 emotion-26"
           >
             <span
-              class="emotion-31 emotion-32"
+              class="emotion-27 emotion-28"
             >
               <span
-                class="emotion-33 emotion-34"
+                class="emotion-29 emotion-30"
                 dir="ltr"
                 id="Most-Read"
               >
@@ -1324,43 +1279,43 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </h2>
       </div>
       <ol
-        class="emotion-35 emotion-36 emotion-4"
+        class="emotion-31 emotion-32 emotion-4"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-43 emotion-44"
+              class="emotion-39 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 1
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-46729879"
               >
                 Public Holidays wey go happun for 2019
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-05-21"
                 >
                   De one we dem update for: 21st May 2019
@@ -1370,38 +1325,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-60 emotion-44"
+              class="emotion-56 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 2
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50304653"
               >
                 Liberia banks don run out of money
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-05"
                 >
                   De one we dem update for: 5th November 2019
@@ -1411,38 +1366,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-43 emotion-44"
+              class="emotion-39 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 3
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50298882"
               >
                 Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-05"
                 >
                   De one we dem update for: 5th November 2019
@@ -1452,38 +1407,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-60 emotion-44"
+              class="emotion-56 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 4
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50315150"
               >
                 Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   De one we dem update for: 6th November 2019
@@ -1493,38 +1448,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-111 emotion-44"
+              class="emotion-107 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 5
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50315157"
               >
                 How Balogun market fire kill Policeman for Lagos
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   De one we dem update for: 6th November 2019
@@ -1534,38 +1489,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-128 emotion-44"
+              class="emotion-124 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 6
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50093818"
               >
                 Labour, FG finally agree minimum wage salary adjustment
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-10-18"
                 >
                   De one we dem update for: 18th October 2019
@@ -1575,38 +1530,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-145 emotion-44"
+              class="emotion-141 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 7
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-50187218"
               >
                 Naira Marley na 'Bad Influence'?
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-10-25"
                 >
                   De one we dem update for: 25th October 2019
@@ -1616,38 +1571,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-128 emotion-44"
+              class="emotion-124 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 8
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-48347911"
               >
                 Tins you suppose know about Naira Marley
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-05-23"
                 >
                   De one we dem update for: 23rd May 2019
@@ -1657,38 +1612,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-145 emotion-44"
+              class="emotion-141 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 9
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/sport-50312710"
               >
                 Golden Eaglets crash out of Fifa U17 World Cup
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   De one we dem update for: 6th November 2019
@@ -1698,38 +1653,38 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-196 emotion-44"
+              class="emotion-192 emotion-40"
               dir="ltr"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 10
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="ltr"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/pidgin/tori-42945173"
               >
                 Tiger nut drink fit wake up your sex drive - Nutritionist
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-05-21"
                 >
                   De one we dem update for: 21st May 2019
@@ -2051,7 +2006,7 @@ exports[`should render a news article correctly 1`] = `
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -2188,7 +2143,7 @@ exports[`should render a news article correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -2581,7 +2536,7 @@ exports[`should render a news article with headline in the middle correctly 1`] 
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -2712,7 +2667,7 @@ exports[`should render a news article with headline in the middle correctly 1`] 
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
   font-weight: 500;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -3127,7 +3082,7 @@ exports[`should render a news article without headline correctly 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -3504,7 +3459,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -3641,7 +3596,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -3699,7 +3654,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 .emotion-21 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
@@ -3722,50 +3677,11 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 .emotion-23 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-23 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-23 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-25 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-25 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-25 {
-    display: none;
-  }
-}
-
-.emotion-27 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-29 {
+.emotion-25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3775,7 +3691,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   flex-direction: column;
 }
 
-.emotion-31 {
+.emotion-27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3795,7 +3711,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-31 {
+  .emotion-27 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3803,11 +3719,11 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 }
 
-.emotion-33 {
+.emotion-29 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F6F6F6;
   margin: 1rem 0;
@@ -3823,32 +3739,32 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-29 {
     padding-left: 1rem;
   }
 }
 
-.emotion-36 {
+.emotion-32 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -3857,7 +3773,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-36 {
+  .emotion-32 {
     display: grid;
     position: initial;
     width: initial;
@@ -3865,7 +3781,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3873,7 +3789,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3881,7 +3797,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3889,7 +3805,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -3897,7 +3813,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -3905,7 +3821,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-36 {
+    .emotion-32 {
       grid-template-columns: repeat(20, 1fr);
       grid-column-end: span 20;
       grid-column-gap: 1rem;
@@ -3914,7 +3830,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-36 {
+  .emotion-32 {
     grid-template-rows: repeat(
           5,
           auto
@@ -3923,18 +3839,18 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 80rem) {
-  .emotion-36 {
+  .emotion-32 {
     grid-auto-flow: row;
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -3942,7 +3858,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -3950,7 +3866,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -3958,7 +3874,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -3966,7 +3882,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -3974,7 +3890,7 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 80rem) {
-  .emotion-39 {
+  .emotion-35 {
     width: calc(20%);
     display: inline-block;
     vertical-align: top;
@@ -3982,56 +3898,56 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-39 {
+  .emotion-35 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-39 {
+    .emotion-35 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-41 {
+.emotion-37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4044,50 +3960,50 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 1.5rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-43 {
+    .emotion-39 {
       min-width: 1.5rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-43 {
+  .emotion-39 {
     min-width: 1.5rem;
   }
 }
 
-.emotion-45 {
+.emotion-41 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -4100,32 +4016,32 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
-.emotion-47 {
+.emotion-43 {
   padding-top: 0.375rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-47 {
+  .emotion-43 {
     padding-left: 0;
   }
 }
 
-.emotion-49 {
+.emotion-45 {
   font-size: 0.9375rem;
   line-height: 1.5rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -4139,26 +4055,26 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-49:hover,
-.emotion-49:focus {
+.emotion-45:hover,
+.emotion-45:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-49:before {
+.emotion-45:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -4171,34 +4087,34 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 25rem) {
-  .emotion-49 {
+  .emotion-45 {
     font-size: 1.125rem;
     line-height: 1.625rem;
   }
 
   @media (min-width: 20rem) and (max-width: 37.4375rem) {
-    .emotion-49 {
+    .emotion-45 {
       font-size: 1.125rem;
       line-height: 1.625rem;
     }
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-49 {
+    .emotion-45 {
       font-size: 1.25rem;
       line-height: 1.75rem;
     }
   }
 }
 
-.emotion-51 {
+.emotion-47 {
   padding-top: 0.5rem;
 }
 
-.emotion-53 {
+.emotion-49 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -4206,235 +4122,235 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-60 {
+    .emotion-56 {
       min-width: 1.5rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-60 {
+  .emotion-56 {
     min-width: 1.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 1.5rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-111 {
+    .emotion-107 {
       min-width: 1.5rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-111 {
+  .emotion-107 {
     min-width: 2rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-128 {
+    .emotion-124 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-128 {
+  .emotion-124 {
     min-width: 1.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 1.5rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-145 {
+    .emotion-141 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-145 {
+  .emotion-141 {
     min-width: 1.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-196 {
+    .emotion-192 {
       min-width: 2rem;
     }
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-196 {
+  .emotion-192 {
     min-width: 2rem;
   }
 }
@@ -4494,23 +4410,17 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
       <div
         class="emotion-20 emotion-21 emotion-22"
       >
-        <div
-          class="emotion-23 emotion-24"
-        />
-        <div
-          class="emotion-25 emotion-26"
-        />
         <h2
-          class="emotion-27 emotion-28"
+          class="emotion-23 emotion-24"
         >
           <span
-            class="emotion-29 emotion-30"
+            class="emotion-25 emotion-26"
           >
             <span
-              class="emotion-31 emotion-32"
+              class="emotion-27 emotion-28"
             >
               <span
-                class="emotion-33 emotion-34"
+                class="emotion-29 emotion-30"
                 dir="rtl"
                 id="Most-Read"
               >
@@ -4521,43 +4431,43 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </h2>
       </div>
       <ol
-        class="emotion-35 emotion-36 emotion-4"
+        class="emotion-31 emotion-32 emotion-4"
         dir="rtl"
         role="list"
       >
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-43 emotion-44"
+              class="emotion-39 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۱
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/world-50317704"
               >
                 توافق با جدایی‌طلبان یمن؛ ایران اعتراض کرد، سازمان ملل استقبال
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4567,38 +4477,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-60 emotion-44"
+              class="emotion-56 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۲
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/iran-50319870"
               >
                 فراخوان آذری جهرمی برای مناظره اینستاگرامی - زرآبادی: در مجلس مناظره کنیم
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4608,38 +4518,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-43 emotion-44"
+              class="emotion-39 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۳
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/world-50320610"
               >
                 ترکیه: همسر ابوبکر بغدادی را 'دستگیر کردیم'
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4649,38 +4559,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-60 emotion-44"
+              class="emotion-56 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۴
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/world-50316456"
               >
                 غنی سازی مجدد در فردو: مکرون اقدام ایران را 'عمیقا مایه نگرانی' خواند
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4690,38 +4600,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-111 emotion-44"
+              class="emotion-107 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۵
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/magazine-50249226"
               >
                 دوازده دلیل حکمرانی حشرات: سوسک می‌تواند دو هفته بدون سر زنده بماند
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4731,38 +4641,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-128 emotion-44"
+              class="emotion-124 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۶
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/world-50317700"
               >
                 انتخابات ایالتی آمریکا؛ دموکرات‌ها از جمهوری‌خواهان پیش افتادند
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4772,38 +4682,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-145 emotion-44"
+              class="emotion-141 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۷
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/sport-50322486"
               >
                 عراق اردن را به عنوان میزبان بازی با ایران معرفی کرد
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4813,38 +4723,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-128 emotion-44"
+              class="emotion-124 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۸
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/iran-features-50310665"
               >
                 آیا تهران بازی هسته ای را به هم می‌زند؟
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4854,38 +4764,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-145 emotion-44"
+              class="emotion-141 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۹
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/world-50316450"
               >
                 آمریکا: دو ایرانی اتهام جمع‌آوری اطلاعات علیه سازمان مجاهدین در خاک آمریکا را پذیرفتند
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4895,38 +4805,38 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
           </div>
         </li>
         <li
-          class="emotion-38 emotion-39 emotion-4"
+          class="emotion-34 emotion-35 emotion-4"
           dir="rtl"
           role="listitem"
         >
           <div
-            class="emotion-41 emotion-42"
+            class="emotion-37 emotion-38"
           >
             <div
-              class="emotion-196 emotion-44"
+              class="emotion-192 emotion-40"
               dir="rtl"
             >
               <span
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
               >
                 ۱۰
               </span>
             </div>
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-43 emotion-44"
               dir="rtl"
             >
               <a
-                class="emotion-49 emotion-50"
+                class="emotion-45 emotion-46"
                 href="/persian/sport-50318030"
               >
                 فوتبال ایران و عراق؛ ایران: امن است بازی می‌کنیم، فیفا: ناامن است بازی نکنید
               </a>
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-47 emotion-48"
               >
                 <time
-                  class="emotion-53 emotion-54"
+                  class="emotion-49 emotion-50"
                   datetime="2019-11-06"
                 >
                   به روز شده در ۶ نوامبر ۲۰۱۹

--- a/src/app/pages/ArticlePage/fixtureData.js
+++ b/src/app/pages/ArticlePage/fixtureData.js
@@ -15,6 +15,7 @@ const articleDataBuilder = (
   promoHeadline,
   summary,
   things,
+  allowAdvertising = false,
 ) => ({
   metadata: {
     id: `urn:bbc:ares::article:${id}`,
@@ -37,6 +38,7 @@ const articleDataBuilder = (
       genre: null,
     },
     tags: things,
+    allowAdvertising,
   },
   content: {
     model: {
@@ -144,4 +146,18 @@ export const articleDataPidgin = articleDataBuilder(
   'Article Headline for Promo in Pidgin',
   'Article summary in Pidgin',
   emptyThings,
+);
+
+export const articleDataPidginWithAds = articleDataBuilder(
+  'cwl08rd38l6o',
+  'Pidgin',
+  'pcm',
+  'http://www.bbc.co.uk/ontologies/passport/home/Pidgin',
+  'Article Headline in Pidgin',
+  'A paragraph in Pidgin.',
+  'Article Headline for SEO in Pidgin',
+  'Article Headline for Promo in Pidgin',
+  'Article summary in Pidgin',
+  emptyThings,
+  true,
 );

--- a/src/app/pages/ArticlePage/index.test.jsx
+++ b/src/app/pages/ArticlePage/index.test.jsx
@@ -1,4 +1,6 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { render, waitFor } from '@testing-library/react';
 import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { RequestContextProvider } from '#contexts/RequestContext';
@@ -8,6 +10,7 @@ import {
   articleDataNews,
   articleDataPersian,
   articleDataPidgin,
+  articleDataPidginWithAds,
 } from '#pages/ArticlePage/fixtureData';
 import newsMostReadData from '#data/news/mostRead';
 import persianMostReadData from '#data/persian/mostRead';
@@ -20,10 +23,6 @@ import {
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import ArticlePage from './ArticlePage';
 
-// temporary: will be removed with https://github.com/bbc/simorgh/issues/836
-const articleDataNewsNoHeadline = JSON.parse(JSON.stringify(articleDataNews));
-articleDataNewsNoHeadline.content.model.blocks.shift();
-
 jest.mock('#containers/ChartbeatAnalytics', () => {
   const ChartbeatAnalytics = () => <div>chartbeat</div>;
   return ChartbeatAnalytics;
@@ -34,10 +33,24 @@ jest.mock('#containers/OptimizelyPageViewTracking', () => {
   return OptimizelyPageViewTracking;
 });
 
-// eslint-disable-next-line react/prop-types
-const Context = ({ service, children }) => (
-  <ToggleContextProvider>
-    <ServiceContextProvider service={service}>
+const Context = ({
+  service = 'pidgin',
+  children,
+  adsToggledOn = false,
+  mostReadToggledOn = true,
+  showAdsBasedOnLocation = false,
+} = {}) => (
+  <BrowserRouter>
+    <ToggleContextProvider
+      toggles={{
+        mostRead: {
+          enabled: mostReadToggledOn,
+        },
+        ads: {
+          enabled: adsToggledOn,
+        },
+      }}
+    >
       <RequestContextProvider
         bbcOrigin="https://www.test.bbc.co.uk"
         id="c0000000000o"
@@ -46,11 +59,14 @@ const Context = ({ service, children }) => (
         pathname="/pathname"
         service={service}
         statusCode={200}
+        showAdsBasedOnLocation={showAdsBasedOnLocation}
       >
-        {children}
+        <ServiceContextProvider service={service}>
+          {children}
+        </ServiceContextProvider>
       </RequestContextProvider>
-    </ServiceContextProvider>
-  </ToggleContextProvider>
+    </ToggleContextProvider>
+  </BrowserRouter>
 );
 
 beforeEach(() => {
@@ -208,6 +224,7 @@ it('should render a rtl article (persian) with most read correctly', async () =>
   );
 
   await waitFor(() => container.querySelector('#Most-Read'));
+
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();
@@ -224,6 +241,7 @@ it('should render a ltr article (pidgin) with most read correctly', async () => 
   );
 
   await waitFor(() => container.querySelector('#Most-Read'));
+
   const mostReadSection = container.querySelector('#Most-Read');
 
   expect(mostReadSection).not.toBeNull();
@@ -319,4 +337,31 @@ it('should render the top stories and features when passed', async () => {
 
   expect(getByTestId('top-stories')).toBeInTheDocument();
   expect(getByTestId('features')).toBeInTheDocument();
+});
+
+it('should show ads when enabled', async () => {
+  [
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ].forEach(([adsToggledOn, showAdsBasedOnLocation]) => {
+    const { container } = render(
+      <Context
+        service="pidgin"
+        adsToggledOn={adsToggledOn}
+        showAdsBasedOnLocation={showAdsBasedOnLocation}
+      >
+        <ArticlePage pageData={articleDataPidginWithAds} />
+      </Context>,
+    );
+
+    const shouldShowAds = adsToggledOn && showAdsBasedOnLocation;
+    const adElement = container.querySelector('[data-e2e="advertisement"]');
+    if (shouldShowAds) {
+      expect(adElement).toBeInTheDocument();
+    } else {
+      expect(adElement).not.toBeInTheDocument();
+    }
+  });
 });

--- a/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ErrorPage/__snapshots__/index.test.jsx.snap
@@ -231,7 +231,7 @@ exports[`ErrorPage should correctly render for 404 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -562,7 +562,7 @@ exports[`ErrorPage should correctly render for 404 for persian 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -893,7 +893,7 @@ exports[`ErrorPage should correctly render for 500 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -1219,7 +1219,7 @@ exports[`ErrorPage should correctly render for 500 for persian 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;
@@ -1545,7 +1545,7 @@ exports[`ErrorPage should correctly render for other status code 1`] = `
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-top: 0.2rem;

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -96,7 +96,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 .emotion-6 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -120,50 +120,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-8 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-8 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-10 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-10 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    display: none;
-  }
-}
-
-.emotion-12 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-14 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -173,7 +134,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   flex-direction: column;
 }
 
-.emotion-16 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -193,7 +154,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -201,11 +162,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 }
 
-.emotion-18 {
+.emotion-14 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -221,68 +182,68 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-14 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     padding-left: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-20 {
+  .emotion-16 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-20 {
+  .emotion-16 {
     margin-top: 2rem;
   }
 }
 
-.emotion-22 {
+.emotion-18 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-22 {
+  .emotion-18 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(12, 1fr);
     }
   }
 }
 
-.emotion-24 {
+.emotion-20 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -291,36 +252,36 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-24 {
+  .emotion-20 {
     width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-24 {
+  .emotion-20 {
     width: calc(50% - 0.5rem);
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
+  .emotion-20 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
-    .emotion-24 {
+    .emotion-20 {
       grid-column: 1/span 3;
     }
   }
 }
 
-.emotion-26 {
+.emotion-22 {
   position: relative;
 }
 
-.emotion-28 {
+.emotion-24 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -335,61 +296,61 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
-.emotion-30 {
+.emotion-26 {
   display: block;
   width: 100%;
   visibility: visible;
 }
 
-.emotion-33 {
+.emotion-29 {
   display: block;
   width: 100%;
   height: auto;
 }
 
-.emotion-35 {
+.emotion-31 {
   position: absolute;
   bottom: 0;
 }
 
-.emotion-35>* {
+.emotion-31>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.emotion-37 {
+.emotion-33 {
   display: inline-block;
   vertical-align: top;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-33 {
     width: 50%;
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-33 {
     width: 50%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-37 {
+  .emotion-33 {
     display: block;
     width: initial;
     padding: initial;
@@ -397,19 +358,19 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-37 {
+    .emotion-33 {
       grid-column: 4/span 3;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-37 {
+    .emotion-33 {
       grid-column: 7/span 6;
     }
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -421,20 +382,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1.375rem;
     line-height: 1.875rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1.75rem;
     line-height: 2.375rem;
   }
 }
 
-.emotion-41 {
+.emotion-37 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -443,7 +404,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   overflow-wrap: anywhere;
 }
 
-.emotion-41:before {
+.emotion-37:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -455,17 +416,17 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   z-index: 1;
 }
 
-.emotion-41:hover,
-.emotion-41:focus {
+.emotion-37:hover,
+.emotion-37:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-41:visited {
+.emotion-37:visited {
   color: #6E6E73;
 }
 
-.emotion-43 {
+.emotion-39 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -477,30 +438,30 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-45 {
+.emotion-41 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
@@ -508,46 +469,46 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-49 {
+.emotion-45 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-49 {
+  .emotion-45 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-49 {
+  .emotion-45 {
     margin-bottom: 1.5rem;
   }
 }
 
-.emotion-64 {
+.emotion-56 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-64 {
+  .emotion-56 {
     display: grid;
     position: initial;
     width: initial;
@@ -555,7 +516,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -563,7 +524,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -571,7 +532,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -579,7 +540,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -587,7 +548,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -595,7 +556,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 80rem) {
-    .emotion-64 {
+    .emotion-56 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -603,48 +564,48 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 }
 
-.emotion-67 {
+.emotion-59 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-67 {
+  .emotion-59 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-67:last-child {
+.emotion-59:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-67 {
+  .emotion-59 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-67 {
+  .emotion-59 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-67:first-child {
+.emotion-59:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-67:first-child {
+  .emotion-59:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-67:last-child {
+.emotion-59:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -653,7 +614,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -662,7 +623,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -671,7 +632,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -680,7 +641,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -689,7 +650,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 80rem) {
-  .emotion-67 {
+  .emotion-59 {
     width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -698,56 +659,56 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (display: grid) {
-  .emotion-67 {
+  .emotion-59 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-67 {
+    .emotion-59 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
   }
 }
 
-.emotion-79 {
+.emotion-71 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -759,20 +720,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-79 {
+  .emotion-71 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-79 {
+  .emotion-71 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-81 {
+.emotion-73 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -784,7 +745,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   height: 100%;
 }
 
-.emotion-83 {
+.emotion-75 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -793,11 +754,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   height: 0.75rem;
 }
 
-.emotion-85 {
+.emotion-77 {
   padding: 0 0.25rem;
 }
 
-.emotion-93 {
+.emotion-85 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -808,48 +769,48 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   margin: 0;
 }
 
-.emotion-102 {
+.emotion-94 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-102:last-child {
+.emotion-94:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-102 {
+  .emotion-94 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-102 {
+  .emotion-94 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-102:first-child {
+.emotion-94:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-102:first-child {
+  .emotion-94:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-102:last-child {
+.emotion-94:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -858,7 +819,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -867,7 +828,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -876,7 +837,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -885,7 +846,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -894,7 +855,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 80rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -903,80 +864,80 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (display: grid) {
-  .emotion-102 {
+  .emotion-94 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 }
 
-.emotion-104 {
+.emotion-96 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-104 {
+  .emotion-96 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-104 {
+    .emotion-96 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-104 {
+    .emotion-96 {
       display: block;
     }
   }
 }
 
-.emotion-106 {
+.emotion-98 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -984,39 +945,39 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 63rem) {
-  .emotion-106 {
+  .emotion-98 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-106 {
+  .emotion-98 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-112 {
+  .emotion-104 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-112>* {
+.emotion-104>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-112>* {
+  .emotion-104>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-122 {
+.emotion-114 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -1024,13 +985,13 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-122 {
+  .emotion-114 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-122 {
+  .emotion-114 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -1038,7 +999,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-122 {
+  .emotion-114 {
     display: block;
     width: initial;
     padding: initial;
@@ -1046,13 +1007,13 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 63rem) {
-    .emotion-122 {
+    .emotion-114 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-124 {
+.emotion-116 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -1064,20 +1025,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-124 {
+  .emotion-116 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-124 {
+  .emotion-116 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-132 {
+.emotion-124 {
   font-size: 0.9375rem;
   line-height: 1.375rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -1089,34 +1050,34 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-132 {
+  .emotion-124 {
     font-size: 0.9375rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-132 {
+  .emotion-124 {
     font-size: 0.875rem;
     line-height: 1.375rem;
   }
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-132 {
+  .emotion-124 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-132 {
+  .emotion-124 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-242 {
+.emotion-234 {
   background-color: #F2F2F2;
   padding: 0 1rem;
   content-visibility: auto;
@@ -1124,52 +1085,52 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 15rem) {
-  .emotion-242 {
+  .emotion-234 {
     contain-intrinsic-size: 56.563rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-242 {
+  .emotion-234 {
     contain-intrinsic-size: 51.063rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-242 {
+  .emotion-234 {
     contain-intrinsic-size: 30.75rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-242 {
+  .emotion-234 {
     contain-intrinsic-size: 21.25rem;
   }
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-242 {
+  .emotion-234 {
     margin: 2rem -0.5rem 0;
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-242 {
+  .emotion-234 {
     margin: 2rem -1rem 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-242 {
+  .emotion-234 {
     margin: 1.5rem -1rem 0;
   }
 }
 
-.emotion-245 {
+.emotion-237 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0 auto;
   width: 100%;
@@ -1177,36 +1138,36 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-245 {
+  .emotion-237 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-245 {
+  .emotion-237 {
     margin-bottom: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-245 {
+  .emotion-237 {
     margin: 0 auto;
     padding-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-245 {
+  .emotion-237 {
     max-width: 63rem;
     padding-top: 2rem;
   }
 }
 
-.emotion-255 {
+.emotion-245 {
   font-size: 1.25rem;
   line-height: 1.75rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F2F2F2;
   margin: 1rem 0;
@@ -1222,75 +1183,75 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-255 {
+  .emotion-245 {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-255 {
+  .emotion-245 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-255 {
+  .emotion-245 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-255 {
+  .emotion-245 {
     padding-left: 1rem;
   }
 }
 
-.emotion-257 {
+.emotion-247 {
   margin: 0 auto;
   width: 100%;
   padding-bottom: 1rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-257 {
+  .emotion-247 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-257 {
+  .emotion-247 {
     max-width: 63rem;
     padding-bottom: 1.5rem;
   }
 }
 
-.emotion-260 {
+.emotion-250 {
   padding: 0;
   margin: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-260 {
+  .emotion-250 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-260 {
+  .emotion-250 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-260 {
+  .emotion-250 {
     padding: 0 1rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-260 {
+  .emotion-250 {
     display: grid;
     position: initial;
     width: initial;
@@ -1298,7 +1259,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1307,7 +1268,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1316,7 +1277,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1325,7 +1286,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -1333,7 +1294,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1341,7 +1302,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 80rem) {
-    .emotion-260 {
+    .emotion-250 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1350,18 +1311,18 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (max-width: 37.5rem) {
-  .emotion-260 {
+  .emotion-250 {
     padding: 0;
   }
 }
 
-.emotion-263 {
+.emotion-253 {
   position: relative;
   padding-bottom: 1rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1370,7 +1331,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1379,7 +1340,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1388,7 +1349,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1397,7 +1358,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1406,7 +1367,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 80rem) {
-  .emotion-263 {
+  .emotion-253 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1415,49 +1376,49 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (display: grid) {
-  .emotion-263 {
+  .emotion-253 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-263 {
+    .emotion-253 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
@@ -1465,7 +1426,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-263 {
+  .emotion-253 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1476,11 +1437,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 }
 
-.emotion-265 {
+.emotion-255 {
   padding-bottom: 0.5rem;
 }
 
-.emotion-267 {
+.emotion-257 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1491,7 +1452,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   align-items: center;
 }
 
-.emotion-269 {
+.emotion-259 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1503,20 +1464,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   padding-left: 0.25rem;
 }
 
-.emotion-269>svg {
+.emotion-259>svg {
   color: #5A5A5A;
   margin: 0;
   overflow: visible;
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-269>svg {
+  .emotion-259>svg {
     padding-left: 0.25rem;
     fill: canvasText;
   }
 }
 
-.emotion-271 {
+.emotion-261 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1525,7 +1486,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   height: 0.725rem;
 }
 
-.emotion-273 {
+.emotion-263 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1540,7 +1501,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   width: 100%;
 }
 
-.emotion-273>time {
+.emotion-263>time {
   color: #5A5A5A;
   font-size: 0.75rem;
   line-height: 1.125rem;
@@ -1550,20 +1511,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-273>time {
+  .emotion-263>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-273>time {
+  .emotion-263>time {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
-.emotion-273::after {
+.emotion-263::after {
   content: '';
   border-top: 0.0625rem solid #AEAEB5;
   top: 1.0625rem;
@@ -1571,7 +1532,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   width: 100%;
 }
 
-.emotion-277 {
+.emotion-267 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -1585,7 +1546,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   height: 100%;
 }
 
-.emotion-279 {
+.emotion-269 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1593,7 +1554,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   flex-grow: 1;
 }
 
-.emotion-281 {
+.emotion-271 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1604,20 +1565,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-281 {
+  .emotion-271 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-281 {
+  .emotion-271 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-285 {
+.emotion-275 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1629,20 +1590,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-285 {
+  .emotion-275 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-285 {
+  .emotion-275 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-289 {
+.emotion-279 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
@@ -1655,20 +1616,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-289 {
+  .emotion-279 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-289 {
+  .emotion-279 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-293 {
+.emotion-283 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1680,20 +1641,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-293 {
+  .emotion-283 {
     font-size: 0.875rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-293 {
+  .emotion-283 {
     font-size: 0.8125rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-295 {
+.emotion-285 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1706,27 +1667,27 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-295 {
+  .emotion-285 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-295 {
+  .emotion-285 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-295 {
+  .emotion-285 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-297>svg {
+.emotion-287>svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -1735,12 +1696,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-297>svg {
+  .emotion-287>svg {
     fill: canvasText;
   }
 }
 
-.emotion-299 {
+.emotion-289 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1749,11 +1710,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   height: 0.75rem;
 }
 
-.emotion-301 {
+.emotion-291 {
   padding-right: 0.5rem;
 }
 
-.emotion-322 {
+.emotion-312 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1764,20 +1725,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-322 {
+  .emotion-312 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-322 {
+  .emotion-312 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-324 {
+.emotion-314 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1785,7 +1746,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   overflow-wrap: break-word;
 }
 
-.emotion-324:before {
+.emotion-314:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1797,27 +1758,27 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   z-index: 1;
 }
 
-.emotion-324:hover,
-.emotion-324:focus {
+.emotion-314:hover,
+.emotion-314:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-324:visited {
+.emotion-314:visited {
   color: #6E6E73;
 }
 
-.emotion-324:hover .emotion-290 {
+.emotion-314:hover .emotion-280 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-324:focus .emotion-290 {
+.emotion-314:focus .emotion-280 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-330 {
+.emotion-320 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
@@ -1830,20 +1791,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-330 {
+  .emotion-320 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-330 {
+  .emotion-320 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-336 {
+.emotion-326 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1856,27 +1817,27 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-336 {
+  .emotion-326 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-336 {
+  .emotion-326 {
     font-size: 0.75rem;
     line-height: 1.125rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-336 {
+  .emotion-326 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-338>svg {
+.emotion-328>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1885,48 +1846,48 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-338>svg {
+  .emotion-328>svg {
     fill: canvasText;
   }
 }
 
-.emotion-560 {
+.emotion-546 {
   margin: 0 auto;
   width: 100%;
 }
 
 @media (min-width: 63rem) {
-  .emotion-560 {
+  .emotion-546 {
     max-width: 63rem;
   }
 }
 
-.emotion-563 {
+.emotion-549 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-563 {
+  .emotion-549 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-563 {
+  .emotion-549 {
     margin-bottom: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-563 {
+  .emotion-549 {
     margin-bottom: 1rem;
   }
 }
 
-.emotion-578 {
+.emotion-560 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -1935,7 +1896,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (display: grid) {
-  .emotion-578 {
+  .emotion-560 {
     display: grid;
     position: initial;
     width: initial;
@@ -1943,7 +1904,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1951,7 +1912,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1959,7 +1920,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1967,7 +1928,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -1975,7 +1936,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1983,7 +1944,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 
   @media (min-width: 80rem) {
-    .emotion-578 {
+    .emotion-560 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1992,7 +1953,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-578 {
+  .emotion-560 {
     grid-template-rows: repeat(
           5,
           auto
@@ -2000,13 +1961,13 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   }
 }
 
-.emotion-581 {
+.emotion-563 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -2014,7 +1975,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -2022,7 +1983,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(100%);
     display: inline-block;
     vertical-align: top;
@@ -2030,7 +1991,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -2038,7 +1999,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -2046,7 +2007,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 80rem) {
-  .emotion-581 {
+  .emotion-563 {
     width: calc(50%);
     display: inline-block;
     vertical-align: top;
@@ -2054,56 +2015,56 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @supports (display: grid) {
-  .emotion-581 {
+  .emotion-563 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-581 {
+    .emotion-563 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-583 {
+.emotion-565 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2116,44 +2077,44 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-585 {
+  .emotion-567 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-585 {
+  .emotion-567 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-585 {
+  .emotion-567 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-585 {
+  .emotion-567 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-585 {
+  .emotion-567 {
     min-width: 1.5rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-585 {
+    .emotion-567 {
       min-width: 1.5rem;
     }
   }
 }
 
-.emotion-587 {
+.emotion-569 {
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -2166,32 +2127,32 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-587 {
+  .emotion-569 {
     font-size: 2.5rem;
     line-height: 2.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-587 {
+  .emotion-569 {
     font-size: 3.5rem;
     line-height: 3.75rem;
   }
 }
 
-.emotion-589 {
+.emotion-571 {
   padding-top: 0.375rem;
   padding-right: 1rem;
   padding-left: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-589 {
+  .emotion-571 {
     padding-left: 0;
   }
 }
 
-.emotion-591 {
+.emotion-573 {
   font-size: 0.9375rem;
   line-height: 1.5rem;
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
@@ -2205,26 +2166,26 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-591 {
+  .emotion-573 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-591 {
+  .emotion-573 {
     font-size: 1rem;
     line-height: 1.5rem;
   }
 }
 
-.emotion-591:hover,
-.emotion-591:focus {
+.emotion-573:hover,
+.emotion-573:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-591:before {
+.emotion-573:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -2237,139 +2198,139 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 @media (min-width: 25rem) {
-  .emotion-591 {
+  .emotion-573 {
     font-size: 1.125rem;
     line-height: 1.625rem;
   }
 
   @media (min-width: 20rem) and (max-width: 37.4375rem) {
-    .emotion-591 {
+    .emotion-573 {
       font-size: 1.125rem;
       line-height: 1.625rem;
     }
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-591 {
+    .emotion-573 {
       font-size: 1.25rem;
       line-height: 1.75rem;
     }
   }
 }
 
-.emotion-593 {
+.emotion-575 {
   padding-top: 0.5rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-602 {
+  .emotion-584 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-602 {
+  .emotion-584 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-602 {
+  .emotion-584 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-602 {
+  .emotion-584 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-602 {
+  .emotion-584 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-602 {
+    .emotion-584 {
       min-width: 1.5rem;
     }
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-670 {
+  .emotion-652 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-670 {
+  .emotion-652 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-670 {
+  .emotion-652 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-670 {
+  .emotion-652 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-670 {
+  .emotion-652 {
     min-width: 2rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-670 {
+    .emotion-652 {
       min-width: 2rem;
     }
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-687 {
+  .emotion-669 {
     min-width: 1rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-687 {
+  .emotion-669 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-687 {
+  .emotion-669 {
     min-width: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-687 {
+  .emotion-669 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-687 {
+  .emotion-669 {
     min-width: 1.5rem;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
   @media (min-width: 37.5rem) {
-    .emotion-687 {
+    .emotion-669 {
       min-width: 2rem;
     }
   }
@@ -2402,23 +2363,17 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
         <div
           class="emotion-6 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="rtl"
                   id="Top-story"
                 >
@@ -2429,26 +2384,26 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           </h2>
         </div>
         <div
-          class="emotion-20 emotion-21"
+          class="emotion-16 emotion-17"
         >
           <div
-            class="emotion-22 emotion-23"
+            class="emotion-18 emotion-19"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-20 emotion-21"
               dir="rtl"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-22 emotion-23"
               >
                 <div
-                  class="emotion-28 emotion-29"
+                  class="emotion-24 emotion-25"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
                   <picture
-                    class="emotion-30 emotion-31"
+                    class="emotion-26 emotion-27"
                   >
                     <source
                       sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
@@ -2462,7 +2417,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     />
                     <img
                       alt="هبت الله آخوندزاده"
-                      class="emotion-32 emotion-33 emotion-34"
+                      class="emotion-28 emotion-29 emotion-30"
                       height="351"
                       src="https://ichef.bbci.co.uk/news/660/cpsprodpb/7729/production/_91750503_1f1635b5-2a70-437b-8579-b0dcedab31fb.jpg"
                       width="624"
@@ -2470,20 +2425,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </picture>
                 </div>
                 <div
-                  class="emotion-35 emotion-36"
+                  class="emotion-31 emotion-32"
                 />
               </div>
             </div>
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-33 emotion-34"
               dir="rtl"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-35 emotion-36"
               >
                 <a
                   aria-labelledby="promo-persianafghanistan52735886-1"
-                  class="emotion-41 emotion-42"
+                  class="emotion-37 emotion-38"
                   href="/persian/afghanistan-52735886"
                 >
                   <span
@@ -2494,12 +2449,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </a>
               </h3>
               <p
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
               >
                 ملا هبت الله آخوندزاده، رهبر طالبان در یک پیام به مناسبت عید فطر، از آمریکا خواسته که به کسی اجازه ندهد که موافقتنامه صلح آنها را با مانع، تاخیر و ناکامی رو به رو سازد. در همین حال سخنگوی رئیس جمهوری افغانستان گفته با ادامه خشونت‌ها از سوی طالبان، پیام عیدی رهبر این گروه "ارزشی ندارد.".
               </p>
               <time
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
                 datetime="2020-05-20"
               >
                 ۳۱ اردیبهشت ۱۳۹۹ - ۲۰ مه ۲۰۲۰
@@ -2514,25 +2469,19 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
         role="region"
       >
         <div
-          class="emotion-49 emotion-7"
+          class="emotion-45 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="rtl"
                   id="WatchListen"
                 >
@@ -2543,27 +2492,27 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           </h2>
         </div>
         <ul
-          class="emotion-63 emotion-64 emotion-65"
+          class="emotion-55 emotion-56 emotion-57"
           dir="rtl"
           role="list"
         >
           <li
-            class="emotion-63 emotion-67 emotion-68"
+            class="emotion-55 emotion-59 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-22 emotion-23"
+              class="emotion-18 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-24 emotion-25"
+                class="emotion-20 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -2576,20 +2525,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   >
                     <div
                       aria-hidden="true"
-                      class="emotion-79 emotion-80"
+                      class="emotion-71 emotion-72"
                       data-e2e="media-indicator"
                       dir="rtl"
                     >
                       <div
-                        class="emotion-81 emotion-82"
+                        class="emotion-73 emotion-74"
                       >
                         <svg
                           aria-hidden="true"
-                          class="emotion-83 emotion-84"
+                          class="emotion-75 emotion-76"
                           focusable="false"
                           height="12px"
                           viewBox="0 0 32 32"
@@ -2600,7 +2549,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           />
                         </svg>
                         <time
-                          class="emotion-85 emotion-86"
+                          class="emotion-77 emotion-78"
                           datetime="PT2M32S"
                         >
                           2:32
@@ -2611,15 +2560,15 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-37 emotion-38"
+                class="emotion-33 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-39 emotion-40"
+                  class="emotion-35 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-persianafghanistan52726383-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52726383"
                   >
                     <span
@@ -2627,7 +2576,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         ویدیو, 
                       </span>
@@ -2635,7 +2584,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         ابراز نگرانی سازمان ملل از افزایش کشتار غیر نظامیان در افغانستان
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , مدت 2,32
                       </span>
@@ -2643,12 +2592,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-43 emotion-44"
+                  class="emotion-39 emotion-40"
                 >
                   در حالیکه شمار رسمی مبتلایان به ویروس کرونا از چهار و نیم میلیون نفر عبور کرده، این روزها کشورهای آمریکای لاتین به کانون های اصلی شیوع تبدیل شده‌اند..
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-19"
                 >
                   ۳۰ اردیبهشت ۱۳۹۹ - ۱۹ مه ۲۰۲۰
@@ -2657,22 +2606,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -2685,20 +2634,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   >
                     <div
                       aria-hidden="true"
-                      class="emotion-79 emotion-80"
+                      class="emotion-71 emotion-72"
                       data-e2e="media-indicator"
                       dir="rtl"
                     >
                       <div
-                        class="emotion-81 emotion-82"
+                        class="emotion-73 emotion-74"
                       >
                         <svg
                           aria-hidden="true"
-                          class="emotion-83 emotion-84"
+                          class="emotion-75 emotion-76"
                           focusable="false"
                           height="12px"
                           viewBox="0 0 32 32"
@@ -2709,7 +2658,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           />
                         </svg>
                         <time
-                          class="emotion-85 emotion-86"
+                          class="emotion-77 emotion-78"
                           datetime="PT2M12S"
                         >
                           2:12
@@ -2720,15 +2669,15 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-watchlisten-persianafghanistan52710877-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52710877"
                   >
                     <span
@@ -2736,7 +2685,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         ویدیو, 
                       </span>
@@ -2744,7 +2693,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         حمله انتحاری طالبان به دفتر امنیت ملی درغزنی
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , مدت 2,12
                       </span>
@@ -2752,12 +2701,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   مقام‌های محلی غزنی گفته‌اند در حمله صبح امروز طالبان در شهر غزنی در جنوب افغانستان هفت نفر کشته و چهل نفر زخمی شده‌اند.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-18"
                 >
                   ۲۹ اردیبهشت ۱۳۹۹ - ۱۸ مه ۲۰۲۰
@@ -2766,22 +2715,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -2794,20 +2743,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   >
                     <div
                       aria-hidden="true"
-                      class="emotion-79 emotion-80"
+                      class="emotion-71 emotion-72"
                       data-e2e="media-indicator"
                       dir="rtl"
                     >
                       <div
-                        class="emotion-81 emotion-82"
+                        class="emotion-73 emotion-74"
                       >
                         <svg
                           aria-hidden="true"
-                          class="emotion-83 emotion-84"
+                          class="emotion-75 emotion-76"
                           focusable="false"
                           height="12px"
                           viewBox="0 0 32 32"
@@ -2818,7 +2767,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           />
                         </svg>
                         <time
-                          class="emotion-85 emotion-86"
+                          class="emotion-77 emotion-78"
                           datetime="PT6M14S"
                         >
                           6:14
@@ -2829,15 +2778,15 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-watchlisten-persianafghanistan52699256-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52699256"
                   >
                     <span
@@ -2845,7 +2794,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         ویدیو, 
                       </span>
@@ -2853,7 +2802,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         توافقنامه‌ای پایان بخش اختلافات چند ماهه غنی و عبدالله
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , مدت 6,14
                       </span>
@@ -2861,12 +2810,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   در افغانستان عبدالله عبدالله با امضای یک توافق از ادعای خود به عنوان رییس جمهوری گذشت و اشرف غنی را به عنوان رییس دولت پذیرفت.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-17"
                 >
                   ۲۸ اردیبهشت ۱۳۹۹ - ۱۷ مه ۲۰۲۰
@@ -2875,22 +2824,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -2903,20 +2852,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   >
                     <div
                       aria-hidden="true"
-                      class="emotion-79 emotion-80"
+                      class="emotion-71 emotion-72"
                       data-e2e="media-indicator"
                       dir="rtl"
                     >
                       <div
-                        class="emotion-81 emotion-82"
+                        class="emotion-73 emotion-74"
                       >
                         <svg
                           aria-hidden="true"
-                          class="emotion-83 emotion-84"
+                          class="emotion-75 emotion-76"
                           focusable="false"
                           height="12px"
                           viewBox="0 0 32 32"
@@ -2927,7 +2876,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           />
                         </svg>
                         <time
-                          class="emotion-85 emotion-86"
+                          class="emotion-77 emotion-78"
                           datetime="PT3M21S"
                         >
                           3:21
@@ -2938,15 +2887,15 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-watchlisten-persianafghanistan52651714-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52651714"
                   >
                     <span
@@ -2954,7 +2903,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         ویدیو, 
                       </span>
@@ -2962,7 +2911,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         واکنش‌ها به حملات اخیر افغانستان؛ دعوت به همکاری طالبان با دولت
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , مدت 3,21
                       </span>
@@ -2970,12 +2919,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   وزارت صحت افغانستان اعلام کرده که شمار قربانیان حمله به بیمارستان کابل به ۲۴ نفر رسیده‌است.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-13"
                 >
                   ۲۴ اردیبهشت ۱۳۹۹ - ۱۳ مه ۲۰۲۰
@@ -2984,22 +2933,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3012,20 +2961,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   >
                     <div
                       aria-hidden="true"
-                      class="emotion-79 emotion-80"
+                      class="emotion-71 emotion-72"
                       data-e2e="media-indicator"
                       dir="rtl"
                     >
                       <div
-                        class="emotion-81 emotion-82"
+                        class="emotion-73 emotion-74"
                       >
                         <svg
                           aria-hidden="true"
-                          class="emotion-83 emotion-84"
+                          class="emotion-75 emotion-76"
                           focusable="false"
                           height="12px"
                           viewBox="0 0 32 32"
@@ -3036,7 +2985,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                           />
                         </svg>
                         <time
-                          class="emotion-85 emotion-86"
+                          class="emotion-77 emotion-78"
                           datetime="PT4M48S"
                         >
                           4:48
@@ -3047,15 +2996,15 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-watchlisten-persianafghanistan52640314-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52640314"
                   >
                     <span
@@ -3063,7 +3012,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         ویدیو, 
                       </span>
@@ -3071,7 +3020,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         روایت بازماندگان از حادثه مرزی ایران و افغانستان
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , مدت 4,48
                       </span>
@@ -3079,12 +3028,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   سخنگوی وزارت خارجه ایران، دست داشتن نیروی انتظامی در مرگ شهروندان افغانستان در مرز دو کشور را تکذیب کرده‌است.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-12"
                 >
                   ۲۳ اردیبهشت ۱۳۹۹ - ۱۲ مه ۲۰۲۰
@@ -3096,27 +3045,24 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
       </section>
       <section
         aria-labelledby="Radio-Schedule"
-        class=" emotion-241 emotion-242 emotion-243"
+        class=" emotion-233 emotion-234 emotion-235"
         lang="fa-AF"
         role="region"
       >
         <div
-          class="emotion-244 emotion-245 emotion-7"
+          class="emotion-236 emotion-237 emotion-7"
         >
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-255 emotion-19"
+                  class="emotion-245 emotion-15"
                   dir="rtl"
                   id="Radio-Schedule"
                 >
@@ -3127,33 +3073,33 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           </h2>
         </div>
         <div
-          class="emotion-257 emotion-258"
+          class="emotion-247 emotion-248"
           data-e2e="radio-schedule"
         >
           <div
-            class="emotion-259 emotion-260 emotion-63"
+            class="emotion-249 emotion-250 emotion-55"
             dir="rtl"
             role="list"
           >
             <li
-              class="emotion-262 emotion-263 emotion-63"
+              class="emotion-252 emotion-253 emotion-55"
               data-e2e="next"
               dir="rtl"
               role="listitem"
             >
               <div
-                class="emotion-265 emotion-266"
+                class="emotion-255 emotion-256"
               >
                 <div
-                  class="emotion-267 emotion-268"
+                  class="emotion-257 emotion-258"
                 >
                   <span
-                    class="emotion-269 emotion-270"
+                    class="emotion-259 emotion-260"
                     dir="rtl"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-271 emotion-272"
+                      class="emotion-261 emotion-262"
                       focusable="false"
                       height="13"
                       viewBox="0 0 13 13"
@@ -3169,11 +3115,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-273 emotion-274"
+                    class="emotion-263 emotion-264"
                     dir="rtl"
                   >
                     <time
-                      class="emotion-45 emotion-46"
+                      class="emotion-41 emotion-42"
                       datetime="2030-01-01"
                     >
                       ۰۹:۰۰
@@ -3182,63 +3128,63 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-277 emotion-278"
+                class="emotion-267 emotion-268"
               >
                 <div
-                  class="emotion-279 emotion-280"
+                  class="emotion-269 emotion-270"
                 >
                   <h3
-                    class="emotion-281 emotion-282"
+                    class="emotion-271 emotion-272"
                   >
                     <span
                       id="scheduleItem-p086pmsf"
                       role="text"
                     >
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         به بعدی گوش کنید, 
                       </span>
                       <span
                         aria-hidden="true"
-                        class="emotion-285 emotion-286"
+                        class="emotion-275 emotion-276"
                         dir="rtl"
                       >
                         بعدی 
                       </span>
                       چشم انداز بامدادی 1
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , ۰۹:۰۰, 
                       </span>
                       <span
-                        class="emotion-289 emotion-290"
+                        class="emotion-279 emotion-280"
                       >
                         ۱ ژانویه ۲۰۳۰
                       </span>
                       <span
-                        class="emotion-93 emotion-94"
+                        class="emotion-85 emotion-86"
                       >
                         , ۲۶،۳۰ المدة الزمنية 
                       </span>
                     </span>
                   </h3>
                   <p
-                    class="emotion-293 emotion-294"
+                    class="emotion-283 emotion-284"
                   >
                     تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
                   </p>
                 </div>
                 <div
-                  class="emotion-295 emotion-296"
+                  class="emotion-285 emotion-286"
                 >
                   <span
-                    class="emotion-297 emotion-298"
+                    class="emotion-287 emotion-288"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-299 emotion-300"
+                      class="emotion-289 emotion-290"
                       focusable="false"
                       height="12px"
                       viewBox="0 0 13 12"
@@ -3253,7 +3199,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </svg>
                   </span>
                   <time
-                    class="emotion-301 emotion-302"
+                    class="emotion-291 emotion-292"
                     datetime="PT26M30S"
                     dir="rtl"
                   >
@@ -3267,24 +3213,24 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
               </div>
             </li>
             <li
-              class="emotion-262 emotion-263 emotion-63"
+              class="emotion-252 emotion-253 emotion-55"
               data-e2e="onDemand"
               dir="rtl"
               role="listitem"
             >
               <div
-                class="emotion-265 emotion-266"
+                class="emotion-255 emotion-256"
               >
                 <div
-                  class="emotion-267 emotion-268"
+                  class="emotion-257 emotion-258"
                 >
                   <span
-                    class="emotion-269 emotion-270"
+                    class="emotion-259 emotion-260"
                     dir="rtl"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-271 emotion-272"
+                      class="emotion-261 emotion-262"
                       focusable="false"
                       height="13"
                       viewBox="0 0 13 13"
@@ -3300,11 +3246,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-273 emotion-274"
+                    class="emotion-263 emotion-264"
                     dir="rtl"
                   >
                     <time
-                      class="emotion-45 emotion-46"
+                      class="emotion-41 emotion-42"
                       datetime="2020-03-26"
                     >
                       ۰۵:۳۰
@@ -3313,17 +3259,17 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-277 emotion-278"
+                class="emotion-267 emotion-268"
               >
                 <div
-                  class="emotion-279 emotion-280"
+                  class="emotion-269 emotion-270"
                 >
                   <h3
-                    class="emotion-322 emotion-282"
+                    class="emotion-312 emotion-272"
                   >
                     <a
                       aria-labelledby="scheduleItem-p086pms9"
-                      class="emotion-324 emotion-325"
+                      class="emotion-314 emotion-315"
                       href="/persian/bbc_dari_radio/w172x1rwggbcdq8"
                     >
                       <span
@@ -3331,23 +3277,23 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         role="text"
                       >
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           بشنوید, 
                         </span>
                         نبض خبر
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۰۵:۳۰, 
                         </span>
                         <span
-                          class="emotion-330 emotion-290"
+                          class="emotion-320 emotion-280"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۰۳،۰۰ المدة الزمنية 
                         </span>
@@ -3355,20 +3301,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </a>
                   </h3>
                   <p
-                    class="emotion-293 emotion-294"
+                    class="emotion-283 emotion-284"
                   >
                     تازه ترین خبرهای جهان
                   </p>
                 </div>
                 <div
-                  class="emotion-336 emotion-296"
+                  class="emotion-326 emotion-286"
                 >
                   <span
-                    class="emotion-338 emotion-298"
+                    class="emotion-328 emotion-288"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-299 emotion-300"
+                      class="emotion-289 emotion-290"
                       focusable="false"
                       height="12px"
                       viewBox="0 0 13 12"
@@ -3383,7 +3329,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </svg>
                   </span>
                   <time
-                    class="emotion-301 emotion-302"
+                    class="emotion-291 emotion-292"
                     datetime="PT3M"
                     dir="rtl"
                   >
@@ -3397,24 +3343,24 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
               </div>
             </li>
             <li
-              class="emotion-262 emotion-263 emotion-63"
+              class="emotion-252 emotion-253 emotion-55"
               data-e2e="onDemand"
               dir="rtl"
               role="listitem"
             >
               <div
-                class="emotion-265 emotion-266"
+                class="emotion-255 emotion-256"
               >
                 <div
-                  class="emotion-267 emotion-268"
+                  class="emotion-257 emotion-258"
                 >
                   <span
-                    class="emotion-269 emotion-270"
+                    class="emotion-259 emotion-260"
                     dir="rtl"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-271 emotion-272"
+                      class="emotion-261 emotion-262"
                       focusable="false"
                       height="13"
                       viewBox="0 0 13 13"
@@ -3430,11 +3376,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-273 emotion-274"
+                    class="emotion-263 emotion-264"
                     dir="rtl"
                   >
                     <time
-                      class="emotion-45 emotion-46"
+                      class="emotion-41 emotion-42"
                       datetime="2020-03-26"
                     >
                       ۰۲:۳۰
@@ -3443,17 +3389,17 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-277 emotion-278"
+                class="emotion-267 emotion-268"
               >
                 <div
-                  class="emotion-279 emotion-280"
+                  class="emotion-269 emotion-270"
                 >
                   <h3
-                    class="emotion-322 emotion-282"
+                    class="emotion-312 emotion-272"
                   >
                     <a
                       aria-labelledby="scheduleItem-p086pjpq"
-                      class="emotion-324 emotion-325"
+                      class="emotion-314 emotion-315"
                       href="/persian/bbc_dari_radio/w3csz8fk"
                     >
                       <span
@@ -3461,23 +3407,23 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         role="text"
                       >
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           بشنوید, 
                         </span>
                         چشم انداز بامدادی 2
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۰۲:۳۰, 
                         </span>
                         <span
-                          class="emotion-330 emotion-290"
+                          class="emotion-320 emotion-280"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۲۹،۳۰ المدة الزمنية 
                         </span>
@@ -3485,20 +3431,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </a>
                   </h3>
                   <p
-                    class="emotion-293 emotion-294"
+                    class="emotion-283 emotion-284"
                   >
                     تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
                   </p>
                 </div>
                 <div
-                  class="emotion-336 emotion-296"
+                  class="emotion-326 emotion-286"
                 >
                   <span
-                    class="emotion-338 emotion-298"
+                    class="emotion-328 emotion-288"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-299 emotion-300"
+                      class="emotion-289 emotion-290"
                       focusable="false"
                       height="12px"
                       viewBox="0 0 13 12"
@@ -3513,7 +3459,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </svg>
                   </span>
                   <time
-                    class="emotion-301 emotion-302"
+                    class="emotion-291 emotion-292"
                     datetime="PT29M30S"
                     dir="rtl"
                   >
@@ -3527,24 +3473,24 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
               </div>
             </li>
             <li
-              class="emotion-262 emotion-263 emotion-63"
+              class="emotion-252 emotion-253 emotion-55"
               data-e2e="onDemand"
               dir="rtl"
               role="listitem"
             >
               <div
-                class="emotion-265 emotion-266"
+                class="emotion-255 emotion-256"
               >
                 <div
-                  class="emotion-267 emotion-268"
+                  class="emotion-257 emotion-258"
                 >
                   <span
-                    class="emotion-269 emotion-270"
+                    class="emotion-259 emotion-260"
                     dir="rtl"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-271 emotion-272"
+                      class="emotion-261 emotion-262"
                       focusable="false"
                       height="13"
                       viewBox="0 0 13 13"
@@ -3560,11 +3506,11 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-273 emotion-274"
+                    class="emotion-263 emotion-264"
                     dir="rtl"
                   >
                     <time
-                      class="emotion-45 emotion-46"
+                      class="emotion-41 emotion-42"
                       datetime="2020-03-26"
                     >
                       ۰۱:۳۰
@@ -3573,17 +3519,17 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                 </div>
               </div>
               <div
-                class="emotion-277 emotion-278"
+                class="emotion-267 emotion-268"
               >
                 <div
-                  class="emotion-279 emotion-280"
+                  class="emotion-269 emotion-270"
                 >
                   <h3
-                    class="emotion-322 emotion-282"
+                    class="emotion-312 emotion-272"
                   >
                     <a
                       aria-labelledby="scheduleItem-p086phc8"
-                      class="emotion-324 emotion-325"
+                      class="emotion-314 emotion-315"
                       href="/persian/bbc_dari_radio/w3csz7tn"
                     >
                       <span
@@ -3591,23 +3537,23 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                         role="text"
                       >
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           بشنوید, 
                         </span>
                         چشم انداز بامدادی 1
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۰۱:۳۰, 
                         </span>
                         <span
-                          class="emotion-330 emotion-290"
+                          class="emotion-320 emotion-280"
                         >
                           ۲۶ مارس ۲۰۲۰
                         </span>
                         <span
-                          class="emotion-93 emotion-94"
+                          class="emotion-85 emotion-86"
                         >
                           , ۲۹،۳۰ المدة الزمنية 
                         </span>
@@ -3615,20 +3561,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </a>
                   </h3>
                   <p
-                    class="emotion-293 emotion-294"
+                    class="emotion-283 emotion-284"
                   >
                     تازه ترین خبرهای افغانستان، منطقه و جهان همراه با گزارش ها و بررسی روزنامه های مهم جهان وافغانستان.
                   </p>
                 </div>
                 <div
-                  class="emotion-336 emotion-296"
+                  class="emotion-326 emotion-286"
                 >
                   <span
-                    class="emotion-338 emotion-298"
+                    class="emotion-328 emotion-288"
                   >
                     <svg
                       aria-hidden="true"
-                      class="emotion-299 emotion-300"
+                      class="emotion-289 emotion-290"
                       focusable="false"
                       height="12px"
                       viewBox="0 0 13 12"
@@ -3643,7 +3589,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </svg>
                   </span>
                   <time
-                    class="emotion-301 emotion-302"
+                    class="emotion-291 emotion-292"
                     datetime="PT29M30S"
                     dir="rtl"
                   >
@@ -3665,25 +3611,19 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
         role="region"
       >
         <div
-          class="emotion-49 emotion-7"
+          class="emotion-45 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="rtl"
                   id="Features"
                 >
@@ -3694,27 +3634,27 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           </h2>
         </div>
         <ul
-          class="emotion-63 emotion-64 emotion-65"
+          class="emotion-55 emotion-56 emotion-57"
           dir="rtl"
           role="list"
         >
           <li
-            class="emotion-63 emotion-67 emotion-68"
+            class="emotion-55 emotion-59 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-22 emotion-23"
+              class="emotion-18 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-24 emotion-25"
+                class="emotion-20 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3727,20 +3667,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-37 emotion-38"
+                class="emotion-33 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-39 emotion-40"
+                  class="emotion-35 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-persianafghanistan52722865-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52722865"
                   >
                     <span
@@ -3751,12 +3691,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-43 emotion-44"
+                  class="emotion-39 emotion-40"
                 >
                   چانه‌زنی برای دست‌یابی به یک توافق سیاسی بین اشرف غنی، رئیس جمهوری و عبدالله عبدالله که همزمان با او اعلام ریاست جمهوری کرده بود، از اوایل اسفند/حوت سال گذشته خورشیدی آغاز شد و حدود سه ماه زمان گرفت. مذاکراتی که پشت درهای بسته برگزار می‌شد به قول منابعی که با آنها صحبت کرده‌ام بارها به بن‌بست رسید و جلسات بارها با عصبانیت یکی از دو طرف مذاکره بی‌نتیجه پایان یافت.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-20"
                 >
                   ۳۱ اردیبهشت ۱۳۹۹ - ۲۰ مه ۲۰۲۰
@@ -3765,22 +3705,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3793,20 +3733,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-persianafghanistan52697976-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52697976"
                   >
                     <span
@@ -3817,12 +3757,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   شیوع ویروس کرونا در افغانستان گردشگری را در این کشور با رکود مواجه کرده و اماکن توریستی از شرق تا غرب و از شمال تا جنوب بر روی گردشگران بسته شده است. از صنعت توریزم که هم دولت نفع می‌برد و هم مردم، حالا با رکود بی‌سابقه مواجه شده است.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-19"
                 >
                   ۳۰ اردیبهشت ۱۳۹۹ - ۱۹ مه ۲۰۲۰
@@ -3831,22 +3771,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3859,20 +3799,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-persianblogviewpoints52616632-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/blog-viewpoints-52616632"
                   >
                     <span
@@ -3883,12 +3823,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   سانگه صدیقی، فعال سیاسی و مدنی در مطلبی برای صفحه ناظران بی‌بی‌سی فارسی به توافق‌نامه بین محمد اشرف غنی و عبدالله پرداخته است و آن را "زوال دموکراسی" خوانده است.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-18"
                 >
                   ۲۹ اردیبهشت ۱۳۹۹ - ۱۸ مه ۲۰۲۰
@@ -3897,22 +3837,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3925,20 +3865,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-persianafghanistan52700014-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/afghanistan-52700014"
                   >
                     <span
@@ -3949,12 +3889,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   محمد اشرف غنی، رئیس جمهور افغانستان موافقت‌نامه‌ای با عبدالله عبدالله، رئیس اجرایی پیشین امضا کرده است. با امضای این موافقت‌نامه میان دو رقیب سیاسی، جنجال پس از اعلام نتیجه انتخابات اخیر افغانستان پس از نزدیک به پنج ماه پایان یافت. اختلاف بین این دو رهبر چه بود و چگونه حل شد؟
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-17"
                 >
                   ۲۸ اردیبهشت ۱۳۹۹ - ۱۷ مه ۲۰۲۰
@@ -3963,22 +3903,22 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-63 emotion-102 emotion-68"
+            class="emotion-55 emotion-94 emotion-60"
             dir="rtl"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="rtl"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -3991,20 +3931,20 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-122 emotion-38"
+                class="emotion-114 emotion-34"
                 dir="rtl"
               >
                 <h3
-                  class="emotion-124 emotion-40"
+                  class="emotion-116 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-persianblogviewpoints52692067-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/persian/blog-viewpoints-52692067"
                   >
                     <span
@@ -4015,12 +3955,12 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
                   </a>
                 </h3>
                 <p
-                  class="emotion-132 emotion-44"
+                  class="emotion-124 emotion-40"
                 >
                   نویسنده در این یادداشت که برای صفحه ناظران فرستاده، می‌گوید که "آرمان ایران، داشتنِ نفوذ شبیه به عراق در افغانستان نیست" اما دارای منافع در افغانستان است از جمله صادرات و روابط تجاری و گاهی دشمن مشترک مانند داعش.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-16"
                 >
                   ۲۷ اردیبهشت ۱۳۹۹ - ۱۶ مه ۲۰۲۰
@@ -4032,30 +3972,24 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
       </section>
       <section
         aria-labelledby="Most-Read"
-        class=" emotion-560 emotion-561"
+        class=" emotion-546 emotion-547"
         data-e2e="most-read"
         role="region"
       >
         <div
-          class="emotion-562 emotion-563 emotion-7"
+          class="emotion-548 emotion-549 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="rtl"
                   id="Most-Read"
                 >
@@ -4066,43 +4000,43 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
           </h2>
         </div>
         <ol
-          class="emotion-577 emotion-578 emotion-63"
+          class="emotion-559 emotion-560 emotion-55"
           dir="rtl"
           role="list"
         >
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-585 emotion-586"
+                class="emotion-567 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۱
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/world-50317704"
                 >
                   توافق با جدایی‌طلبان یمن؛ ایران اعتراض کرد، سازمان ملل استقبال
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4112,38 +4046,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-602 emotion-586"
+                class="emotion-584 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۲
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/iran-50319870"
                 >
                   فراخوان آذری جهرمی برای مناظره اینستاگرامی - زرآبادی: در مجلس مناظره کنیم
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4153,38 +4087,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-585 emotion-586"
+                class="emotion-567 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۳
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/world-50320610"
                 >
                   ترکیه: همسر ابوبکر بغدادی را 'دستگیر کردیم'
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4194,38 +4128,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-602 emotion-586"
+                class="emotion-584 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۴
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/world-50316456"
                 >
                   غنی سازی مجدد در فردو: مکرون اقدام ایران را 'عمیقا مایه نگرانی' خواند
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4235,38 +4169,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-585 emotion-586"
+                class="emotion-567 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۵
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/magazine-50249226"
                 >
                   دوازده دلیل حکمرانی حشرات: سوسک می‌تواند دو هفته بدون سر زنده بماند
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4276,38 +4210,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-670 emotion-586"
+                class="emotion-652 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۶
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/world-50317700"
                 >
                   انتخابات ایالتی آمریکا؛ دموکرات‌ها از جمهوری‌خواهان پیش افتادند
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4317,38 +4251,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-687 emotion-586"
+                class="emotion-669 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۷
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/sport-50322486"
                 >
                   عراق اردن را به عنوان میزبان بازی با ایران معرفی کرد
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4358,38 +4292,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-670 emotion-586"
+                class="emotion-652 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۸
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/iran-features-50310665"
                 >
                   آیا تهران بازی هسته ای را به هم می‌زند؟
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4399,38 +4333,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-687 emotion-586"
+                class="emotion-669 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۹
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/world-50316450"
                 >
                   آمریکا: دو ایرانی اتهام جمع‌آوری اطلاعات علیه سازمان مجاهدین در خاک آمریکا را پذیرفتند
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4440,38 +4374,38 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
             </div>
           </li>
           <li
-            class="emotion-580 emotion-581 emotion-63"
+            class="emotion-562 emotion-563 emotion-55"
             dir="rtl"
             role="listitem"
           >
             <div
-              class="emotion-583 emotion-584"
+              class="emotion-565 emotion-566"
             >
               <div
-                class="emotion-670 emotion-586"
+                class="emotion-652 emotion-568"
                 dir="rtl"
               >
                 <span
-                  class="emotion-587 emotion-588"
+                  class="emotion-569 emotion-570"
                 >
                   ۱۰
                 </span>
               </div>
               <div
-                class="emotion-589 emotion-590"
+                class="emotion-571 emotion-572"
                 dir="rtl"
               >
                 <a
-                  class="emotion-591 emotion-592"
+                  class="emotion-573 emotion-574"
                   href="/persian/sport-50318030"
                 >
                   فوتبال ایران و عراق؛ ایران: امن است بازی می‌کنیم، فیفا: ناامن است بازی نکنید
                 </a>
                 <div
-                  class="emotion-593 emotion-594"
+                  class="emotion-575 emotion-576"
                 >
                   <time
-                    class="emotion-45 emotion-46"
+                    class="emotion-41 emotion-42"
                     datetime="2019-11-06"
                   >
                     به روز شده در ۶ نوامبر ۲۰۱۹
@@ -4583,7 +4517,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 .emotion-6 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
@@ -4607,50 +4541,11 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 .emotion-8 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-8 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-8 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-10 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-10 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-10 {
-    display: none;
-  }
-}
-
-.emotion-12 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-14 {
+.emotion-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4660,7 +4555,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   flex-direction: column;
 }
 
-.emotion-16 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4680,7 +4575,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-16 {
+  .emotion-12 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -4688,11 +4583,11 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-18 {
+.emotion-14 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -4708,68 +4603,68 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-18 {
+  .emotion-14 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-18 {
+  .emotion-14 {
     padding-right: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-20 {
+  .emotion-16 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-20 {
+  .emotion-16 {
     margin-top: 2rem;
   }
 }
 
-.emotion-22 {
+.emotion-18 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-22 {
+  .emotion-18 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-22 {
+    .emotion-18 {
       grid-template-columns: repeat(12, 1fr);
     }
   }
 }
 
-.emotion-24 {
+.emotion-20 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -4778,36 +4673,36 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-24 {
+  .emotion-20 {
     width: calc(50% - 0.5rem);
     margin-bottom: 0;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-24 {
+  .emotion-20 {
     width: calc(50% - 0.5rem);
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-24 {
+  .emotion-20 {
     width: initial;
     grid-column: 1/span 6;
   }
 
   @media (min-width: 37.5rem) and (max-width: 79.9375rem) {
-    .emotion-24 {
+    .emotion-20 {
       grid-column: 1/span 3;
     }
   }
 }
 
-.emotion-26 {
+.emotion-22 {
   position: relative;
 }
 
-.emotion-28 {
+.emotion-24 {
   position: relative;
   height: 0;
   overflow: hidden;
@@ -4822,61 +4717,61 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 25rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 77px 22px;
     background-size: 77px 22px;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-28 {
+  .emotion-24 {
     -webkit-background-size: 93px 27px;
     background-size: 93px 27px;
   }
 }
 
-.emotion-30 {
+.emotion-26 {
   display: block;
   width: 100%;
   visibility: visible;
 }
 
-.emotion-33 {
+.emotion-29 {
   display: block;
   width: 100%;
   height: auto;
 }
 
-.emotion-35 {
+.emotion-31 {
   position: absolute;
   bottom: 0;
 }
 
-.emotion-35>* {
+.emotion-31>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
-.emotion-37 {
+.emotion-33 {
   display: inline-block;
   vertical-align: top;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-33 {
     width: 50%;
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-33 {
     width: 50%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-37 {
+  .emotion-33 {
     display: block;
     width: initial;
     padding: initial;
@@ -4884,19 +4779,19 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-37 {
+    .emotion-33 {
       grid-column: 4/span 3;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-37 {
+    .emotion-33 {
       grid-column: 7/span 6;
     }
   }
 }
 
-.emotion-39 {
+.emotion-35 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -4908,20 +4803,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1.375rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-35 {
     font-size: 1.75rem;
     line-height: 2rem;
   }
 }
 
-.emotion-41 {
+.emotion-37 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -4930,7 +4825,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   overflow-wrap: anywhere;
 }
 
-.emotion-41:before {
+.emotion-37:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -4942,17 +4837,17 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   z-index: 1;
 }
 
-.emotion-41:hover,
-.emotion-41:focus {
+.emotion-37:hover,
+.emotion-37:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-41:visited {
+.emotion-37:visited {
   color: #6E6E73;
 }
 
-.emotion-43 {
+.emotion-39 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -4964,30 +4859,30 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-43 {
+  .emotion-39 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
+  .emotion-39 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-45 {
+.emotion-41 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4995,26 +4890,26 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-41 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-47 {
+.emotion-43 {
   position: relative;
   z-index: 2;
   padding: 1rem 0 0;
 }
 
-.emotion-49 {
+.emotion-45 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -5025,12 +4920,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   margin: 0;
 }
 
-.emotion-51 {
+.emotion-47 {
   border-top: 1px solid #F2F2F2;
   padding: 0.5rem 0;
 }
 
-.emotion-53 {
+.emotion-49 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -5042,65 +4937,65 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-53:hover,
-.emotion-53:focus {
+.emotion-49:hover,
+.emotion-49:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-53:visited {
+.emotion-49:visited {
   color: #6E6E73;
 }
 
-.emotion-53 svg {
+.emotion-49 svg {
   margin: 0;
 }
 
-.emotion-57 {
+.emotion-53 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-57 {
+  .emotion-53 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-57 {
+  .emotion-53 {
     margin-bottom: 1.5rem;
   }
 }
 
-.emotion-65 {
+.emotion-57 {
   color: #222222;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-65:focus,
-.emotion-65:hover {
+.emotion-57:focus,
+.emotion-57:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-73 {
+.emotion-65 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -5122,33 +5017,33 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-73 {
+  .emotion-65 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-73 {
+  .emotion-65 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-73 {
+  .emotion-65 {
     margin: 0;
   }
 }
 
-.emotion-76 {
+.emotion-68 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-76 {
+  .emotion-68 {
     display: grid;
     position: initial;
     width: initial;
@@ -5156,7 +5051,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5164,7 +5059,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5172,7 +5067,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5180,7 +5075,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -5188,7 +5083,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -5196,7 +5091,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 80rem) {
-    .emotion-76 {
+    .emotion-68 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -5204,48 +5099,48 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 }
 
-.emotion-79 {
+.emotion-71 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-79 {
+  .emotion-71 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-79:last-child {
+.emotion-71:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-79 {
+  .emotion-71 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-79 {
+  .emotion-71 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-79:first-child {
+.emotion-71:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-79:first-child {
+  .emotion-71:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-79:last-child {
+.emotion-71:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5254,7 +5149,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5263,7 +5158,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5272,7 +5167,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5281,7 +5176,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5290,7 +5185,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 80rem) {
-  .emotion-79 {
+  .emotion-71 {
     width: calc(6/8*(100% - 8 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5299,94 +5194,94 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @supports (display: grid) {
-  .emotion-79 {
+  .emotion-71 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-79 {
+    .emotion-71 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 }
 
-.emotion-81 {
+.emotion-73 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-81 {
+  .emotion-73 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-81 {
+    .emotion-73 {
       grid-column-gap: 1rem;
     }
   }
 }
 
-.emotion-83 {
+.emotion-75 {
   display: inline-block;
   vertical-align: top;
   width: 100%;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-83 {
+  .emotion-75 {
     padding-right: 0.5rem;
     width: 50%;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-83 {
+  .emotion-75 {
     width: 33.33%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-83 {
+  .emotion-75 {
     display: block;
     width: initial;
     padding: initial;
@@ -5397,14 +5292,14 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-83 {
+    .emotion-75 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-83 {
+    .emotion-75 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
@@ -5412,12 +5307,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-83>time {
+  .emotion-75>time {
     padding-bottom: 0.5rem;
   }
 }
 
-.emotion-85 {
+.emotion-77 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -5429,20 +5324,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-85 {
+  .emotion-77 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-85 {
+  .emotion-77 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
-.emotion-89 {
+.emotion-81 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -5454,34 +5349,34 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-89 {
+  .emotion-81 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-89 {
+  .emotion-81 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (max-width: 37.4375rem) {
-  .emotion-89 {
+  .emotion-81 {
     display: none;
     visibility: hidden;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-89 {
+  .emotion-81 {
     display: none;
     visibility: hidden;
   }
 }
 
-.emotion-93 {
+.emotion-85 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -5489,20 +5384,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-93 {
+  .emotion-85 {
     padding-right: 0.5rem;
     width: 50%;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-93 {
+  .emotion-85 {
     width: 66.67%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-93 {
+  .emotion-85 {
     width: initial;
     padding: 0;
     grid-template-columns: repeat(6, 1fr);
@@ -5510,62 +5405,62 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-93 {
+    .emotion-85 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-93 {
+    .emotion-85 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-102 {
+.emotion-94 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-102:last-child {
+.emotion-94:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-102 {
+  .emotion-94 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-102 {
+  .emotion-94 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-102:first-child {
+.emotion-94:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-102:first-child {
+  .emotion-94:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-102:last-child {
+.emotion-94:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5574,7 +5469,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5583,7 +5478,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5592,7 +5487,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5601,7 +5496,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5610,7 +5505,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 80rem) {
-  .emotion-102 {
+  .emotion-94 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5619,80 +5514,80 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @supports (display: grid) {
-  .emotion-102 {
+  .emotion-94 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-102 {
+    .emotion-94 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 }
 
-.emotion-104 {
+.emotion-96 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-104 {
+  .emotion-96 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-104 {
+    .emotion-96 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-104 {
+    .emotion-96 {
       display: block;
     }
   }
 }
 
-.emotion-106 {
+.emotion-98 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -5700,39 +5595,39 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 63rem) {
-  .emotion-106 {
+  .emotion-98 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-106 {
+  .emotion-98 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
 @media (min-width: 25rem) {
-  .emotion-112 {
+  .emotion-104 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-112>* {
+.emotion-104>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-112>* {
+  .emotion-104>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-114 {
+.emotion-106 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -5740,13 +5635,13 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-114 {
+  .emotion-106 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-114 {
+  .emotion-106 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -5754,7 +5649,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-114 {
+  .emotion-106 {
     display: block;
     width: initial;
     padding: initial;
@@ -5762,13 +5657,13 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
   }
 
   @media (min-width: 63rem) {
-    .emotion-114 {
+    .emotion-106 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-116 {
+.emotion-108 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -5780,61 +5675,61 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-116 {
+  .emotion-108 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-116 {
+  .emotion-108 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-397 {
+.emotion-381 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-397 {
+  .emotion-381 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-397:last-child {
+.emotion-381:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-397 {
+  .emotion-381 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-397 {
+  .emotion-381 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-397:first-child {
+.emotion-381:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-397:first-child {
+  .emotion-381:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-397:last-child {
+.emotion-381:last-child {
   padding-bottom: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5843,7 +5738,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5852,7 +5747,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -5861,7 +5756,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(6/6*(100% - 6 * 1rem) + 5 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5870,7 +5765,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5879,7 +5774,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @media (min-width: 80rem) {
-  .emotion-397 {
+  .emotion-381 {
     width: calc(8/8*(100% - 8 * 1rem) + 7 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -5888,49 +5783,49 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
 }
 
 @supports (display: grid) {
-  .emotion-397 {
+  .emotion-381 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-397 {
+    .emotion-381 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
@@ -5964,23 +5859,17 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
         <div
           class="emotion-6 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="ltr"
                   id="Top-story"
                 >
@@ -5991,26 +5880,26 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
           </h2>
         </div>
         <div
-          class="emotion-20 emotion-21"
+          class="emotion-16 emotion-17"
         >
           <div
-            class="emotion-22 emotion-23"
+            class="emotion-18 emotion-19"
             data-e2e="story-promo"
           >
             <div
-              class="emotion-24 emotion-25"
+              class="emotion-20 emotion-21"
               dir="ltr"
             >
               <div
-                class="emotion-26 emotion-27"
+                class="emotion-22 emotion-23"
               >
                 <div
-                  class="emotion-28 emotion-29"
+                  class="emotion-24 emotion-25"
                   data-e2e="image-placeholder"
                   style="padding-bottom: 56.25%;"
                 >
                   <picture
-                    class="emotion-30 emotion-31"
+                    class="emotion-26 emotion-27"
                   >
                     <source
                       sizes="(max-width: 600px) 100vw, (max-width: 1008px) 50vw, 496px"
@@ -6024,7 +5913,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     />
                     <img
                       alt="трамвай"
-                      class="emotion-32 emotion-33 emotion-34"
+                      class="emotion-28 emotion-29 emotion-30"
                       height="549"
                       src="https://ichef.bbci.co.uk/news/660/cpsprodpb/1667D/production/_112337719_gettyimages-1210623351.jpg"
                       width="976"
@@ -6032,20 +5921,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </picture>
                 </div>
                 <div
-                  class="emotion-35 emotion-36"
+                  class="emotion-31 emotion-32"
                 />
               </div>
             </div>
             <div
-              class="emotion-37 emotion-38"
+              class="emotion-33 emotion-34"
               dir="ltr"
             >
               <h3
-                class="emotion-39 emotion-40"
+                class="emotion-35 emotion-36"
               >
                 <a
                   aria-labelledby="promo-ukrainiannewsrussian52721557-1"
-                  class="emotion-41 emotion-42"
+                  class="emotion-37 emotion-38"
                   href="/ukrainian/news-russian-52721557"
                 >
                   <span
@@ -6056,30 +5945,30 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                 </a>
               </h3>
               <p
-                class="emotion-43 emotion-44"
+                class="emotion-39 emotion-40"
               >
                 Президент призывает дать людям возможность добираться на работу. В то же время Минздрав говорит, что ситуация в восьми регионах не позволяет запускать там транспорт.
               </p>
               <time
-                class="emotion-45 emotion-46"
+                class="emotion-41 emotion-42"
                 datetime="2020-05-19"
               >
                 19 мая 2020
               </time>
               <div
-                class="emotion-47 emotion-48"
+                class="emotion-43 emotion-44"
                 data-e2e="index-alsos"
               >
                 <h4
-                  class="emotion-49 emotion-50"
+                  class="emotion-45 emotion-46"
                 >
                   Читайте также
                 </h4>
                 <div
-                  class="emotion-51 emotion-52"
+                  class="emotion-47 emotion-48"
                 >
                   <a
-                    class="emotion-53 emotion-54"
+                    class="emotion-49 emotion-50"
                     href="/ukrainian/features-russian-52633464"
                   >
                     <span>
@@ -6098,30 +5987,24 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
         role="region"
       >
         <div
-          class="emotion-57 emotion-7"
+          class="emotion-53 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <a
-              class="emotion-65 emotion-66"
+              class="emotion-57 emotion-58"
               href="/ukrainian/magazine_russian"
             >
               <span
-                class="emotion-14 emotion-15"
+                class="emotion-10 emotion-11"
               >
                 <span
-                  class="emotion-16 emotion-17"
+                  class="emotion-12 emotion-13"
                   role="text"
                 >
                   <span
-                    class="emotion-18 emotion-19"
+                    class="emotion-14 emotion-15"
                     dir="ltr"
                     id="Verticals"
                   >
@@ -6129,7 +6012,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-73 emotion-74"
+                    class="emotion-65 emotion-66"
                     dir="ltr"
                   >
                     Посмотреть все
@@ -6140,28 +6023,28 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
           </h2>
         </div>
         <ul
-          class="emotion-75 emotion-76 emotion-77"
+          class="emotion-67 emotion-68 emotion-69"
           dir="ltr"
           role="list"
         >
           <li
-            class="emotion-75 emotion-79 emotion-80"
+            class="emotion-67 emotion-71 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-81 emotion-23"
+              class="emotion-73 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-83 emotion-38"
+                class="emotion-75 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-85 emotion-40"
+                  class="emotion-77 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-verticals-ukrainianfeaturesrussian52261329-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52261329"
                   >
                     <span
@@ -6172,26 +6055,26 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Как справиться со скукой и стрессом во время карантина? Для кого-то лучшим "помощником" стал алкоголь.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-12"
                 >
                   12 апреля 2020
                 </time>
               </div>
               <div
-                class="emotion-93 emotion-25"
+                class="emotion-85 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6204,29 +6087,29 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   />
                 </div>
               </div>
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6239,20 +6122,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-ukrainianfeaturesrussian52357130-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52357130"
                   >
                     <span
@@ -6263,12 +6146,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Личность человека не остается одинаковой на протяжении всей жизни, как считали ранее. Недавно исследователи выяснили - наш характер с возрастом улучшается.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-20"
                 >
                   20 апреля 2020
@@ -6284,25 +6167,19 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
         role="region"
       >
         <div
-          class="emotion-57 emotion-7"
+          class="emotion-53 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="ltr"
                   id="Also-in-the-news"
                 >
@@ -6313,28 +6190,28 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
           </h2>
         </div>
         <ul
-          class="emotion-75 emotion-76 emotion-77"
+          class="emotion-67 emotion-68 emotion-69"
           dir="ltr"
           role="list"
         >
           <li
-            class="emotion-75 emotion-79 emotion-80"
+            class="emotion-67 emotion-71 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-81 emotion-23"
+              class="emotion-73 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-83 emotion-38"
+                class="emotion-75 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-85 emotion-40"
+                  class="emotion-77 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52663545-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52663545"
                   >
                     <span
@@ -6345,26 +6222,26 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   На украинском сайте компании уже доступен перечень товаров и цены. С сегодняшнего дня можно делать заказы.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-14"
                 >
                   14 мая 2020
                 </time>
               </div>
               <div
-                class="emotion-93 emotion-25"
+                class="emotion-85 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6377,29 +6254,29 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   />
                 </div>
               </div>
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6412,20 +6289,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-ukrainianvertfutrussian52663551-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/vert-fut-russian-52663551"
                   >
                     <span
@@ -6436,12 +6313,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Семья Робертсонов 38 дней дрейфовала в открытом океане, после того как их маленькую яхту перевернула и потопила косатка.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-14"
                 >
                   14 мая 2020
@@ -6450,22 +6327,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6478,20 +6355,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52633464-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52633464"
                   >
                     <span
@@ -6502,12 +6379,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Многие украинцы из-за пандемии оказались заблокированными далеко за границей: из-за закрытия украинского неба добраться домой им очень сложно.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-12"
                 >
                   12 мая 2020
@@ -6516,22 +6393,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6544,20 +6421,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52647120-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52647120"
                   >
                     <span
@@ -6568,12 +6445,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Мэр Киева Виталий Кличко заявил, что наземный транспорт в столице начнет восстанавливать нормальную работу с 22 мая, а об открытии метро с 25 мая он будет просить правительство. Все из-за транспортного коллапса.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-13"
                 >
                   13 мая 2020
@@ -6582,22 +6459,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6610,20 +6487,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52493624-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52493624"
                   >
                     <span
@@ -6634,12 +6511,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Власти Швейцарии заявили, что бабушки и дедушки могут обнимать своих внуков в возрасте до 10 лет.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-30"
                 >
                   30 апреля 2020
@@ -6648,22 +6525,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6676,20 +6553,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52395098-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52395098"
                   >
                     <span
@@ -6700,12 +6577,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Могла ли эпидемия Covid-19 произойти из-за утечки вируса?
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-23"
                 >
                   23 апреля 2020
@@ -6714,22 +6591,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6742,20 +6619,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainiannewsrussian52443350-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52443350"
                   >
                     <span
@@ -6766,12 +6643,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Кабинет министров отрабатывает возможность открыть рынки в стране на этой неделе.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-27"
                 >
                   27 апреля 2020
@@ -6780,22 +6657,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6808,20 +6685,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52339462-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52339462"
                   >
                     <span
@@ -6832,12 +6709,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Что можете сделать именно вы, чтобы остановить распространение неправдивой информации?
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-18"
                 >
                   18 апреля 2020
@@ -6846,22 +6723,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6874,20 +6751,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52336989-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52336989"
                   >
                     <span
@@ -6898,12 +6775,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Почему один за другим в Украине происходят эти явления, с чем они связаны и когда закончатся?
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-18"
                 >
                   18 апреля 2020
@@ -6912,22 +6789,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -6940,20 +6817,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-also-in-the-news-ukrainianfeaturesrussian52344279-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52344279"
                   >
                     <span
@@ -6964,12 +6841,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Коронавирус распространился уже почти во всем мире. Так какие симптомы имеет эта болезнь и как от нее защититься?
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-04-19"
                 >
                   19 апреля 2020
@@ -6985,30 +6862,24 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
         role="region"
       >
         <div
-          class="emotion-57 emotion-7"
+          class="emotion-53 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <a
-              class="emotion-65 emotion-66"
+              class="emotion-57 emotion-58"
               href="/ukrainian/russian/media/photogalleries"
             >
               <span
-                class="emotion-14 emotion-15"
+                class="emotion-10 emotion-11"
               >
                 <span
-                  class="emotion-16 emotion-17"
+                  class="emotion-12 emotion-13"
                   role="text"
                 >
                   <span
-                    class="emotion-18 emotion-19"
+                    class="emotion-14 emotion-15"
                     dir="ltr"
                     id="Picture-galleries"
                   >
@@ -7016,7 +6887,7 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-73 emotion-74"
+                    class="emotion-65 emotion-66"
                     dir="ltr"
                   >
                     Посмотреть все
@@ -7027,27 +6898,27 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
           </h2>
         </div>
         <ul
-          class="emotion-75 emotion-76 emotion-77"
+          class="emotion-67 emotion-68 emotion-69"
           dir="ltr"
           role="list"
         >
           <li
-            class="emotion-75 emotion-397 emotion-80"
+            class="emotion-67 emotion-381 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-22 emotion-23"
+              class="emotion-18 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-24 emotion-25"
+                class="emotion-20 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7060,20 +6931,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-37 emotion-38"
+                class="emotion-33 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-39 emotion-40"
+                  class="emotion-35 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-ukrainianfeaturesrussian50186307-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-50186307"
                   >
                     <span
@@ -7084,12 +6955,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-43 emotion-44"
+                  class="emotion-39 emotion-40"
                 >
                   Завоевать доверие животного - дело непростое, но результат того стоит, считает фотограф.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2019-10-25"
                 >
                   25 октября 2019
@@ -7098,22 +6969,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.187290969899664%;"
                   >
@@ -7126,20 +6997,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49780932-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-49780932"
                   >
                     <span
@@ -7150,12 +7021,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   .
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2019-09-21"
                 >
                   21 сентября 2019
@@ -7164,22 +7035,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7192,20 +7063,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49621722-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-49621722"
                   >
                     <span
@@ -7216,12 +7087,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   .
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2019-09-07"
                 >
                   7 сентября 2019
@@ -7230,22 +7101,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7258,20 +7129,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-picture-galleries-ukrainiannewsrussian49613573-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-49613573"
                   >
                     <span
@@ -7282,12 +7153,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   В школу четырехлетнюю принцессу повели ее родители - принц Уильям и герцогиня Кейт, а также старший брат Джордж.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2019-09-06"
                 >
                   6 сентября 2019
@@ -7296,22 +7167,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7324,20 +7195,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-picture-galleries-ukrainianfeaturesrussian49382281-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-49382281"
                   >
                     <span
@@ -7348,12 +7219,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Задолго до того, как коты завоевали интернет, Уолтер Чандоха пленил мир своими фото. Он фотографировал пушистых моделей в течение 70 лет.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2019-08-17"
                 >
                   17 августа 2019
@@ -7369,25 +7240,19 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
         role="region"
       >
         <div
-          class="emotion-57 emotion-7"
+          class="emotion-53 emotion-7"
         >
-          <div
-            class="emotion-8 emotion-9"
-          />
-          <div
-            class="emotion-10 emotion-11"
-          />
           <h2
-            class="emotion-12 emotion-13"
+            class="emotion-8 emotion-9"
           >
             <span
-              class="emotion-14 emotion-15"
+              class="emotion-10 emotion-11"
             >
               <span
-                class="emotion-16 emotion-17"
+                class="emotion-12 emotion-13"
               >
                 <span
-                  class="emotion-18 emotion-19"
+                  class="emotion-14 emotion-15"
                   dir="ltr"
                   id="Features"
                 >
@@ -7398,28 +7263,28 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
           </h2>
         </div>
         <ul
-          class="emotion-75 emotion-76 emotion-77"
+          class="emotion-67 emotion-68 emotion-69"
           dir="ltr"
           role="list"
         >
           <li
-            class="emotion-75 emotion-79 emotion-80"
+            class="emotion-67 emotion-71 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-81 emotion-23"
+              class="emotion-73 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-83 emotion-38"
+                class="emotion-75 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-85 emotion-40"
+                  class="emotion-77 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-ukrainianfeaturesrussian52653319-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52653319"
                   >
                     <span
@@ -7430,26 +7295,26 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Максим Степанов - третий министр, возглавляющий Минздрав во время пандемии коронавируса. В интервью ВВС News Украина он прокомментировал конфликт вокруг закупок лекарств, а также рассказал, когда откроют детсады и когда медиками привезут костюмы из Китая.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-17"
                 >
                   17 мая 2020
                 </time>
               </div>
               <div
-                class="emotion-93 emotion-25"
+                class="emotion-85 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7462,29 +7327,29 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-35 emotion-36"
+                    class="emotion-31 emotion-32"
                   />
                 </div>
               </div>
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7497,20 +7362,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-ukrainiannewsrussian52675911-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52675911"
                   >
                     <span
@@ -7521,12 +7386,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   В соцсетях и некоторых СМИ решение немецкого регулятора называют победой, но действительно ли это победа?
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-15"
                 >
                   15 мая 2020
@@ -7535,22 +7400,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7563,20 +7428,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-ukrainiannewsrussian52688931-1"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52688931"
                   >
                     <span
@@ -7587,12 +7452,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Интересно, что тестирование прекратили не из-за их провала - а возможно, как раз наоборот.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-16"
                 >
                   16 мая 2020
@@ -7601,22 +7466,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7629,20 +7494,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-ukrainianfeaturesrussian52620256-2"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52620256"
                   >
                     <span
@@ -7653,12 +7518,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Ученые пытаются найти метод лечения Covid-19 или разработать вакцину, которая позволила бы смягчить карантинные меры, включая социальное дистанцирование. Вероятным кандидатом в спасители человечества называют ламу.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-11"
                 >
                   11 мая 2020
@@ -7667,22 +7532,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7695,20 +7560,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-ukrainiannewsrussian52597888-3"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/news-russian-52597888"
                   >
                     <span
@@ -7719,12 +7584,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Несмотря на то, что карантин, согласно решению правительства, будет действовать в Украине как минимум до 22 мая, ряд ограничений снимут уже с понедельника.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-09"
                 >
                   9 мая 2020
@@ -7733,22 +7598,22 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
             </div>
           </li>
           <li
-            class="emotion-75 emotion-102 emotion-80"
+            class="emotion-67 emotion-94 emotion-72"
             dir="ltr"
           >
             <div
-              class="emotion-104 emotion-23"
+              class="emotion-96 emotion-19"
               data-e2e="story-promo"
             >
               <div
-                class="emotion-106 emotion-25"
+                class="emotion-98 emotion-21"
                 dir="ltr"
               >
                 <div
-                  class="emotion-26 emotion-27"
+                  class="emotion-22 emotion-23"
                 >
                   <div
-                    class="emotion-28 emotion-29"
+                    class="emotion-24 emotion-25"
                     data-e2e="image-placeholder"
                     style="padding-bottom: 56.25%;"
                   >
@@ -7761,20 +7626,20 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                     </div>
                   </div>
                   <div
-                    class="emotion-112 emotion-36"
+                    class="emotion-104 emotion-32"
                   />
                 </div>
               </div>
               <div
-                class="emotion-114 emotion-38"
+                class="emotion-106 emotion-34"
                 dir="ltr"
               >
                 <h3
-                  class="emotion-116 emotion-40"
+                  class="emotion-108 emotion-36"
                 >
                   <a
                     aria-labelledby="promo-features-ukrainianfeaturesrussian52573535-4"
-                    class="emotion-41 emotion-42"
+                    class="emotion-37 emotion-38"
                     href="/ukrainian/features-russian-52573535"
                   >
                     <span
@@ -7785,12 +7650,12 @@ exports[`IdxPage - Ukrainian Snapshots should render a ukrainian idx page correc
                   </a>
                 </h3>
                 <p
-                  class="emotion-89 emotion-44"
+                  class="emotion-81 emotion-40"
                 >
                   Одно из исследований выявило мутацию, которая, по словам ученых, может сделать коронавирус более заразным.
                 </p>
                 <time
-                  class="emotion-45 emotion-46"
+                  class="emotion-41 emotion-42"
                   datetime="2020-05-07"
                 >
                   7 мая 2020

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -191,7 +191,7 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -223,7 +223,7 @@ exports[`Radio Page Main should match snapshot for AMP 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -642,7 +642,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -674,7 +674,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -811,7 +811,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 .emotion-25 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin: 0 auto;
   width: 100%;
@@ -845,28 +845,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 .emotion-27 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-27 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-27 {
-    display: none;
-  }
-}
-
-.emotion-29 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-31 {
+.emotion-29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -876,7 +859,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   flex-direction: column;
 }
 
-.emotion-33 {
+.emotion-31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -896,7 +879,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-33 {
+  .emotion-31 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -904,11 +887,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 }
 
-.emotion-35 {
+.emotion-33 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #F2F2F2;
   margin: 1rem 0;
@@ -924,75 +907,75 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-35 {
+  .emotion-33 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-35 {
+  .emotion-33 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-35 {
+  .emotion-33 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-35 {
+  .emotion-33 {
     padding-right: 1rem;
   }
 }
 
-.emotion-37 {
+.emotion-35 {
   margin: 0 auto;
   width: 100%;
   padding-bottom: 1rem;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-35 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-35 {
     max-width: 63rem;
     padding-bottom: 1.5rem;
   }
 }
 
-.emotion-40 {
+.emotion-38 {
   padding: 0;
   margin: 0;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-40 {
+  .emotion-38 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-40 {
+  .emotion-38 {
     padding: 0 0.5rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-40 {
+  .emotion-38 {
     padding: 0 1rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-40 {
+  .emotion-38 {
     display: grid;
     position: initial;
     width: initial;
@@ -1000,7 +983,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1009,7 +992,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
       grid-column-gap: 0.5rem;
@@ -1018,7 +1001,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -1027,7 +1010,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -1035,7 +1018,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1043,7 +1026,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-40 {
+    .emotion-38 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -1052,18 +1035,18 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (max-width: 37.5rem) {
-  .emotion-40 {
+  .emotion-38 {
     padding: 0;
   }
 }
 
-.emotion-43 {
+.emotion-41 {
   position: relative;
   padding-bottom: 1rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1072,7 +1055,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(4/4*(100% - 4 * 0.5rem) + 3 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1081,7 +1064,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(6/6*(100% - 6 * 0.5rem) + 5 * 0.5rem );
     margin: 0 0.25rem;
     display: inline-block;
@@ -1090,7 +1073,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(3/6*(100% - 6 * 1rem) + 2 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1099,7 +1082,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1108,7 +1091,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 80rem) {
-  .emotion-43 {
+  .emotion-41 {
     width: calc(2/8*(100% - 8 * 1rem) + 1 * 1rem );
     margin: 0 0.5rem;
     display: inline-block;
@@ -1117,49 +1100,49 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-43 {
+  .emotion-41 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(3, 1fr);
       grid-column-end: span 3;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(2, 1fr);
       grid-column-end: span 2;
     }
@@ -1167,7 +1150,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-43 {
+  .emotion-41 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1178,8 +1161,19 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   }
 }
 
-.emotion-45 {
+.emotion-43 {
   padding-bottom: 0.5rem;
+}
+
+.emotion-45 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .emotion-47 {
@@ -1191,34 +1185,23 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.emotion-49 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   padding-right: 0.25rem;
 }
 
-.emotion-49>svg {
+.emotion-47>svg {
   color: #5A5A5A;
   margin: 0;
   overflow: visible;
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-49>svg {
+  .emotion-47>svg {
     padding-right: 0.25rem;
     fill: canvasText;
   }
 }
 
-.emotion-51 {
+.emotion-49 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1227,7 +1210,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   height: 0.725rem;
 }
 
-.emotion-53 {
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1242,7 +1225,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   width: 100%;
 }
 
-.emotion-53>time {
+.emotion-51>time {
   color: #5A5A5A;
   font-size: 0.75rem;
   line-height: 1rem;
@@ -1252,20 +1235,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53>time {
+  .emotion-51>time {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53>time {
+  .emotion-51>time {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
-.emotion-53::after {
+.emotion-51::after {
   content: '';
   border-top: 0.0625rem solid #AEAEB5;
   top: 1rem;
@@ -1273,10 +1256,10 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   width: 100%;
 }
 
-.emotion-55 {
+.emotion-53 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1284,20 +1267,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-55 {
+  .emotion-53 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-55 {
+  .emotion-53 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-57 {
+.emotion-55 {
   padding-top: 0.5rem;
   background-color: #FFFFFF;
   display: -webkit-box;
@@ -1311,7 +1294,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   height: 100%;
 }
 
-.emotion-59 {
+.emotion-57 {
   padding: 0 0.5rem;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -1319,7 +1302,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   flex-grow: 1;
 }
 
-.emotion-61 {
+.emotion-59 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1330,20 +1313,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-61 {
+  .emotion-59 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-61 {
+  .emotion-59 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-63 {
+.emotion-61 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1351,7 +1334,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   overflow-wrap: break-word;
 }
 
-.emotion-63:before {
+.emotion-61:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1363,27 +1346,27 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   z-index: 1;
 }
 
-.emotion-63:hover,
-.emotion-63:focus {
+.emotion-61:hover,
+.emotion-61:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-63:visited {
+.emotion-61:visited {
   color: #6E6E73;
 }
 
-.emotion-63:hover .emotion-70 {
+.emotion-61:hover .emotion-68 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-63:focus .emotion-70 {
+.emotion-61:focus .emotion-68 {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-65 {
+.emotion-63 {
   -webkit-clip-path: inset(100%);
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -1394,7 +1377,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   margin: 0;
 }
 
-.emotion-69 {
+.emotion-67 {
   color: #3F3F42;
   padding: 0.5rem 0;
   display: inline-block;
@@ -1407,20 +1390,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-69 {
+  .emotion-67 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-69 {
+  .emotion-67 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-73 {
+.emotion-71 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1432,20 +1415,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-73 {
+  .emotion-71 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-73 {
+  .emotion-71 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-75 {
+.emotion-73 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1458,27 +1441,27 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-75 {
+  .emotion-73 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-75 {
+  .emotion-73 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-75 {
+  .emotion-73 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-77>svg {
+.emotion-75>svg {
   color: #FFFFFF;
   fill: currentColor;
   width: 1.0625rem;
@@ -1487,12 +1470,12 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-77>svg {
+  .emotion-75>svg {
     fill: canvasText;
   }
 }
 
-.emotion-79 {
+.emotion-77 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -1501,11 +1484,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   height: 0.75rem;
 }
 
-.emotion-81 {
+.emotion-79 {
   padding-left: 0.5rem;
 }
 
-.emotion-184 {
+.emotion-182 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1516,20 +1499,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-184 {
+  .emotion-182 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-188 {
+.emotion-186 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1541,20 +1524,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-188 {
+  .emotion-186 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-188 {
+  .emotion-186 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-192 {
+.emotion-190 {
   color: #6E6E73;
   padding: 0.5rem 0;
   display: inline-block;
@@ -1567,20 +1550,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-192 {
+  .emotion-190 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-192 {
+  .emotion-190 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-198 {
+.emotion-196 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -1593,27 +1576,27 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-198 {
+  .emotion-196 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-198 {
+  .emotion-196 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .emotion-198 {
+  .emotion-196 {
     background-color: transparent;
     outline: none;
   }
 }
 
-.emotion-200>svg {
+.emotion-198>svg {
   color: #11708C;
   fill: currentColor;
   width: 1.0625rem;
@@ -1622,7 +1605,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 @media screen and (forced-colors: active) {
-  .emotion-200>svg {
+  .emotion-198>svg {
     fill: canvasText;
   }
 }
@@ -1716,20 +1699,17 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
     <div
       class="emotion-24 emotion-25 emotion-26"
     >
-      <div
-        class="emotion-27 emotion-28"
-      />
       <h2
-        class="emotion-29 emotion-30"
+        class="emotion-27 emotion-28"
       >
         <span
-          class="emotion-31 emotion-32"
+          class="emotion-29 emotion-30"
         >
           <span
-            class="emotion-33 emotion-34"
+            class="emotion-31 emotion-32"
           >
             <span
-              class="emotion-35 emotion-36"
+              class="emotion-33 emotion-34"
               dir="ltr"
               id="Radio-Schedule"
             >
@@ -1740,33 +1720,33 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
       </h2>
     </div>
     <div
-      class="emotion-37 emotion-38"
+      class="emotion-35 emotion-36"
       data-e2e="radio-schedule"
     >
       <div
-        class="emotion-39 emotion-40 emotion-2"
+        class="emotion-37 emotion-38 emotion-2"
         dir="ltr"
         role="list"
       >
         <li
-          class="emotion-42 emotion-43 emotion-2"
+          class="emotion-40 emotion-41 emotion-2"
           data-e2e="onDemand"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-45 emotion-46"
+            class="emotion-43 emotion-44"
           >
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-45 emotion-46"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-47 emotion-48"
                 dir="ltr"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-51 emotion-52"
+                  class="emotion-49 emotion-50"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -1782,11 +1762,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-53 emotion-54"
+                class="emotion-51 emotion-52"
                 dir="ltr"
               >
                 <time
-                  class="emotion-55 emotion-56"
+                  class="emotion-53 emotion-54"
                   datetime="2020-03-26"
                 >
                   05:30
@@ -1795,17 +1775,17 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
             </div>
           </div>
           <div
-            class="emotion-57 emotion-58"
+            class="emotion-55 emotion-56"
           >
             <div
-              class="emotion-59 emotion-60"
+              class="emotion-57 emotion-58"
             >
               <h3
-                class="emotion-61 emotion-62"
+                class="emotion-59 emotion-60"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pmts"
-                  class="emotion-63 emotion-64"
+                  class="emotion-61 emotion-62"
                   href="/afrique/bbc_afrique_radio/w172x371xccjp2q"
                 >
                   <span
@@ -1813,23 +1793,23 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                     role="text"
                   >
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       Ecoutez, 
                     </span>
                     Actu Monde
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , 05:30, 
                     </span>
                     <span
-                      class="emotion-69 emotion-70"
+                      class="emotion-67 emotion-68"
                     >
                       26 mars 2020
                     </span>
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , Durée 06,00 
                     </span>
@@ -1837,20 +1817,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </a>
               </h3>
               <p
-                class="emotion-73 emotion-74"
+                class="emotion-71 emotion-72"
               >
                 C'est la principale tranche dédiée à l'actualité internationale. De 5H 30 à 6H 30, des interviews d'analystes et des information
               </p>
             </div>
             <div
-              class="emotion-75 emotion-76"
+              class="emotion-73 emotion-74"
             >
               <span
-                class="emotion-77 emotion-78"
+                class="emotion-75 emotion-76"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-79 emotion-80"
+                  class="emotion-77 emotion-78"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1865,7 +1845,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </svg>
               </span>
               <time
-                class="emotion-81 emotion-82"
+                class="emotion-79 emotion-80"
                 datetime="PT6M"
                 dir="ltr"
               >
@@ -1879,24 +1859,24 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
           </div>
         </li>
         <li
-          class="emotion-42 emotion-43 emotion-2"
+          class="emotion-40 emotion-41 emotion-2"
           data-e2e="onDemand"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-45 emotion-46"
+            class="emotion-43 emotion-44"
           >
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-45 emotion-46"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-47 emotion-48"
                 dir="ltr"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-51 emotion-52"
+                  class="emotion-49 emotion-50"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -1912,11 +1892,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-53 emotion-54"
+                class="emotion-51 emotion-52"
                 dir="ltr"
               >
                 <time
-                  class="emotion-55 emotion-56"
+                  class="emotion-53 emotion-54"
                   datetime="2020-03-26"
                 >
                   05:16
@@ -1925,17 +1905,17 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
             </div>
           </div>
           <div
-            class="emotion-57 emotion-58"
+            class="emotion-55 emotion-56"
           >
             <div
-              class="emotion-59 emotion-60"
+              class="emotion-57 emotion-58"
             >
               <h3
-                class="emotion-61 emotion-62"
+                class="emotion-59 emotion-60"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pmv1"
-                  class="emotion-63 emotion-64"
+                  class="emotion-61 emotion-62"
                   href="/afrique/bbc_afrique_radio/w172x6djbb3rg44"
                 >
                   <span
@@ -1943,23 +1923,23 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                     role="text"
                   >
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       Ecoutez, 
                     </span>
                     Reportage
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , 05:16, 
                     </span>
                     <span
-                      class="emotion-69 emotion-70"
+                      class="emotion-67 emotion-68"
                     >
                       26 mars 2020
                     </span>
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , Durée 08,00 
                     </span>
@@ -1967,20 +1947,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </a>
               </h3>
               <p
-                class="emotion-73 emotion-74"
+                class="emotion-71 emotion-72"
               >
                 Un sujet traité en profondeur et qui fait appel aux différents genres journalistiques.
               </p>
             </div>
             <div
-              class="emotion-75 emotion-76"
+              class="emotion-73 emotion-74"
             >
               <span
-                class="emotion-77 emotion-78"
+                class="emotion-75 emotion-76"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-79 emotion-80"
+                  class="emotion-77 emotion-78"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -1995,7 +1975,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </svg>
               </span>
               <time
-                class="emotion-81 emotion-82"
+                class="emotion-79 emotion-80"
                 datetime="PT8M"
                 dir="ltr"
               >
@@ -2009,24 +1989,24 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
           </div>
         </li>
         <li
-          class="emotion-42 emotion-43 emotion-2"
+          class="emotion-40 emotion-41 emotion-2"
           data-e2e="onDemand"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-45 emotion-46"
+            class="emotion-43 emotion-44"
           >
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-45 emotion-46"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-47 emotion-48"
                 dir="ltr"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-51 emotion-52"
+                  class="emotion-49 emotion-50"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2042,11 +2022,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-53 emotion-54"
+                class="emotion-51 emotion-52"
                 dir="ltr"
               >
                 <time
-                  class="emotion-55 emotion-56"
+                  class="emotion-53 emotion-54"
                   datetime="2020-03-26"
                 >
                   05:15
@@ -2055,17 +2035,17 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
             </div>
           </div>
           <div
-            class="emotion-57 emotion-58"
+            class="emotion-55 emotion-56"
           >
             <div
-              class="emotion-59 emotion-60"
+              class="emotion-57 emotion-58"
             >
               <h3
-                class="emotion-61 emotion-62"
+                class="emotion-59 emotion-60"
               >
                 <a
                   aria-labelledby="scheduleItem-p086pmtq"
-                  class="emotion-63 emotion-64"
+                  class="emotion-61 emotion-62"
                   href="/afrique/bbc_afrique_radio/w172x5n20y5f68g"
                 >
                   <span
@@ -2073,23 +2053,23 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                     role="text"
                   >
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       Ecoutez, 
                     </span>
                     Bulletin D'informations
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , 05:15, 
                     </span>
                     <span
-                      class="emotion-69 emotion-70"
+                      class="emotion-67 emotion-68"
                     >
                       26 mars 2020
                     </span>
                     <span
-                      class="emotion-65 emotion-66"
+                      class="emotion-63 emotion-64"
                     >
                       , Durée 01,00 
                     </span>
@@ -2097,20 +2077,20 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </a>
               </h3>
               <p
-                class="emotion-73 emotion-74"
+                class="emotion-71 emotion-72"
               >
                 Le tour du monde de l'actualité en 2 minutes 
               </p>
             </div>
             <div
-              class="emotion-75 emotion-76"
+              class="emotion-73 emotion-74"
             >
               <span
-                class="emotion-77 emotion-78"
+                class="emotion-75 emotion-76"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-79 emotion-80"
+                  class="emotion-77 emotion-78"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2125,7 +2105,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </svg>
               </span>
               <time
-                class="emotion-81 emotion-82"
+                class="emotion-79 emotion-80"
                 datetime="PT1M"
                 dir="ltr"
               >
@@ -2139,24 +2119,24 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
           </div>
         </li>
         <li
-          class="emotion-42 emotion-43 emotion-2"
+          class="emotion-40 emotion-41 emotion-2"
           data-e2e="next"
           dir="ltr"
           role="listitem"
         >
           <div
-            class="emotion-45 emotion-46"
+            class="emotion-43 emotion-44"
           >
             <div
-              class="emotion-47 emotion-48"
+              class="emotion-45 emotion-46"
             >
               <span
-                class="emotion-49 emotion-50"
+                class="emotion-47 emotion-48"
                 dir="ltr"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-51 emotion-52"
+                  class="emotion-49 emotion-50"
                   focusable="false"
                   height="13"
                   viewBox="0 0 13 13"
@@ -2172,11 +2152,11 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
               </span>
               <span
                 aria-hidden="true"
-                class="emotion-53 emotion-54"
+                class="emotion-51 emotion-52"
                 dir="ltr"
               >
                 <time
-                  class="emotion-55 emotion-56"
+                  class="emotion-53 emotion-54"
                   datetime="2030-01-01"
                 >
                   09:00
@@ -2185,63 +2165,63 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
             </div>
           </div>
           <div
-            class="emotion-57 emotion-58"
+            class="emotion-55 emotion-56"
           >
             <div
-              class="emotion-59 emotion-60"
+              class="emotion-57 emotion-58"
             >
               <h3
-                class="emotion-184 emotion-62"
+                class="emotion-182 emotion-60"
               >
                 <span
                   id="scheduleItem-p086pmtv"
                   role="text"
                 >
                   <span
-                    class="emotion-65 emotion-66"
+                    class="emotion-63 emotion-64"
                   >
                     Listen Next, 
                   </span>
                   <span
                     aria-hidden="true"
-                    class="emotion-188 emotion-189"
+                    class="emotion-186 emotion-187"
                     dir="ltr"
                   >
                     SUIVANT 
                   </span>
                   A Vous L'antenne
                   <span
-                    class="emotion-65 emotion-66"
+                    class="emotion-63 emotion-64"
                   >
                     , 09:00, 
                   </span>
                   <span
-                    class="emotion-192 emotion-70"
+                    class="emotion-190 emotion-68"
                   >
                     1 janvier 2030
                   </span>
                   <span
-                    class="emotion-65 emotion-66"
+                    class="emotion-63 emotion-64"
                   >
                     , Durée 15,00 
                   </span>
                 </span>
               </h3>
               <p
-                class="emotion-73 emotion-74"
+                class="emotion-71 emotion-72"
               >
                 Du lundi au vendredi les auditeurs réagissent à chaud sur les sujets qui rythment l'actualité 
               </p>
             </div>
             <div
-              class="emotion-198 emotion-76"
+              class="emotion-196 emotion-74"
             >
               <span
-                class="emotion-200 emotion-78"
+                class="emotion-198 emotion-76"
               >
                 <svg
                   aria-hidden="true"
-                  class="emotion-79 emotion-80"
+                  class="emotion-77 emotion-78"
                   focusable="false"
                   height="12px"
                   viewBox="0 0 13 12"
@@ -2256,7 +2236,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
                 </svg>
               </span>
               <time
-                class="emotion-81 emotion-82"
+                class="emotion-79 emotion-80"
                 datetime="PT15M"
                 dir="ltr"
               >

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -390,7 +390,7 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -543,7 +543,7 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
 .emotion-27 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -675,7 +675,7 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -1935,7 +1935,7 @@ exports[`Media Asset Page should render component 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -2088,7 +2088,7 @@ exports[`Media Asset Page should render component 1`] = `
 .emotion-27 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2220,7 +2220,7 @@ exports[`Media Asset Page should render component 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -2251,7 +2251,7 @@ exports[`Media Asset Page should render component 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -3066,7 +3066,7 @@ exports[`Media Asset Page should render component 1`] = `
 .emotion-231 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -3090,50 +3090,11 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 .emotion-233 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-233 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-233 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-235 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-235 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-235 {
-    display: none;
-  }
-}
-
-.emotion-237 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-239 {
+.emotion-235 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3143,7 +3104,7 @@ exports[`Media Asset Page should render component 1`] = `
   flex-direction: column;
 }
 
-.emotion-241 {
+.emotion-237 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3163,7 +3124,7 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-241 {
+  .emotion-237 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3171,11 +3132,11 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-.emotion-243 {
+.emotion-239 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -3191,39 +3152,39 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-243 {
+  .emotion-239 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-243 {
+  .emotion-239 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-243 {
+  .emotion-239 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-243 {
+  .emotion-239 {
     padding-right: 1rem;
   }
 }
 
-.emotion-246 {
+.emotion-242 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-246 {
+  .emotion-242 {
     display: grid;
     position: initial;
     width: initial;
@@ -3231,7 +3192,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3239,7 +3200,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3247,7 +3208,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -3255,7 +3216,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -3263,7 +3224,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -3271,7 +3232,7 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-246 {
+    .emotion-242 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -3279,134 +3240,134 @@ exports[`Media Asset Page should render component 1`] = `
   }
 }
 
-.emotion-249 {
+.emotion-245 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-249 {
+  .emotion-245 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-249:last-child {
+.emotion-245:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-249 {
+  .emotion-245 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-249 {
+  .emotion-245 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-249:first-child {
+.emotion-245:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-249:first-child {
+  .emotion-245:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-249:last-child {
+.emotion-245:last-child {
   padding-bottom: 0;
 }
 
 @media (min-width: 63rem) {
-  .emotion-249 {
+  .emotion-245 {
     border-bottom: 0.0625rem solid #F2F2F2;
     padding: 1rem 0 1rem;
   }
 }
 
 @supports (display: grid) {
-  .emotion-249 {
+  .emotion-245 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-249 {
+    .emotion-245 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
     }
   }
 }
 
-.emotion-252 {
+.emotion-248 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-252 {
+  .emotion-248 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-252 {
+    .emotion-248 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-252 {
+    .emotion-248 {
       display: block;
     }
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-252 {
+  .emotion-248 {
     display: grid;
   }
 }
 
-.emotion-254 {
+.emotion-250 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -3414,43 +3375,43 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 63rem) {
-  .emotion-254 {
+  .emotion-250 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-254 {
+  .emotion-250 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-256 {
+.emotion-252 {
   position: relative;
 }
 
 @media (min-width: 25rem) {
-  .emotion-260 {
+  .emotion-256 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-260>* {
+.emotion-256>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-260>* {
+  .emotion-256>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-262 {
+.emotion-258 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -3458,13 +3419,13 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-262 {
+  .emotion-258 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-262 {
+  .emotion-258 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -3472,7 +3433,7 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-262 {
+  .emotion-258 {
     display: block;
     width: initial;
     padding: initial;
@@ -3480,13 +3441,13 @@ exports[`Media Asset Page should render component 1`] = `
   }
 
   @media (min-width: 63rem) {
-    .emotion-262 {
+    .emotion-258 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-264 {
+.emotion-260 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -3498,20 +3459,20 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-264 {
+  .emotion-260 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-264 {
+  .emotion-260 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-266 {
+.emotion-262 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -3520,7 +3481,7 @@ exports[`Media Asset Page should render component 1`] = `
   overflow-wrap: anywhere;
 }
 
-.emotion-266:before {
+.emotion-262:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -3532,20 +3493,20 @@ exports[`Media Asset Page should render component 1`] = `
   z-index: 1;
 }
 
-.emotion-266:hover,
-.emotion-266:focus {
+.emotion-262:hover,
+.emotion-262:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-266:visited {
+.emotion-262:visited {
   color: #6E6E73;
 }
 
-.emotion-268 {
+.emotion-264 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -3553,20 +3514,20 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-268 {
+  .emotion-264 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-268 {
+  .emotion-264 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-306 {
+.emotion-302 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -3578,20 +3539,20 @@ exports[`Media Asset Page should render component 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-306 {
+  .emotion-302 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-306 {
+  .emotion-302 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
-.emotion-308 {
+.emotion-304 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3603,7 +3564,7 @@ exports[`Media Asset Page should render component 1`] = `
   height: 100%;
 }
 
-.emotion-310 {
+.emotion-306 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -3612,7 +3573,7 @@ exports[`Media Asset Page should render component 1`] = `
   height: 0.8125rem;
 }
 
-.emotion-340 {
+.emotion-336 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -3621,11 +3582,11 @@ exports[`Media Asset Page should render component 1`] = `
   height: 0.75rem;
 }
 
-.emotion-342 {
+.emotion-338 {
   padding: 0 0.25rem;
 }
 
-.emotion-356 {
+.emotion-352 {
   padding-bottom: 2rem;
 }
 
@@ -4302,23 +4263,17 @@ exports[`Media Asset Page should render component 1`] = `
                 <div
                   class="emotion-230 emotion-231 emotion-232"
                 >
-                  <div
-                    class="emotion-233 emotion-234"
-                  />
-                  <div
-                    class="emotion-235 emotion-236"
-                  />
                   <h2
-                    class="emotion-237 emotion-238"
+                    class="emotion-233 emotion-234"
                   >
                     <span
-                      class="emotion-239 emotion-240"
+                      class="emotion-235 emotion-236"
                     >
                       <span
-                        class="emotion-241 emotion-242"
+                        class="emotion-237 emotion-238"
                       >
                         <span
-                          class="emotion-243 emotion-244"
+                          class="emotion-239 emotion-240"
                           dir="ltr"
                           id="related-content-heading"
                         >
@@ -4329,25 +4284,25 @@ exports[`Media Asset Page should render component 1`] = `
                   </h2>
                 </div>
                 <ol
-                  class="emotion-3 emotion-246 emotion-247"
+                  class="emotion-3 emotion-242 emotion-243"
                   data-e2e="most-watched-ol"
                   dir="ltr"
                   role="list"
                 >
                   <li
-                    class="emotion-3 emotion-249 emotion-250"
+                    class="emotion-3 emotion-245 emotion-246"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-251 emotion-252 emotion-253"
+                      class="emotion-247 emotion-248 emotion-249"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-254 emotion-255"
+                        class="emotion-250 emotion-251"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-256 emotion-257"
+                          class="emotion-252 emotion-253"
                         >
                           <div
                             class="emotion-17 emotion-18"
@@ -4363,20 +4318,20 @@ exports[`Media Asset Page should render component 1`] = `
                             </div>
                           </div>
                           <div
-                            class="emotion-260 emotion-261"
+                            class="emotion-256 emotion-257"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-262 emotion-263"
+                        class="emotion-258 emotion-259"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-264 emotion-265"
+                          class="emotion-260 emotion-261"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidgintori23145776-1"
-                            class="emotion-266 emotion-267"
+                            class="emotion-262 emotion-263"
                             href="/pidgin/tori-23145776"
                           >
                             <span
@@ -4387,7 +4342,7 @@ exports[`Media Asset Page should render component 1`] = `
                           </a>
                         </h3>
                         <time
-                          class="emotion-268 emotion-28"
+                          class="emotion-264 emotion-28"
                           datetime="2017-08-08"
                         >
                           8th August 2017
@@ -4396,19 +4351,19 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-249 emotion-250"
+                    class="emotion-3 emotion-245 emotion-246"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-251 emotion-252 emotion-253"
+                      class="emotion-247 emotion-248 emotion-249"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-254 emotion-255"
+                        class="emotion-250 emotion-251"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-256 emotion-257"
+                          class="emotion-252 emotion-253"
                         >
                           <div
                             class="emotion-17 emotion-18"
@@ -4424,20 +4379,20 @@ exports[`Media Asset Page should render component 1`] = `
                             </div>
                           </div>
                           <div
-                            class="emotion-260 emotion-261"
+                            class="emotion-256 emotion-257"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-262 emotion-263"
+                        class="emotion-258 emotion-259"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-264 emotion-265"
+                          class="emotion-260 emotion-261"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidgintori23143754-2"
-                            class="emotion-266 emotion-267"
+                            class="emotion-262 emotion-263"
                             href="/pidgin/tori-23143754"
                           >
                             <span
@@ -4448,7 +4403,7 @@ exports[`Media Asset Page should render component 1`] = `
                           </a>
                         </h3>
                         <time
-                          class="emotion-268 emotion-28"
+                          class="emotion-264 emotion-28"
                           datetime="2017-08-08"
                         >
                           8th August 2017
@@ -4457,19 +4412,19 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-249 emotion-250"
+                    class="emotion-3 emotion-245 emotion-246"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-251 emotion-252 emotion-253"
+                      class="emotion-247 emotion-248 emotion-249"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-254 emotion-255"
+                        class="emotion-250 emotion-251"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-256 emotion-257"
+                          class="emotion-252 emotion-253"
                         >
                           <div
                             class="emotion-17 emotion-18"
@@ -4477,20 +4432,20 @@ exports[`Media Asset Page should render component 1`] = `
                             style="padding-bottom: 56.25%;"
                           />
                           <div
-                            class="emotion-260 emotion-261"
+                            class="emotion-256 emotion-257"
                           >
                             <div
                               aria-hidden="true"
-                              class="emotion-306 emotion-307"
+                              class="emotion-302 emotion-303"
                               data-e2e="media-indicator"
                               dir="ltr"
                             >
                               <div
-                                class="emotion-308 emotion-309"
+                                class="emotion-304 emotion-305"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="emotion-310 emotion-311"
+                                  class="emotion-306 emotion-307"
                                   focusable="false"
                                   height="13px"
                                   viewBox="0 0 32 26"
@@ -4511,15 +4466,15 @@ exports[`Media Asset Page should render component 1`] = `
                         </div>
                       </div>
                       <div
-                        class="emotion-262 emotion-263"
+                        class="emotion-258 emotion-259"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-264 emotion-265"
+                          class="emotion-260 emotion-261"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidgin23146654-3"
-                            class="emotion-266 emotion-267"
+                            class="emotion-262 emotion-263"
                             href="/pidgin/23146654"
                           >
                             <span
@@ -4538,7 +4493,7 @@ exports[`Media Asset Page should render component 1`] = `
                           </a>
                         </h3>
                         <time
-                          class="emotion-268 emotion-28"
+                          class="emotion-264 emotion-28"
                           datetime="2017-08-08"
                         >
                           8th August 2017
@@ -4547,19 +4502,19 @@ exports[`Media Asset Page should render component 1`] = `
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-249 emotion-250"
+                    class="emotion-3 emotion-245 emotion-246"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-251 emotion-252 emotion-253"
+                      class="emotion-247 emotion-248 emotion-249"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-254 emotion-255"
+                        class="emotion-250 emotion-251"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-256 emotion-257"
+                          class="emotion-252 emotion-253"
                         >
                           <div
                             class="emotion-17 emotion-18"
@@ -4575,20 +4530,20 @@ exports[`Media Asset Page should render component 1`] = `
                             </div>
                           </div>
                           <div
-                            class="emotion-260 emotion-261"
+                            class="emotion-256 emotion-257"
                           >
                             <div
                               aria-hidden="true"
-                              class="emotion-306 emotion-307"
+                              class="emotion-302 emotion-303"
                               data-e2e="media-indicator"
                               dir="ltr"
                             >
                               <div
-                                class="emotion-308 emotion-309"
+                                class="emotion-304 emotion-305"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="emotion-340 emotion-341"
+                                  class="emotion-336 emotion-337"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 13 12"
@@ -4602,7 +4557,7 @@ exports[`Media Asset Page should render component 1`] = `
                                   />
                                 </svg>
                                 <time
-                                  class="emotion-342 emotion-343"
+                                  class="emotion-338 emotion-339"
                                   datetime="PT15S"
                                 >
                                   0:15
@@ -4613,15 +4568,15 @@ exports[`Media Asset Page should render component 1`] = `
                         </div>
                       </div>
                       <div
-                        class="emotion-262 emotion-263"
+                        class="emotion-258 emotion-259"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-264 emotion-265"
+                          class="emotion-260 emotion-261"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidginmedia23147054-4"
-                            class="emotion-266 emotion-267"
+                            class="emotion-262 emotion-263"
                             href="/pidgin/media-23147054"
                           >
                             <span
@@ -4645,7 +4600,7 @@ exports[`Media Asset Page should render component 1`] = `
                           </a>
                         </h3>
                         <time
-                          class="emotion-268 emotion-28"
+                          class="emotion-264 emotion-28"
                           datetime="2017-08-17"
                         >
                           17th August 2017
@@ -4657,7 +4612,7 @@ exports[`Media Asset Page should render component 1`] = `
               </div>
             </section>
             <div
-              class="emotion-356 emotion-357"
+              class="emotion-352 emotion-353"
             />
           </div>
         </div>

--- a/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostReadPage/__snapshots__/index.test.jsx.snap
@@ -534,7 +534,7 @@ exports[`Most Read Page Main should match snapshot for most read page 1`] = `
 .emotion-29 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MostWatchedPage/__snapshots__/index.test.jsx.snap
@@ -701,7 +701,7 @@ exports[`Most Watched Page Main should match snapshot for the Most Watched page 
 .emotion-44 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
@@ -383,7 +383,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -517,7 +517,7 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-bottom: 16px;
@@ -1313,7 +1313,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1447,7 +1447,7 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
   font-family: "BBC Reith Qalam",Arial,Verdana,Geneva,Helvetica,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-bottom: 16px;
@@ -2239,7 +2239,7 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   font-family: "Apple SD Gothic Neo",AppleGothic,"Malgun Gothic",Dotum,"Noto Sans CJK KR",sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -2373,7 +2373,7 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
   font-family: "Apple SD Gothic Neo",AppleGothic,"Malgun Gothic",Dotum,"Noto Sans CJK KR",sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-bottom: 16px;
@@ -3107,7 +3107,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   font-family: "Apple SD Gothic Neo",AppleGothic,"Malgun Gothic",Dotum,"Noto Sans CJK KR",sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -3241,7 +3241,7 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
   font-family: "Apple SD Gothic Neo",AppleGothic,"Malgun Gothic",Dotum,"Noto Sans CJK KR",sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
   padding-bottom: 16px;

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -190,7 +190,7 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -327,7 +327,7 @@ exports[`Photo Gallery Page should not show the pop-out timestamp when allowDate
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -2113,7 +2113,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -2259,7 +2259,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -2391,7 +2391,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with about t
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -4189,7 +4189,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -4335,7 +4335,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4467,7 +4467,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -5146,7 +5146,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 .emotion-205 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -5170,50 +5170,11 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 .emotion-207 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-207 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-207 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-209 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-209 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-209 {
-    display: none;
-  }
-}
-
-.emotion-211 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-213 {
+.emotion-209 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5223,7 +5184,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   flex-direction: column;
 }
 
-.emotion-215 {
+.emotion-211 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5243,7 +5204,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-215 {
+  .emotion-211 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -5251,11 +5212,11 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 }
 
-.emotion-217 {
+.emotion-213 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -5271,39 +5232,39 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-217 {
+  .emotion-213 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-217 {
+  .emotion-213 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-217 {
+  .emotion-213 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-217 {
+  .emotion-213 {
     padding-right: 1rem;
   }
 }
 
-.emotion-220 {
+.emotion-216 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-220 {
+  .emotion-216 {
     display: grid;
     position: initial;
     width: initial;
@@ -5311,7 +5272,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5319,7 +5280,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5327,7 +5288,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5335,7 +5296,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -5343,7 +5304,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -5351,7 +5312,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 80rem) {
-    .emotion-220 {
+    .emotion-216 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -5359,121 +5320,121 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 }
 
-.emotion-223 {
+.emotion-219 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-223 {
+  .emotion-219 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-223:last-child {
+.emotion-219:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-223 {
+  .emotion-219 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-223 {
+  .emotion-219 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-223:first-child {
+.emotion-219:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-223:first-child {
+  .emotion-219:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-223:last-child {
+.emotion-219:last-child {
   padding-bottom: 0;
 }
 
 @supports (display: grid) {
-  .emotion-223 {
+  .emotion-219 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-223 {
+    .emotion-219 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-225 {
+.emotion-221 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-225 {
+  .emotion-221 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-225 {
+    .emotion-221 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-225 {
+    .emotion-221 {
       display: block;
     }
   }
 }
 
-.emotion-227 {
+.emotion-223 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -5481,43 +5442,43 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 63rem) {
-  .emotion-227 {
+  .emotion-223 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-227 {
+  .emotion-223 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-229 {
+.emotion-225 {
   position: relative;
 }
 
 @media (min-width: 25rem) {
-  .emotion-233 {
+  .emotion-229 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-233>* {
+.emotion-229>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-233>* {
+  .emotion-229>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-235 {
+.emotion-231 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -5525,13 +5486,13 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-235 {
+  .emotion-231 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-235 {
+  .emotion-231 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -5539,7 +5500,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-235 {
+  .emotion-231 {
     display: block;
     width: initial;
     padding: initial;
@@ -5547,13 +5508,13 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   }
 
   @media (min-width: 63rem) {
-    .emotion-235 {
+    .emotion-231 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-237 {
+.emotion-233 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -5565,20 +5526,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-237 {
+  .emotion-233 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-237 {
+  .emotion-233 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-239 {
+.emotion-235 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -5587,7 +5548,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   overflow-wrap: anywhere;
 }
 
-.emotion-239:before {
+.emotion-235:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -5599,20 +5560,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   z-index: 1;
 }
 
-.emotion-239:hover,
-.emotion-239:focus {
+.emotion-235:hover,
+.emotion-235:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-239:visited {
+.emotion-235:visited {
   color: #6E6E73;
 }
 
-.emotion-241 {
+.emotion-237 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5620,20 +5581,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-241 {
+  .emotion-237 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-241 {
+  .emotion-237 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-256 {
+.emotion-252 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -5645,20 +5606,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-256 {
+  .emotion-252 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-256 {
+  .emotion-252 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
-.emotion-258 {
+.emotion-254 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5670,7 +5631,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
   height: 100%;
 }
 
-.emotion-260 {
+.emotion-256 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -6330,23 +6291,17 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                 <div
                   class="emotion-204 emotion-205 emotion-206"
                 >
-                  <div
-                    class="emotion-207 emotion-208"
-                  />
-                  <div
-                    class="emotion-209 emotion-210"
-                  />
                   <h2
-                    class="emotion-211 emotion-212"
+                    class="emotion-207 emotion-208"
                   >
                     <span
-                      class="emotion-213 emotion-214"
+                      class="emotion-209 emotion-210"
                     >
                       <span
-                        class="emotion-215 emotion-216"
+                        class="emotion-211 emotion-212"
                       >
                         <span
-                          class="emotion-217 emotion-218"
+                          class="emotion-213 emotion-214"
                           dir="ltr"
                           id="related-content-heading"
                         >
@@ -6357,24 +6312,24 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                   </h2>
                 </div>
                 <ul
-                  class="emotion-3 emotion-220 emotion-221"
+                  class="emotion-3 emotion-216 emotion-217"
                   dir="ltr"
                   role="list"
                 >
                   <li
-                    class="emotion-3 emotion-223 emotion-224"
+                    class="emotion-3 emotion-219 emotion-220"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-225 emotion-226"
+                      class="emotion-221 emotion-222"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-227 emotion-228"
+                        class="emotion-223 emotion-224"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-229 emotion-230"
+                          class="emotion-225 emotion-226"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -6390,20 +6345,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-233 emotion-234"
+                            class="emotion-229 emotion-230"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-235 emotion-236"
+                        class="emotion-231 emotion-232"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-237 emotion-238"
+                          class="emotion-233 emotion-234"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidginmedia45132087-1"
-                            class="emotion-239 emotion-240"
+                            class="emotion-235 emotion-236"
                             href="/pidgin/media-45132087"
                           >
                             <span
@@ -6417,7 +6372,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-241 emotion-12"
+                          class="emotion-237 emotion-12"
                           datetime="2018-08-09"
                         >
                           9th August 2018
@@ -6426,19 +6381,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-223 emotion-224"
+                    class="emotion-3 emotion-219 emotion-220"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-225 emotion-226"
+                      class="emotion-221 emotion-222"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-227 emotion-228"
+                        class="emotion-223 emotion-224"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-229 emotion-230"
+                          class="emotion-225 emotion-226"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -6446,20 +6401,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                             style="padding-bottom: 56.25%;"
                           />
                           <div
-                            class="emotion-233 emotion-234"
+                            class="emotion-229 emotion-230"
                           >
                             <div
                               aria-hidden="true"
-                              class="emotion-256 emotion-257"
+                              class="emotion-252 emotion-253"
                               data-e2e="media-indicator"
                               dir="ltr"
                             >
                               <div
-                                class="emotion-258 emotion-259"
+                                class="emotion-254 emotion-255"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="emotion-260 emotion-261"
+                                  class="emotion-256 emotion-257"
                                   focusable="false"
                                   height="13px"
                                   viewBox="0 0 32 26"
@@ -6480,15 +6435,15 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                         </div>
                       </div>
                       <div
-                        class="emotion-235 emotion-236"
+                        class="emotion-231 emotion-232"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-237 emotion-238"
+                          class="emotion-233 emotion-234"
                         >
                           <a
                             aria-labelledby="promo-rel-content-pidgintori45242255-2"
-                            class="emotion-239 emotion-240"
+                            class="emotion-235 emotion-236"
                             href="/pidgin/tori-45242255"
                           >
                             <span
@@ -6507,7 +6462,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with all CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-241 emotion-12"
+                          class="emotion-237 emotion-12"
                           datetime="2018-08-19"
                         >
                           19th August 2018
@@ -6715,7 +6670,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -6861,7 +6816,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -6993,7 +6948,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -8219,7 +8174,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -8365,7 +8320,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 .emotion-11 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -8497,7 +8452,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -9473,7 +9428,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 .emotion-419 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -9497,50 +9452,11 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 .emotion-421 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-421 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-421 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.5rem;
-  }
-}
-
-.emotion-423 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-423 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-423 {
-    display: none;
-  }
-}
-
-.emotion-425 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-427 {
+.emotion-423 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9550,7 +9466,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   flex-direction: column;
 }
 
-.emotion-429 {
+.emotion-425 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9570,7 +9486,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-429 {
+  .emotion-425 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -9578,11 +9494,11 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 }
 
-.emotion-431 {
+.emotion-427 {
   font-size: 1.125rem;
   line-height: 1.5rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -9598,39 +9514,39 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-431 {
+  .emotion-427 {
     font-size: 1.25rem;
     line-height: 1.625rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-431 {
+  .emotion-427 {
     font-size: 1.5rem;
     line-height: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-431 {
+  .emotion-427 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-431 {
+  .emotion-427 {
     padding-right: 1rem;
   }
 }
 
-.emotion-434 {
+.emotion-430 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @supports (display: grid) {
-  .emotion-434 {
+  .emotion-430 {
     display: grid;
     position: initial;
     width: initial;
@@ -9638,7 +9554,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9646,7 +9562,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9654,7 +9570,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9662,7 +9578,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 1rem;
@@ -9670,7 +9586,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -9678,7 +9594,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 80rem) {
-    .emotion-434 {
+    .emotion-430 {
       grid-template-columns: repeat(8, 1fr);
       grid-column-end: span 8;
       grid-column-gap: 1rem;
@@ -9686,121 +9602,121 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 }
 
-.emotion-437 {
+.emotion-433 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-437 {
+  .emotion-433 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-437:last-child {
+.emotion-433:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-437 {
+  .emotion-433 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-437 {
+  .emotion-433 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-437:first-child {
+.emotion-433:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-437:first-child {
+  .emotion-433:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-437:last-child {
+.emotion-433:last-child {
   padding-bottom: 0;
 }
 
 @supports (display: grid) {
-  .emotion-437 {
+  .emotion-433 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-437 {
+    .emotion-433 {
       grid-template-columns: repeat(4, 1fr);
       grid-column-end: span 4;
     }
   }
 }
 
-.emotion-439 {
+.emotion-435 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-439 {
+  .emotion-435 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-439 {
+    .emotion-435 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-439 {
+    .emotion-435 {
       display: block;
     }
   }
 }
 
-.emotion-441 {
+.emotion-437 {
   display: inline-block;
   vertical-align: top;
   position: relative;
@@ -9808,43 +9724,43 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 63rem) {
-  .emotion-441 {
+  .emotion-437 {
     display: block;
     width: 100%;
   }
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-441 {
+  .emotion-437 {
     width: initial;
     grid-column: 1/span 2;
   }
 }
 
-.emotion-443 {
+.emotion-439 {
   position: relative;
 }
 
 @media (min-width: 25rem) {
-  .emotion-447 {
+  .emotion-443 {
     position: absolute;
     bottom: 0;
   }
 }
 
-.emotion-447>* {
+.emotion-443>* {
   height: 2rem;
   padding: 0.5rem 0.25rem;
 }
 
 @media (max-width: 24.9375rem) {
-  .emotion-447>* {
+  .emotion-443>* {
     height: 1.25rem;
     padding: 0.25rem 0.25rem 0;
   }
 }
 
-.emotion-449 {
+.emotion-445 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -9852,13 +9768,13 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-449 {
+  .emotion-445 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-449 {
+  .emotion-445 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
@@ -9866,7 +9782,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-449 {
+  .emotion-445 {
     display: block;
     width: initial;
     padding: initial;
@@ -9874,13 +9790,13 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   }
 
   @media (min-width: 63rem) {
-    .emotion-449 {
+    .emotion-445 {
       padding-top: 0.5rem;
     }
   }
 }
 
-.emotion-451 {
+.emotion-447 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -9892,20 +9808,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-451 {
+  .emotion-447 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-451 {
+  .emotion-447 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-453 {
+.emotion-449 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -9914,7 +9830,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   overflow-wrap: anywhere;
 }
 
-.emotion-453:before {
+.emotion-449:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -9926,20 +9842,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
   z-index: 1;
 }
 
-.emotion-453:hover,
-.emotion-453:focus {
+.emotion-449:hover,
+.emotion-449:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-453:visited {
+.emotion-449:visited {
   color: #6E6E73;
 }
 
-.emotion-455 {
+.emotion-451 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -9947,14 +9863,14 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-455 {
+  .emotion-451 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-455 {
+  .emotion-451 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -11304,23 +11220,17 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                 <div
                   class="emotion-418 emotion-419 emotion-420"
                 >
-                  <div
-                    class="emotion-421 emotion-422"
-                  />
-                  <div
-                    class="emotion-423 emotion-424"
-                  />
                   <h2
-                    class="emotion-425 emotion-426"
+                    class="emotion-421 emotion-422"
                   >
                     <span
-                      class="emotion-427 emotion-428"
+                      class="emotion-423 emotion-424"
                     >
                       <span
-                        class="emotion-429 emotion-430"
+                        class="emotion-425 emotion-426"
                       >
                         <span
-                          class="emotion-431 emotion-432"
+                          class="emotion-427 emotion-428"
                           dir="ltr"
                           id="related-content-heading"
                         >
@@ -11331,24 +11241,24 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                   </h2>
                 </div>
                 <ul
-                  class="emotion-3 emotion-434 emotion-435"
+                  class="emotion-3 emotion-430 emotion-431"
                   dir="ltr"
                   role="list"
                 >
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11364,20 +11274,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan44124647-1"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-44124647"
                           >
                             <span
@@ -11388,7 +11298,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-05-17"
                         >
                           17 May 2018
@@ -11397,19 +11307,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11425,20 +11335,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan43540056-2"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-43540056"
                           >
                             <span
@@ -11449,7 +11359,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-03-27"
                         >
                           27 Mart 2018
@@ -11458,19 +11368,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11486,20 +11396,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan44022776-3"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-44022776"
                           >
                             <span
@@ -11510,7 +11420,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-05-10"
                         >
                           10 May 2018
@@ -11519,19 +11429,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11547,20 +11457,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan43713137-4"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-43713137"
                           >
                             <span
@@ -11571,7 +11481,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-04-10"
                         >
                           10 Aprel 2018
@@ -11580,19 +11490,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11608,20 +11518,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan37688691-5"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-37688691"
                           >
                             <span
@@ -11632,7 +11542,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2016-10-18"
                         >
                           18 Oktyabr 2016
@@ -11641,19 +11551,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11669,20 +11579,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan37691096-6"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-37691096"
                           >
                             <span
@@ -11696,7 +11606,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2016-10-18"
                         >
                           18 Oktyabr 2016
@@ -11705,19 +11615,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11733,20 +11643,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan43499221-7"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-43499221"
                           >
                             <span
@@ -11757,7 +11667,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-03-22"
                         >
                           22 Mart 2018
@@ -11766,19 +11676,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11794,20 +11704,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan44004471-8"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-44004471"
                           >
                             <span
@@ -11818,7 +11728,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-05-04"
                         >
                           4 May 2018
@@ -11827,19 +11737,19 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </div>
                   </li>
                   <li
-                    class="emotion-3 emotion-437 emotion-438"
+                    class="emotion-3 emotion-433 emotion-434"
                     dir="ltr"
                   >
                     <div
-                      class="emotion-439 emotion-440"
+                      class="emotion-435 emotion-436"
                       data-e2e="story-promo"
                     >
                       <div
-                        class="emotion-441 emotion-442"
+                        class="emotion-437 emotion-438"
                         dir="ltr"
                       >
                         <div
-                          class="emotion-443 emotion-444"
+                          class="emotion-439 emotion-440"
                         >
                           <div
                             class="emotion-25 emotion-26"
@@ -11855,20 +11765,20 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                             </div>
                           </div>
                           <div
-                            class="emotion-447 emotion-448"
+                            class="emotion-443 emotion-444"
                           />
                         </div>
                       </div>
                       <div
-                        class="emotion-449 emotion-450"
+                        class="emotion-445 emotion-446"
                         dir="ltr"
                       >
                         <h3
-                          class="emotion-451 emotion-452"
+                          class="emotion-447 emotion-448"
                         >
                           <a
                             aria-labelledby="promo-rel-content-azeriazerbaijan43870815-9"
-                            class="emotion-453 emotion-454"
+                            class="emotion-449 emotion-450"
                             href="/azeri/azerbaijan-43870815"
                           >
                             <span
@@ -11879,7 +11789,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                           </a>
                         </h3>
                         <time
-                          class="emotion-455 emotion-12"
+                          class="emotion-451 emotion-12"
                           datetime="2018-04-29"
                         >
                           29 Aprel 2018

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -331,7 +331,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -1092,7 +1092,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -1438,7 +1438,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -1593,7 +1593,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 .emotion-191 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -1617,50 +1617,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 .emotion-193 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-193 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-193 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-195 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-195 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-195 {
-    display: none;
-  }
-}
-
-.emotion-197 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-199 {
+.emotion-195 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1670,7 +1631,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   flex-direction: column;
 }
 
-.emotion-201 {
+.emotion-197 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1690,7 +1651,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-201 {
+  .emotion-197 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -1698,11 +1659,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
-.emotion-203 {
+.emotion-199 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -1718,102 +1679,102 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-203 {
+  .emotion-199 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-203 {
+  .emotion-199 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-203 {
+  .emotion-199 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-203 {
+  .emotion-199 {
     padding-right: 1rem;
   }
 }
 
-.emotion-205 {
+.emotion-201 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.emotion-207 {
+.emotion-203 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-207 {
+  .emotion-203 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-207:last-child {
+.emotion-203:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-207 {
+  .emotion-203 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-207 {
+  .emotion-203 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-207:first-child {
+.emotion-203:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-207:first-child {
+  .emotion-203:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-207:last-child {
+.emotion-203:last-child {
   padding-bottom: 0;
 }
 
-.emotion-209 {
+.emotion-205 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-209 {
+  .emotion-205 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-209 {
+    .emotion-205 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-209 {
+    .emotion-205 {
       display: block;
     }
   }
 }
 
-.emotion-211 {
+.emotion-207 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -1822,25 +1783,25 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-211 {
+  .emotion-207 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-211 {
+  .emotion-207 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
   }
 }
 
-.emotion-211>div {
+.emotion-207>div {
   vertical-align: middle;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-211 {
+  .emotion-207 {
     display: block;
     width: initial;
     padding: initial;
@@ -1849,22 +1810,22 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 63rem) {
-    .emotion-211 {
+    .emotion-207 {
       padding-top: 0;
     }
   }
 }
 
-.emotion-211>div {
+.emotion-207>div {
   display: inline-block;
   vertical-align: initial;
 }
 
-.emotion-211 svg {
+.emotion-207 svg {
   margin: 0;
 }
 
-.emotion-213 {
+.emotion-209 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -1877,20 +1838,20 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-213 {
+  .emotion-209 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-213 {
+  .emotion-209 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-215 {
+.emotion-211 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -1899,7 +1860,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   overflow-wrap: anywhere;
 }
 
-.emotion-215:before {
+.emotion-211:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -1911,20 +1872,20 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   z-index: 1;
 }
 
-.emotion-215:hover,
-.emotion-215:focus {
+.emotion-211:hover,
+.emotion-211:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-215:visited {
+.emotion-211:visited {
   color: #6E6E73;
 }
 
-.emotion-217 {
+.emotion-213 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -1932,20 +1893,20 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-217 {
+  .emotion-213 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-217 {
+  .emotion-213 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-229 {
+.emotion-225 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
@@ -1954,7 +1915,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   margin-right: 0.5rem;
 }
 
-.emotion-237 {
+.emotion-233 {
   color: #222222;
   background-color: #FFFFFF;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -1968,20 +1929,20 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-237 {
+  .emotion-233 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-237 {
+  .emotion-233 {
     font-size: 0.75rem;
     line-height: 1rem;
   }
 }
 
-.emotion-239 {
+.emotion-235 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1993,7 +1954,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   height: 100%;
 }
 
-.emotion-241 {
+.emotion-237 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -2002,14 +1963,14 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   height: 0.75rem;
 }
 
-.emotion-270 {
+.emotion-262 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-270 {
+  .emotion-262 {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     -webkit-column-gap: 1rem;
@@ -2018,92 +1979,92 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
-.emotion-272 {
+.emotion-264 {
   padding: 0.5rem 0 1rem;
   line-height: 0;
   height: 100%;
 }
 
-.emotion-272:last-child {
+.emotion-264:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-272 {
+  .emotion-264 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-272 {
+  .emotion-264 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-272:first-child {
+.emotion-264:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-272:first-child {
+  .emotion-264:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-272:last-child {
+.emotion-264:last-child {
   padding-bottom: 0;
 }
 
-.emotion-272:first-child {
+.emotion-264:first-child {
   padding: 0 0 0.5rem 0;
 }
 
-.emotion-272:not(:first-child):not(:last-child) {
+.emotion-264:not(:first-child):not(:last-child) {
   padding: 0.5rem 0 0.5rem 0;
 }
 
-.emotion-272:last-child {
+.emotion-264:last-child {
   padding: 0.5rem 0 0 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-272 {
+  .emotion-264 {
     padding: 0;
   }
 
-  .emotion-272:first-child,
-  .emotion-272:not(:first-child):not(:last-child),
-  .emotion-272:last-child {
+  .emotion-264:first-child,
+  .emotion-264:not(:first-child):not(:last-child),
+  .emotion-264:last-child {
     padding: 0;
   }
 }
 
-.emotion-290 {
+.emotion-282 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
 
-.emotion-293 {
+.emotion-285 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-293 {
+  .emotion-285 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-293 {
+  .emotion-285 {
     margin-bottom: 1.5rem;
   }
 }
 
-.emotion-308 {
+.emotion-296 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -2112,7 +2073,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @supports (display: grid) {
-  .emotion-308 {
+  .emotion-296 {
     display: grid;
     position: initial;
     width: initial;
@@ -2120,7 +2081,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -2128,7 +2089,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -2136,7 +2097,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -2144,7 +2105,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -2152,7 +2113,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -2160,7 +2121,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 
   @media (min-width: 80rem) {
-    .emotion-308 {
+    .emotion-296 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -2168,62 +2129,62 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   }
 }
 
-.emotion-311 {
+.emotion-299 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @supports (display: grid) {
-  .emotion-311 {
+  .emotion-299 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-311 {
+    .emotion-299 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 }
 
-.emotion-313 {
+.emotion-301 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2236,30 +2197,30 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-315 {
+  .emotion-303 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-315 {
+  .emotion-303 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-315 {
+  .emotion-303 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-315 {
+  .emotion-303 {
     min-width: 2.5rem;
   }
 }
 
-.emotion-317 {
+.emotion-305 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -2272,32 +2233,32 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-317 {
+  .emotion-305 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-317 {
+  .emotion-305 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
-.emotion-319 {
+.emotion-307 {
   padding-top: 0.2rem;
   padding-left: 0.5rem;
   padding-right: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-319 {
+  .emotion-307 {
     padding-right: 0;
   }
 }
 
-.emotion-321 {
+.emotion-309 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -2311,26 +2272,26 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-321 {
+  .emotion-309 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-321 {
+  .emotion-309 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-321:hover,
-.emotion-321:focus {
+.emotion-309:hover,
+.emotion-309:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-321:before {
+.emotion-309:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -2342,7 +2303,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
   z-index: 1;
 }
 
-.emotion-323 {
+.emotion-311 {
   padding-top: 0.5rem;
 }
 
@@ -2932,23 +2893,17 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                     <div
                       class="emotion-190 emotion-191 emotion-192"
                     >
-                      <div
-                        class="emotion-193 emotion-194"
-                      />
-                      <div
-                        class="emotion-195 emotion-196"
-                      />
                       <h2
-                        class="emotion-197 emotion-198"
+                        class="emotion-193 emotion-194"
                       >
                         <span
-                          class="emotion-199 emotion-200"
+                          class="emotion-195 emotion-196"
                         >
                           <span
-                            class="emotion-201 emotion-202"
+                            class="emotion-197 emotion-198"
                           >
                             <span
-                              class="emotion-203 emotion-204"
+                              class="emotion-199 emotion-200"
                               dir="ltr"
                               id="top-stories-heading"
                             >
@@ -2959,26 +2914,26 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                       </h2>
                     </div>
                     <ul
-                      class="emotion-205 emotion-206"
+                      class="emotion-201 emotion-202"
                       role="list"
                     >
                       <li
-                        class="emotion-207 emotion-208"
+                        class="emotion-203 emotion-204"
                       >
                         <div
-                          class="emotion-209 emotion-210"
+                          class="emotion-205 emotion-206"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-211 emotion-212"
+                            class="emotion-207 emotion-208"
                             dir="ltr"
                           >
                             <h3
-                              class="emotion-213 emotion-214"
+                              class="emotion-209 emotion-210"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-igbo23182501-1"
-                                class="emotion-215 emotion-216"
+                                class="emotion-211 emotion-212"
                                 href="/igbo/23182501"
                               >
                                 <span
@@ -2989,7 +2944,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="emotion-217 emotion-218"
+                              class="emotion-213 emotion-214"
                               datetime="2019-09-25"
                             >
                               25th September 2019
@@ -2998,22 +2953,22 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208"
+                        class="emotion-203 emotion-204"
                       >
                         <div
-                          class="emotion-209 emotion-210"
+                          class="emotion-205 emotion-206"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-211 emotion-212"
+                            class="emotion-207 emotion-208"
                             dir="ltr"
                           >
                             <h3
-                              class="emotion-213 emotion-214"
+                              class="emotion-209 emotion-210"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-igboliveinstitutional23162153-1"
-                                class="emotion-215 emotion-216"
+                                class="emotion-211 emotion-212"
                                 href="/igbo/live/institutional-23162153"
                               >
                                 <span
@@ -3021,7 +2976,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                                   role="text"
                                 >
                                   <span
-                                    class="emotion-229 emotion-230"
+                                    class="emotion-225 emotion-226"
                                     dir="ltr"
                                   >
                                     As E Dey Happen 
@@ -3036,28 +2991,28 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208"
+                        class="emotion-203 emotion-204"
                       >
                         <div
-                          class="emotion-209 emotion-210"
+                          class="emotion-205 emotion-206"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-211 emotion-212"
+                            class="emotion-207 emotion-208"
                             dir="ltr"
                           >
                             <div
                               aria-hidden="true"
-                              class="emotion-237 emotion-238"
+                              class="emotion-233 emotion-234"
                               data-e2e="media-indicator"
                               dir="ltr"
                             >
                               <div
-                                class="emotion-239 emotion-240"
+                                class="emotion-235 emotion-236"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="emotion-241 emotion-242"
+                                  class="emotion-237 emotion-238"
                                   focusable="false"
                                   height="12px"
                                   viewBox="0 0 13 12"
@@ -3073,11 +3028,11 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </div>
                             </div>
                             <h3
-                              class="emotion-213 emotion-214"
+                              class="emotion-209 emotion-210"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-igbo23183171-1"
-                                class="emotion-215 emotion-216"
+                                class="emotion-211 emotion-212"
                                 href="/igbo/23183171"
                               >
                                 <span
@@ -3096,7 +3051,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                               </a>
                             </h3>
                             <time
-                              class="emotion-217 emotion-218"
+                              class="emotion-213 emotion-214"
                               datetime="2018-01-22"
                             >
                               22nd January 2018
@@ -3119,23 +3074,17 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                     <div
                       class="emotion-190 emotion-191 emotion-192"
                     >
-                      <div
-                        class="emotion-193 emotion-194"
-                      />
-                      <div
-                        class="emotion-195 emotion-196"
-                      />
                       <h2
-                        class="emotion-197 emotion-198"
+                        class="emotion-193 emotion-194"
                       >
                         <span
-                          class="emotion-199 emotion-200"
+                          class="emotion-195 emotion-196"
                         >
                           <span
-                            class="emotion-201 emotion-202"
+                            class="emotion-197 emotion-198"
                           >
                             <span
-                              class="emotion-203 emotion-204"
+                              class="emotion-199 emotion-200"
                               dir="ltr"
                               id="features-analysis-heading"
                             >
@@ -3146,67 +3095,67 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                       </h2>
                     </div>
                     <ul
-                      class="emotion-270 emotion-271"
+                      class="emotion-262 emotion-263"
                       role="list"
                     >
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-272 emotion-273"
+                        class="emotion-264 emotion-265"
                       >
                         <span
                           data-testid="frosted-promo-loader"
@@ -3216,7 +3165,7 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                   </section>
                 </div>
                 <div
-                  class="emotion-290 emotion-291"
+                  class="emotion-282 emotion-283"
                 >
                   <section
                     aria-labelledby="Most-Read"
@@ -3224,25 +3173,19 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                     role="region"
                   >
                     <div
-                      class="emotion-292 emotion-293 emotion-192"
+                      class="emotion-284 emotion-285 emotion-192"
                     >
-                      <div
-                        class="emotion-193 emotion-194"
-                      />
-                      <div
-                        class="emotion-195 emotion-196"
-                      />
                       <h2
-                        class="emotion-197 emotion-198"
+                        class="emotion-193 emotion-194"
                       >
                         <span
-                          class="emotion-199 emotion-200"
+                          class="emotion-195 emotion-196"
                         >
                           <span
-                            class="emotion-201 emotion-202"
+                            class="emotion-197 emotion-198"
                           >
                             <span
-                              class="emotion-203 emotion-204"
+                              class="emotion-199 emotion-200"
                               dir="ltr"
                               id="Most-Read"
                             >
@@ -3253,43 +3196,43 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                       </h2>
                     </div>
                     <ol
-                      class="emotion-307 emotion-308 emotion-2"
+                      class="emotion-295 emotion-296 emotion-2"
                       dir="ltr"
                       role="list"
                     >
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               1
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50299413"
                             >
                               Obi adịghị ndị Igbo mma n'ọnọdụ ha nọ na Naịjirịa - Ekweremadu
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -3299,38 +3242,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               2
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50295552"
                             >
                               Ihe gọọmentị Naịjirịa sị a ga-eme tupu ha agbapee 'border'
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -3340,38 +3283,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               3
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50227971"
                             >
                               Onye bụ 'Sarah Baartman' a e ji maka ya adọri Dice Ailes?
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-10-31"
                               >
                                 De one we dem update for: 31st October 2019
@@ -3381,38 +3324,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               4
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50299416"
                             >
                               Ụlọ na-agba ọkụ n'ahia Balogun, Legọs
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -3422,38 +3365,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               5
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50259685"
                             >
                               Gịnị bụ ikuchi nwaanyị n'ala Igbo?
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-03"
                               >
                                 De one we dem update for: 3rd November 2019
@@ -3463,38 +3406,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               6
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50294336"
                             >
                               Nne ụmụaka atọ ụlọ aja dagburu n'Ebonyi amabeghị na ha nwụrụ
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-04"
                               >
                                 De one we dem update for: 4th November 2019
@@ -3504,38 +3447,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               7
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50292027"
                             >
                               Akwamozu o kwesiri ịbụ oriri na nkwari?
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-04"
                               >
                                 De one we dem update for: 4th November 2019
@@ -3545,38 +3488,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               8
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50289214"
                             >
                               Gịnị ka ị ma maka 'Aba Women's riot' mere afọ 90 gara aga?
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-04"
                               >
                                 De one we dem update for: 4th November 2019
@@ -3586,38 +3529,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               9
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/mba-uba-50266111"
                             >
                               Eke adọgbuola nwaanyị ji ya eme ihe olu
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-03"
                               >
                                 De one we dem update for: 3rd November 2019
@@ -3627,38 +3570,38 @@ exports[`Story Page should not show the pop-out timestamp when allowDateStamp is
                         </div>
                       </li>
                       <li
-                        class="emotion-310 emotion-311 emotion-2"
+                        class="emotion-298 emotion-299 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-313 emotion-314"
+                          class="emotion-301 emotion-302"
                         >
                           <div
-                            class="emotion-315 emotion-316"
+                            class="emotion-303 emotion-304"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-317 emotion-318"
+                              class="emotion-305 emotion-306"
                             >
                               10
                             </span>
                           </div>
                           <div
-                            class="emotion-319 emotion-320"
+                            class="emotion-307 emotion-308"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-321 emotion-322"
+                              class="emotion-309 emotion-310"
                               href="/igbo/afirika-50279948"
                             >
                               Etu dị na nwunye zụtara ụmụaka abụọ si ma n'ọnya ndị uweojii
                             </a>
                             <div
-                              class="emotion-323 emotion-324"
+                              class="emotion-311 emotion-312"
                             >
                               <time
-                                class="emotion-217 emotion-218"
+                                class="emotion-213 emotion-214"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -4010,7 +3953,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -4314,7 +4257,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 .emotion-24 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -4912,7 +4855,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -5258,7 +5201,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -5395,7 +5338,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 .emotion-190 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -5413,50 +5356,11 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 .emotion-192 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-192 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-192 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-194 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-194 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-194 {
-    display: none;
-  }
-}
-
-.emotion-196 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-198 {
+.emotion-194 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5466,7 +5370,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   flex-direction: column;
 }
 
-.emotion-200 {
+.emotion-196 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5486,7 +5390,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-200 {
+  .emotion-196 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -5494,11 +5398,11 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 }
 
-.emotion-202 {
+.emotion-198 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -5514,32 +5418,32 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-202 {
+  .emotion-198 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-202 {
+  .emotion-198 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-202 {
+  .emotion-198 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-202 {
+  .emotion-198 {
     padding-right: 1rem;
   }
 }
 
-.emotion-205 {
+.emotion-201 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -5548,7 +5452,7 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @supports (display: grid) {
-  .emotion-205 {
+  .emotion-201 {
     display: grid;
     position: initial;
     width: initial;
@@ -5556,7 +5460,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5564,7 +5468,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5572,7 +5476,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -5580,7 +5484,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -5588,7 +5492,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -5596,7 +5500,7 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 
   @media (min-width: 80rem) {
-    .emotion-205 {
+    .emotion-201 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -5604,62 +5508,62 @@ exports[`Story Page should render correctly when the secondary column data is no
   }
 }
 
-.emotion-208 {
+.emotion-204 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @supports (display: grid) {
-  .emotion-208 {
+  .emotion-204 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-208 {
+    .emotion-204 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 }
 
-.emotion-210 {
+.emotion-206 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5672,30 +5576,30 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-212 {
+  .emotion-208 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-212 {
+  .emotion-208 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-212 {
+  .emotion-208 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-212 {
+  .emotion-208 {
     min-width: 2.5rem;
   }
 }
 
-.emotion-214 {
+.emotion-210 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -5708,32 +5612,32 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-214 {
+  .emotion-210 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-214 {
+  .emotion-210 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
-.emotion-216 {
+.emotion-212 {
   padding-top: 0.2rem;
   padding-left: 0.5rem;
   padding-right: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-216 {
+  .emotion-212 {
     padding-right: 0;
   }
 }
 
-.emotion-218 {
+.emotion-214 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -5747,26 +5651,26 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-218 {
+  .emotion-214 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-218 {
+  .emotion-214 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-218:hover,
-.emotion-218:focus {
+.emotion-214:hover,
+.emotion-214:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-218:before {
+.emotion-214:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -5778,14 +5682,14 @@ exports[`Story Page should render correctly when the secondary column data is no
   z-index: 1;
 }
 
-.emotion-220 {
+.emotion-216 {
   padding-top: 0.5rem;
 }
 
-.emotion-222 {
+.emotion-218 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -5793,14 +5697,14 @@ exports[`Story Page should render correctly when the secondary column data is no
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-222 {
+  .emotion-218 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-222 {
+  .emotion-218 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
@@ -6391,23 +6295,17 @@ exports[`Story Page should render correctly when the secondary column data is no
                     <div
                       class="emotion-189 emotion-190 emotion-191"
                     >
-                      <div
-                        class="emotion-192 emotion-193"
-                      />
-                      <div
-                        class="emotion-194 emotion-195"
-                      />
                       <h2
-                        class="emotion-196 emotion-197"
+                        class="emotion-192 emotion-193"
                       >
                         <span
-                          class="emotion-198 emotion-199"
+                          class="emotion-194 emotion-195"
                         >
                           <span
-                            class="emotion-200 emotion-201"
+                            class="emotion-196 emotion-197"
                           >
                             <span
-                              class="emotion-202 emotion-203"
+                              class="emotion-198 emotion-199"
                               dir="ltr"
                               id="Most-Read"
                             >
@@ -6418,43 +6316,43 @@ exports[`Story Page should render correctly when the secondary column data is no
                       </h2>
                     </div>
                     <ol
-                      class="emotion-204 emotion-205 emotion-2"
+                      class="emotion-200 emotion-201 emotion-2"
                       dir="ltr"
                       role="list"
                     >
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               1
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-46729879"
                             >
                               Public Holidays wey go happun for 2019
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-05-21"
                               >
                                 De one we dem update for: 21st May 2019
@@ -6464,38 +6362,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               2
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50304653"
                             >
                               Liberia banks don run out of money
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -6505,38 +6403,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               3
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50298882"
                             >
                               Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -6546,38 +6444,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               4
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50315150"
                             >
                               Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -6587,38 +6485,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               5
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50315157"
                             >
                               How Balogun market fire kill Policeman for Lagos
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -6628,38 +6526,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               6
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50093818"
                             >
                               Labour, FG finally agree minimum wage salary adjustment
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-10-18"
                               >
                                 De one we dem update for: 18th October 2019
@@ -6669,38 +6567,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               7
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-50187218"
                             >
                               Naira Marley na 'Bad Influence'?
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-10-25"
                               >
                                 De one we dem update for: 25th October 2019
@@ -6710,38 +6608,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               8
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-48347911"
                             >
                               Tins you suppose know about Naira Marley
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-05-23"
                               >
                                 De one we dem update for: 23rd May 2019
@@ -6751,38 +6649,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               9
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/sport-50312710"
                             >
                               Golden Eaglets crash out of Fifa U17 World Cup
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -6792,38 +6690,38 @@ exports[`Story Page should render correctly when the secondary column data is no
                         </div>
                       </li>
                       <li
-                        class="emotion-207 emotion-208 emotion-2"
+                        class="emotion-203 emotion-204 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               10
                             </span>
                           </div>
                           <div
-                            class="emotion-216 emotion-217"
+                            class="emotion-212 emotion-213"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-218 emotion-219"
+                              class="emotion-214 emotion-215"
                               href="/pidgin/tori-42945173"
                             >
                               Tiger nut drink fit wake up your sex drive - Nutritionist
                             </a>
                             <div
-                              class="emotion-220 emotion-221"
+                              class="emotion-216 emotion-217"
                             >
                               <time
-                                class="emotion-222 emotion-25"
+                                class="emotion-218 emotion-25"
                                 datetime="2019-05-21"
                               >
                                 De one we dem update for: 21st May 2019
@@ -7175,7 +7073,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   display: block;
   margin: 0;
   padding: 2rem 0;
@@ -7479,7 +7377,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 .emotion-24 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -8077,7 +7975,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   padding-bottom: 1.5rem;
   margin: 0;
 }
@@ -8423,7 +8321,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 700;
   font-style: normal;
-  color: #3F3F42;
+  color: #141414;
   margin: 0;
   padding: 1.5rem 0;
 }
@@ -8578,7 +8476,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 .emotion-192 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
@@ -8602,50 +8500,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 .emotion-194 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-  display: none;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-194 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-194 {
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 1.375rem;
-  }
-}
-
-.emotion-196 {
-  border-top: 0.0625rem solid #AEAEB5;
-  z-index: -1;
-}
-
-@media screen and (-ms-high-contrast: active) {
-  .emotion-196 {
-    border-color: windowText;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-196 {
-    display: none;
-  }
-}
-
-.emotion-198 {
   margin: 0;
   padding: 0;
 }
 
-.emotion-200 {
+.emotion-196 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8655,7 +8514,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   flex-direction: column;
 }
 
-.emotion-202 {
+.emotion-198 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8675,7 +8534,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-202 {
+  .emotion-198 {
     -webkit-align-items: stretch;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -8683,11 +8542,11 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-204 {
+.emotion-200 {
   font-size: 1.125rem;
   line-height: 1.375rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
-  font-weight: 400;
+  font-weight: 700;
   font-style: normal;
   background-color: #FDFDFD;
   margin: 1rem 0;
@@ -8703,102 +8562,102 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-204 {
+  .emotion-200 {
     font-size: 1.25rem;
     line-height: 1.5rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-204 {
+  .emotion-200 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-204 {
+  .emotion-200 {
     margin: 0;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-204 {
+  .emotion-200 {
     padding-right: 1rem;
   }
 }
 
-.emotion-206 {
+.emotion-202 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.emotion-208 {
+.emotion-204 {
   padding: 0.5rem 0 1rem;
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-208 {
+  .emotion-204 {
     border-bottom: 0.0625rem solid #F2F2F2;
   }
 }
 
-.emotion-208:last-child {
+.emotion-204:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-208 {
+  .emotion-204 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-208 {
+  .emotion-204 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-208:first-child {
+.emotion-204:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-208:first-child {
+  .emotion-204:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-208:last-child {
+.emotion-204:last-child {
   padding-bottom: 0;
 }
 
-.emotion-210 {
+.emotion-206 {
   position: relative;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-210 {
+  .emotion-206 {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 0.5rem;
   }
 
   @media (min-width: 37.5rem) {
-    .emotion-210 {
+    .emotion-206 {
       grid-column-gap: 1rem;
     }
   }
 
   @media (min-width: 63rem) {
-    .emotion-210 {
+    .emotion-206 {
       display: block;
     }
   }
 }
 
-.emotion-212 {
+.emotion-208 {
   display: inline-block;
   vertical-align: top;
   width: 66.67%;
@@ -8807,25 +8666,25 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-212 {
+  .emotion-208 {
     padding: 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-212 {
+  .emotion-208 {
     display: block;
     width: 100%;
     padding: 0.5rem 0;
   }
 }
 
-.emotion-212>div {
+.emotion-208>div {
   vertical-align: middle;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-212 {
+  .emotion-208 {
     display: block;
     width: initial;
     padding: initial;
@@ -8834,22 +8693,22 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 63rem) {
-    .emotion-212 {
+    .emotion-208 {
       padding-top: 0;
     }
   }
 }
 
-.emotion-212>div {
+.emotion-208>div {
   display: inline-block;
   vertical-align: initial;
 }
 
-.emotion-212 svg {
+.emotion-208 svg {
   margin: 0;
 }
 
-.emotion-214 {
+.emotion-210 {
   color: #222222;
   margin: 0;
   padding-bottom: 0.5rem;
@@ -8862,20 +8721,20 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-214 {
+  .emotion-210 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-214 {
+  .emotion-210 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-216 {
+.emotion-212 {
   position: static;
   color: #222222;
   -webkit-text-decoration: none;
@@ -8884,7 +8743,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   overflow-wrap: anywhere;
 }
 
-.emotion-216:before {
+.emotion-212:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -8896,20 +8755,20 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   z-index: 1;
 }
 
-.emotion-216:hover,
-.emotion-216:focus {
+.emotion-212:hover,
+.emotion-212:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-216:visited {
+.emotion-212:visited {
   color: #6E6E73;
 }
 
-.emotion-218 {
+.emotion-214 {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  color: #6E6E73;
+  color: #545658;
   display: block;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
@@ -8917,27 +8776,27 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-218 {
+  .emotion-214 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-218 {
+  .emotion-214 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-263 {
+.emotion-255 {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-263 {
+  .emotion-255 {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     -webkit-column-gap: 1rem;
@@ -8946,92 +8805,92 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-265 {
+.emotion-257 {
   padding: 0.5rem 0 1rem;
   line-height: 0;
   height: 100%;
 }
 
-.emotion-265:last-child {
+.emotion-257:last-child {
   border: none;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-265 {
+  .emotion-257 {
     padding: 1rem 0 1rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-265 {
+  .emotion-257 {
     padding: 0 0 1.5rem;
   }
 }
 
-.emotion-265:first-child {
+.emotion-257:first-child {
   padding-top: 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-265:first-child {
+  .emotion-257:first-child {
     padding-top: 1rem;
   }
 }
 
-.emotion-265:last-child {
+.emotion-257:last-child {
   padding-bottom: 0;
 }
 
-.emotion-265:first-child {
+.emotion-257:first-child {
   padding: 0 0 0.5rem 0;
 }
 
-.emotion-265:not(:first-child):not(:last-child) {
+.emotion-257:not(:first-child):not(:last-child) {
   padding: 0.5rem 0 0.5rem 0;
 }
 
-.emotion-265:last-child {
+.emotion-257:last-child {
   padding: 0.5rem 0 0 0;
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-265 {
+  .emotion-257 {
     padding: 0;
   }
 
-  .emotion-265:first-child,
-  .emotion-265:not(:first-child):not(:last-child),
-  .emotion-265:last-child {
+  .emotion-257:first-child,
+  .emotion-257:not(:first-child):not(:last-child),
+  .emotion-257:last-child {
     padding: 0;
   }
 }
 
-.emotion-283 {
+.emotion-275 {
   margin-bottom: 1.5rem;
   padding: 1rem;
 }
 
-.emotion-286 {
+.emotion-278 {
   position: relative;
   z-index: 0;
-  color: #3F3F42;
+  color: #141414;
   margin-top: 2rem;
   margin-top: 0;
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-286 {
+  .emotion-278 {
     margin-top: 1.5rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-286 {
+  .emotion-278 {
     margin-bottom: 1.5rem;
   }
 }
 
-.emotion-301 {
+.emotion-289 {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -9040,7 +8899,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @supports (display: grid) {
-  .emotion-301 {
+  .emotion-289 {
     display: grid;
     position: initial;
     width: initial;
@@ -9048,7 +8907,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9056,7 +8915,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9064,7 +8923,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-gap: 0.5rem;
@@ -9072,7 +8931,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -9080,7 +8939,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -9088,7 +8947,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-301 {
+    .emotion-289 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
       grid-column-gap: 1rem;
@@ -9096,62 +8955,62 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   }
 }
 
-.emotion-304 {
+.emotion-292 {
   position: relative;
   padding-bottom: 1.5rem;
 }
 
 @supports (display: grid) {
-  .emotion-304 {
+  .emotion-292 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
     }
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 
   @media (min-width: 80rem) {
-    .emotion-304 {
+    .emotion-292 {
       grid-template-columns: repeat(1, 1fr);
       grid-column-end: span 1;
     }
   }
 }
 
-.emotion-306 {
+.emotion-294 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9164,30 +9023,30 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-308 {
+  .emotion-296 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-308 {
+  .emotion-296 {
     min-width: 1.75rem;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-308 {
+  .emotion-296 {
     min-width: 2rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-308 {
+  .emotion-296 {
     min-width: 2.5rem;
   }
 }
 
-.emotion-310 {
+.emotion-298 {
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -9200,32 +9059,32 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-310 {
+  .emotion-298 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-310 {
+  .emotion-298 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
-.emotion-312 {
+.emotion-300 {
   padding-top: 0.2rem;
   padding-left: 0.5rem;
   padding-right: 1rem;
 }
 
 @supports (grid-template-columns: fit-content(200px)) {
-  .emotion-312 {
+  .emotion-300 {
     padding-right: 0;
   }
 }
 
-.emotion-314 {
+.emotion-302 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: Helmet,Freesans,Helvetica,Arial,sans-serif;
@@ -9239,26 +9098,26 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-314 {
+  .emotion-302 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-314 {
+  .emotion-302 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-314:hover,
-.emotion-314:focus {
+.emotion-302:hover,
+.emotion-302:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-314:before {
+.emotion-302:before {
   bottom: 0;
   content: '';
   left: 0;
@@ -9270,7 +9129,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
   z-index: 1;
 }
 
-.emotion-316 {
+.emotion-304 {
   padding-top: 0.5rem;
 }
 
@@ -9860,23 +9719,17 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                     <div
                       class="emotion-191 emotion-192 emotion-193"
                     >
-                      <div
-                        class="emotion-194 emotion-195"
-                      />
-                      <div
-                        class="emotion-196 emotion-197"
-                      />
                       <h2
-                        class="emotion-198 emotion-199"
+                        class="emotion-194 emotion-195"
                       >
                         <span
-                          class="emotion-200 emotion-201"
+                          class="emotion-196 emotion-197"
                         >
                           <span
-                            class="emotion-202 emotion-203"
+                            class="emotion-198 emotion-199"
                           >
                             <span
-                              class="emotion-204 emotion-205"
+                              class="emotion-200 emotion-201"
                               dir="ltr"
                               id="top-stories-heading"
                             >
@@ -9887,26 +9740,26 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </h2>
                     </div>
                     <ul
-                      class="emotion-206 emotion-207"
+                      class="emotion-202 emotion-203"
                       role="list"
                     >
                       <li
-                        class="emotion-208 emotion-209"
+                        class="emotion-204 emotion-205"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <h3
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-pidgin23248287-1"
-                                class="emotion-216 emotion-217"
+                                class="emotion-212 emotion-213"
                                 href="/pidgin/23248287"
                               >
                                 <span
@@ -9917,7 +9770,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               </a>
                             </h3>
                             <time
-                              class="emotion-218 emotion-25"
+                              class="emotion-214 emotion-25"
                               datetime="2019-09-10"
                             >
                               10th September 2019
@@ -9926,22 +9779,22 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-208 emotion-209"
+                        class="emotion-204 emotion-205"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <h3
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-pidgintori23146434-1"
-                                class="emotion-216 emotion-217"
+                                class="emotion-212 emotion-213"
                                 href="/pidgin/tori-23146434"
                               >
                                 <span
@@ -9952,7 +9805,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               </a>
                             </h3>
                             <time
-                              class="emotion-218 emotion-25"
+                              class="emotion-214 emotion-25"
                               datetime="2017-08-08"
                             >
                               8th August 2017
@@ -9961,22 +9814,22 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-208 emotion-209"
+                        class="emotion-204 emotion-205"
                       >
                         <div
-                          class="emotion-210 emotion-211"
+                          class="emotion-206 emotion-207"
                           data-e2e="story-promo"
                         >
                           <div
-                            class="emotion-212 emotion-213"
+                            class="emotion-208 emotion-209"
                             dir="ltr"
                           >
                             <h3
-                              class="emotion-214 emotion-215"
+                              class="emotion-210 emotion-211"
                             >
                               <a
                                 aria-labelledby="top-stories-promo-news-feature-1"
-                                class="emotion-216 emotion-217"
+                                class="emotion-212 emotion-213"
                                 href="/news"
                               >
                                 <span
@@ -9987,7 +9840,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                               </a>
                             </h3>
                             <time
-                              class="emotion-218 emotion-25"
+                              class="emotion-214 emotion-25"
                               datetime="2019-12-06"
                             >
                               6th December 2019
@@ -10010,23 +9863,17 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                     <div
                       class="emotion-191 emotion-192 emotion-193"
                     >
-                      <div
-                        class="emotion-194 emotion-195"
-                      />
-                      <div
-                        class="emotion-196 emotion-197"
-                      />
                       <h2
-                        class="emotion-198 emotion-199"
+                        class="emotion-194 emotion-195"
                       >
                         <span
-                          class="emotion-200 emotion-201"
+                          class="emotion-196 emotion-197"
                         >
                           <span
-                            class="emotion-202 emotion-203"
+                            class="emotion-198 emotion-199"
                           >
                             <span
-                              class="emotion-204 emotion-205"
+                              class="emotion-200 emotion-201"
                               dir="ltr"
                               id="features-analysis-heading"
                             >
@@ -10037,67 +9884,67 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </h2>
                     </div>
                     <ul
-                      class="emotion-263 emotion-264"
+                      class="emotion-255 emotion-256"
                       role="list"
                     >
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
                         />
                       </li>
                       <li
-                        class="emotion-265 emotion-266"
+                        class="emotion-257 emotion-258"
                       >
                         <span
                           data-testid="frosted-promo-loader"
@@ -10107,7 +9954,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                   </section>
                 </div>
                 <div
-                  class="emotion-283 emotion-284"
+                  class="emotion-275 emotion-276"
                 >
                   <section
                     aria-labelledby="Most-Read"
@@ -10115,25 +9962,19 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                     role="region"
                   >
                     <div
-                      class="emotion-285 emotion-286 emotion-193"
+                      class="emotion-277 emotion-278 emotion-193"
                     >
-                      <div
-                        class="emotion-194 emotion-195"
-                      />
-                      <div
-                        class="emotion-196 emotion-197"
-                      />
                       <h2
-                        class="emotion-198 emotion-199"
+                        class="emotion-194 emotion-195"
                       >
                         <span
-                          class="emotion-200 emotion-201"
+                          class="emotion-196 emotion-197"
                         >
                           <span
-                            class="emotion-202 emotion-203"
+                            class="emotion-198 emotion-199"
                           >
                             <span
-                              class="emotion-204 emotion-205"
+                              class="emotion-200 emotion-201"
                               dir="ltr"
                               id="Most-Read"
                             >
@@ -10144,43 +9985,43 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </h2>
                     </div>
                     <ol
-                      class="emotion-300 emotion-301 emotion-2"
+                      class="emotion-288 emotion-289 emotion-2"
                       dir="ltr"
                       role="list"
                     >
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               1
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-46729879"
                             >
                               Public Holidays wey go happun for 2019
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-05-21"
                               >
                                 De one we dem update for: 21st May 2019
@@ -10190,38 +10031,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               2
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50304653"
                             >
                               Liberia banks don run out of money
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -10231,38 +10072,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               3
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50298882"
                             >
                               Why Oscars disqualify Genevieve Nnaji 'Lionheart' film
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-11-05"
                               >
                                 De one we dem update for: 5th November 2019
@@ -10272,38 +10113,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               4
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50315150"
                             >
                               Ghana opposition NDC list 51 family and friends inside Akufo-Addo govment
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -10313,38 +10154,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               5
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50315157"
                             >
                               How Balogun market fire kill Policeman for Lagos
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -10354,38 +10195,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               6
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50093818"
                             >
                               Labour, FG finally agree minimum wage salary adjustment
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-10-18"
                               >
                                 De one we dem update for: 18th October 2019
@@ -10395,38 +10236,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               7
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-50187218"
                             >
                               Naira Marley na 'Bad Influence'?
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-10-25"
                               >
                                 De one we dem update for: 25th October 2019
@@ -10436,38 +10277,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               8
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-48347911"
                             >
                               Tins you suppose know about Naira Marley
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-05-23"
                               >
                                 De one we dem update for: 23rd May 2019
@@ -10477,38 +10318,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               9
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/sport-50312710"
                             >
                               Golden Eaglets crash out of Fifa U17 World Cup
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-11-06"
                               >
                                 De one we dem update for: 6th November 2019
@@ -10518,38 +10359,38 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                         </div>
                       </li>
                       <li
-                        class="emotion-303 emotion-304 emotion-2"
+                        class="emotion-291 emotion-292 emotion-2"
                         dir="ltr"
                         role="listitem"
                       >
                         <div
-                          class="emotion-306 emotion-307"
+                          class="emotion-294 emotion-295"
                         >
                           <div
-                            class="emotion-308 emotion-309"
+                            class="emotion-296 emotion-297"
                             dir="ltr"
                           >
                             <span
-                              class="emotion-310 emotion-311"
+                              class="emotion-298 emotion-299"
                             >
                               10
                             </span>
                           </div>
                           <div
-                            class="emotion-312 emotion-313"
+                            class="emotion-300 emotion-301"
                             dir="ltr"
                           >
                             <a
-                              class="emotion-314 emotion-315"
+                              class="emotion-302 emotion-303"
                               href="/pidgin/tori-42945173"
                             >
                               Tiger nut drink fit wake up your sex drive - Nutritionist
                             </a>
                             <div
-                              class="emotion-316 emotion-317"
+                              class="emotion-304 emotion-305"
                             >
                               <time
-                                class="emotion-218 emotion-25"
+                                class="emotion-214 emotion-25"
                                 datetime="2019-05-21"
                               >
                                 De one we dem update for: 21st May 2019

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.js
@@ -3,7 +3,6 @@ import splitAt from 'ramda/src/splitAt';
 import flatten from 'ramda/src/flatten';
 import clone from 'ramda/src/clone';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
-import isLive from '#app/lib/utilities/isLive';
 
 const mpuBlock = {
   type: 'mpu',
@@ -92,9 +91,7 @@ const addMpuBlock = json => {
   const { allowAdvertising } = path(['metadata'], json);
   const pageType = path(['metadata', 'type'], json);
 
-  /* TODO: Remove `isLive` checks when editorial are happy with the ads display */
-  if (isLive() || (!isLive() && !allowAdvertising) || pageType !== ARTICLE_PAGE)
-    return json;
+  if (!allowAdvertising || pageType !== ARTICLE_PAGE) return json;
 
   const pageData = clone(json);
 

--- a/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
+++ b/src/app/routes/article/getInitialData/addMpuBlock/index.test.js
@@ -266,32 +266,23 @@ describe('addMpuBlock', () => {
     expect(addMpuBlock(input)).toEqual(expected);
   });
 
-  it('should return input if `isLive` is true', async () => {
+  it('should return input if page type is not Article', async () => {
     const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'live';
+    input.metadata.type = 'STY';
 
     expect(addMpuBlock(input)).toEqual(input);
   });
 
-  it('should return input if `isLive` is true and `allowAdvertising` is true', async () => {
+  it('should return input if "allowAdvertising" is "false"', async () => {
     const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'live';
-    input.metadata.allowAdvertising = true;
-
-    expect(addMpuBlock(input)).toEqual(input);
-  });
-
-  it('should return input if `isLive` is false and `allowAdvertising` is false', async () => {
-    const input = clone(styInput);
-    process.env.SIMORGH_APP_ENV = 'test';
     input.metadata.allowAdvertising = false;
 
     expect(addMpuBlock(input)).toEqual(input);
   });
 
-  it('should return input if page type is not Article', async () => {
+  it('should return input if "allowAdvertising" is "undefined"', async () => {
     const input = clone(styInput);
-    input.metadata.type = 'STY';
+    delete input.metadata.allowAdvertising;
 
     expect(addMpuBlock(input)).toEqual(input);
   });


### PR DESCRIPTION
3 weeks ago, a load of stuff was rolled back, and nobody noticed:

https://github.com/bbc/simorgh/compare/ce99d7c71070562e3d3bbfeaf27e0dd602b6f7d8..47ba0872ef6943c6ba1369bbe217060604a2d908

More context in slack thread: https://bbcnews.slack.com/archives/C01TRJUMWMP/p1658214001701929

The things that were rolled back seem to be:

- @emilysaffron - Chameleon Navigation Bar - https://github.com/bbc/simorgh/pull/10159 +  https://github.com/bbc/simorgh/pull/10164
- @amoore108 - Putting Optimo Ads Live - https://github.com/bbc/simorgh/pull/10163
- @mfonofm - Article Page Design Updates - https://github.com/bbc/simorgh/pull/10158

This PR puts those things back in

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
