### PR TITLE
pin version of moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "trim": "1.0.1",
     "minimist": "1.2.6",
     "async": "3.2.3",
-    "terser": "5.14.2"
+    "terser": "5.14.2",
+    "moment": "2.29.4"
   },
   "scripts": {
     "amp:validate": "wait-on -t 20000 http://localhost:7080/status && node ./scripts/ampHtmlValidator/cli.js",
@@ -119,7 +120,7 @@
     "json5": "^2.1.3",
     "lru-cache": "6.0.0",
     "mkdirp": "1.0.0",
-    "moment": "^2.29.4",
+    "moment": "2.29.4",
     "moment-timezone": "0.5.26",
     "morgan": "1.10.0",
     "path-to-regexp": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15329,7 +15329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:>= 2.9.0, moment@npm:^2.29.4":
+"moment@npm:2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
@@ -19104,7 +19104,7 @@ __metadata:
     mkdirp: 1.0.0
     mocha: 9.2.2
     mocha-junit-reporter: 2.0.2
-    moment: ^2.29.4
+    moment: 2.29.4
     moment-timezone: 0.5.26
     morgan: 1.10.0
     node-fetch: 2.6.7


### PR DESCRIPTION
**Overall change:**
This PR is a more permenant version of the following fix by @ExcitedBlob to use only one version of moment in Simorgh: https://github.com/bbc/simorgh/pull/10128/commits/aa57b5df3739acf9c7d8571fe4a7369569ecd278

It adds moment to the resolutions ensuring future package updates don't remove @ExcitedBlob 's manual fix to the yarn lockfile.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
