### PR TITLE
WSTEAM1-211 - YouTube short url fix

### DIFF
--- a/src/app/legacy/containers/SocialEmbed/Cps/index.jsx
+++ b/src/app/legacy/containers/SocialEmbed/Cps/index.jsx
@@ -28,7 +28,7 @@ const CpsSocialEmbedContainer = ({ blocks }) => {
   const id = path(['id'], model);
   const href = path(['href'], model);
 
-  if (!href) return null;
+  if (!id || !href) return null;
 
   const oEmbed = path(['embed', 'oembed'], model);
 

--- a/src/app/legacy/containers/SocialEmbed/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/SocialEmbed/__snapshots__/index.test.jsx.snap
@@ -2326,7 +2326,7 @@ exports[`SocialEmbedContainer Canonical should render an Instagram block and unm
 >
   <div
     class="emotion-2 emotion-3"
-    data-e2e="instagram-embed-https://www.instagram.com/reel/CeWO3HcIE9w/?utm_source=ig_embed&ig_rid=b6b91062-7174-4784-9a99-139d52bc5b29"
+    data-e2e="instagram-embed-https://www.instagram.com/p/CgNAEjOK46_"
   >
     <div
       class="emotion-4 emotion-5"

--- a/src/app/legacy/containers/SocialEmbed/index.jsx
+++ b/src/app/legacy/containers/SocialEmbed/index.jsx
@@ -29,6 +29,8 @@ const SocialEmbedContainer = ({ blocks, source }) => {
 
   const id = getIdFromSource(source);
 
+  if (!id) return null;
+
   const oEmbed = path(['blocks', 0, 'model', 'oembed'], model);
   const oEmbedIndexOfType = path(['indexOfType'], oEmbed);
   const oEmbedPosition = is(Number, oEmbedIndexOfType) && oEmbedIndexOfType + 1;

--- a/src/app/legacy/containers/SocialEmbed/index.test.jsx
+++ b/src/app/legacy/containers/SocialEmbed/index.test.jsx
@@ -62,7 +62,7 @@ describe('SocialEmbedContainer', () => {
       const { container, unmount } = render(
         <SocialEmbedContainer
           blocks={[instagramBlock]}
-          source="https://www.instagram.com/reel/CeWO3HcIE9w/?utm_source=ig_embed&ig_rid=b6b91062-7174-4784-9a99-139d52bc5b29"
+          source="https://www.instagram.com/p/CgNAEjOK46_"
         />,
         { service: 'news', isAmp: false, pageType: ARTICLE_PAGE },
       );
@@ -76,7 +76,7 @@ describe('SocialEmbedContainer', () => {
       expect(loggerMock.info).toHaveBeenCalledTimes(1);
       expect(loggerMock.info).toHaveBeenCalledWith(SOCIAL_EMBED_RENDERED, {
         provider: 'instagram',
-        href: 'https://www.instagram.com/reel/CeWO3HcIE9w/?utm_source=ig_embed&ig_rid=b6b91062-7174-4784-9a99-139d52bc5b29',
+        href: 'https://www.instagram.com/p/CgNAEjOK46_',
       });
       unmount();
       expect(
@@ -178,6 +178,18 @@ describe('SocialEmbedContainer', () => {
           'head script[src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v15.0"]',
         ),
       ).toBeFalsy();
+    });
+
+    it('should not render the embed if the ID is invalid', () => {
+      const { container } = render(
+        <SocialEmbedContainer
+          blocks={[youtubeBlockEmbed]}
+          source="https://yout.be/1e05_rwHvOM"
+        />,
+        { service: 'news', isAmp: false, pageType: ARTICLE_PAGE },
+      );
+
+      expect(container.firstChild).toBe(null);
     });
 
     it('should render the correct skip link text when indexOfType is provided (means this is one of multiple e.g. Twitter embeds in the article)', () => {

--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
@@ -21,7 +21,8 @@ export const getProviderFromSource = source => {
   }
   if (
     source.match(/^https:\/\/www\.youtube-nocookie\.com/) ||
-    source.match(/^https:\/\/www\.youtube\.com/)
+    source.match(/^https:\/\/www\.youtube\.com/) ||
+    source.match(/^https:\/\/youtu\.be/)
   ) {
     return PROVIDERS.YOUTUBE;
   }
@@ -43,13 +44,14 @@ export const getProviderFromSource = source => {
 export const getIdFromSource = source => {
   const sourceIds = {
     twitter: /\/status\/([0-9]+)/,
-    youtube: /\/watch\?v=([0-9A-Z a-z_-]+)/,
+    youtube: /([0-9A-Z a-z_-]+$)/,
     instagram: /\/p\/([0-9A-Za-z_-]+)/,
     tiktok: /\/video\/([0-9]+)/,
     facebook: /\/(?:posts|videos)\/([0-9A-Za-z]+)/,
   };
   const NO_ID = '';
   const provider = getProviderFromSource(source);
+
   if (
     [
       PROVIDERS.TWITTER,

--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.js
@@ -44,7 +44,7 @@ export const getProviderFromSource = source => {
 export const getIdFromSource = source => {
   const sourceIds = {
     twitter: /\/status\/([0-9]+)/,
-    youtube: /([0-9A-Z a-z_-]+$)/,
+    youtube: /([0-9A-Za-z_-]+$)/,
     instagram: /\/p\/([0-9A-Za-z_-]+)/,
     tiktok: /\/video\/([0-9]+)/,
     facebook: /\/(?:posts|videos)\/([0-9A-Za-z]+)/,

--- a/src/app/legacy/containers/SocialEmbed/sourceHelpers.test.js
+++ b/src/app/legacy/containers/SocialEmbed/sourceHelpers.test.js
@@ -7,6 +7,7 @@ describe('sourceHelpers', () => {
   const INSTAGRAM_SOURCE_UNDERSCORED =
     'https://www.instagram.com/p/CZ4ght5sIR3_';
   const YOUTUBE_SOURCE = 'https://www.youtube.com/watch?v=1e05_rwHvOM';
+  const YOUTUBE_SHORTENED_URL_SOURCE = 'https://youtu.be/OWMasi_9PCY';
   const TIKTOK_SOURCE =
     'https://www.tiktok.com/@cuppymusic/video/7086167423639997701';
   const FACEBOOK_POST_SOURCE =
@@ -42,6 +43,12 @@ describe('sourceHelpers', () => {
 
     it('should return a social embed ID for a valid Youtube source', () => {
       expect(getIdFromSource(YOUTUBE_SOURCE)).toEqual('1e05_rwHvOM');
+    });
+
+    it('should return a social embed ID for a valid shortened Youtube source', () => {
+      expect(getIdFromSource(YOUTUBE_SHORTENED_URL_SOURCE)).toEqual(
+        'OWMasi_9PCY',
+      );
     });
 
     it('should return a social embed ID for a valid TikTok source', () => {


### PR DESCRIPTION
Resolves WSTEAM1-211

**Overall change:**
Adds checks for the shortened version of YouTube URLs e.g. `youtu.be/xxxxxx`.

Also adds checks to ensure embeds are not rendered if the ID cannot be extracted from the URL

**Code changes:**
- Updates the regex checks for YouTube to include the shortened URL version
- Adds `null` checks on the `ID` value to ensure the embed isn't rendered if the ID cannot be extracted from the source URL

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
