### PR TITLE
Force cache to miss on topics pages to get fresh data (fixes failing tests)

### DIFF
--- a/cypress/integration/pages/topicPage/index.js
+++ b/cypress/integration/pages/topicPage/index.js
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import config from '../../../support/config/services';
 import getPaths from '../../../support/helpers/getPaths';
 import serviceHasPageType from '../../../support/helpers/serviceHasPageType';
@@ -18,7 +19,11 @@ Object.keys(config)
         before(() => {
           Cypress.env('currentPath', currentPath);
 
-          const newPath = `${currentPath}${overrideRendererOnTest()}`;
+          // const newPath = `${currentPath}${overrideRendererOnTest()}`;
+          const overrideSuffix = overrideRendererOnTest();
+          const newPath = `${
+            currentPath + overrideSuffix + (overrideSuffix ? '&' : '?')
+          }id=${uuid()}`;
 
           visitPage(newPath, pageType);
         });

--- a/cypress/integration/pages/topicPage/index.js
+++ b/cypress/integration/pages/topicPage/index.js
@@ -19,7 +19,6 @@ Object.keys(config)
         before(() => {
           Cypress.env('currentPath', currentPath);
 
-          // const newPath = `${currentPath}${overrideRendererOnTest()}`;
           const overrideSuffix = overrideRendererOnTest();
           const newPath = `${
             currentPath + overrideSuffix + (overrideSuffix ? '&' : '?')

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -38,7 +38,73 @@ export default ({ service, pageType, variant }) => {
       });
       cy.log(`topic id ${topicId}`);
     });
+    describe(`Page content`, () => {
+      it('should render a H1, which contains/displays topic title', () => {
+        cy.log(Cypress.env('currentPath'));
 
+        cy.get('h1').should('contain', topicTitle);
+      });
+      it('should render the correct number of items', () => {
+        cy.log(numberOfItems);
+        // Checks number of items on page
+        cy.get('[data-testid="topic-promos"]')
+          .children()
+          .its('length')
+          .should('eq', numberOfItems);
+      });
+      it('First item has correct headline', () => {
+        cy.log(firstItemHeadline);
+        // Goes down into the first item's h2 text and compares to title
+        cy.get('[data-testid="topic-promos"]')
+          .children()
+          .first()
+          .within(() => {
+            cy.get('h2').should('have.text', firstItemHeadline);
+          });
+      });
+      it('Clicking the first item should navigate to the correct page (goes to live article)', () => {
+        // Goes down into the first item's href
+        cy.get('[data-testid="topic-promos"]')
+          .children()
+          .first()
+          .within(() => {
+            cy.get('a')
+              .should('have.attr', 'href')
+              .then($href => {
+                cy.log($href);
+                // Clicks the first item, then checks the page navigates to has the expected url
+                cy.get('a').click();
+                cy.url()
+                  .should('eq', $href)
+                  .then(url => {
+                    // Check the page navigated to has the short headline that was on the topic item
+                    cy.request(`${url}.json`).then(({ body }) => {
+                      if (body.metadata.locators.cpsUrn) {
+                        cy.log('cps article');
+                        const { shortHeadline } = body.promo.headlines;
+                        expect(shortHeadline).to.equal(firstItemHeadline);
+                      }
+                      if (body.promo.locators.optimoUrn) {
+                        cy.log('optimo article');
+                        cy.window().then(win => {
+                          const jsonData = win.SIMORGH_DATA.pageData;
+                          const headline =
+                            jsonData.promo.headlines.promoHeadline.blocks[0]
+                              .model.blocks[0].model.text;
+                          cy.log(
+                            jsonData.promo.headlines.promoHeadline.blocks[0]
+                              .model.blocks[0].model.text,
+                          );
+                          expect(headline).to.equal(firstItemHeadline);
+                        });
+                      }
+                    });
+                  });
+              });
+          });
+        cy.go('back');
+      });
+    });
     describe(`Pagination`, () => {
       it('should show pagination if there is more than one page', () => {
         cy.log(`pagecount is ${pageCount}`);
@@ -101,7 +167,7 @@ export default ({ service, pageType, variant }) => {
         if (pageCount > 1) {
           cy.get('[data-testid="topic-pagination"] > ul > li').last().click();
           cy.url().should('include', `?page=${pageCount}`);
-          cy.get('[data-testid="topic-promos"] li');
+          cy.get('[data-testid="curation-grid-normal"]');
         } else {
           cy.log('No pagination as there is only one page');
         }
@@ -173,72 +239,6 @@ export default ({ service, pageType, variant }) => {
         } else {
           cy.log('Not a script switch service');
         }
-      });
-    });
-    describe(`Page content`, () => {
-      it('should render a H1, which contains/displays topic title', () => {
-        cy.log(Cypress.env('currentPath'));
-
-        cy.get('h1').should('contain', topicTitle);
-      });
-      it('should render the correct number of items', () => {
-        cy.log(numberOfItems);
-        // Checks number of items on page
-        cy.get('[data-testid="topic-promos"]')
-          .children()
-          .its('length')
-          .should('eq', numberOfItems);
-      });
-      it('First item has correct headline', () => {
-        cy.log(firstItemHeadline);
-        // Goes down into the first item's h2 text and compares to title
-        cy.get('[data-testid="topic-promos"]')
-          .children()
-          .first()
-          .within(() => {
-            cy.get('h2').should('have.text', firstItemHeadline);
-          });
-      });
-      it('Clicking the first item should navigate to the correct page (goes to live article)', () => {
-        // Goes down into the first item's href
-        cy.get('[data-testid="topic-promos"]')
-          .children()
-          .first()
-          .within(() => {
-            cy.get('a')
-              .should('have.attr', 'href')
-              .then($href => {
-                cy.log($href);
-                // Clicks the first item, then checks the page navigates to has the expected url
-                cy.get('a').click();
-                cy.url()
-                  .should('eq', $href)
-                  .then(url => {
-                    // Check the page navigated to has the short headline that was on the topic item
-                    cy.request(`${url}.json`).then(({ body }) => {
-                      if (body.metadata.locators.cpsUrn) {
-                        cy.log('cps article');
-                        const { shortHeadline } = body.promo.headlines;
-                        expect(shortHeadline).to.equal(firstItemHeadline);
-                      }
-                      if (body.promo.locators.optimoUrn) {
-                        cy.log('optimo article');
-                        cy.window().then(win => {
-                          const jsonData = win.SIMORGH_DATA.pageData;
-                          const headline =
-                            jsonData.promo.headlines.promoHeadline.blocks[0]
-                              .model.blocks[0].model.text;
-                          cy.log(
-                            jsonData.promo.headlines.promoHeadline.blocks[0]
-                              .model.blocks[0].model.text,
-                          );
-                          expect(headline).to.equal(firstItemHeadline);
-                        });
-                      }
-                    });
-                  });
-              });
-          });
       });
     });
   });


### PR DESCRIPTION
We get a lot of test failures due to a mismatch of the up-to-date data requested from the BFF and the out-of-date cached topics page. Adding the random query string to the end forces to cache to be missed and the page always has fresh data. This is done with the uuid package for generating a random ID.

Also allows one item on the last page (fails when isn't in a list, but this will sometimes happen on the last page).

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Passes on test and live
