### PR TITLE
Removes the Pidgin topics page URL with Pidgin Minute causing test failures

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -5447,7 +5447,6 @@ module.exports = () => ({
         environments: {
           live: {
             paths: [
-              '/pidgin/topics/c0823e52dd0t',
               '/pidgin/topics/c95y35941vrt',
               '/pidgin/topics/cnq68qvkjp1t', // One page only
             ],
@@ -5455,7 +5454,6 @@ module.exports = () => ({
           },
           test: {
             paths: [
-              '/pidgin/topics/c0823e52dd0t',
               '/pidgin/topics/cqywjyzk2vyt',
               '/pidgin/topics/cnq68qvkjp1t', // One page only
             ],


### PR DESCRIPTION
We already have the tests running on two other Pidgin pages anyway. This one has been causing failures, probably because of the frequently changing position of the Pidgin Minute which regularly updates episode.
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

There is no reason removing a URL should cause a test failure