### PR TITLE
WSTEAM1-47 - Embed consent banner a11y fixes

### DIFF
--- a/src/app/components/EmbedConsentBanner/ConsentBanner.styles.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.styles.tsx
@@ -10,6 +10,7 @@ export default {
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'flex-start',
+      border: '0.1875rem solid transparent',
     }),
 
   heading: ({ palette }: Theme) =>
@@ -25,16 +26,16 @@ export default {
       a: {
         color: 'inherit',
         textDecoration: 'none',
-        borderBottom: `1px solid ${palette.GREY_10}`,
+        borderBottom: `0.0625rem solid ${palette.GREY_10}`,
 
         '&:hover, &:focus': {
           color: palette.POSTBOX,
-          borderBottom: `2px solid ${palette.POSTBOX}`,
+          borderBottom: `0.125rem solid ${palette.POSTBOX}`,
         },
 
         '&:visited': {
           color: palette.GREY_6,
-          borderBottom: `1px solid ${palette.GREY_6}`,
+          borderBottom: `0.0625rem solid ${palette.GREY_6}`,
         },
       },
     }),
@@ -43,7 +44,7 @@ export default {
     css({
       color: palette.GREY_10,
       backgroundColor: palette.WHITE,
-      border: `1px solid ${palette.PHILIPPINE_GREY}`,
+      border: `0.0625rem solid ${palette.PHILIPPINE_GREY}`,
       borderRadius: 0,
       fontWeight: 'bold',
       padding: `${spacings.FULL}rem`,
@@ -52,7 +53,7 @@ export default {
       '&:hover, &:focus': {
         backgroundColor: palette.POSTBOX,
         color: palette.WHITE,
-        border: `1px solid ${palette.POSTBOX}`,
+        border: `0.0625rem solid ${palette.POSTBOX}`,
       },
     }),
 };

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.styles.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { css, Theme } from '@emotion/react';
+import pixelsToRem from '../../utilities/pixelsToRem';
 
 export default {
   parent: ({ spacings, palette }: Theme) =>
@@ -10,7 +11,7 @@ export default {
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'flex-start',
-      border: '0.1875rem solid transparent',
+      border: `${pixelsToRem(3)}rem solid transparent`,
     }),
 
   heading: ({ palette }: Theme) =>
@@ -26,16 +27,16 @@ export default {
       a: {
         color: 'inherit',
         textDecoration: 'none',
-        borderBottom: `0.0625rem solid ${palette.GREY_10}`,
+        borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_10}`,
 
         '&:hover, &:focus': {
           color: palette.POSTBOX,
-          borderBottom: `0.125rem solid ${palette.POSTBOX}`,
+          borderBottom: `${pixelsToRem(2)}rem solid ${palette.POSTBOX}`,
         },
 
         '&:visited': {
           color: palette.GREY_6,
-          borderBottom: `0.0625rem solid ${palette.GREY_6}`,
+          borderBottom: `${pixelsToRem(1)}rem solid ${palette.GREY_6}`,
         },
       },
     }),
@@ -44,7 +45,7 @@ export default {
     css({
       color: palette.GREY_10,
       backgroundColor: palette.WHITE,
-      border: `0.0625rem solid ${palette.PHILIPPINE_GREY}`,
+      border: `${pixelsToRem(1)}rem solid ${palette.PHILIPPINE_GREY}`,
       borderRadius: 0,
       fontWeight: 'bold',
       padding: `${spacings.FULL}rem`,
@@ -53,7 +54,7 @@ export default {
       '&:hover, &:focus': {
         backgroundColor: palette.POSTBOX,
         color: palette.WHITE,
-        border: `0.0625rem solid ${palette.POSTBOX}`,
+        border: `${pixelsToRem(1)}rem solid ${palette.POSTBOX}`,
       },
     }),
 };

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.test.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.test.tsx
@@ -29,9 +29,11 @@ describe('Embed Consent Banner - Content', () => {
     const heading = screen.getByTestId('banner-heading');
     const body = screen.getByTestId('banner-body');
 
-    expect(heading.textContent).toEqual('¿Permitir el contenido de YouTube?');
+    expect(heading.textContent).toEqual(
+      '¿Permitir el contenido de Google YouTube?',
+    );
     expect(body.textContent).toEqual(
-      "Este artículo contiene contenido proporcionado por YouTube. Solicitamos tu permiso antes de que algo  se cargue, ya que ese sitio  puede estar usando cookies y otras tecnologías. Es posible que quieras leer política de cookies y política de privacidad de YouTube antes de aceptar. Para ver este contenido, selecciona 'aceptar y continuar'.",
+      "Este artículo contiene contenido proporcionado por Google YouTube. Solicitamos tu permiso antes de que algo  se cargue, ya que ese sitio  puede estar usando cookies y otras tecnologías. Es posible que quieras leer política de cookies y política de privacidad de Google YouTube antes de aceptar. Para ver este contenido, selecciona 'aceptar y continuar'.",
     );
   });
 
@@ -65,9 +67,9 @@ describe('Embed Consent Banner - Content', () => {
     const heading = screen.getByTestId('banner-heading');
     const body = screen.getByTestId('banner-body');
 
-    expect(heading.textContent).toEqual('Allow YouTube content?');
+    expect(heading.textContent).toEqual('Allow Google YouTube content?');
     expect(body.textContent).toEqual(
-      "This article contains content provided by YouTube.  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read Google's cookie policy and privacy policy before accepting. To view this content choose 'accept and continue'.",
+      "This article contains content provided by Google YouTube.  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read Google YouTube cookie policy and privacy policy before accepting. To view this content choose 'accept and continue'.",
     );
   });
 

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
@@ -21,7 +21,7 @@ import consentBannerCss from './ConsentBanner.styles';
 
 const defaultTranslations: Translations['socialEmbed']['consentBanner'] = {
   heading: 'Allow [social_media_site] content?',
-  body: `This article contains content provided by [social_media_site].  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read [link] [social_media_site] cookie policy [/link] and [link] [social_media_site] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
+  body: `This article contains content provided by YouTube.  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read Google's [link] cookie policy [/link] and [link] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
   button: 'Accept and continue',
   cookiesUrl: {
     youtube: 'https://policies.google.com/technologies/cookies',

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
@@ -21,7 +21,7 @@ import consentBannerCss from './ConsentBanner.styles';
 
 const defaultTranslations: Translations['socialEmbed']['consentBanner'] = {
   heading: 'Allow [social_media_site] content?',
-  body: `This article contains content provided by YouTube.  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read Google's [link] cookie policy [/link] and [link] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
+  body: `This article contains content provided by [social_media_site].  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read [social_media_site] [link] cookie policy [/link] and [link] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
   button: 'Accept and continue',
   cookiesUrl: {
     youtube: 'https://policies.google.com/technologies/cookies',
@@ -35,7 +35,7 @@ const getProviderName = (provider: SocialEmbedProviders) => {
   return {
     instagram: 'Instagram',
     twitter: 'Twitter',
-    youtube: 'YouTube',
+    youtube: 'Google YouTube',
     facebook: 'Facebook',
   }[provider];
 };

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
@@ -107,8 +107,6 @@ const getTranslations = (
           .replaceAll('[link]', '')
           .replaceAll('[/link]', '')
           .trim()}${externalLinkText}`}
-        target="_blank"
-        rel="noreferrer"
         key={cookiesUrl}
       >
         {linkTextElements[0]
@@ -124,8 +122,6 @@ const getTranslations = (
           .replaceAll('[link]', '')
           .replaceAll('[/link]', '')
           .trim()}${externalLinkText}`}
-        target="_blank"
-        rel="noreferrer"
         key={privacyUrl}
       >
         {linkTextElements[1]

--- a/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
+++ b/src/app/components/EmbedConsentBanner/ConsentBanner.tsx
@@ -20,8 +20,8 @@ import {
 import consentBannerCss from './ConsentBanner.styles';
 
 const defaultTranslations: Translations['socialEmbed']['consentBanner'] = {
-  heading: 'Allow YouTube content?',
-  body: `This article contains content provided by YouTube.  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read Google's [link] cookie policy [/link] and [link] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
+  heading: 'Allow [social_media_site] content?',
+  body: `This article contains content provided by [social_media_site].  We ask for your permission before anything is loaded, as they may be using cookies and other technologies.  You may want to read [link] [social_media_site] cookie policy [/link] and [link] [social_media_site] privacy policy [/link] before accepting. To view this content choose 'accept and continue'.`,
   button: 'Accept and continue',
   cookiesUrl: {
     youtube: 'https://policies.google.com/technologies/cookies',

--- a/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
@@ -143,8 +143,6 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
       <a
         aria-label="política de cookies, externo"
         href="https://policies.google.com/technologies/cookies"
-        rel="noreferrer"
-        target="_blank"
       >
         política de cookies
       </a>
@@ -152,8 +150,6 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
       <a
         aria-label="política de privacidad, externo"
         href="https://policies.google.com/privacy"
-        rel="noreferrer"
-        target="_blank"
       >
         política de privacidad
       </a>

--- a/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
@@ -134,13 +134,13 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
       class="emotion-1"
       data-testid="banner-heading"
     >
-      ¿Permitir el contenido de YouTube?
+      ¿Permitir el contenido de Google YouTube?
     </strong>
     <p
       class="emotion-2"
       data-testid="banner-body"
     >
-      Este artículo contiene contenido proporcionado por YouTube. Solicitamos tu permiso antes de que algo  se cargue, ya que ese sitio  puede estar usando cookies y otras tecnologías. Es posible que quieras leer 
+      Este artículo contiene contenido proporcionado por Google YouTube. Solicitamos tu permiso antes de que algo  se cargue, ya que ese sitio  puede estar usando cookies y otras tecnologías. Es posible que quieras leer 
       <a
         aria-label="política de cookies, externo"
         href="https://policies.google.com/technologies/cookies"
@@ -154,7 +154,7 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
       >
         política de privacidad
       </a>
-       de YouTube antes de aceptar. Para ver este contenido, selecciona 'aceptar y continuar'.
+       de Google YouTube antes de aceptar. Para ver este contenido, selecciona 'aceptar y continuar'.
     </p>
     <button
       class="emotion-3"

--- a/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/EmbedConsentBanner/__snapshots__/index.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+  border: 0.1875rem solid transparent;
 }
 
 .emotion-1 {
@@ -59,18 +60,18 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom: 1px solid #141414;
+  border-bottom: 0.0625rem solid #141414;
 }
 
 .emotion-2 a:hover,
 .emotion-2 a:focus {
   color: #B80000;
-  border-bottom: 2px solid #B80000;
+  border-bottom: 0.125rem solid #B80000;
 }
 
 .emotion-2 a:visited {
   color: #545658;
-  border-bottom: 1px solid #545658;
+  border-bottom: 0.0625rem solid #545658;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -90,7 +91,7 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
 .emotion-3 {
   color: #141414;
   background-color: #FFFFFF;
-  border: 1px solid #8A8C8E;
+  border: 0.0625rem solid #8A8C8E;
   border-radius: 0;
   font-weight: bold;
   padding: 0.5rem;
@@ -106,7 +107,7 @@ exports[`Embed Consent Banner should match snapshot 1`] = `
 .emotion-3:focus {
   background-color: #B80000;
   color: #FFFFFF;
-  border: 1px solid #B80000;
+  border: 0.0625rem solid #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {


### PR DESCRIPTION
Part of WSTEAM1-47

**Overall change:**
Some small fixes from a11y feedback for the embed consent banner:
- Adds transparent border around the consent banner to highlight when users set colour / contrast preferences
- Changes underline borders from `px` to `rem` values
- Removes `target` and `rel` attributes from anchor tags 
- Changes the YouTube provider text from `YouTube` to `Google YouTube`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
