### PR TITLE
WSTEAMA 38 Topic Media Indicators

### DIFF
--- a/src/app/legacy/components/Promo/media-icon.jsx
+++ b/src/app/legacy/components/Promo/media-icon.jsx
@@ -39,7 +39,7 @@ const formatChildren = children => {
 };
 
 const MediaIcon = ({ script, service, children, type }) => {
-  if (!type) return null;
+  if (!type || !mediaIcons[type]) return null;
   return (
     <Wrapper script={script} service={service}>
       {mediaIcons[type]}

--- a/src/app/pages/TopicPage/Curation/CurationPromo/index.jsx
+++ b/src/app/pages/TopicPage/Curation/CurationPromo/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { bool, string, number, oneOf, oneOfType } from 'prop-types';
+import { bool, string, number, oneOfType } from 'prop-types';
 
-import Promo, { MEDIA_TYPES } from '#components/Promo';
+import Promo from '#components/Promo';
 
 const CurationPromo = ({
   title,
@@ -10,14 +10,14 @@ const CurationPromo = ({
   imageAlt,
   lazy,
   link,
-  mediaType,
+  type,
   mediaDuration,
   headingLevel,
 }) => {
   return (
     <Promo>
       <Promo.Image src={imageUrl} alt={imageAlt} lazyLoad={lazy}>
-        <Promo.MediaIcon type={mediaType}>{mediaDuration}</Promo.MediaIcon>
+        <Promo.MediaIcon type={type}>{mediaDuration}</Promo.MediaIcon>
       </Promo.Image>
       <Promo.Heading as={`h${headingLevel}`}>
         <Promo.A href={link}>{title}</Promo.A>
@@ -35,14 +35,14 @@ CurationPromo.propTypes = {
   imageAlt: string.isRequired,
   lazy: bool,
   link: string.isRequired,
-  mediaType: oneOf(Object.values(MEDIA_TYPES)),
+  type: string,
   mediaDuration: number,
   headingLevel: number,
 };
 
 CurationPromo.defaultProps = {
   lazy: false,
-  mediaType: null,
+  type: null,
   mediaDuration: null,
   headingLevel: 2,
 };

--- a/src/app/pages/TopicPage/Curation/CurationPromo/index.stories.jsx
+++ b/src/app/pages/TopicPage/Curation/CurationPromo/index.stories.jsx
@@ -33,7 +33,7 @@ const WithMediaIndicator = ({ service, variant }) => {
         <Wrapper>
           <Promo
             {...fixture.data.summaries[0]}
-            mediaType={MEDIA_TYPES.VIDEO}
+            type={MEDIA_TYPES.VIDEO}
             mediaDuration={123}
           />
         </Wrapper>

--- a/src/app/pages/TopicPage/HierarchicalGrid/index.tsx
+++ b/src/app/pages/TopicPage/HierarchicalGrid/index.tsx
@@ -59,7 +59,7 @@ const HiearchicalGrid = ({ summaries }: Summaries) => {
                 alt={promo.imageAlt}
                 loading="lazy"
               >
-                <Promo.MediaIcon type={promo.mediaType}>
+                <Promo.MediaIcon type={promo.type}>
                   {promo.mediaDuration}
                 </Promo.MediaIcon>
               </Promo.Image>

--- a/src/app/pages/TopicPage/TopicPage.jsx
+++ b/src/app/pages/TopicPage/TopicPage.jsx
@@ -29,7 +29,7 @@ const TopicPage = ({ pageData }) => {
   const linkedDataEntities = curations
     .map(({ summaries }) =>
       summaries.map(summary => ({
-        '@type': 'Article',
+        '@type': summary.type,
         name: summary.title,
         headline: summary.title,
         url: summary.link,


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAMA-38

**Overall change:**
Show media icons on promos of type audio/video/photogallery

**Code changes:**

- Replace `mediaType` with `type`. `mediaType` is not returned by `content-summaries`
- Update the metadata to show the correct type for each promo

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
