### PR TITLE
Adds GHSA-w573-4hg7-7wgq to npm audit allow list

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,4 @@
 {
   "low": true,
-  "allowlist": []
+  "allowlist": ["GHSA-w573-4hg7-7wgq"]
 }


### PR DESCRIPTION
Resolves #N/A

**Overall change:**
Adds https://github.com/advisories/GHSA-w573-4hg7-7wgq advisory to allowlist

**Code changes:**

- Adds https://github.com/advisories/GHSA-w573-4hg7-7wgq advisory to allowlist

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
