### PR TITLE
Do not render subtitle if no promo content

### DIFF
--- a/src/app/pages/TopicPage/Curation/index.jsx
+++ b/src/app/pages/TopicPage/Curation/index.jsx
@@ -30,6 +30,7 @@ const Curation = ({
   position,
   curationLength,
 }) => {
+  if (!promos.length) return null;
   const Component = pathOr(
     CurationGrid,
     [visualStyle, visualProminance],


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAMA-151

**Overall change:**
We are currently rendering the curation subheading when there are no promos in the curation. Return early if no promos.

**Code changes:**

- Return null if promo array is empty

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
