### PR TITLE
Update Reith Qalam Font in Simorgh to v1.210 - [WSTEAMA100]

### DIFF
--- a/src/app/legacy/psammead-styles/src/__snapshots__/fonts.test.js.snap
+++ b/src/app/legacy/psammead-styles/src/__snapshots__/fonts.test.js.snap
@@ -262,7 +262,7 @@ exports[`Psammead Styles - Fonts should match REITH QALAM BOLD base font url 1`]
     font-family: \\"BBC Reith Qalam\\";
     font-weight: 700;
     font-style: normal;
-    src: url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.100/bold.woff2') format('woff2'), url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.100/bold.woff') format('woff');
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.210/bold.woff2') format('woff2'), url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.210/bold.woff') format('woff');
     font-display: optional;
   }
 "
@@ -286,7 +286,7 @@ exports[`Psammead Styles - Fonts should match REITH QALAM REGULAR base font url 
     font-family: \\"BBC Reith Qalam\\";
     font-weight: 400;
     font-style: normal;
-    src: url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.100/normal.woff2') format('woff2'), url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.100/normal.woff') format('woff');
+    src: url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.210/normal.woff2') format('woff2'), url('https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.210/normal.woff') format('woff');
     font-display: optional;
   }
 "

--- a/src/app/legacy/psammead-styles/src/fonts.js
+++ b/src/app/legacy/psammead-styles/src/fonts.js
@@ -19,7 +19,7 @@ const baseUrlNotoSerifBengali =
   'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifBengali/v1.00/';
 
 const baseUrlBBCReithQalam =
-  'https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.100/';
+  'https://ws-downloads.files.bbci.co.uk/fonts/ReithQalam/v1.210/';
 
 // Reith Serif
 export const F_REITH_SERIF_REGULAR = baseUrlOverride => `


### PR DESCRIPTION
Relates to WSTEAMA100

**Overall change:**
Updates Reith Qalam to the latest version (v1.210)

**Code changes:**

- Updates baseUrl to new font server version of Reith Qalam

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
