### PR TITLE
Persian and Ukrainian navs updates

### DIFF
--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -371,14 +371,6 @@ export const service: DefaultServiceConfig = {
         url: '/persian',
       },
       {
-        title: 'اوکراین',
-        url: '/persian/topics/cw9q48x6558t',
-      },
-      {
-        title: 'کرونا',
-        url: '/persian/science-52004647',
-      },
-      {
         title: 'پخش زنده',
         url: '/persian/media-49522521',
       },

--- a/src/app/lib/config/services/ukrainian.ts
+++ b/src/app/lib/config/services/ukrainian.ts
@@ -367,10 +367,6 @@ const baseServiceConfig = {
       title: 'Подкасти',
       url: '/ukrainian/podcasts/p09jsy3h',
     },
-    {
-      title: 'РУС',
-      url: '/ukrainian/ukraine_in_russian',
-    },
   ],
 };
 

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -172,96 +172,82 @@ Object {
 
 exports[`AMP Articles Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`AMP Articles Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`AMP Articles Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 5`] = `
+exports[`AMP Articles Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 6`] = `
+exports[`AMP Articles Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 7`] = `
+exports[`AMP Articles Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 8`] = `
+exports[`AMP Articles Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 9`] = `
+exports[`AMP Articles Header Navigation link should match text and url 7`] = `
 Object {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 10`] = `
+exports[`AMP Articles Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 11`] = `
+exports[`AMP Articles Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 12`] = `
+exports[`AMP Articles Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 13`] = `
+exports[`AMP Articles Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 14`] = `
+exports[`AMP Articles Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Articles Header Navigation link should match text and url 15`] = `
+exports[`AMP Articles Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -82,96 +82,82 @@ Object {
 
 exports[`Canonical Articles Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 7`] = `
 Object {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 14`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Articles Header Navigation link should match text and url 15`] = `
+exports[`Canonical Articles Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/amp.test.js.snap
@@ -216,96 +216,82 @@ Object {
 
 exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 5`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 6`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 7`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 8`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 9`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "صفحه فعلی, افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 10`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 11`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 12`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 14`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 15`] = `
+exports[`AMP persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",

--- a/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/persian_afghanistan/__snapshots__/canonical.test.js.snap
@@ -82,96 +82,82 @@ Object {
 
 exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 5`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 6`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 7`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 8`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 9`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "صفحه فعلی, افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 10`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 11`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 12`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 14`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 15`] = `
+exports[`Canonical persian/afghanistan IDX page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/amp.test.js.snap
@@ -244,13 +244,6 @@ Object {
 }
 `;
 
-exports[`AMP ukrainian/ukraine_in_russian IDX page Header Navigation link should match text and url 7`] = `
-Object {
-  "text": "Поточна сторінка, РУС",
-  "url": "/ukrainian/ukraine_in_russian",
-}
-`;
-
 exports[`AMP ukrainian/ukraine_in_russian IDX page Header lang code should match text 1`] = `"uk"`;
 
 exports[`AMP ukrainian/ukraine_in_russian IDX page Main heading should match text 1`] = `"РУС"`;

--- a/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/idxPage/ukraine_in_russian/__snapshots__/canonical.test.js.snap
@@ -110,13 +110,6 @@ Object {
 }
 `;
 
-exports[`Canonical ukrainian/ukraine_in_russian IDX page Header Navigation link should match text and url 7`] = `
-Object {
-  "text": "Поточна сторінка, РУС",
-  "url": "/ukrainian/ukraine_in_russian",
-}
-`;
-
 exports[`Canonical ukrainian/ukraine_in_russian IDX page Header lang code should match text 1`] = `"uk"`;
 
 exports[`Canonical ukrainian/ukraine_in_russian IDX page Main heading should match text 1`] = `"РУС"`;

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/amp.test.js.snap
@@ -216,96 +216,82 @@ Object {
 
 exports[`AMP Media Asset Page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`AMP Media Asset Page Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 14`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`AMP Media Asset Page Header Navigation link should match text and url 15`] = `
+exports[`AMP Media Asset Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",

--- a/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/persian/__snapshots__/canonical.test.js.snap
@@ -82,96 +82,82 @@ Object {
 
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 2`] = `
 Object {
-  "text": "اوکراین",
-  "url": "/persian/topics/cw9q48x6558t",
-}
-`;
-
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 3`] = `
-Object {
-  "text": "کرونا",
-  "url": "/persian/science-52004647",
-}
-`;
-
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
-Object {
   "text": "پخش زنده",
   "url": "/persian/media-49522521",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 3`] = `
 Object {
   "text": "ویدیو",
   "url": "/persian/media/video",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "تلویزیون",
   "url": "/persian/tv-and-radio-37434377",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "رادیو",
   "url": "/persian/tv-and-radio-37434376",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 6`] = `
 Object {
   "text": "ايران",
   "url": "/persian/topics/ckdxnwvwwjnt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 7`] = `
 Object {
   "text": "افغانستان",
   "url": "/persian/afghanistan",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 8`] = `
 Object {
   "text": "جهان",
   "url": "/persian/topics/c1d8ye58xl8t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 9`] = `
 Object {
   "text": "هنر",
   "url": "/persian/topics/c9wpm0epm45t",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "ورزش",
   "url": "/persian/topics/cnq6879k7yjt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 11`] = `
 Object {
   "text": "اقتصاد",
   "url": "/persian/topics/cl8l9mvlllqt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 14`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 12`] = `
 Object {
   "text": "دانش",
   "url": "/persian/topics/ckdxnwr4r1yt",
 }
 `;
 
-exports[`Canonical Media Asset Page Header Navigation link should match text and url 15`] = `
+exports[`Canonical Media Asset Page Header Navigation link should match text and url 13`] = `
 Object {
   "text": "ناظران می‌گویند",
   "url": "/persian/blogs-54099951",


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Remove links to Corona virus and Ukraine war feature indexes on Persian nav. Remove LInk to Ukraine in Russian index on Ukrainian nav


**Code changes:**

- Removed links to Corona and Ukraine war in the navigation section in /simorgh/src/app/lib/config/services/persian.ts
- Removed link to Ukraine in Russian in the navgation section in /simorgh/src/app/lib/config/services/ukrainian.ts
- Updated spashots
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
