### PR TITLE
Test setting `x-frame-options` and `Cross Domain` headers for Article embeds

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -18,6 +18,7 @@ import {
 } from '#lib/logger.const';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import { OK } from '#lib/statusCodes.const';
+import isLive from '#lib/utilities/isLive';
 import injectCspHeader from './utilities/cspHeader';
 import logResponseTime from './utilities/logResponseTime';
 import renderDocument from './Document';
@@ -130,10 +131,23 @@ const injectDefaultCacheHeader = (req, res, next) => {
   next();
 };
 
+const injectTestEmbedHeaderControl = (req, res, next) => {
+  if (!isLive()) {
+    res
+      .set('x-frame-options', 'SAMEORIGIN')
+      .removeHeader('X-Permitted-Cross-Domain-Policies');
+  }
+  next();
+};
+
 // Catch all for all routes
 server.get(
   '/*',
-  [injectCspHeaderProdBuild, injectDefaultCacheHeader],
+  [
+    injectCspHeaderProdBuild,
+    injectDefaultCacheHeader,
+    injectTestEmbedHeaderControl,
+  ],
   async ({ url, query, headers, path: urlPath }, res) => {
     logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
       url,


### PR DESCRIPTION
Related to WSTEAM1-96

**Overall change:**
Attempts to set the `x-frame-options` header and removes the `X-Permitted-Cross-Domain-Policies` header for consistency across different page types. Currently, CPS pages have `x-frame-options: SAMEORIGIN`, whereas Article pages have `x-frame-options: DENY`. Article pages includes the header `X-Permitted-Cross-Domain-Policies: deny` as well, whereas CPS pages don't have this header at all.

This is an attempt to see if this is the cause of the Instagram embeds not rendering images correctly.

This is isolated to Test only.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
