### PR TITLE
WSTEAMA-165 Hide media icon and duration from screen readers

### DIFF
--- a/src/app/legacy/components/Promo/media-icon.jsx
+++ b/src/app/legacy/components/Promo/media-icon.jsx
@@ -41,7 +41,7 @@ const formatChildren = children => {
 const MediaIcon = ({ script, service, children, type }) => {
   if (!type || !mediaIcons[type]) return null;
   return (
-    <Wrapper script={script} service={service}>
+    <Wrapper script={script} service={service} aria-hidden="true">
       {mediaIcons[type]}
       {formatChildren(children)}
     </Wrapper>


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAMA-165

**Overall change:**
The media type + duration should be read out with the title, not as part of the image.

**Code changes:**
- Hide media icon + duration from screenreaders with aria-hidden

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
