### PR TITLE
Cy.go('back') moved to beginning of next test

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -72,6 +72,7 @@ export default ({ service, pageType, variant }) => {
               .should('have.attr', 'href')
               .then($href => {
                 cy.log($href);
+
                 // Clicks the first item, then checks the page navigates to has the expected url
                 cy.get('a').click();
                 cy.url()
@@ -102,11 +103,12 @@ export default ({ service, pageType, variant }) => {
                   });
               });
           });
-        cy.go('back');
       });
     });
     describe(`Pagination`, () => {
       it('should show pagination if there is more than one page', () => {
+        // First return to the topics page. Last test has page on article
+        cy.go('back');
         cy.log(`pagecount is ${pageCount}`);
         // Checks pagination only is on page if there is more than one page
         if (pageCount > 1) {


### PR DESCRIPTION
If the previous test fails, the test does not return to the topics page and the rest of the tests will fail. This just moves the back command into a better position: stops all test failing if that one fails, but also is a better test structure according to the Arrange, Act, Assert pattern

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**
Passes on live
