### PR TITLE
Add underscores and hyphens to regex matching for Instagram embeds

### DIFF
--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
@@ -36,7 +36,7 @@ export const getIdFromSource = source => {
   const sourceIds = {
     twitter: /\/status\/([0-9]+)/,
     youtube: /\/watch\?v=([0-9 A-Z a-z _-]+)/,
-    instagram: /\/p\/([0-9 A-Z a-z]+)/,
+    instagram: /\/p\/([0-9 A-Z a-z _-]+)/,
   };
   const NO_ID = '';
   const provider = getProviderFromSource(source);

--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
@@ -35,8 +35,8 @@ export const getProviderFromSource = source => {
 export const getIdFromSource = source => {
   const sourceIds = {
     twitter: /\/status\/([0-9]+)/,
-    youtube: /\/watch\?v=([0-9 A-Z a-z _-]+)/,
-    instagram: /\/p\/([0-9 A-Z a-z _-]+)/,
+    youtube: /\/watch\?v=([0-9A-Z a-z_-]+)/,
+    instagram: /\/p\/([0-9A-Za-z_-]+)/,
   };
   const NO_ID = '';
   const provider = getProviderFromSource(source);

--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.test.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.test.js
@@ -4,6 +4,8 @@ describe('sourceHelpers', () => {
   const TWITTER_SOURCE =
     'https://twitter.com/BBCNews/status/1384138850478346243?s=20';
   const INSTAGRAM_SOURCE = 'https://www.instagram.com/p/CZ4ght5sIR3';
+  const INSTAGRAM_SOURCE_UNDERSCORED =
+    'https://www.instagram.com/p/CZ4ght5sIR3_';
   const YOUTUBE_SOURCE = 'https://www.youtube.com/watch?v=1e05_rwHvOM';
   const UNKNOWN_SOURCE = 'https://www.randomSource.com/watch?v=XWxjmToNSjQ';
 
@@ -24,6 +26,12 @@ describe('sourceHelpers', () => {
 
     it('should return a social embed ID for a valid Instagram source', () => {
       expect(getIdFromSource(INSTAGRAM_SOURCE)).toEqual('CZ4ght5sIR3');
+    });
+
+    it('should return a social embed ID for a valid Instagram source that ends with an underscore', () => {
+      expect(getIdFromSource(INSTAGRAM_SOURCE_UNDERSCORED)).toEqual(
+        'CZ4ght5sIR3_',
+      );
     });
 
     it('should return a social embed ID for a valid Youtube source', () => {


### PR DESCRIPTION
Part of WSTEAM1-122

**Overall change:**
Adds checks for underscores and hyphens to the regex matching against Instagram URLs. This caused some issues for Instagram embeds not loading on AMP

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
