### PR TITLE
Revert "Test setting `x-frame-options` and `Cross Domain` headers for Article embeds (#10220)"

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '#lib/logger.const';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import { OK } from '#lib/statusCodes.const';
-import isLive from '#lib/utilities/isLive';
 import injectCspHeader from './utilities/cspHeader';
 import logResponseTime from './utilities/logResponseTime';
 import renderDocument from './Document';
@@ -131,23 +130,10 @@ const injectDefaultCacheHeader = (req, res, next) => {
   next();
 };
 
-const injectTestEmbedHeaderControl = (req, res, next) => {
-  if (!isLive()) {
-    res
-      .set('x-frame-options', 'SAMEORIGIN')
-      .removeHeader('X-Permitted-Cross-Domain-Policies');
-  }
-  next();
-};
-
 // Catch all for all routes
 server.get(
   '/*',
-  [
-    injectCspHeaderProdBuild,
-    injectDefaultCacheHeader,
-    injectTestEmbedHeaderControl,
-  ],
+  [injectCspHeaderProdBuild, injectDefaultCacheHeader],
   async ({ url, query, headers, path: urlPath }, res) => {
     logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
       url,


### PR DESCRIPTION
This reverts commit 9fe338c4505146ff31e17e57344263cf1bb42557.

**Overall change:**
Reverts setting of the `x-frame-options` header and removal of the `X-Permitted-Cross-Domain-Policies` header. These changes didn't have an effect on the Instagram embed display issue.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
