### PR TITLE
FIX: hearken changed classnames

### DIFF
--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -30,8 +30,7 @@ export const testsThatAlwaysRunForCanonicalOnly = () => {
         if (win.location.pathname.includes('/mundo/23263889')) {
           cy.get(`div[id="hearken-curiosity-14838"] > div`).within(() => {
             cy.get('div[id*="hearken-embed-module"]').within(() => {
-              cy.get('div')
-                .should('exist')
+              cy.get('div').should('exist')
                 .and('be.visible');
             });
           });

--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -30,8 +30,7 @@ export const testsThatAlwaysRunForCanonicalOnly = () => {
         if (win.location.pathname.includes('/mundo/23263889')) {
           cy.get(`div[id="hearken-curiosity-14838"] > div`).within(() => {
             cy.get('div[id*="hearken-embed-module"]').within(() => {
-              cy.get('div').should('exist')
-                .and('be.visible');
+              cy.get('div').should('exist').and('be.visible');
             });
           });
         }

--- a/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
+++ b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js
@@ -30,7 +30,7 @@ export const testsThatAlwaysRunForCanonicalOnly = () => {
         if (win.location.pathname.includes('/mundo/23263889')) {
           cy.get(`div[id="hearken-curiosity-14838"] > div`).within(() => {
             cy.get('div[id*="hearken-embed-module"]').within(() => {
-              cy.get('div[class="embed-content-container"]')
+              cy.get('div')
                 .should('exist')
                 .and('be.visible');
             });


### PR DESCRIPTION
hearken have made a change to their classnames, meaning tests fail

suggest leaving out classname on sub div