### PR TITLE
Improved types for `altCalendar`, `brandSVG` and `fonts` in ServiceConfigs

### DIFF
--- a/src/app/models/types/serviceConfig.ts
+++ b/src/app/models/types/serviceConfig.ts
@@ -56,7 +56,9 @@ export type ServiceConfig = {
   serviceName: string;
   serviceLang?: string;
   languageName: string;
-  altCalendar?: unknown;
+  altCalendar?: {
+    formatDate: (gregorianMoment: unknown) => string | null;
+  };
   themeColor: string;
   twitterCreator: string;
   twitterSite: string;
@@ -89,13 +91,20 @@ export type ServiceConfig = {
     para3: string;
   };
   translations: Translations;
-  brandSVG: unknown;
+  brandSVG: {
+    group: JSX.Element;
+    ratio: number;
+    viewbox: {
+      height: number;
+      width: number;
+    };
+  };
   mostRead: MostRead;
   mostWatched: MostWatched;
   radioSchedule?: RadioSchedule;
   recommendations?: Recommendations;
   footer: Footer;
-  fonts?: unknown;
+  fonts?: ((baseUrlOverride: string) => string)[];
   navigation?: {
     title: string;
     url: string;


### PR DESCRIPTION
**Overall change:**
Improves the type definitions for `altCalendar`, `brandSVG` and `fonts`, as these were previously set to `unknown`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
