### PR TITLE
WSTEAM-1 129 Bylines Photo

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -117,6 +117,7 @@ export const service: DefaultServiceConfig = {
       byline: {
         author: 'Barreessaa',
         articleInformation: 'Odeeffannoo barreeffamichaa',
+        listItemImage: 'Tarree, suuraa',
         published: 'Maxxanfame',
         reportingFrom: 'Gabaasni irraati',
         role: 'Gahee',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -109,7 +109,11 @@ export const service: DefaultServiceConfig = {
         },
       },
       byline: {
+        author: 'ፀሐፊ',
+        articleInformation: 'የጽሁፉ መረጃ',
+        listItemImage: 'ዝርዝር፣ ምስል',
         published: 'ታትሟል',
+        reportingFrom: 'ዘገባው ከ',
         role: 'የሥራ ድርሻ',
       },
       consentBanner: {

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -115,6 +115,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Məqalə barədə məlumat',
+        author: 'Müəllif',
+        listItemImage: 'Siyahı elementi, foto',
         published: 'Çap edildi',
         reportingFrom: 'Məkan',
         role: 'Vəzifə',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -128,6 +128,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'ဆောင်းပါးအချက်အလက်',
+        author: 'ရေးသားသူ',
+        listItemImage: 'ရုပ်ပုံ ',
         published: 'ရေးသားခဲ့သည်။',
         reportingFrom: 'ရေးသားပေးပို့သည့်နေရာ',
         role: 'ရာထူးတာဝန်',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -127,8 +127,10 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Ibiranga iyi nkuru',
+        author: 'Umwanditsi',
+        listItemImage: 'Tondeka iyi nkuru, ifoto',
         published: 'Yatangajwe',
-        reportingFrom: '',
+        reportingFrom: 'Yakoze inkuru ari',
         role: 'Igikorwa',
       },
       consentBanner: {

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -114,6 +114,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'લેખની માહિતી',
+        author: 'લેેખક',
+        listItemImage: 'તસવીર',
         published: 'પ્રકાશિત',
         reportingFrom: 'દ્વારા રિપોર્ટિંગ',
         role: 'પદ',

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -125,6 +125,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Bayani kan maƙala',
+        author: 'Marubuci',
+        listItemImage: 'Jerin abubuwa, hoto',
         published: 'An wallafa',
         reportingFrom: 'Aiko rahoto daga',
         role: 'Sanya sunan wanda ya rubuta labari',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -135,6 +135,7 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: '....में',
+        listItemImage: 'तस्वीर',
         published: 'प्रकाशित',
         reportingFrom: '........से',
         role: 'पदनाम',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -118,6 +118,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Ebe akụkọ a si',
+        author: 'Onye dere ya',
+        listItemImage: 'Ndepụta ihe, foto',
         published: 'Mgbe e biputara ya',
         reportingFrom: 'Ebeg o si',
         role: 'Ndị mere akụkọ a',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -135,6 +135,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Informasi artikel',
+        author: 'Penulis',
+        listItemImage: 'Daftar isi, gambar',
         published: 'Telah diterbitkan',
         reportingFrom: 'Melaporkan dari',
         role: 'Peranan',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -112,6 +112,13 @@ export const service: DefaultServiceConfig = {
           callToActionLinkUrl: 'https://www.bbc.com/korean',
         },
       },
+      byline: {
+        articleInformation: '기사 관련 정보',
+        author: '기자',
+        listItemImage: '기자 사진',
+        published: '게재 시간',
+        role: '기자',
+      },
       consentBanner: {
         privacy: {
           title: '개인 정보와 쿠키 처리 방침이 업데이트되었습니다',

--- a/src/app/lib/config/services/pashto.ts
+++ b/src/app/lib/config/services/pashto.ts
@@ -115,6 +115,7 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'د مطلب په اړه جزییات',
+        listItemImage: 'د توکو نوملړ، انځور',
         published: 'د خپرېدو وخت',
         reportingFrom: 'رپوټ له:',
         role: 'دنده',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -137,6 +137,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'اطلاعات مقاله',
+        author: 'نویسنده',
+        listItemImage: 'تصویر نویسنده مقاله',
         published: 'منتشر شده در',
         reportingFrom: 'در',
         role: 'شغل',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -111,6 +111,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: '...ਵਿੱਚ',
+        author: 'ਲੇਖਕ',
+        listItemImage: 'ਤਸਵੀਰ',
         published: 'ਪ੍ਰਕਾਸ਼ਿਤ',
         reportingFrom: '...ਤੋਂ',
         role: 'ਰੋਲ',

--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -167,6 +167,8 @@ export const mainTranslations = {
   },
   byline: {
     articleInformation: 'О статье',
+    author: 'Автор',
+    listItemImage: 'Добавить фото',
     published: 'Опубликовано',
     reportingFrom: 'Место сообщения',
     role: 'Должность',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -220,6 +220,8 @@ export const service: SerbianConfig = {
       },
       byline: {
         articleInformation: 'Podaci o članku',
+        author: 'Autor',
+        listItemImage: 'Prikazane fotografije',
         published: 'Objavljeno',
         reportingFrom: 'Izveštava iz',
         role: 'Funkcija',
@@ -545,6 +547,8 @@ export const service: SerbianConfig = {
       },
       byline: {
         articleInformation: 'Подаци о чланку',
+        author: 'Аутор',
+        listItemImage: 'Приказане фотографије',
         published: 'Објављено',
         reportingFrom: 'Извештава из',
         role: 'Функција',

--- a/src/app/lib/config/services/swahili.ts
+++ b/src/app/lib/config/services/swahili.ts
@@ -115,6 +115,7 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Maelezo kuhusu taarifa',
+        listItemImage: 'Orodha,Picha',
         published: 'Iliyochapishwa',
         reportingFrom: 'Akiripoti kutoka',
         role: 'Nafasi',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -115,6 +115,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'கட்டுரை தகவல்',
+        author: 'எழுதியவர்',
+        listItemImage: 'பட்டியல், படம்',
         published: 'பிரசுரிக்கப்பட்டது',
         reportingFrom: 'இருந்து',
         role: 'பதவி',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -114,6 +114,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'కథనం',
+        author: 'రచయిత',
+        listItemImage: 'చిత్రం',
         published: 'ప్రచురణ',
         reportingFrom: 'నుంచి',
         role: 'హోదా',

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -116,6 +116,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'Haber bilgisi',
+        author: 'Yazan',
+        listItemImage: 'Muhabir görseli',
         published: 'Yayın tarihi',
         reportingFrom: 'Bildirdiği yer',
         role: 'Unvan',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -131,6 +131,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: 'مضمون کی تفصیل',
+        author: 'مصنف',
+        listItemImage: 'لسٹ آئٹم، تصویر',
         published: 'وقت اشاعت',
         reportingFrom: 'مقام',
         role: 'عہدہ',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -113,6 +113,8 @@ export const service: DefaultServiceConfig = {
       },
       byline: {
         articleInformation: '',
+        author: 'Tác giả',
+        listItemImage: 'Danh sách mục, hình ảnh',
         published: 'Được đăng',
         reportingFrom: '',
         role: 'Vai trò',

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -37,6 +37,7 @@ export interface Translations {
   byline?: {
     author?: string;
     articleInformation?: string;
+    listItemImage?: string;
     published?: string;
     reportingFrom?: string;
     role?: string;

--- a/src/app/pages/ArticlePage/Byline/fixture/index.js
+++ b/src/app/pages/ArticlePage/Byline/fixture/index.js
@@ -554,3 +554,156 @@ export const bylineWithLinkAndLocation = [
     },
   },
 ];
+
+export const bylineWithPhoto = [
+  {
+    type: 'contributor',
+    model: {
+      blocks: [
+        {
+          type: 'name',
+          model: {
+            blocks: [
+              {
+                type: 'text',
+                model: {
+                  blocks: [
+                    {
+                      type: 'paragraph',
+                      model: {
+                        text: 'Clark Kent',
+                        blocks: [
+                          {
+                            type: 'fragment',
+                            model: {
+                              text: 'Single Byline (all values)',
+                              attributes: [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'role',
+          model: {
+            blocks: [
+              {
+                type: 'text',
+                model: {
+                  blocks: [
+                    {
+                      type: 'paragraph',
+                      model: {
+                        text: 'Journalist',
+                        blocks: [
+                          {
+                            type: 'fragment',
+                            model: {
+                              text: 'Test',
+                              attributes: [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'link',
+          model: {
+            blocks: [
+              {
+                type: 'text',
+                model: {
+                  blocks: [
+                    {
+                      type: 'paragraph',
+                      model: {
+                        text: 'superman',
+                        blocks: [
+                          {
+                            type: 'urlLink',
+                            model: {
+                              text: 'superman',
+                              locator: 'https://twitter.com/Superman',
+                              blocks: [
+                                {
+                                  type: 'fragment',
+                                  model: {
+                                    text: 'test',
+                                    attributes: [],
+                                  },
+                                },
+                              ],
+                              isExternal: true,
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'location',
+          model: {
+            blocks: [
+              {
+                type: 'text',
+                model: {
+                  blocks: [
+                    {
+                      type: 'paragraph',
+                      model: {
+                        text: 'Metropolis, US',
+                        blocks: [
+                          {
+                            type: 'fragment',
+                            model: {
+                              text: 'Metropolis, US',
+                              attributes: [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'image',
+          model: {
+            blocks: [
+              {
+                type: 'rawImage',
+                model: {
+                  width: 640,
+                  height: 562,
+                  locator:
+                    'https://scarletjourney.rutgers.edu/crm/wp-content/uploads/sites/393/2017/12/christopher-reeve-superman.jpg',
+                  originCode: 'cpsdevpb',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+];

--- a/src/app/pages/ArticlePage/Byline/index.stories.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.stories.tsx
@@ -6,6 +6,7 @@ import {
   bylineWithNameAndRole,
   bylineWithLink,
   bylineWithLinkAndLocation,
+  bylineWithPhoto,
 } from './fixture';
 import Byline from '.';
 import { withServicesKnob } from '../../../legacy/psammead/psammead-storybook-helpers/src';
@@ -64,6 +65,15 @@ export const LinkAndLocationByline = ({ service, variant }: Props) => (
     service={service}
     variant={variant}
   >
+    <Timestamp
+      firstPublished={1660658887}
+      lastPublished={1660658887}
+      popOut={false}
+    />
+  </Component>
+);
+export const LinkLocationPhotoByline = ({ service, variant }: Props) => (
+  <Component fixture={bylineWithPhoto} service={service} variant={variant}>
     <Timestamp
       firstPublished={1660658887}
       lastPublished={1660658887}

--- a/src/app/pages/ArticlePage/Byline/index.styles.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.styles.tsx
@@ -77,7 +77,8 @@ export default {
   location: () =>
     css({
       margin: '0',
-      display: 'inline-block',
+      display: 'block',
+      clear: 'both',
     }),
 
   locationText: ({ palette }: Theme) =>
@@ -100,6 +101,40 @@ export default {
         display: 'block',
         margin: `${spacings.DOUBLE}rem 0`,
       },
+    }),
+
+  imageLtr: () =>
+    css({
+      display: 'block',
+      width: `${pixelsToRem(80)}rem`,
+      height: `${pixelsToRem(80)}rem`,
+      border: `solid ${pixelsToRem(1)}rem #979797`,
+      margin: `${pixelsToRem(25)}rem ${pixelsToRem(8)}rem ${pixelsToRem(
+        16,
+      )}rem 0px`,
+      backgroundColor: '#d8d8d8',
+      overflow: 'hidden',
+      float: 'left',
+    }),
+
+  imageRtl: () =>
+    css({
+      display: 'block',
+      width: `${pixelsToRem(80)}rem`,
+      height: `${pixelsToRem(80)}rem`,
+      border: `solid ${pixelsToRem(1)}rem #979797`,
+      margin: `${pixelsToRem(25)}rem 0px ${pixelsToRem(16)}rem ${pixelsToRem(
+        8,
+      )}rem`,
+      backgroundColor: '#d8d8d8',
+      overflow: 'hidden',
+      float: 'right',
+    }),
+
+  imageSource: () =>
+    css({
+      maxWidth: '100%',
+      height: 'auto',
     }),
 
   authorLink: () => css({ paddingTop: '1.375rem' }),

--- a/src/app/pages/ArticlePage/Byline/index.styles.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.styles.tsx
@@ -103,33 +103,37 @@ export default {
       },
     }),
 
-  imageLtr: () =>
+  Image: () =>
     css({
       display: 'block',
       width: `${pixelsToRem(80)}rem`,
       height: `${pixelsToRem(80)}rem`,
       border: `solid ${pixelsToRem(1)}rem #979797`,
-      margin: `${pixelsToRem(25)}rem ${pixelsToRem(8)}rem ${pixelsToRem(
-        16,
-      )}rem 0px`,
       backgroundColor: '#d8d8d8',
       overflow: 'hidden',
-      float: 'left',
     }),
 
+  imageLtr: () =>
+    css([
+      { ...Image },
+      {
+        float: 'left',
+        margin: `${pixelsToRem(25)}rem ${pixelsToRem(8)}rem ${pixelsToRem(
+          16,
+        )}rem 0px`,
+      },
+    ]),
+
   imageRtl: () =>
-    css({
-      display: 'block',
-      width: `${pixelsToRem(80)}rem`,
-      height: `${pixelsToRem(80)}rem`,
-      border: `solid ${pixelsToRem(1)}rem #979797`,
-      margin: `${pixelsToRem(25)}rem 0px ${pixelsToRem(16)}rem ${pixelsToRem(
-        8,
-      )}rem`,
-      backgroundColor: '#d8d8d8',
-      overflow: 'hidden',
-      float: 'right',
-    }),
+    css([
+      { ...Image },
+      {
+        float: 'right',
+        margin: `${pixelsToRem(25)}rem 0px ${pixelsToRem(16)}rem ${pixelsToRem(
+          8,
+        )}rem`,
+      },
+    ]),
 
   imageSource: () =>
     css({

--- a/src/app/pages/ArticlePage/Byline/index.test.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.test.tsx
@@ -12,6 +12,7 @@ import {
   bylineWithNameAndRole,
   bylineWithLink,
   bylineWithLinkAndLocation,
+  bylineWithPhoto,
 } from './fixture';
 
 describe('Byline', () => {
@@ -66,11 +67,19 @@ describe('Byline', () => {
   });
 
   it('should render all listitems correctly', () => {
-    render(<Byline blocks={bylineWithNameAndRole} />);
+    render(<Byline blocks={bylineWithPhoto} />);
 
     const listItems = screen.getAllByRole('listitem');
 
-    expect(listItems.length).toBe(2);
+    expect(listItems.length).toBe(5);
+  });
+
+  it('should render one image in the byline', () => {
+    render(<Byline blocks={bylineWithPhoto} />);
+
+    const image = screen.getAllByRole('img');
+
+    expect(image.length).toBe(1);
   });
 
   it('should correctly render Timestamp when passed as a child', () => {
@@ -105,18 +114,20 @@ describe('Byline', () => {
     expect(listItems.length).toBe(3);
   });
 
-  it('should render the Byline correctly with location', () => {
-    render(<Byline blocks={bylineWithLinkAndLocation} />);
+  it('should render the Byline correctly with location, image and links', () => {
+    render(<Byline blocks={bylineWithPhoto} />);
 
-    const AuthorLink = screen.getByText('Single Byline (all values)');
-    const TwitterLink = screen.getByText('@test');
+    const AuthorLink = screen.getByText('Clark Kent');
+    const TwitterLink = screen.getByText('@superman');
     const Links = screen.getAllByRole('link');
-    const Location = screen.getByText('London');
+    const Location = screen.getByText('Metropolis, US');
+    const Image = screen.getByRole('img');
 
     expect(AuthorLink).toBeInTheDocument();
     expect(TwitterLink).toBeInTheDocument();
     expect(Links.length).toBe(2);
     expect(Location).toBeInTheDocument();
+    expect(Image).toBeInTheDocument();
   });
 
   it.each`
@@ -163,6 +174,17 @@ describe('Byline', () => {
     );
 
     const findTranslation = screen.getByText(translation);
+
+    expect(findTranslation).toBeInTheDocument();
+  });
+
+  it.each`
+    info               | translation
+    ${'listItemImage'} | ${'Jerin abubuwa, hoto'}
+  `('should correctly translate image alt text', ({ translation }) => {
+    render(<Byline blocks={bylineWithPhoto} />, { service: 'hausa' });
+
+    const findTranslation = screen.getByAltText(translation);
 
     expect(findTranslation).toBeInTheDocument();
   });

--- a/src/app/pages/ArticlePage/Byline/index.test.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.test.tsx
@@ -177,15 +177,4 @@ describe('Byline', () => {
 
     expect(findTranslation).toBeInTheDocument();
   });
-
-  it.each`
-    info               | translation
-    ${'listItemImage'} | ${'Jerin abubuwa, hoto'}
-  `('should correctly translate image alt text', ({ translation }) => {
-    render(<Byline blocks={bylineWithPhoto} />, { service: 'hausa' });
-
-    const findTranslation = screen.getByAltText(translation);
-
-    expect(findTranslation).toBeInTheDocument();
-  });
 });

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -87,11 +87,7 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
     translations,
   );
   const jobRoleTranslated = pathOr('Role', ['byline', 'role'], translations);
-  const imageTranslated = pathOr(
-    'List item, image',
-    ['byline', 'listItemImage'],
-    translations,
-  );
+
   const publishedTranslated = pathOr(
     'Published',
     ['byline', 'published'],
@@ -117,19 +113,11 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
           <React.Fragment>
             {isRtl ? (
               <li css={BylineCss.imageRtl}>
-                <img
-                  css={BylineCss.imageSource}
-                  src={image}
-                  alt={imageTranslated}
-                />
+                <img css={BylineCss.imageSource} src={image} alt="" />
               </li>
             ) : (
               <li css={BylineCss.imageLtr}>
-                <img
-                  css={BylineCss.imageSource}
-                  src={image}
-                  alt={imageTranslated}
-                />
+                <img css={BylineCss.imageSource} src={image} alt="" />
               </li>
             )}
           </React.Fragment>

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -109,19 +109,17 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
         {articleInformationTranslated}
       </VisuallyHiddenText>
       <ul css={BylineCss.bylineList} role="list">
-        {image ? (
-          <React.Fragment>
-            {isRtl ? (
-              <li css={BylineCss.imageRtl}>
-                <img css={BylineCss.imageSource} src={image} alt="" />
-              </li>
-            ) : (
-              <li css={BylineCss.imageLtr}>
-                <img css={BylineCss.imageSource} src={image} alt="" />
-              </li>
-            )}
-          </React.Fragment>
-        ) : null}
+        {image && (
+          <li
+            css={
+              isRtl
+                ? [BylineCss.imageRtl, BylineCss.Image]
+                : [BylineCss.imageLtr, BylineCss.Image]
+            }
+          >
+            <img css={BylineCss.imageSource} src={image} alt="" />
+          </li>
+        )}
         <li>
           {twitterLink ? (
             <React.Fragment>

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -33,6 +33,7 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
   const locationBlock = bylineBlocks.find(
     (block: any) => block.type === 'location',
   );
+  const imageBlock = bylineBlocks.find((block: any) => block.type === 'image');
 
   const author = pathOr(
     '',
@@ -71,23 +72,31 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
     ['model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'text'],
     locationBlock,
   );
+  const image = pathOr(
+    '',
+    ['model', 'blocks', 0, 'model', 'locator'],
+    imageBlock,
+  );
 
   if (!(author && jobRole)) return null;
 
   const authorTranslated = pathOr('Author', ['byline', 'author'], translations);
-  const jobRoleTranslated = pathOr('Role', ['byline', 'role'], translations);
-  const publishedTranslated = pathOr(
-    'Published',
-    ['byline', 'published'],
-    translations,
-  );
-
   const articleInformationTranslated = pathOr(
     'Article information',
     ['byline', 'articleInformation'],
     translations,
   );
-
+  const jobRoleTranslated = pathOr('Role', ['byline', 'role'], translations);
+  const imageTranslated = pathOr(
+    'List item, image',
+    ['byline', 'listItemImage'],
+    translations,
+  );
+  const publishedTranslated = pathOr(
+    'Published',
+    ['byline', 'published'],
+    translations,
+  );
   const reportingFromTranslated = pathOr(
     'Reporting from',
     ['byline', 'reportingFrom'],
@@ -104,6 +113,27 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
         {articleInformationTranslated}
       </VisuallyHiddenText>
       <ul css={BylineCss.bylineList} role="list">
+        {image ? (
+          <React.Fragment>
+            {isRtl ? (
+              <li css={BylineCss.imageRtl}>
+                <img
+                  css={BylineCss.imageSource}
+                  src={image}
+                  alt={imageTranslated}
+                />
+              </li>
+            ) : (
+              <li css={BylineCss.imageLtr}>
+                <img
+                  css={BylineCss.imageSource}
+                  src={image}
+                  alt={imageTranslated}
+                />
+              </li>
+            )}
+          </React.Fragment>
+        ) : null}
         <li>
           {twitterLink ? (
             <React.Fragment>


### PR DESCRIPTION
Resolves #WSTEAM1-129

Overall change:
Adds functionality to include a photo in the byline

Code changes:

- Add `image` to byline
- Add rtl and ltr styles
- Add `bylineWithPhoto` fixture data
- Add byline with image for Storybook
- Add `listItemImage` type to translations
- Add tranlations for 'list item, image'
- Add unit tests


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
