### PR TITLE
WSTEAM1-138 - Add TikTok domains to CSP header

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -112,6 +112,7 @@ const directives = {
       'https://www.youtube.com', // Social Embeds, <amp-youtube />
       'https://www.youtube-nocookie.com', // Social Embeds, youtube no-cookie
       'https://www.instagram.com', // Social Embeds, <amp-instagram />
+      'https://www.tiktok.com', // Social Embeds, <amp-tiktok />
       'https://*.ampproject.net', // Social Embeds
       'https://www.riddle.com', // STY Includes
       ...advertisingDirectives.frameSrc,
@@ -124,6 +125,7 @@ const directives = {
       'https://www.youtube.com', // Social Embeds
       'https://www.youtube-nocookie.com', // Social Embeds, youtube no-cookie
       'https://www.instagram.com', // Social Embeds
+      'https://www.tiktok.com', // Social Embeds
       'https://*.twitter.com', // Social Embeds
       'https://bbc.com', // Media Player
       'https://bbc-maps.carto.com', // STY include maps
@@ -137,6 +139,7 @@ const directives = {
       'https://www.youtube.com', // Social Embeds, <amp-youtube />
       'https://www.youtube-nocookie.com', // Social Embeds, youtube no-cookie
       'https://www.instagram.com', // Social Embeds, <amp-instagram />
+      'https://www.tiktok.com', // Social Embeds, <amp-tiktok />
       'https://*.ampproject.net', // Social Embeds
       'https://www.riddle.com', // STY Includes
       ...advertisingDirectives.frameSrc,
@@ -149,6 +152,7 @@ const directives = {
       'https://www.youtube.com', // Social Embeds
       'https://www.youtube-nocookie.com', // Social Embeds, youtube no-cookie
       'https://www.instagram.com', // Social Embeds
+      'https://www.tiktok.com', // Social Embeds
       'https://*.twitter.com', // Social Embeds
       'https://bbc.com', // Media Player
       'https://bbc-maps.carto.com', // STY include maps
@@ -165,6 +169,8 @@ const directives = {
       'https://i.ytimg.com', // Social Embeds, <amp-youtube />
       'https://www.instagram.com', // Social Embeds, <amp-instagram />
       'https://*.cdninstagram.com', // Social Embeds, <amp-instagram />
+      'https://www.tiktok.com', // Social Embeds, <amp-tiktok />
+      'https://*.tiktokcdn.com', // Social Embeds, <amp-tiktok />
       ...advertisingDirectives.imgSrc,
       'https://*.googleusercontent.com', // Google Play Store - BBC News Apps - Arabic, Hindi, Mundo, Russian
       "data: 'self'",
@@ -175,6 +181,7 @@ const directives = {
       'https://*.twitter.com', // Social Embeds
       'https://*.twimg.com', // Social Embeds
       'https://*.cdninstagram.com', // Social Embeds
+      'https://*.tiktokcdn.com', // Social Embeds
       'https://i.ytimg.com', // Social Embeds
       ...advertisingDirectives.imgSrc,
       'https://*.googleusercontent.com', // Google Play Store - BBC News Apps - Arabic, Hindi, Mundo, Russian
@@ -188,6 +195,8 @@ const directives = {
       'https://i.ytimg.com', // Social Embeds, <amp-youtube />
       'https://www.instagram.com', // Social Embeds, <amp-instagram />
       'https://*.cdninstagram.com', // Social Embeds, <amp-instagram />
+      'https://www.tiktok.com', // Social Embeds, <amp-tiktok />
+      'https://*.tiktokcdn.com', // Social Embeds, <amp-tiktok />
       ...advertisingDirectives.imgSrc,
       'https://*.googleusercontent.com', // Google Play Store - BBC News Apps - Arabic, Hindi, Mundo, Russian
       "data: 'self'",
@@ -200,6 +209,7 @@ const directives = {
       'https://*.twitter.com', // Social Embeds
       'https://*.twimg.com', // Social Embeds
       'https://*.cdninstagram.com', // Social Embeds
+      'https://*.tiktokcdn.com', // Social Embeds
       'https://i.ytimg.com', // Social Embeds
       ...advertisingDirectives.imgSrc,
       'https://*.googleusercontent.com', // Google Play Store - BBC News Apps - Arabic, Hindi, Mundo, Russian
@@ -221,6 +231,7 @@ const directives = {
       'https://*.chartbeat.com',
       'https://*.twitter.com', // Social Embeds
       'https://www.instagram.com', // Social Embeds
+      'https://www.tiktok.com', // Social Embeds
       'https://*.twimg.com', // Social Embeds
       'https://public.flourish.studio', // STY includes
       'https://client.rum.us-east-1.amazonaws.com', // CloudWatch RUM
@@ -244,6 +255,7 @@ const directives = {
       'http://localhost:1124', // for localhost canonical JavaScript
       'https://*.twitter.com', // Social Embeds
       'https://www.instagram.com', // Social Embeds
+      'https://www.tiktok.com', // Social Embeds
       'https://*.twimg.com', // Social Embeds
       'https://public.flourish.studio', // STY includes
       'https://client.rum.us-east-1.amazonaws.com', // CloudWatch RUM

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -79,6 +79,7 @@ describe('cspHeader', () => {
         'https://*.googlesyndication.com',
         'https://www.instagram.com',
         'https://www.riddle.com',
+        'https://www.tiktok.com',
         'https://www.youtube.com',
         'https://www.youtube-nocookie.com',
         "'self'",
@@ -95,7 +96,9 @@ describe('cspHeader', () => {
         'https://*.googleusercontent.com',
         'https://*.gstatic.com',
         'https://*.imrworldwide.com',
+        'https://*.tiktokcdn.com',
         'https://www.instagram.com',
+        'https://www.tiktok.com',
         'https://sb.scorecardresearch.com',
         'https://i.ytimg.com',
         "data: 'self'",
@@ -161,6 +164,7 @@ describe('cspHeader', () => {
         'https://*.doubleclick.net',
         'https://*.googlesyndication.com',
         'https://edigitalsurvey.com',
+        'https://www.tiktok.com',
         "'self'",
       ].sort(),
       imgSrcExpectation: [
@@ -179,6 +183,7 @@ describe('cspHeader', () => {
         'https://*.twimg.com',
         'https://*.twitter.com',
         'https://i.ytimg.com',
+        'https://*.tiktokcdn.com',
         "data: 'self'",
       ].sort(),
       scriptSrcExpectation: [
@@ -201,6 +206,7 @@ describe('cspHeader', () => {
         'https://*.twimg.com',
         'https://*.twitter.com',
         'https://*.wearehearken.eu',
+        'https://www.tiktok.com',
         ...advertisingServiceCountryDomains,
         "'self'",
         "'unsafe-inline'",
@@ -254,6 +260,7 @@ describe('cspHeader', () => {
         'https://www.riddle.com',
         'https://www.youtube.com',
         'https://www.youtube-nocookie.com',
+        'https://www.tiktok.com',
         "'self'",
       ].sort(),
       imgSrcExpectation: [
@@ -273,6 +280,8 @@ describe('cspHeader', () => {
         'https://www.instagram.com',
         'https://sb.scorecardresearch.com',
         'https://i.ytimg.com',
+        'https://www.tiktok.com',
+        'https://*.tiktokcdn.com',
         "data: 'self'",
       ].sort(),
       scriptSrcExpectation: [
@@ -337,6 +346,7 @@ describe('cspHeader', () => {
         'https://*.twitter.com',
         'https://www.youtube.com',
         'https://www.youtube-nocookie.com',
+        'https://www.tiktok.com',
         "'self'",
       ].sort(),
       imgSrcExpectation: [
@@ -357,6 +367,7 @@ describe('cspHeader', () => {
         'https://*.gstatic.com',
         'https://*.imrworldwide.com',
         'https://sb.scorecardresearch.com',
+        'https://*.tiktokcdn.com',
         "data: 'self'",
       ].sort(),
       scriptSrcExpectation: [
@@ -381,6 +392,7 @@ describe('cspHeader', () => {
         'https://bbc.gscontxt.net',
         'https://sb.scorecardresearch.com',
         'https://*.imrworldwide.com',
+        'https://www.tiktok.com',
         ...advertisingServiceCountryDomains,
         "'self'",
         "'unsafe-inline'",


### PR DESCRIPTION
Part of WSTEAM1-138

**Overall change:**
Updates the CSP header to include domains for TikTok embeds

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
