### PR TITLE
[NEWSWORLDSERVICE-1582] Update Cache-Control header in sw.js

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -95,6 +95,10 @@ server
 server
   .get([articleSwPath, frontPageSwPath], (req, res) => {
     const swPath = `${__dirname}/public/sw.js`;
+    res.set(
+      `Cache-Control`,
+      `public, stale-if-error=6000, stale-while-revalidate=300, max-age=300`,
+    );
     res.sendFile(swPath, {}, error => {
       if (error) {
         logger.error(SERVICE_WORKER_SENDFILE_ERROR, { error });

--- a/src/server/index.test.jsx
+++ b/src/server/index.test.jsx
@@ -815,6 +815,13 @@ describe('Server', () => {
       expect(sendFileSpy.mock.calls.length).toEqual(0);
       expect(statusCode).toEqual(500);
     });
+
+    it('should serve the sw.js with cache control information', async () => {
+      const { header } = await makeRequest('/pidgin/sw.js');
+      expect(header['cache-control']).toBe(
+        'public, stale-if-error=6000, stale-while-revalidate=300, max-age=300',
+      );
+    });
   });
 
   describe('Manifest json', () => {
@@ -830,6 +837,7 @@ describe('Server', () => {
       expect(sendFileSpy.mock.calls.length).toEqual(0);
       expect(statusCode).toEqual(500);
     });
+
     it('should serve a response cache control of 7 days', async () => {
       const { header } = await makeRequest('/news/articles/manifest.json');
       expect(header['cache-control']).toBe('public, max-age=604800');


### PR DESCRIPTION
Resolves #[NEWSWORLDSERVICE-1582](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1582)

**Overall change:**
Updates the `Cache-Control` header in `sw.js`

from: `Cache-Control: public, stale-if-error=90, stale-while-revalidate=30, max-age=0`

to:  `Cache-Control:public, stale-if-error=6000, stale-while-revalidate=300, max-age=300`

**Code changes:**

- Add `'Cache-Control', 'public, stale-if-error=6000, stale-while-revalidate=300, max-age=300'` to sw.js
- Add test to check that correct header is being sent

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [x] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
