### PR TITLE
Update Brasil nav to add elections link and remove Sala Social

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -361,6 +361,10 @@ export const service: DefaultServiceConfig = {
         url: '/portuguese',
       },
       {
+        title: 'Eleições 2022',
+        url: '/portuguese/topics/c20d7ez6mqpt',
+      },
+      {
         title: 'Brasil',
         url: '/portuguese/topics/cz74k717pw5t',
       },
@@ -383,10 +387,6 @@ export const service: DefaultServiceConfig = {
       {
         title: 'Tecnologia',
         url: '/portuguese/topics/c404v027pd4t',
-      },
-      {
-        title: '#SalaSocial',
-        url: '/portuguese/topics/cx6pxx22x5pt',
       },
       {
         title: 'Vídeos',


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Update Brasil nav to add a link to the Elections topic and remove Sala Social as it's no longer needed.

**Code changes:**

- Edits in the navigation section of src/app/lib/config/services/portuguese.ts 

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
