### PR TITLE
Fix failing test - remove 'picture' element from locator

### DIFF
--- a/cypress/integration/pages/storyPage/tests.js
+++ b/cypress/integration/pages/storyPage/tests.js
@@ -147,7 +147,7 @@ export const testsThatFollowSmokeTestConfig = ({
                     ).should('have.attr', 'width');
                   } else {
                     cy.get(
-                      `[data-e2e=story-promo-wrapper] > div > [data-e2e=image-placeholder] > div > picture > img`,
+                      `[data-e2e=story-promo-wrapper] > div > [data-e2e=image-placeholder] > div > img`,
                     ).should('have.attr', 'width');
                   }
                 });


### PR DESCRIPTION
New locator path need for recommendations images

now [data-e2e=story-promo-wrapper] > div > [data-e2e=image-placeholder] > div > img`
instead of what they were before this started failing which is `[data-e2e=story-promo-wrapper] > div > [data-e2e=image-placeholder] > div > picture > img`
(previously had a picture element in there, now does not)