### PR TITLE
WSTEAM1-130 Bylines TopicUrl

### DIFF
--- a/src/app/pages/ArticlePage/Byline/fixture/index.js
+++ b/src/app/pages/ArticlePage/Byline/fixture/index.js
@@ -2,6 +2,8 @@ export const bylineWithNoRole = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '/news/topics/c8qx38nq177t',
       blocks: [
         {
           type: 'name',
@@ -125,6 +127,8 @@ export const bylineWithNoAuthor = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '',
       blocks: [
         {
           type: 'role',
@@ -248,6 +252,8 @@ export const bylineWithNameAndRole = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '',
       blocks: [
         {
           type: 'name',
@@ -316,6 +322,8 @@ export const bylineWithLink = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '/news/topics/c8qx38nq177t',
       blocks: [
         {
           type: 'name',
@@ -423,6 +431,8 @@ export const bylineWithLinkAndLocation = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '',
       blocks: [
         {
           type: 'name',
@@ -559,6 +569,8 @@ export const bylineWithPhoto = [
   {
     type: 'contributor',
     model: {
+      topicId: '',
+      topicUrl: '',
       blocks: [
         {
           type: 'name',

--- a/src/app/pages/ArticlePage/Byline/index.test.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.test.tsx
@@ -127,7 +127,7 @@ describe('Byline', () => {
 
     expect(AuthorLink).toBeInTheDocument();
     expect(TwitterLink).toBeInTheDocument();
-    expect(Links.length).toBe(2);
+    expect(Links.length).toBe(1);
     expect(Location).toBeInTheDocument();
     expect(Image).toBeInTheDocument();
   });

--- a/src/app/pages/ArticlePage/Byline/index.test.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.test.tsx
@@ -44,14 +44,12 @@ describe('Byline', () => {
     const AuthorLink = screen.getByText('Single Byline (all values)');
     const TwitterLink = screen.getByText('@test');
     const Links = screen.getAllByRole('link');
-    const AuthorTopicUrl = screen
-      .getByText('Single Byline (all values)')
-      .closest('a');
 
     expect(AuthorLink).toBeInTheDocument();
     expect(TwitterLink).toBeInTheDocument();
     expect(Links.length).toBe(2);
-    expect(AuthorTopicUrl).toHaveAttribute('href', '/news/topics/c8qx38nq177t');
+    expect(Links[0]).toHaveAttribute('href', '/news/topics/c8qx38nq177t');
+    expect(Links[1]).toHaveAttribute('href', 'https://twitter.com/test');
   });
 
   it('should render a section with role region', () => {

--- a/src/app/pages/ArticlePage/Byline/index.test.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.test.tsx
@@ -38,16 +38,20 @@ describe('Byline', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('should render Byline correctly when passed a Twitter Link', () => {
+  it('should render Byline correctly when passed Twitter and TopicUrl links', () => {
     render(<Byline blocks={bylineWithLink} />);
 
     const AuthorLink = screen.getByText('Single Byline (all values)');
     const TwitterLink = screen.getByText('@test');
     const Links = screen.getAllByRole('link');
+    const AuthorTopicUrl = screen
+      .getByText('Single Byline (all values)')
+      .closest('a');
 
     expect(AuthorLink).toBeInTheDocument();
     expect(TwitterLink).toBeInTheDocument();
     expect(Links.length).toBe(2);
+    expect(AuthorTopicUrl).toHaveAttribute('href', '/news/topics/c8qx38nq177t');
   });
 
   it('should render a section with role region', () => {

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -78,6 +78,9 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
     imageBlock,
   );
 
+  const contributorBlock = pathOr([], [0], blocks);
+  const authorTopicUrl = pathOr('', ['model', 'topicUrl'], contributorBlock);
+
   if (!(author && jobRole)) return null;
 
   const authorTranslated = pathOr('Author', ['byline', 'author'], translations);
@@ -126,7 +129,7 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
               <VisuallyHiddenText>{`${authorTranslated}, `}</VisuallyHiddenText>
               <a
                 css={[BylineCss.link, BylineCss.authorLink]}
-                href={twitterLink}
+                href={authorTopicUrl}
               >
                 <strong
                   className="byline__link-text"

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -124,7 +124,7 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
           </li>
         )}
         <li>
-          {twitterLink ? (
+          {authorTopicUrl ? (
             <React.Fragment>
               <VisuallyHiddenText>{`${authorTranslated}, `}</VisuallyHiddenText>
               <a
@@ -154,6 +154,7 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
               <strong
                 css={[
                   BylineCss.author,
+                  BylineCss.authorLink,
                   getSansBold(service),
                   getBodyCopy(script),
                 ]}


### PR DESCRIPTION
Resolves #WSTEAM-1 130

**Overall change:**
Adds functionality in Optimo to link to an authors topic page

**Code changes:**

- Add function to get the `topicUrl` (as `authorTopicUrl`)
- Add `topicId` and `topicUrl` fields to the fixture data
- Add unit test

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
