### PR TITLE
Temporarily remove grouping of minor+patch upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
     {
       "packagePatterns": ["*"],
       "excludePackagePatterns": ["^@bbc", "^@loadable", "webpack"],
-      "updateTypes": ["minor", "patch"],
-      "groupName": "all 3rd party non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "updateTypes": ["minor"],
+      "groupName": "all 3rd party minor dependencies",
+      "groupSlug": "all-minor"
     },
     {
       "packagePatterns": ["^@loadable"],

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
     {
       "packagePatterns": ["*"],
       "excludePackagePatterns": ["^@bbc", "^@loadable", "webpack"],
-      "updateTypes": ["minor"],
-      "groupName": "all 3rd party minor dependencies",
-      "groupSlug": "all-minor"
+      "updateTypes": ["patch"],
+      "groupName": "all 3rd party patch dependencies",
+      "groupSlug": "all-patch"
     },
     {
       "packagePatterns": ["^@loadable"],


### PR DESCRIPTION
**Overall change:**
This PR removes minor upgrades from the grouped minor+patch dependency PR.

The [current PR](https://github.com/bbc/simorgh/pull/10096) has lots of failing tests and after spending a day trying to identify the cause it seems better remove minor upgrades to see if patch upgrades can be merged as group PR. We can then narrow down which minor upgrades are causing this issue; we _should_ expect patch upgrades to be less likely to cause a breaking change.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
