### PR TITLE
NEWSWORLDSERVICE-1579 Adds new script for BFF_PATH detection and secret.env removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ Services with variants can't be accessed using the format above, instead the var
 
 Topic pages use internal BBC APIs that are not publicly accessible. This can cause the following warnings to appear when developing locally:
 
-envConfig/secret.env: No such file or directory
-You will not have access to topics
+```
+No BFF_PATH set as environment variable, you will not have access to topics
+```
 
 Internal developers who need to work on topic pages locally should contact the team for access.
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cypress:interactive": "cypress open",
     "cypress:3rdParty": "yarn cypress -- --project ./3rdPartyCypress/.",
     "cypress:adhoc": "yarn cypress:interactive -- --project ./AdHocCypress/.",
-    "setupDevEnv": "cp envConfig/local.env .env && cat envConfig/secret.env >> .env || echo 'You will not have access to topics'",
+    "setupDevEnv": "cp envConfig/local.env .env && rm -rf envConfig/secret.env && ./scripts/checkSecretEnvVariables.sh",
     "dev": "yarn setupDevEnv && rm -rf build && run-p webpack:dev:client webpack:dev:server",
     "lighthouse": "./scripts/lighthouseRun.sh",
     "postshrinkwrap": "test -z $CI && ./scripts/packagelockHttps.sh; git update-index --assume-unchanged .env",

--- a/scripts/checkSecretEnvVariables.sh
+++ b/scripts/checkSecretEnvVariables.sh
@@ -1,0 +1,3 @@
+if [ -z "$BFF_PATH" ]; then 
+    echo No BFF_PATH set as environment variable, you will not have access to topics; 
+fi


### PR DESCRIPTION
Resolves NEWSWORLDSERVICE-1579

**Overall change:**
Runs script on dev startup to check for BFF_PATH environment variable and deletes secret.env

**Code changes:**

- Adds `checkSecretEnvVariables.sh` script as part of dev script
- Adds command to delete secret.env as part of dev script

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
