### PR TITLE
Turn off tailable on file logging

### DIFF
--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -40,7 +40,7 @@ const loggerOptions = {
     level: LOG_LEVEL,
     maxFiles: 5,
     maxsize: 104857600, // 100MB
-    tailable: true,
+    tailable: false,
     format: combine(json()),
   },
   console: {

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -87,7 +87,7 @@ describe('Logger node - for the server', () => {
           level: 'info',
           maxFiles: 5,
           maxsize: 104857600,
-          tailable: true,
+          tailable: false,
         });
       });
 
@@ -103,7 +103,7 @@ describe('Logger node - for the server', () => {
           level: 'info',
           maxFiles: 5,
           maxsize: 104857600,
-          tailable: true,
+          tailable: false,
         });
       });
 


### PR DESCRIPTION
**Overall change:**
We found that Simorgh was retaining deleted log files causing high disk usage. We found this issue with winston that could be the cause: https://github.com/winstonjs/winston/issues/2100

We are turning off tailable as we believe that just affects the order of logs in the files; cloudwatch logs uses the timestamp to order the logs - we hope this will workaround this bug occurring.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
