### PR TITLE
WSTEAM1-140 - Fix Optimo image promo path finding

### DIFF
--- a/src/app/legacy/containers/CpsRecommendations/RecommendationsPromo/utility/index.ts
+++ b/src/app/legacy/containers/CpsRecommendations/RecommendationsPromo/utility/index.ts
@@ -23,7 +23,16 @@ const extractPromoData = ({ promo }) => {
     };
   }
 
-  const optimoImage = path(['images', 'defaultPromoImage', 'blocks'], promo);
+  const optimoImageBlocks = path<any[]>(
+    ['images', 'defaultPromoImage', 'blocks'],
+    promo,
+  );
+  const optimoImage = optimoImageBlocks?.find(
+    block => block.type === 'rawImage',
+  );
+  const optimoImageAltText = optimoImageBlocks?.find(
+    block => block.type === 'altText',
+  );
 
   return {
     headline: path(
@@ -42,15 +51,15 @@ const extractPromoData = ({ promo }) => {
     ),
     url: path(['locators', 'canonicalUrl'], promo),
     indexImage: {
-      width: path([1, 'model', 'width'], optimoImage),
-      height: path([1, 'model', 'height'], optimoImage),
+      width: path(['model', 'width'], optimoImage),
+      height: path(['model', 'height'], optimoImage),
       altText: path(
-        [0, 'model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'text'],
-        optimoImage,
+        ['model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'text'],
+        optimoImageAltText,
       ),
-      copyrightHolder: path([1, 'model', 'copyrightHolder'], optimoImage),
-      originCode: path([1, 'model', 'originCode'], optimoImage),
-      locator: path([1, 'model', 'locator'], optimoImage),
+      copyrightHolder: path(['model', 'copyrightHolder'], optimoImage),
+      originCode: path(['model', 'originCode'], optimoImage),
+      locator: path(['model', 'locator'], optimoImage),
     },
   };
 };


### PR DESCRIPTION
Part of WSTEAM1-140

**Overall change:**
Fixes the pathing for Optimo OJ promo images and alt text so as to not assume that they will always be fixed positions in the image blocks

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
