### PR TITLE
Update GH Actions for Node16 Compatibility

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,7 +61,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -75,4 +75,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -24,9 +24,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Simorgh E2Es
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
           build: yarn build
           start: yarn start

--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -23,16 +23,16 @@ jobs:
       LOG_LEVEL: 'error'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/simorgh-local-server-tests.yml
+++ b/.github/workflows/simorgh-local-server-tests.yml
@@ -23,15 +23,15 @@ jobs:
       LOG_LEVEL: 'error'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./scripts/installNodeModules.sh
 
       - name: Chromatic UI Tests
-        uses: chromaui/action@v2
+        uses: chromaui/action@v1
         if: github.ref != 'refs/heads/latest' && github.event.pull_request.head.repo.full_name == 'bbc/simorgh' # Only run when not on latest or not a fork.
         with:
           token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
@@ -49,7 +49,7 @@ jobs:
           exitOnceUploaded: true
 
       - name: Chromatic UI Tests - Latest
-        uses: chromaui/action@v2
+        uses: chromaui/action@v1
         if: github.ref == 'refs/heads/latest' # Only run on latest branch
         with:
           token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -19,18 +19,18 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./scripts/installNodeModules.sh
 
       - name: Chromatic UI Tests
-        uses: chromaui/action@v1
+        uses: chromaui/action@v2
         if: github.ref != 'refs/heads/latest' && github.event.pull_request.head.repo.full_name == 'bbc/simorgh' # Only run when not on latest or not a fork.
         with:
           token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
@@ -49,7 +49,7 @@ jobs:
           exitOnceUploaded: true
 
       - name: Chromatic UI Tests - Latest
-        uses: chromaui/action@v1
+        uses: chromaui/action@v2
         if: github.ref == 'refs/heads/latest' # Only run on latest branch
         with:
           token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}

--- a/.github/workflows/simorgh-unit-tests.yml
+++ b/.github/workflows/simorgh-unit-tests.yml
@@ -25,9 +25,9 @@ jobs:
       GIT_COMMIT_SHA: ${{ github.sha }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Cache Node Modules
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION


**Overall change:**
Our current GitHub actions will be deprecated from the 7th of Dec 2022. This PR upgrades them in line with the Node 16 upgrade.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ 

**Code changes:**

- Updates CodeQL to @v2
- Updates other actions to @v3 
- Chromatic are addressing the upgrade to Node 16, those chromaui actions are still @v1 
---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
