### PR TITLE
WSTEAM1-112 - Restrict social media providers to pagetypes

### DIFF
--- a/src/app/legacy/containers/SocialEmbed/Cps/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/SocialEmbed/Cps/__snapshots__/index.test.jsx.snap
@@ -710,7 +710,9 @@ exports[`CpsSocialEmbedContainer Canonical should render correctly without an em
         <div
           class="emotion-8 emotion-9"
         >
-          <p>
+          <p
+            data-testid="social-embed-fallback-title"
+          >
             Content is not available
           </p>
           <a

--- a/src/app/legacy/psammead/psammead-social-embed/src/Amp/index.jsx
+++ b/src/app/legacy/psammead/psammead-social-embed/src/Amp/index.jsx
@@ -63,9 +63,9 @@ const TikTok = ({ id }) => (
 const Facebook = ({ source }) => {
   const getEmbedType = () => {
     switch (true) {
-      case source.includes('posts'):
+      case source?.includes('posts'):
         return 'post';
-      case source.includes('videos'):
+      case source?.includes('videos'):
         return 'video';
       default:
         return 'post';

--- a/src/app/legacy/psammead/psammead-social-embed/src/Notice/index.jsx
+++ b/src/app/legacy/psammead/psammead-social-embed/src/Notice/index.jsx
@@ -80,7 +80,9 @@ const Notice = ({
 
   return (
     <Wrapper service={service}>
-      <p>{detokenise(text, dictionary)}</p>
+      <p data-testid="social-embed-fallback-title">
+        {detokenise(text, dictionary)}
+      </p>
       <a
         href={linkHref}
         aria-label={

--- a/src/app/legacy/psammead/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/psammead/psammead-social-embed/src/__snapshots__/index.test.jsx.snap
@@ -137,7 +137,9 @@ exports[`AmpSocialEmbed should render a notice when the provider is unsupported 
     <div
       class="emotion-4 emotion-5"
     >
-      <p>
+      <p
+        data-testid="social-embed-fallback-title"
+      >
         Sorry but we're having trouble displaying this content
       </p>
       <a
@@ -155,6 +157,103 @@ exports[`AmpSocialEmbed should render a notice when the provider is unsupported 
       tabindex="-1"
     >
       End of unknown content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`AmpSocialEmbed should render correctly for Facebook 1`] = `
+.emotion-0 {
+  position: relative;
+}
+
+.emotion-2 {
+  font-family: ReithSans,Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  background-color: #FFFFFF;
+  border: 0.125rem solid #222222;
+  display: block;
+  left: 0;
+  line-height: 1;
+  padding: 0.75rem;
+  position: absolute;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  top: 0;
+  z-index: 10;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-2 {
+    line-height: 1.125rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-2 {
+    font-size: 0.8125rem;
+  }
+}
+
+.emotion-2 span {
+  color: #222222;
+}
+
+.emotion-2:hover span,
+.emotion-2:focus span {
+  color: #B80000;
+  border-bottom: 2px solid #B80000;
+}
+
+.emotion-2:not(:focus):not(:active) {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+.emotion-4 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+  margin: 0;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <a
+      class="emotion-2 emotion-3"
+      href="#skip-facebook-content"
+    >
+      <span>
+        Skip Facebook content
+      </span>
+    </a>
+    <amp-facebook
+      data-embed-as="post"
+      height="1"
+      layout="responsive"
+      width="1"
+    />
+    <p
+      class="emotion-4 emotion-5"
+      id="skip-facebook-content"
+      tabindex="-1"
+    >
+      End of Facebook content
     </p>
   </div>
 </div>
@@ -1390,7 +1489,9 @@ exports[`CanonicalSocialEmbed should render a notice when the provider is unsupp
     <div
       class="emotion-4 emotion-5"
     >
-      <p>
+      <p
+        data-testid="social-embed-fallback-title"
+      >
         Sorry but we're having trouble displaying this content
       </p>
       <a
@@ -1551,7 +1652,9 @@ exports[`CanonicalSocialEmbed should render a notice when there is no oEmbed res
     <div
       class="emotion-4 emotion-5"
     >
-      <p>
+      <p
+        data-testid="social-embed-fallback-title"
+      >
         Sorry but we're having trouble displaying this content
       </p>
       <a

--- a/src/app/legacy/psammead/psammead-social-embed/src/fixtures/facebook.json
+++ b/src/app/legacy/psammead/psammead-social-embed/src/fixtures/facebook.json
@@ -1,0 +1,24 @@
+{
+  "href": "https://www.facebook.com/BBCnewsMarathi/videos/568952960644257",
+  "source": "facebook",
+  "embed": {
+    "oembed": {
+      "version": "1.0",
+      "author_name": "BBC News Marathi",
+      "author_url": "https://www.facebook.com/BBCnewsMarathi/",
+      "provider_name": "Facebook",
+      "provider_url": "https://www.facebook.com",
+      "url": "https://www.facebook.com/BBCnewsMarathi/videos/568952960644257",
+      "html": "<div class=\"fb-video\" data-href=\"https://www.facebook.com/BBCnewsMarathi/videos/568952960644257\"><blockquote cite=\"https://www.facebook.com/BBCnewsMarathi/videos/568952960644257/\" class=\"fb-xfbml-parse-ignore\"><a href=\"https://www.facebook.com/BBCnewsMarathi/videos/568952960644257/\"></a><p>जनता कर्फ्यूला टाळ्या आणि शंखनादाची साथ</p>Posted by <a href=\"https://www.facebook.com/BBCnewsMarathi/\">BBC News Marathi</a> on Sunday, March 22, 2020</blockquote></div>",
+      "width": 500,
+      "height": 889
+    },
+    "fallback_image": {
+      "fallback_image_width": 550,
+      "fallback_image_height": 1069,
+      "alt_text": "Facebook post by BBC News Marathi: जनता कर्फ्यूला टाळ्या आणि शंखनादाची साथ"
+    }
+  },
+  "id": "568952960644257",
+  "type": "social_embed"
+}

--- a/src/app/legacy/psammead/psammead-social-embed/src/fixtures/index.js
+++ b/src/app/legacy/psammead/psammead-social-embed/src/fixtures/index.js
@@ -1,5 +1,6 @@
 import instagram from './instagram.json';
 import twitter from './twitter.json';
 import youtube from './youtube.json';
+import facebook from './facebook.json';
 
-export default { instagram, twitter, youtube };
+export default { instagram, twitter, youtube, facebook };

--- a/src/app/legacy/psammead/psammead-social-embed/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-social-embed/src/index.jsx
@@ -9,9 +9,27 @@ import SkipLinkWrapper from './SkipLinkWrapper';
 import CaptionWrapper from './CaptionWrapper';
 import Notice from './Notice';
 
-import CanonicalEmbed, { providers } from './Canonical';
+import CanonicalEmbed from './Canonical';
 import AmpElements from './Amp';
 import { getCaptionText } from './utilities';
+import {
+  ARTICLE_PAGE,
+  STORY_PAGE,
+  CORRESPONDENT_STORY_PAGE,
+} from '../../../../routes/utils/pageTypes';
+
+const checkIsSupportedProvider = (provider, pageType) => {
+  // Optimo Articles support all social media providers
+  if (pageType === ARTICLE_PAGE) return provider;
+
+  // CPS Pages only support a select few
+  if ([STORY_PAGE, CORRESPONDENT_STORY_PAGE].includes(pageType)) {
+    return ['twitter', 'instagram', 'youtube'].includes(provider);
+  }
+
+  // Only Optimo and CPS articles support social embeds
+  return false;
+};
 
 /**
  * Returns a social embed or fallback component for use on Canonical pages.
@@ -29,7 +47,7 @@ export const CanonicalSocialEmbed = ({
   const { pageType } = useContext(RequestContext);
   const embedCaption = getCaptionText({ pageType, caption, provider });
 
-  const isSupportedProvider = !!providers(provider);
+  const isSupportedProvider = checkIsSupportedProvider(provider, pageType);
 
   if (!isSupportedProvider || !oEmbed)
     return (
@@ -82,10 +100,11 @@ export const AmpSocialEmbed = ({
   if (!id) {
     return null;
   }
+  const isSupportedProvider = checkIsSupportedProvider(provider, pageType);
 
   const AmpElement = AmpElements[provider];
 
-  if (!AmpElement)
+  if (!isSupportedProvider || !AmpElement)
     return (
       <SkipLinkWrapper service={service} provider={provider} {...skipLink}>
         <Notice service={service} provider={provider} {...fallback} />

--- a/src/app/legacy/psammead/psammead-social-embed/src/index.test.jsx
+++ b/src/app/legacy/psammead/psammead-social-embed/src/index.test.jsx
@@ -7,6 +7,12 @@ import {
   waitFor,
   fireEvent,
 } from '../../../../components/react-testing-library-with-providers';
+import {
+  ARTICLE_PAGE,
+  STORY_PAGE,
+  CORRESPONDENT_STORY_PAGE,
+} from '../../../../routes/utils/pageTypes';
+
 import { CanonicalSocialEmbed, AmpSocialEmbed } from './index';
 import fixtures from './fixtures';
 import * as useScript from './Canonical/useScript';
@@ -24,6 +30,81 @@ describe('CanonicalSocialEmbed', () => {
   afterEach(() => {
     global.console.error = error;
   });
+  describe('Facebook', () => {
+    const facebookSocialEmbed = (
+      <CanonicalSocialEmbed
+        provider={fixtures.facebook.source}
+        oEmbed={fixtures.facebook.embed.oembed}
+        skipLink={{
+          text: 'Skip %provider_name% content',
+          endTextId: 'skip-%provider%-content',
+          endTextVisuallyHidden: 'End of %provider_name% content',
+        }}
+        fallback={{
+          text: "Sorry but we're having trouble displaying this content",
+          linkText: 'View content on %provider_name%',
+          linkTextSuffixVisuallyHidden: ', external',
+          linkHref: 'embed-url',
+          warningText:
+            'Warning: BBC is not responsible for third party content',
+        }}
+        service="news"
+      />
+    );
+    it('should render Facebook for Optimo article pages', async () => {
+      const { unmount } = render(facebookSocialEmbed, {
+        pageType: ARTICLE_PAGE,
+      });
+      expect(
+        document.querySelector(
+          'head script[src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v15.0"]',
+        ),
+      ).toBeTruthy();
+      unmount();
+      expect(
+        document.querySelector(
+          'head script[src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v15.0"]',
+        ),
+      ).toBeFalsy();
+    });
+
+    it('should not render Facebook for CPS pages', async () => {
+      render(facebookSocialEmbed, {
+        pageType: STORY_PAGE,
+      });
+      expect(
+        document.querySelector(
+          'head script[src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v15.0"]',
+        ),
+      ).toBeFalsy();
+
+      const fallbackTitle = screen.getByTestId('social-embed-fallback-title');
+
+      expect(fallbackTitle).toBeInTheDocument();
+      expect(fallbackTitle.textContent).toEqual(
+        "Sorry but we're having trouble displaying this content",
+      );
+    });
+
+    it('should not render Facebook for Correspondent pages', async () => {
+      render(facebookSocialEmbed, {
+        pageType: CORRESPONDENT_STORY_PAGE,
+      });
+      expect(
+        document.querySelector(
+          'head script[src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v15.0"]',
+        ),
+      ).toBeFalsy();
+
+      const fallbackTitle = screen.getByTestId('social-embed-fallback-title');
+
+      expect(fallbackTitle).toBeInTheDocument();
+      expect(fallbackTitle.textContent).toEqual(
+        "Sorry but we're having trouble displaying this content",
+      );
+    });
+  });
+
   describe('Twitter', () => {
     const twitterSocialEmbed = (
       <CanonicalSocialEmbed


### PR DESCRIPTION
Part of WSTEAM1-112

**Overall change:**
Adds checks to restrict social media providers to Optimo and CPS article pages.

CPS pages should not render some of the social media providers that Optimo pages can, so checks are added to prevent that from happening, and instead display the fallback notice. This is mainly to retain current behaviour of Facebook embeds on old CPS pages.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
