### PR TITLE
Remove Image type spread to potentially fix Byline image rendering

### DIFF
--- a/src/app/pages/ArticlePage/Byline/index.styles.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.styles.tsx
@@ -117,7 +117,6 @@ export default {
 
   imageLtr: () =>
     css([
-      { ...Image },
       {
         float: 'left',
         margin: `${pixelsToRem(25)}rem ${pixelsToRem(8)}rem ${pixelsToRem(
@@ -128,7 +127,6 @@ export default {
 
   imageRtl: () =>
     css([
-      { ...Image },
       {
         float: 'right',
         margin: `${pixelsToRem(25)}rem 0px ${pixelsToRem(16)}rem ${pixelsToRem(

--- a/src/app/pages/ArticlePage/Byline/index.tsx
+++ b/src/app/pages/ArticlePage/Byline/index.tsx
@@ -77,11 +77,11 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
     ['model', 'blocks', 0, 'model', 'blocks', 0, 'model', 'originCode'],
     imagesBlock,
   );
-  const DEFAULT_IMAGE_RES = 160;
+
   let image = buildIChefURL({
     originCode,
     locator,
-    resolution: DEFAULT_IMAGE_RES,
+    resolution: 160,
     isPng: true,
   });
 
@@ -117,11 +117,10 @@ const Byline = ({ blocks, children }: PropsWithChildren<Props>) => {
       <ul css={BylineCss.bylineList} role="list">
         {image && (
           <li
-            css={
-              isRtl
-                ? [BylineCss.imageRtl, BylineCss.ImageWrapper]
-                : [BylineCss.imageLtr, BylineCss.ImageWrapper]
-            }
+            css={[
+              BylineCss.ImageWrapper,
+              isRtl ? BylineCss.imageRtl : BylineCss.imageLtr,
+            ]}
           >
             <Image
               css={BylineCss.imageSrc}


### PR DESCRIPTION
**Overall change:**
Removes a spread of the `{...Image}` property in the Bylines style file. Not sure what this property actually is, looks like a TypeScript type for an HTML image element.

We've had reports of image not rendering in Bylines. This _could_ be preventing Byline image rendering when deployed, as running `latest` locally against an Article that has a Byline image causes a 500 error of `Image is not defined`.

Also included a minor update to the css class names applied to the `Image` component.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
