### PR TITLE
Pass headingLevel prop to HierarchicalGrid

### DIFF
--- a/src/app/pages/TopicPage/HierarchicalGrid/index.stories.tsx
+++ b/src/app/pages/TopicPage/HierarchicalGrid/index.stories.tsx
@@ -18,6 +18,7 @@ const Component = ({ service, variant }: Props) => {
     <ThemeProvider service={service} variant={variant}>
       <ServiceContextProvider service={service} variant={variant}>
         <HierarchicalGrid
+          headingLevel={2}
           promos={pidginPromos.slice(
             0,
             number('Promo Count', 12, { min: 3, max: 12 }),

--- a/src/app/pages/TopicPage/HierarchicalGrid/index.test.tsx
+++ b/src/app/pages/TopicPage/HierarchicalGrid/index.test.tsx
@@ -4,8 +4,9 @@ import fixture from './fixtures';
 import HierarchicalGrid from '.';
 
 describe('Hierarchical Grid Curation', () => {
+  const headingLevel = 2;
   it('renders twelve promos when twelve items are provided', async () => {
-    render(<HierarchicalGrid promos={fixture} />);
+    render(<HierarchicalGrid headingLevel={headingLevel} promos={fixture} />);
 
     expect(document.querySelectorAll('li').length).toBe(12);
   });
@@ -23,18 +24,25 @@ describe('Hierarchical Grid Curation', () => {
       imageAlt: 'January 6 timeline: Wetin happun for January 6 one year ago?',
       id: 'e2263a1c-8d5a-4a73-a00c-881acfa34381',
     });
-    render(<HierarchicalGrid promos={extraPromos} />);
+    render(
+      <HierarchicalGrid headingLevel={headingLevel} promos={extraPromos} />,
+    );
 
     expect(document.querySelectorAll('li').length).toBe(12);
   });
 
   it('returns null when less than three promos are in the data', async () => {
-    render(<HierarchicalGrid promos={fixture.splice(0, 2)} />);
+    render(
+      <HierarchicalGrid
+        headingLevel={headingLevel}
+        promos={fixture.splice(0, 2)}
+      />,
+    );
     expect(document.querySelectorAll('li').length).toBe(0);
   });
 
   it('renders list with role of list', async () => {
-    render(<HierarchicalGrid promos={fixture} />);
+    render(<HierarchicalGrid headingLevel={headingLevel} promos={fixture} />);
 
     expect(document.querySelectorAll('ul').length).toBe(1);
     expect(document.querySelector('ul')?.getAttribute('role')).toBe('list');

--- a/src/app/pages/TopicPage/HierarchicalGrid/index.tsx
+++ b/src/app/pages/TopicPage/HierarchicalGrid/index.tsx
@@ -19,6 +19,7 @@ type Promo = {
 };
 
 type Promos = {
+  headingLevel: number;
   promos: Promo[];
 };
 
@@ -39,7 +40,7 @@ const getStyles = (promoCount: number, i: number, mq: any) => {
   });
 };
 
-const HiearchicalGrid = ({ promos }: Promos) => {
+const HiearchicalGrid = ({ promos, headingLevel }: Promos) => {
   if (!promos || promos.length < 3) return null;
   const promoItems = promos.slice(0, 12);
   return (
@@ -64,6 +65,7 @@ const HiearchicalGrid = ({ promos }: Promos) => {
                 </Promo.MediaIcon>
               </Promo.Image>
               <Promo.Heading
+                as={`h${headingLevel}`}
                 css={(theme: Theme) => ({
                   color: theme.palette.GREY_10,
                   ...(i === 0 && theme.fontSizes.paragon),


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
Passing headingLevel to HierarchicalGrid so that the first promo titles are h3s, not h2s.

**Code changes:**

- Added missing headingLevel to HierarchicalGrid

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
