### PR TITLE
Add Nepali election link to nav and updates for Ru Hi podcasts 

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -62,16 +62,16 @@ export const service: DefaultServiceConfig = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'पॉडकास्ट',
-      brandTitle: 'बात सरहद पार',
+      brandTitle: 'दिनभर: पूरा दिन,पूरी ख़बर (Dinbhar)',
       brandDescription:
-        'दो देश,दो शख़्सियतें और ढेर सारी बातें. आज़ादी और बँटवारे के 75 साल. सीमा पार संवाद.',
+        'देश और दुनिया की बड़ी ख़बरें और उनका विश्लेषण करता समसामयिक विषयों का कार्यक्रम.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/448xn/p0clc96w.jpg',
-        alt: 'बात सरहद पार',
+        src: 'https://ichef.bbci.co.uk/images/ic/448xn/p09ds7cb.jpg',
+        alt: 'दिनभर: पूरा दिन,पूरी ख़बर',
       },
       linkLabel: {
-        text: 'बात सरहद पार',
-        href: 'https://www.bbc.com/hindi/podcasts/p0clc83k',
+        text: 'दिनभर: पूरा दिन,पूरी ख़बर',
+        href: 'https://www.bbc.com/hindi/podcasts/p09ds7zx',
       },
       skipLink: {
         text: 'छोड़कर %title% आगे बढ़ें',

--- a/src/app/lib/config/services/nepali.ts
+++ b/src/app/lib/config/services/nepali.ts
@@ -331,8 +331,8 @@ export const service: DefaultServiceConfig = {
         url: '/nepali',
       },
       {
-        title: 'कोरोनाभाइरस',
-        url: '/nepali/news-51941128',
+        title: 'नेपाल निर्वाचन २०७९',
+        url: '/nepali/topics/cp2d78r6qppt',
       },
       {
         title: 'पछिल्लो कार्यक्रम',

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
@@ -26,7 +26,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/%D1%87%D1%82%D0%BE-%D1%8D%D1%82%D0%BE-%D0%B1%D1%8B%D0%BB%D0%BE/id1460240829?l=en',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.com/album/7330688' },
       { linkText: 'Castbox', linkUrl: 'https://castbox.fm/vc/2092482' },
     ],
     p08pxjzf: [
@@ -38,10 +37,6 @@ const externalLinks = {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D0%B0%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9-%D0%BF%D0%B8%D1%80%D0%BE%D0%B3/id1529622434',
-      },
-      {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.com/album/11965335',
       },
       { linkText: 'Castbox', linkUrl: 'https://castbox.fm/vc/3283439' },
     ],
@@ -66,7 +61,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8-doc/id1524273697',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.ru/album/11522254' },
       {
         linkText: 'Castbox',
         linkUrl:
@@ -78,10 +72,6 @@ const externalLinks = {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/%D0%BF%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%B9%D0%BE%D0%BC%D0%B5%D0%B9-%D0%BC%D0%B0%D1%80%D1%83/id1575896140',
-      },
-      {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.com/album/16801020',
       },
       {
         linkText: 'Castbox',
@@ -99,7 +89,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/8-%D0%B8%D1%81%D1%82%D0%BE%D1%80%D0%B8%D0%B9-%D0%B8%D0%B7-90-%D1%85/id1470221669',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.ru/album/9875407' },
       {
         linkText: 'Castbox',
         linkUrl:


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Replace Corona link on Nepali nav with Election topic link. Remove Yandex third party links on Russian podcasts as these are now blocked and change Hindi podcast promo on story pages

**Code changes:**

- Updated navigation section in src/app/lib/config/services/nepali.ts
- Updated podcastPromo section in src/app/lib/config/services/hindi.ts
- Removed Yandex links src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
