### PR TITLE
Combine new components in one Storybook folder

### DIFF
--- a/src/app/components/Heading/index.stories.tsx
+++ b/src/app/components/Heading/index.stories.tsx
@@ -85,7 +85,7 @@ const HeadingStory = ({ service, variant, text }: Props) => {
 };
 
 export default {
-  title: 'NewComponents/Heading',
+  title: 'New Components/Heading',
   Component: HeadingStory,
   decorators: [withKnobs, withServicesKnob()],
   parameters: {

--- a/src/app/components/InlineLink/index.stories.tsx
+++ b/src/app/components/InlineLink/index.stories.tsx
@@ -76,7 +76,7 @@ export const InlineLinkInsideText = ({
 };
 
 export default {
-  title: 'NewComponents/InlineLink',
+  title: 'New Components/InlineLink',
   Component: InternalInlineLink,
   decorators: [withKnobs, withServicesKnob()],
   parameters: {

--- a/src/app/components/Paragraph/index.stories.tsx
+++ b/src/app/components/Paragraph/index.stories.tsx
@@ -74,7 +74,7 @@ const ParagraphStory = ({ service, variant, text }: Props) => {
 };
 
 export default {
-  title: 'NewComponents/Paragraph',
+  title: 'New Components/Paragraph',
   Component: ParagraphStory,
   decorators: [withKnobs, withServicesKnob()],
   parameters: {

--- a/src/app/components/Text/index.stories.tsx
+++ b/src/app/components/Text/index.stories.tsx
@@ -75,7 +75,7 @@ const TextStory = ({ service, variant, text }: Props) => {
 };
 
 export default {
-  title: 'NewComponents/Text',
+  title: 'New Components/Text',
   Component: TextStory,
   decorators: [withKnobs, withServicesKnob()],
   parameters: {


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
`Image` is under `New Components` in Storybook
`Heading`, `InlineLink`, `Paragraph`, and `Text` are under `NewComponents`
Moving them all to `New Components`.

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
