### PR TITLE
Robots meta tag - large image preview

### DIFF
--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -116,6 +116,7 @@ const MetadataContainer = ({
     <Helmet htmlAttributes={htmlAttributes}>
       <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
       <meta charSet="utf-8" />
+      <meta name="robots" content="max-image-preview:large" />
       <meta name="robots" content="noodp,noydir" />
       <meta name="theme-color" content={themeColor} />
       <meta

--- a/src/app/containers/Metadata/index.jsx
+++ b/src/app/containers/Metadata/index.jsx
@@ -116,8 +116,7 @@ const MetadataContainer = ({
     <Helmet htmlAttributes={htmlAttributes}>
       <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
       <meta charSet="utf-8" />
-      <meta name="robots" content="max-image-preview:large" />
-      <meta name="robots" content="noodp,noydir" />
+      <meta name="robots" content="noodp, noydir, max-image-preview:large" />
       <meta name="theme-color" content={themeColor} />
       <meta
         name="viewport"

--- a/src/app/containers/Metadata/index.test.jsx
+++ b/src/app/containers/Metadata/index.test.jsx
@@ -353,7 +353,7 @@ it('should render the char set metadata', async () => {
 it('should render the robots meta tag', async () => {
   render(<CanonicalNewsInternationalOrigin />);
 
-  const expected = 'noodp,noydir';
+  const expected = 'noodp, noydir, max-image-preview:large';
 
   await waitFor(() => {
     const actual = document

--- a/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
@@ -430,7 +430,7 @@ exports[`AMP Articles SEO OG url 1`] = `"http://localhost:7080/news/articles/c5j
 
 exports[`AMP Articles SEO Page title 1`] = `"The Germans solving rising rents with people power - BBC News"`;
 
-exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
@@ -325,7 +325,7 @@ exports[`Canonical Articles SEO OG url 1`] = `"http://localhost:7080/news/articl
 
 exports[`Canonical Articles SEO Page title 1`] = `"The Germans solving rising rents with people power - BBC News"`;
 
-exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -457,7 +457,7 @@ exports[`AMP Articles SEO OG url 1`] = `"http://localhost:7080/persian/articles/
 
 exports[`AMP Articles SEO Page title 1`] = `"پهپادی که برایتان قهوه می‌آورد - BBC News فارسی"`;
 
-exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -352,7 +352,7 @@ exports[`Canonical Articles SEO OG url 1`] = `"http://localhost:7080/persian/art
 
 exports[`Canonical Articles SEO Page title 1`] = `"پهپادی که برایتان قهوه می‌آورد - BBC News فارسی"`;
 
-exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
@@ -357,7 +357,7 @@ exports[`AMP Articles SEO OG url 1`] = `"http://localhost:7080/scotland/articles
 
 exports[`AMP Articles SEO Page title 1`] = `"This is the SEO headline of this test article - BBC Scotland"`;
 
-exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
@@ -252,7 +252,7 @@ exports[`Canonical Articles SEO OG url 1`] = `"http://localhost:7080/scotland/ar
 
 exports[`Canonical Articles SEO Page title 1`] = `"This is the SEO headline of this test article - BBC Scotland"`;
 
-exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Articles SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Articles SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -433,7 +433,7 @@ exports[`AMP Feature Index page SEO OG url 1`] = `"http://localhost:7080/afrique
 
 exports[`AMP Feature Index page SEO Page title 1`] = `"Tout savoir sur la CAN 2019 - BBC News Afrique"`;
 
-exports[`AMP Feature Index page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Feature Index page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Feature Index page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -299,7 +299,7 @@ exports[`Canonical Feature Index page SEO OG url 1`] = `"http://localhost:7080/a
 
 exports[`Canonical Feature Index page SEO Page title 1`] = `"Tout savoir sur la CAN 2019 - BBC News Afrique"`;
 
-exports[`Canonical Feature Index page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Feature Index page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Feature Index page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
@@ -405,7 +405,7 @@ exports[`AMP Feature Index page SEO OG url 1`] = `"http://localhost:7080/urdu/sc
 
 exports[`AMP Feature Index page SEO Page title 1`] = `"کورونا وائرس: تحقیق، تشخیص اور احتیاط - BBC News اردو"`;
 
-exports[`AMP Feature Index page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Feature Index page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Feature Index page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -271,7 +271,7 @@ exports[`Canonical Feature Index page SEO OG url 1`] = `"http://localhost:7080/u
 
 exports[`Canonical Feature Index page SEO Page title 1`] = `"کورونا وائرس: تحقیق، تشخیص اور احتیاط - BBC News اردو"`;
 
-exports[`Canonical Feature Index page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Feature Index page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Feature Index page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/frontPage/arabic/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/arabic/__snapshots__/amp.test.js.snap
@@ -428,7 +428,7 @@ exports[`AMP Front Page SEO OG url 1`] = `"http://localhost:7080/arabic"`;
 
 exports[`AMP Front Page SEO Page title 1`] = `"الرئيسية - BBC News عربي"`;
 
-exports[`AMP Front Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Front Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Front Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/arabic/__snapshots__/canonical.test.js.snap
@@ -294,7 +294,7 @@ exports[`Canonical Front Page SEO OG url 1`] = `"http://localhost:7080/arabic"`;
 
 exports[`Canonical Front Page SEO Page title 1`] = `"الرئيسية - BBC News عربي"`;
 
-exports[`Canonical Front Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Front Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Front Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/amp.test.js.snap
@@ -407,7 +407,7 @@ exports[`AMP Front Page SEO OG url 1`] = `"http://localhost:7080/pidgin"`;
 
 exports[`AMP Front Page SEO Page title 1`] = `"Domot - BBC News Pidgin"`;
 
-exports[`AMP Front Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Front Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Front Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -273,7 +273,7 @@ exports[`Canonical Front Page SEO OG url 1`] = `"http://localhost:7080/pidgin"`;
 
 exports[`Canonical Front Page SEO Page title 1`] = `"Domot - BBC News Pidgin"`;
 
-exports[`Canonical Front Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Front Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Front Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
@@ -454,7 +454,7 @@ exports[`AMP persian/afghanistan IDX page SEO OG url 1`] = `"http://localhost:70
 
 exports[`AMP persian/afghanistan IDX page SEO Page title 1`] = `"صفحه افغانستان - BBC News فارسی"`;
 
-exports[`AMP persian/afghanistan IDX page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP persian/afghanistan IDX page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP persian/afghanistan IDX page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
@@ -320,7 +320,7 @@ exports[`Canonical persian/afghanistan IDX page SEO OG url 1`] = `"http://localh
 
 exports[`Canonical persian/afghanistan IDX page SEO Page title 1`] = `"صفحه افغانستان - BBC News فارسی"`;
 
-exports[`Canonical persian/afghanistan IDX page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical persian/afghanistan IDX page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical persian/afghanistan IDX page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
@@ -395,7 +395,7 @@ exports[`AMP ukrainian/ukraine_in_russian IDX page SEO OG url 1`] = `"http://loc
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Page title 1`] = `"РУС - BBC News Україна"`;
 
-exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
@@ -261,7 +261,7 @@ exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO OG url 1`] = `"http
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Page title 1`] = `"РУС - BBC News Україна"`;
 
-exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/amp.test.js.snap
@@ -383,7 +383,7 @@ exports[`AMP Live Radio SEO OG url 1`] = `"http://localhost:7080/gahuza/bbc_gahu
 
 exports[`AMP Live Radio SEO Page title 1`] = `"Radio BBC Gahuza - BBC News Gahuza"`;
 
-exports[`AMP Live Radio SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Live Radio SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Live Radio SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
@@ -249,7 +249,7 @@ exports[`Canonical Live Radio SEO OG url 1`] = `"http://localhost:7080/gahuza/bb
 
 exports[`Canonical Live Radio SEO Page title 1`] = `"Radio BBC Gahuza - BBC News Gahuza"`;
 
-exports[`Canonical Live Radio SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Live Radio SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Live Radio SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/korean/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/amp.test.js.snap
@@ -369,7 +369,7 @@ exports[`AMP Korean Live Radio Page SEO OG url 1`] = `"http://localhost:7080/kor
 
 exports[`AMP Korean Live Radio Page SEO Page title 1`] = `"BBC 코리아 라디오 - BBC News 코리아"`;
 
-exports[`AMP Korean Live Radio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Korean Live Radio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Korean Live Radio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/korean/__snapshots__/canonical.test.js.snap
@@ -235,7 +235,7 @@ exports[`Canonical Korean Live Radio Page SEO OG url 1`] = `"http://localhost:70
 
 exports[`Canonical Korean Live Radio Page SEO Page title 1`] = `"BBC 코리아 라디오 - BBC News 코리아"`;
 
-exports[`Canonical Korean Live Radio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Korean Live Radio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Korean Live Radio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/amp.test.js.snap
@@ -362,7 +362,7 @@ exports[`AMP Sinhala Live Radio Page SEO OG url 1`] = `"http://localhost:7080/si
 
 exports[`AMP Sinhala Live Radio Page SEO Page title 1`] = `"බීබීසී සිංහල සංදේශය - BBC News සිංහල"`;
 
-exports[`AMP Sinhala Live Radio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Sinhala Live Radio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Sinhala Live Radio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -228,7 +228,7 @@ exports[`Canonical Sinhala Live Radio Page SEO OG url 1`] = `"http://localhost:7
 
 exports[`Canonical Sinhala Live Radio Page SEO Page title 1`] = `"බීබීසී සිංහල සංදේශය - BBC News සිංහල"`;
 
-exports[`Canonical Sinhala Live Radio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Sinhala Live Radio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Sinhala Live Radio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/amp.test.js.snap
@@ -457,7 +457,7 @@ exports[`AMP Media Asset Page SEO OG url 1`] = `"http://localhost:7080/arabic/wo
 
 exports[`AMP Media Asset Page SEO Page title 1`] = `"شركة شارب للإلكترونيات تحث موظفيها على شراء منتجاتها - BBC News عربي"`;
 
-exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/arabicTC2/__snapshots__/canonical.test.js.snap
@@ -330,7 +330,7 @@ exports[`Canonical Media Asset Page SEO OG url 1`] = `"http://localhost:7080/ara
 
 exports[`Canonical Media Asset Page SEO Page title 1`] = `"شركة شارب للإلكترونيات تحث موظفيها على شراء منتجاتها - BBC News عربي"`;
 
-exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -485,7 +485,7 @@ exports[`AMP Media Asset Page SEO OG url 1`] = `"http://localhost:7080/persian/i
 
 exports[`AMP Media Asset Page SEO Page title 1`] = `"Trump long headline - BBC News فارسی"`;
 
-exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -351,7 +351,7 @@ exports[`Canonical Media Asset Page SEO OG url 1`] = `"http://localhost:7080/per
 
 exports[`Canonical Media Asset Page SEO Page title 1`] = `"Trump long headline - BBC News فارسی"`;
 
-exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
@@ -468,7 +468,7 @@ exports[`AMP Media Asset Page SEO OG url 1`] = `"http://localhost:7080/pidgin/23
 
 exports[`AMP Media Asset Page SEO Page title 1`] = `"Simorgh: Media Pod Build First CPS Media Asset Page in Simorgh & < > - BBC News Pidgin"`;
 
-exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -334,7 +334,7 @@ exports[`Canonical Media Asset Page SEO OG url 1`] = `"http://localhost:7080/pid
 
 exports[`Canonical Media Asset Page SEO Page title 1`] = `"Simorgh: Media Pod Build First CPS Media Asset Page in Simorgh & < > - BBC News Pidgin"`;
 
-exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Media Asset Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Media Asset Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/amp.test.js.snap
@@ -469,7 +469,7 @@ exports[`AMP Most Read Page SEO OG url 1`] = `"http://localhost:7080/mundo/popul
 
 exports[`AMP Most Read Page SEO Page title 1`] = `"Más leídas - BBC News Mundo"`;
 
-exports[`AMP Most Read Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Most Read Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Most Read Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/mundo/__snapshots__/canonical.test.js.snap
@@ -335,7 +335,7 @@ exports[`Canonical Most Read Page SEO OG url 1`] = `"http://localhost:7080/mundo
 
 exports[`Canonical Most Read Page SEO Page title 1`] = `"Más leídas - BBC News Mundo"`;
 
-exports[`Canonical Most Read Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Most Read Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Most Read Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
@@ -427,7 +427,7 @@ exports[`AMP Most Read Page SEO OG url 1`] = `"http://localhost:7080/vietnamese/
 
 exports[`AMP Most Read Page SEO Page title 1`] = `"Đọc nhiều nhất - BBC News Tiếng Việt"`;
 
-exports[`AMP Most Read Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Most Read Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Most Read Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
@@ -293,7 +293,7 @@ exports[`Canonical Most Read Page SEO OG url 1`] = `"http://localhost:7080/vietn
 
 exports[`Canonical Most Read Page SEO Page title 1`] = `"Đọc nhiều nhất - BBC News Tiếng Việt"`;
 
-exports[`Canonical Most Read Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Most Read Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Most Read Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
@@ -436,7 +436,7 @@ exports[`AMP Most Watched Page SEO OG url 1`] = `"http://localhost:7080/afrique/
 
 exports[`AMP Most Watched Page SEO Page title 1`] = `"Les plus vus - BBC News Afrique"`;
 
-exports[`AMP Most Watched Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Most Watched Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Most Watched Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -313,7 +313,7 @@ exports[`Canonical Most Watched Page SEO OG url 1`] = `"http://localhost:7080/af
 
 exports[`Canonical Most Watched Page SEO Page title 1`] = `"Les plus vus - BBC News Afrique"`;
 
-exports[`Canonical Most Watched Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Most Watched Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Most Watched Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
@@ -416,7 +416,7 @@ exports[`AMP Most Watched Page SEO OG url 1`] = `"http://localhost:7080/urdu/med
 
 exports[`AMP Most Watched Page SEO Page title 1`] = `"سب سے زیادہ دیکھی گئی - BBC News اردو"`;
 
-exports[`AMP Most Watched Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Most Watched Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Most Watched Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
@@ -293,7 +293,7 @@ exports[`Canonical Most Watched Page SEO OG url 1`] = `"http://localhost:7080/ur
 
 exports[`Canonical Most Watched Page SEO Page title 1`] = `"سب سے زیادہ دیکھی گئی - BBC News اردو"`;
 
-exports[`Canonical Most Watched Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Most Watched Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Most Watched Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/amp.test.js.snap
@@ -433,7 +433,7 @@ exports[`AMP On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080/indon
 
 exports[`AMP On Demand Audio Page SEO Page title 1`] = `"Dunia Pagi Ini - BBC News Indonesia"`;
 
-exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
@@ -306,7 +306,7 @@ exports[`Canonical On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080
 
 exports[`Canonical On Demand Audio Page SEO Page title 1`] = `"Dunia Pagi Ini - BBC News Indonesia"`;
 
-exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/amp.test.js.snap
@@ -454,7 +454,7 @@ exports[`AMP On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080/pasht
 
 exports[`AMP On Demand Audio Page SEO Page title 1`] = `"ماښامنۍ خپرونه - BBC News پښتو"`;
 
-exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashto/__snapshots__/canonical.test.js.snap
@@ -327,7 +327,7 @@ exports[`Canonical On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080
 
 exports[`Canonical On Demand Audio Page SEO Page title 1`] = `"ماښامنۍ خپرونه - BBC News پښتو"`;
 
-exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/amp.test.js.snap
@@ -454,7 +454,7 @@ exports[`AMP On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080/pasht
 
 exports[`AMP On Demand Audio Page SEO Page title 1`] = `"وروستي خبرونه - BBC News پښتو"`;
 
-exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/pashtoBrand/__snapshots__/canonical.test.js.snap
@@ -327,7 +327,7 @@ exports[`Canonical On Demand Audio Page SEO OG url 1`] = `"http://localhost:7080
 
 exports[`Canonical On Demand Audio Page SEO Page title 1`] = `"وروستي خبرونه - BBC News پښتو"`;
 
-exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical On Demand Audio Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical On Demand Audio Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/amp.test.js.snap
@@ -452,7 +452,7 @@ exports[`AMP On Demand T V Page SEO OG url 1`] = `"http://localhost:7080/pashto/
 
 exports[`AMP On Demand T V Page SEO Page title 1`] = `"نړۍ دا وخت - BBC News پښتو"`;
 
-exports[`AMP On Demand T V Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP On Demand T V Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP On Demand T V Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/pashto/__snapshots__/canonical.test.js.snap
@@ -325,7 +325,7 @@ exports[`Canonical On Demand T V Page SEO OG url 1`] = `"http://localhost:7080/p
 
 exports[`Canonical On Demand T V Page SEO Page title 1`] = `"نړۍ دا وخت - BBC News پښتو"`;
 
-exports[`Canonical On Demand T V Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical On Demand T V Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical On Demand T V Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
@@ -431,7 +431,7 @@ exports[`AMP On Demand T V Page SEO OG url 1`] = `"http://localhost:7080/somali/
 
 exports[`AMP On Demand T V Page SEO Page title 1`] = `"Caawa Iyo Caalamka - BBC News Somali"`;
 
-exports[`AMP On Demand T V Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP On Demand T V Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP On Demand T V Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
@@ -304,7 +304,7 @@ exports[`Canonical On Demand T V Page SEO OG url 1`] = `"http://localhost:7080/s
 
 exports[`Canonical On Demand T V Page SEO Page title 1`] = `"Caawa Iyo Caalamka - BBC News Somali"`;
 
-exports[`Canonical On Demand T V Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical On Demand T V Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical On Demand T V Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/amp.test.js.snap
@@ -511,7 +511,7 @@ exports[`AMP Photo Gallery Page SEO OG url 1`] = `"http://localhost:7080/mundo/d
 
 exports[`AMP Photo Gallery Page SEO Page title 1`] = `"Río 2016, el antes y el ahora: cómo ha cambiado la ropa deportiva en más de un siglo de juegos olímpicos - BBC News Mundo"`;
 
-exports[`AMP Photo Gallery Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Photo Gallery Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Photo Gallery Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/photoGalleryPage/mundo/__snapshots__/canonical.test.js.snap
@@ -364,7 +364,7 @@ exports[`Canonical Photo Gallery Page SEO OG url 1`] = `"http://localhost:7080/m
 
 exports[`Canonical Photo Gallery Page SEO Page title 1`] = `"Río 2016, el antes y el ahora: cómo ha cambiado la ropa deportiva en más de un siglo de juegos olímpicos - BBC News Mundo"`;
 
-exports[`Canonical Photo Gallery Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Photo Gallery Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Photo Gallery Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/amp.test.js.snap
@@ -433,7 +433,7 @@ exports[`AMP Story Page SEO OG url 1`] = `"http://localhost:7080/kyrgyz/23292889
 
 exports[`AMP Story Page SEO Page title 1`] = `"Test STY for social embeds - BBC News Кыргыз Кызматы"`;
 
-exports[`AMP Story Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Story Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Story Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -286,7 +286,7 @@ exports[`Canonical Story Page SEO OG url 1`] = `"http://localhost:7080/kyrgyz/23
 
 exports[`Canonical Story Page SEO Page title 1`] = `"Test STY for social embeds - BBC News Кыргыз Кызматы"`;
 
-exports[`Canonical Story Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Story Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Story Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/amp.test.js.snap
@@ -530,7 +530,7 @@ exports[`AMP Story Page SEO OG url 1`] = `"http://localhost:7080/mundo/noticias-
 
 exports[`AMP Story Page SEO Page title 1`] = `"Brexit: qué cambiará para visitar, trabajar y estudiar en Reino Unido tras la salida del país de la Unión Europea - BBC News Mundo"`;
 
-exports[`AMP Story Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`AMP Story Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`AMP Story Page SEO Twitter card 1`] = `"summary_large_image"`;
 

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -390,7 +390,7 @@ exports[`Canonical Story Page SEO OG url 1`] = `"http://localhost:7080/mundo/not
 
 exports[`Canonical Story Page SEO Page title 1`] = `"Brexit: qué cambiará para visitar, trabajar y estudiar en Reino Unido tras la salida del país de la Unión Europea - BBC News Mundo"`;
 
-exports[`Canonical Story Page SEO Robots meta tag 1`] = `"noodp,noydir"`;
+exports[`Canonical Story Page SEO Robots meta tag 1`] = `"noodp, noydir, max-image-preview:large"`;
 
 exports[`Canonical Story Page SEO Twitter card 1`] = `"summary_large_image"`;
 


### PR DESCRIPTION
Resolves [NEWSWORLDSERVICE-1556](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1556)

**Overall change:**
Add `max-image-preview:large` directive to existing robots meta tag.

**Code changes:**

- Added `max-image-preview:large` directive to the existing robots meta tag in our Metadata component

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
