### PR TITLE
Versioning Puppeteer in GitHub workflow

### DIFF
--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -54,6 +54,6 @@ jobs:
 
       - name: Run Puppeteer Tests
         run: |
-          yarn add puppeteer
+          yarn add puppeteer@18.0.5
           yarn test:puppeteer
-          yarn remove puppeteer
+          yarn remove puppeteer@18.0.5

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -56,4 +56,4 @@ jobs:
         run: |
           yarn add puppeteer@18.0.5
           yarn test:puppeteer
-          yarn remove puppeteer@18.0.5
+          yarn remove puppeteer


### PR DESCRIPTION
**Overall change:**
Pins the version of `puppeteer` used in one of our GitHub workflows. The latest version of Puppeteer seemed to introduce a breaking change for us. Possibly Node related.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
