### PR TITLE
Add services to storybook example

### DIFF
--- a/src/app/pages/TopicPage/HierarchicalGrid/index.stories.tsx
+++ b/src/app/pages/TopicPage/HierarchicalGrid/index.stories.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 
 import { withKnobs, number } from '@storybook/addon-knobs';
 import { ServiceContextProvider } from '../../../contexts/ServiceContext';
+import { withServicesKnob } from '../../../legacy/psammead/psammead-storybook-helpers/src';
 import ThemeProvider from '../../../components/ThemeProvider';
+import { Services, Variants } from '../../../models/types/global';
 import HiearchicalGrid from './index';
 import pidginSummaries from './fixtures';
 
-const Component = () => {
+interface Props {
+  service: Services;
+  variant: Variants;
+}
+
+const Component = ({ service, variant }: Props) => {
   return (
-    <ThemeProvider service="pidgin" variant="default">
-      <ServiceContextProvider service="pidgin">
+    <ThemeProvider service={service} variant={variant}>
+      <ServiceContextProvider service={service} variant={variant}>
         <HiearchicalGrid
           summaries={pidginSummaries.slice(
             0,
@@ -24,7 +31,7 @@ const Component = () => {
 export default {
   title: 'Topic/HierarchicalGrid',
   Component,
-  decorators: [withKnobs],
+  decorators: [withKnobs, withServicesKnob()],
 };
 
-export const HierarchicalGrid = Component;
+export const Example = Component;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Add services dropdown to Hierarchical Grid Storybook component

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
