### PR TITLE
Fix Interactive Cypress (again)

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -50,6 +50,9 @@ module.exports = (on, config) => {
       },
       plugins: [new MomentTimezoneInclude({ startYear: 2010, endYear: 2025 })],
     },
+    watchOptions: {
+      ignored: ['**/tz/**'],
+    },
   };
 
   on('file:preprocessor', webpackPreprocessor(options));


### PR DESCRIPTION
**Overall change:**
This PR disables file watching for `tz` files generated by the `MomentTimeZone` include package. As described on the [first attempted PR](https://github.com/bbc/simorgh/pull/10249) the extraction of the tz files causes an infinite loop in the cypress dev UI.

In this PR instead of the removing the include from the cypress build as in the first PR, we now disable watching for changes to those files to avoid the loop.

An alternative to this is to source control the output of our custom webpack plugin as in this PR: https://github.com/bbc/simorgh/pull/10250 

I am a little hesitent to do this because:
- It adds a lot of file to source control - someone could get the impression we maintain the contents of these files; it isn't our source code as much as build output
- The files will every so often be updated when the user upgrades the `moment-timezone` package. I can't think of a way we can make that intuitive to maintainers.

Please debate this, either solution works, though some additional cleanup will be needed in this PR around our webpack setups for Simorgh and Cypress: https://github.com/bbc/simorgh/pull/10250  

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
