### PR TITLE
WSTEAM1-113 - Enable Indonesian recommendations

### DIFF
--- a/src/app/lib/config/services/indonesia.js
+++ b/src/app/lib/config/services/indonesia.js
@@ -289,7 +289,11 @@ export const service = {
       durationLabel: 'Durasi %duration%',
     },
     recommendations: {
-      hasStoryRecommendations: false,
+      hasStoryRecommendations: true,
+      skipLink: {
+        text: 'Lewatkan %title% dan terus membaca',
+        endTextVisuallyHidden: 'Akhir dari %title%',
+      },
     },
     footer: {
       trustProjectLink: {


### PR DESCRIPTION
Resolves WSTEAM1-113

**Overall change:**
Enables recommendations on the Indonesian service

**Code changes:**
- Enables the `recommendations` flag on the Indonesian service config
- Adds skipLink text to this config to allow skipping of recommendation content

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
