### PR TITLE
restore-storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  stories: ['../src/app/**/!(**psammead)/*.stories.jsx'],
+  stories: ['../src/app/**/!(psammead)/*.stories.jsx'],
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-a11y',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  stories: ['../src/app/!(legacy)/**/*.stories.jsx'],
+  stories: ['../src/app/**/!(**psammead)/*.stories.jsx'],
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-a11y',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,10 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  stories: ['!../src/app/legacy/psammead/**/*.stories.jsx'],
+  stories: [
+    '../src/app/**/*.stories.jsx',
+    '!../src/app/legacy/psammead/**/*.stories.jsx',
+  ],
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-a11y',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,8 +10,9 @@ module.exports = {
     builder: 'webpack5',
   },
   stories: [
-    '../src/app/**/*.stories.jsx',
-    '!../src/app/legacy/psammead/**/*.stories.jsx',
+    '../src/app/legacy/components/**/*.stories.jsx',
+    '../src/app/legacy/containers/**/*.stories.jsx',
+    '../src/app/pages/**/*.stories.jsx',
   ],
   addons: [
     '@storybook/addon-knobs',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  stories: ['../src/app/**/!(psammead)/*.stories.jsx'],
+  stories: ['!../src/app/legacy/psammead/**/*.stories.jsx'],
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-a11y',

--- a/src/app/legacy/components/MediaPlayer/index.stories.jsx
+++ b/src/app/legacy/components/MediaPlayer/index.stories.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { CanonicalMediaPlayer, AmpMediaPlayer } from '.';
-import ampDecorator from '../../../../.storybook/helpers/ampDecorator';
+import ampDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import notes from './README.mdx';
 
 const withDuration = {

--- a/src/app/legacy/containers/ArticleFigure/index.stories.jsx
+++ b/src/app/legacy/containers/ArticleFigure/index.stories.jsx
@@ -15,7 +15,7 @@ import {
   FigureAmpImageWithCaptionContainingMultipleParagraphsAndLink,
   FigureLazyLoadImage,
 } from './fixtureData';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 
 export default {
   title: 'Containers/Article/Article Figure',

--- a/src/app/legacy/containers/ArticleTimestamp/index.stories.jsx
+++ b/src/app/legacy/containers/ArticleTimestamp/index.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
-import WithTimeMachine from '../../../testHelpers/withTimeMachine';
+import WithTimeMachine from '../../../../testHelpers/withTimeMachine';
 import ArticleTimestamp from '.';
 import { timestampGenerator } from './testHelpers';
 

--- a/src/app/legacy/containers/Brand/index.stories.jsx
+++ b/src/app/legacy/containers/Brand/index.stories.jsx
@@ -7,7 +7,8 @@ import BrandContainer from '.';
 // eslint-disable-next-line react/prop-types
 const Component = ({ service, variant }) => {
   // eslint-disable-next-line import/no-dynamic-require,global-require
-  const serviceConfig = require(`../../lib/config/services/${service}`).service;
+  const serviceConfig =
+    require(`../../../lib/config/services/${service}`).service;
 
   const configVariant = serviceConfig[variant];
   return (

--- a/src/app/legacy/containers/Bulletin/index.stories.jsx
+++ b/src/app/legacy/containers/Bulletin/index.stories.jsx
@@ -7,7 +7,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import fixture from '#data/igbo/frontpage';
 import { FRONT_PAGE } from '#app/routes/utils/pageTypes';
 import BulletinContainer from '.';
-import ampDecorator from '../../../../.storybook/helpers/ampDecorator';
+import ampDecorator from '../../../../../.storybook/helpers/ampDecorator';
 
 const bulletinFixture = type =>
   pathOr(null, ['content', 'groups'], fixture)

--- a/src/app/legacy/containers/ConsentBanner/index.stories.jsx
+++ b/src/app/legacy/containers/ConsentBanner/index.stories.jsx
@@ -3,7 +3,7 @@ import { RequestContextProvider } from '#contexts/RequestContext';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import ConsentBanner from '.';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ platform }) => (

--- a/src/app/legacy/containers/CpsAssetMediaPlayer/index.stories.jsx
+++ b/src/app/legacy/containers/CpsAssetMediaPlayer/index.stories.jsx
@@ -8,7 +8,7 @@ import WithTimeMachine from '#testHelpers/withTimeMachine';
 import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import CpsAssetMediaPlayerContainer from '.';
 import videoBlock from './fixtures';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 
 const defaultToggles = {
   mediaPlayer: {

--- a/src/app/legacy/containers/CpsFeaturesAnalysis/index.stories.jsx
+++ b/src/app/legacy/containers/CpsFeaturesAnalysis/index.stories.jsx
@@ -5,7 +5,7 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { STORY_PAGE } from '#app/routes/utils/pageTypes';
 import featuresRtl from './fixturesRtl.json';
 import features from './fixtures.json';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import FeaturesAnalysis from '.';
 
 /* eslint-disable react/prop-types */

--- a/src/app/legacy/containers/CpsRelatedContent/index.stories.jsx
+++ b/src/app/legacy/containers/CpsRelatedContent/index.stories.jsx
@@ -7,7 +7,7 @@ import arabicData from '#data/arabic/cpsAssets/media-49580542.json';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import CpsRelatedContent from '.';
 
 const newsRelatedContentData = newsData.relatedContent.groups[0].promos;

--- a/src/app/legacy/containers/CpsTopStories/index.stories.jsx
+++ b/src/app/legacy/containers/CpsTopStories/index.stories.jsx
@@ -5,7 +5,7 @@ import topStoriesRtl from '#pages/StoryPage/topStoriesRtl.json';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { STORY_PAGE } from '#app/routes/utils/pageTypes';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import TopStories from '.';
 
 // eslint-disable-next-line react/prop-types

--- a/src/app/legacy/containers/ImageWithPlaceholder/index.stories.jsx
+++ b/src/app/legacy/containers/ImageWithPlaceholder/index.stories.jsx
@@ -3,7 +3,7 @@ import {
   AmpImageWithPlaceholder,
   LazyLoadImageWithPlaceholder,
 } from './fixtureData';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import Component from '.';
 
 export default {

--- a/src/app/legacy/containers/IndexPageSection/index.stories.jsx
+++ b/src/app/legacy/containers/IndexPageSection/index.stories.jsx
@@ -8,7 +8,7 @@ import pidginData from '#data/pidgin/frontpage/index.json';
 import russianData from '#data/russian/frontpage/index.json';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { FRONT_PAGE } from '#app/routes/utils/pageTypes';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import IndexPageSection from '.';
 
 // eslint-disable-next-line react/prop-types

--- a/src/app/legacy/containers/InlineLink/index.stories.jsx
+++ b/src/app/legacy/containers/InlineLink/index.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import InlineLinkContainer from '.';
-import { ServiceContextProvider } from '../../contexts/ServiceContext';
+import { ServiceContextProvider } from '../../../contexts/ServiceContext';
 
 const fragmentBlock = (text, attributes = []) => ({
   id: 1,

--- a/src/app/legacy/containers/MediaPlayer/index.stories.jsx
+++ b/src/app/legacy/containers/MediaPlayer/index.stories.jsx
@@ -8,7 +8,7 @@ import { ToggleContext } from '#contexts/ToggleContext';
 import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
 import { validVideoWithCaptionBlock } from './fixtureData';
 import MediaPlayerContainer from '.';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ service, isAmp = false }) => {

--- a/src/app/legacy/containers/Navigation/index.stories.jsx
+++ b/src/app/legacy/containers/Navigation/index.stories.jsx
@@ -4,7 +4,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { ServiceContextProvider } from '#contexts/ServiceContext';
 import { RequestContextProvider } from '#contexts/RequestContext';
 import { FRONT_PAGE } from '#app/routes/utils/pageTypes';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import Navigation from '.';
 
 // eslint-disable-next-line react/prop-types

--- a/src/app/legacy/containers/SocialEmbed/Cps/index.stories.jsx
+++ b/src/app/legacy/containers/SocialEmbed/Cps/index.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 
-import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../../.storybook/helpers/ampDecorator';
 import { cpsTwitterBlock, cpsTwitterBlockNoEmbed } from '../common/fixtures';
 import CpsSocialEmbedContainer from '.';
 

--- a/src/app/legacy/containers/SocialEmbed/index.stories.jsx
+++ b/src/app/legacy/containers/SocialEmbed/index.stories.jsx
@@ -2,8 +2,18 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 
+<<<<<<< HEAD
 import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
 import { twitterBlock, twitterBlockNoEmbed } from './common/fixtures';
+=======
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
+import {
+  twitterBlock,
+  twitterBlockNoEmbed,
+  instagramBlock,
+  instagramBlockNoEmbed,
+} from './common/fixtures';
+>>>>>>> ce3f0331dd (restore storybook)
 import OptimoSocialEmbedContainer from '.';
 import withContexts from './common/testHelper';
 
@@ -46,3 +56,22 @@ export const NoEmbed = props => (
     {...props}
   />
 );
+<<<<<<< HEAD
+=======
+
+export const InstagramCanonicalExample = props => (
+  <Component
+    blocks={[instagramBlock]}
+    source="https://www.instagram.com/p/CgNAEjOK46_"
+    {...props}
+  />
+);
+
+export const InstagramNoEmbed = props => (
+  <Component
+    blocks={[instagramBlock]}
+    source="https://www.instagram.com/p/CgNAEjOK46_"
+    {...props}
+  />
+);
+>>>>>>> ce3f0331dd (restore storybook)

--- a/src/app/legacy/containers/SocialEmbed/index.stories.jsx
+++ b/src/app/legacy/containers/SocialEmbed/index.stories.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 
-<<<<<<< HEAD
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
-import { twitterBlock, twitterBlockNoEmbed } from './common/fixtures';
-=======
 import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import {
   twitterBlock,
@@ -13,7 +9,6 @@ import {
   instagramBlock,
   instagramBlockNoEmbed,
 } from './common/fixtures';
->>>>>>> ce3f0331dd (restore storybook)
 import OptimoSocialEmbedContainer from '.';
 import withContexts from './common/testHelper';
 
@@ -56,8 +51,6 @@ export const NoEmbed = props => (
     {...props}
   />
 );
-<<<<<<< HEAD
-=======
 
 export const InstagramCanonicalExample = props => (
   <Component
@@ -74,4 +67,3 @@ export const InstagramNoEmbed = props => (
     {...props}
   />
 );
->>>>>>> ce3f0331dd (restore storybook)

--- a/src/app/legacy/containers/StoryPromo/index.stories.jsx
+++ b/src/app/legacy/containers/StoryPromo/index.stories.jsx
@@ -7,7 +7,7 @@ import { ToggleContextProvider } from '#contexts/ToggleContext';
 import { ARTICLE_PAGE, MEDIA_ASSET_PAGE } from '#app/routes/utils/pageTypes';
 import fixture from './helpers/storiesFixture';
 import StoryPromoContainer from '.';
-import AmpDecorator from '../../../../.storybook/helpers/ampDecorator';
+import AmpDecorator from '../../../../../.storybook/helpers/ampDecorator';
 import { guideLinkItem } from './helpers/fixtureData';
 
 const mediaFixture = type =>

--- a/src/app/legacy/psammead/psammead-image-placeholder/src/index.amp.stories.jsx
+++ b/src/app/legacy/psammead/psammead-image-placeholder/src/index.amp.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import notes from '../README.md';
 import ImagePlaceholderAmp from './index.amp';
-import { ampDecorator } from '../../../../.storybook/preview';
+import { ampDecorator } from '../../../../../../.storybook/preview';
 
 storiesOf('Components/Images/ImagePlaceholderAmp', module)
   .addDecorator(ampDecorator)

--- a/src/app/legacy/psammead/psammead-image/src/index.amp.stories.jsx
+++ b/src/app/legacy/psammead/psammead-image/src/index.amp.stories.jsx
@@ -1,6 +1,6 @@
 import AmpImg from './index.amp';
 import { stories } from './testHelpers/stories';
-import { ampDecorator } from '../../../../.storybook/preview';
+import { ampDecorator } from '../../../../../../.storybook/preview';
 
 const additionalProps = {
   layout: 'responsive',

--- a/src/app/legacy/psammead/psammead-media-player/src/index.stories.jsx
+++ b/src/app/legacy/psammead/psammead-media-player/src/index.stories.jsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 import { CanonicalMediaPlayer, AmpMediaPlayer } from '.';
 import MediaMessage from './Message';
-import { ampDecorator } from '../../../../.storybook/preview';
+import { ampDecorator } from '../../../../../../.storybook/preview';
 import notes from '../README.md';
 
 const withDuration = {

--- a/src/app/legacy/psammead/psammead-navigation/src/index.stories.jsx
+++ b/src/app/legacy/psammead/psammead-navigation/src/index.stories.jsx
@@ -13,7 +13,7 @@ import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 import * as svgs from '#psammead/psammead-assets/src/svgs';
 import { C_WHITE } from '#psammead/psammead-styles/src/colours';
 import Brand from '#psammead/psammead-brand/src';
-import { ampDecorator } from '../../../../.storybook/preview';
+import { ampDecorator } from '../../../../../../.storybook/preview';
 import Navigation, { NavigationUl, NavigationLi } from './index';
 import {
   CanonicalMenuButton,


### PR DESCRIPTION
**Overall change:**
Fixes Storybook and Chromatic.

**Code changes:**

- Updates storybook glob pattern to match stories in their new locations
- Fixes wrong paths in storybook directory

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
