### PR TITLE
Add `images` block type to bylines

### DIFF
--- a/src/app/pages/ArticlePage/Byline/fixture/index.js
+++ b/src/app/pages/ArticlePage/Byline/fixture/index.js
@@ -103,16 +103,24 @@ export const bylineWithNoRole = [
           },
         },
         {
-          type: 'image',
+          type: 'images',
           model: {
             blocks: [
               {
-                type: 'rawImage',
+                type: 'image',
                 model: {
-                  width: 640,
-                  height: 562,
-                  locator: 'f2f8/test/49056060-fea9-11ec-8adf-7bf4017ee9f9.png',
-                  originCode: 'cpsdevpb',
+                  blocks: [
+                    {
+                      type: 'rawImage',
+                      model: {
+                        width: 640,
+                        height: 562,
+                        locator:
+                          'f974/live/36226e20-94aa-11ec-9acc-37a09ce5ea88.png',
+                        originCode: 'cpsprodpb',
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -228,16 +236,24 @@ export const bylineWithNoAuthor = [
           },
         },
         {
-          type: 'image',
+          type: 'images',
           model: {
             blocks: [
               {
-                type: 'rawImage',
+                type: 'image',
                 model: {
-                  width: 640,
-                  height: 562,
-                  locator: 'f2f8/test/49056060-fea9-11ec-8adf-7bf4017ee9f9.png',
-                  originCode: 'cpsdevpb',
+                  blocks: [
+                    {
+                      type: 'rawImage',
+                      model: {
+                        width: 640,
+                        height: 562,
+                        locator:
+                          'f974/live/36226e20-94aa-11ec-9acc-37a09ce5ea88.png',
+                        originCode: 'cpsprodpb',
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -699,17 +715,24 @@ export const bylineWithNonPngPhoto = [
           },
         },
         {
-          type: 'image',
+          type: 'images',
           model: {
             blocks: [
               {
-                type: 'rawImage',
+                type: 'image',
                 model: {
-                  width: 640,
-                  height: 562,
-                  locator:
-                    'https://scarletjourney.rutgers.edu/crm/wp-content/uploads/sites/393/2017/12/christopher-reeve-superman.jpg',
-                  originCode: 'cpsdevpb',
+                  blocks: [
+                    {
+                      type: 'rawImage',
+                      model: {
+                        width: 640,
+                        height: 562,
+                        locator:
+                          'https://scarletjourney.rutgers.edu/crm/wp-content/uploads/sites/393/2017/12/christopher-reeve-superman.jpg',
+                        originCode: 'cpsdevpb',
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -852,16 +875,24 @@ export const bylineWithPngPhoto = [
           },
         },
         {
-          type: 'image',
+          type: 'images',
           model: {
             blocks: [
               {
-                type: 'rawImage',
+                type: 'image',
                 model: {
-                  width: 640,
-                  height: 562,
-                  locator: 'f974/live/36226e20-94aa-11ec-9acc-37a09ce5ea88.png',
-                  originCode: 'cpsprodpb',
+                  blocks: [
+                    {
+                      type: 'rawImage',
+                      model: {
+                        width: 640,
+                        height: 562,
+                        locator:
+                          'f974/live/36226e20-94aa-11ec-9acc-37a09ce5ea88.png',
+                        originCode: 'cpsprodpb',
+                      },
+                    },
+                  ],
                 },
               },
             ],

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -26,7 +26,9 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
   const locationBlock = bylineBlocks.find(
     (block: any) => block.type === 'location',
   );
-  const imageBlock = bylineBlocks.find((block: any) => block.type === 'image');
+  const imagesBlock = bylineBlocks.find(
+    (block: any) => block.type === 'images',
+  );
 
   const author = pathOr(
     '',
@@ -67,13 +69,13 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
   );
   const locator = pathOr(
     '',
-    ['model', 'blocks', 0, 'model', 'locator'],
-    imageBlock,
+    ['model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'locator'],
+    imagesBlock,
   );
   const originCode = pathOr(
     '',
-    ['model', 'blocks', 0, 'model', 'originCode'],
-    imageBlock,
+    ['model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'originCode'],
+    imagesBlock,
   );
   const DEFAULT_IMAGE_RES = 160;
   let image = buildIChefURL({


### PR DESCRIPTION
**Overall change:**
The bylines schema on `test` shows that `image` is nested within an `images` block. 
This PR adds the `images` block type to bylines and gets the `locator` and `originCode` nested within the `image` block.

**Code changes:**

- Add `images` block type
- Update fixture data


---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
