### PR TITLE
fix: chartbeat && CORS Safari instagram embeds

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '#lib/logger.const';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import { OK } from '#lib/statusCodes.const';
-import isLive from '../app/lib/utilities/isLive';
 import injectCspHeader from './utilities/cspHeader';
 import logResponseTime from './utilities/logResponseTime';
 import renderDocument from './Document';
@@ -128,16 +127,23 @@ const injectDefaultCacheHeader = (req, res, next) => {
     'cache-control',
     `public, stale-if-error=90, stale-while-revalidate=30, max-age=30`,
   );
-  if (!isLive()) {
-    res.set('Referrer-Policy', 'no-referrer-when-downgrade');
-  }
+  next();
+};
+
+// Set Referrer-Policy
+const injectReferrerPolicyHeader = (req, res, next) => {
+  res.set('Referrer-Policy', 'no-referrer-when-downgrade');
   next();
 };
 
 // Catch all for all routes
 server.get(
   '/*',
-  [injectCspHeaderProdBuild, injectDefaultCacheHeader],
+  [
+    injectCspHeaderProdBuild,
+    injectDefaultCacheHeader,
+    injectReferrerPolicyHeader,
+  ],
   async ({ url, query, headers, path: urlPath }, res) => {
     logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
       url,

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -1411,6 +1411,12 @@ describe('Server HTTP Headers - Page Endpoints', () => {
       'public, stale-if-error=90, stale-while-revalidate=30, max-age=30',
     );
   });
+
+  it(`should set a Referrer-Policy header`, async () => {
+    const { header } = await makeRequest('/mundo');
+
+    expect(header['referrer-policy']).toBe('no-referrer-when-downgrade');
+  });
 });
 
 describe('Routing Information Logging', () => {


### PR DESCRIPTION
Resolves: 
[#NEWSWORLDSERVICE-1580](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1580)
[#WSTEAM1-137](https://jira.dev.bbc.co.uk/browse/WSTEAM1-137)

**Overall change:**
Currently, Referrer-Policy is set to `no-referrer` for Optimo pages.
This PR force set `Referrer-Policy` to `no-referrer-when-downgrade` in our middleware.
This fixes [Chartbeat v bug,](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1580) and [Instagram Social Embeds CORS Error in Safari Bug](https://jira.dev.bbc.co.uk/browse/WSTEAM1-137)

Extra docs if you are interested:
[ChartBeat Virtual Referrer](https://docs.chartbeat.com/cbp/tracking/standard-websites/configuration-variables#virtual-referrer)
[ReferrerPolicy](https://www.w3.org/TR/referrer-policy/#referrer-policies)
[referrer-policy-no-referrer-when-downgrade](https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer-when-downgrade)

**Code changes:**

- Removes previous testing code for referrer-policy-no-referrer-when-downgrade
- Creates a new `injectReferrerPolicyHeader`

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
