### PR TITLE
Fix underline in FF HC Mode

### DIFF
--- a/src/app/pages/TopicPage/Curation/Subhead/index.styled.tsx
+++ b/src/app/pages/TopicPage/Curation/Subhead/index.styled.tsx
@@ -35,15 +35,8 @@ export default styled.h2<Props>`
   a:hover,
   a:focus {
     color: ${C_POSTBOX};
-    span::after {
-      bottom: ${3 / 16}rem;
-      content: '';
-      background: ${C_POSTBOX};
-      width: 100%;
-      height: ${2 / 16}rem;
-      position: absolute;
-      left: 0;
-    }
+    span {
+      text-decoration: underline;
   }
   svg {
     margin-inline-start: 0.5rem;


### PR DESCRIPTION
Resolves WSTEAMA-149

Overall change:
The fake underline (done for UX) does not show up in high contrast mode. The line colour is set using background-color. This background colour is overwritten with the high contrast background colour and so the line is not visible.

Code changes:

- use text-decoration property

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
