### PR TITLE
[WSTEAM1-188] Podcast Download Tracking

### DIFF
--- a/data/burmese/podcasts/p02p9f6q.json
+++ b/data/burmese/podcasts/p02p9f6q.json
@@ -1,0 +1,1303 @@
+{
+  "metadata": {
+    "id": "urn:bbc:ares:ws_media:brand:bbc_burmese_radio/p02p9f6q",
+    "locators": { "pid": "p0dmqj1b", "brandPid": "p02p9f6q" },
+    "type": "WSRADIO",
+    "createdBy": "bbc_burmese_radio",
+    "language": "my",
+    "lastUpdated": 1670498922489,
+    "firstPublished": 1670456864000,
+    "lastPublished": 1670456864000,
+    "timestamp": 1670456864000,
+    "options": {},
+    "analyticsLabels": {
+      "pageTitle": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ် - BBC News မြန်မာ",
+      "pageIdentifier": "burmese.bbc_burmese_radio.podcasts.programmes.p02p9f6q.page",
+      "producerId": "35",
+      "contentType": "player-episode",
+      "producer": "BURMESE"
+    },
+    "passport": { "home": "", "taggings": [] },
+    "tags": {},
+    "version": "v1.4.8",
+    "blockTypes": ["media"],
+    "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်",
+    "releaseDateTimeStamp": 1670371200000
+  },
+  "content": {
+    "blocks": [
+      {
+        "id": "p0dmqj1b",
+        "subType": "episode",
+        "format": "Audio",
+        "title": "",
+        "synopses": {
+          "short": "စစ်ကိုင်းတိုင်း ဒီပဲယင်းမြို့နယ်ထဲက စစ်ရှောင်ပြည်သူတွေ အခက်အခဲတွေနဲ့ ရင်ဆိုင်နေရ",
+          "long": "အာရပ်ကမ္ဘာမှာ တရုတ်နိုင်ငံရဲ့ အကြီးဆုံး သံတမန်ရေး ကနဦးခြေလှမ်းအဖြစ် သမ္မတ ရှီကျင်းပင် ဆော်ဒီကို သွားရောက်"
+        },
+        "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+        "embedding": false,
+        "advertising": false,
+        "versions": [
+          {
+            "versionId": "p0dmqhv4",
+            "types": ["Podcast"],
+            "duration": 751,
+            "durationISO8601": "PT12M31S",
+            "warnings": {},
+            "availableTerritories": {
+              "uk": true,
+              "nonUk": true,
+              "world": false
+            },
+            "availableUntil": 1673048700000,
+            "availableFrom": 1670456700000,
+            "availabilityStatus": "available"
+          }
+        ],
+        "availability": "available",
+        "smpKind": "radioProgramme",
+        "episodeTitle": "တရုတ်သမ္မတ ရှီကျင်းပင်ရဲ့ ဆော်ဒီခရီးစဥ် စတင်",
+        "type": "media"
+      }
+    ]
+  },
+  "promo": {
+    "headlines": { "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်" },
+    "locators": { "pid": "p0dmqj1b", "brandPid": "p02p9f6q" },
+    "media": {
+      "id": "p0dmqj1b",
+      "subType": "episode",
+      "format": "Audio",
+      "title": "",
+      "synopses": {
+        "short": "စစ်ကိုင်းတိုင်း ဒီပဲယင်းမြို့နယ်ထဲက စစ်ရှောင်ပြည်သူတွေ အခက်အခဲတွေနဲ့ ရင်ဆိုင်နေရ",
+        "long": "အာရပ်ကမ္ဘာမှာ တရုတ်နိုင်ငံရဲ့ အကြီးဆုံး သံတမန်ရေး ကနဦးခြေလှမ်းအဖြစ် သမ္မတ ရှီကျင်းပင် ဆော်ဒီကို သွားရောက်"
+      },
+      "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+      "embedding": false,
+      "advertising": false,
+      "versions": [
+        {
+          "versionId": "p0dmqhv4",
+          "types": ["Podcast"],
+          "duration": 751,
+          "durationISO8601": "PT12M31S",
+          "warnings": {},
+          "availableTerritories": { "uk": true, "nonUk": true, "world": false },
+          "availableUntil": 1673048700000,
+          "availableFrom": 1670456700000,
+          "availabilityStatus": "available"
+        }
+      ],
+      "availability": "available",
+      "smpKind": "radioProgramme",
+      "episodeTitle": "တရုတ်သမ္မတ ရှီကျင်းပင်ရဲ့ ဆော်ဒီခရီးစဥ် စတင်",
+      "type": "media"
+    },
+    "indexImage": {
+      "id": "",
+      "subType": "index",
+      "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+      "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+      "height": 0,
+      "width": 0,
+      "altText": null,
+      "copyrightHolder": null,
+      "type": "image"
+    },
+    "releaseDateTimestamp": 1670371200000,
+    "brand": {
+      "pid": "p02p9f6q",
+      "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+    },
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dmqj1b",
+    "type": "ws_radio"
+  },
+  "relatedContent": {
+    "site": {
+      "subType": "site",
+      "name": "Burmese",
+      "uri": "/burmese",
+      "type": "simple"
+    },
+    "groups": [
+      {
+        "type": "other-episode",
+        "promos": [
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dmdk3t", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dmdk3t",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "စစ်ပွဲအန္တရာယ်ကြောင့် လောက်ကိုင်မြို့ကနေ လူအများအပြား ထွက်ခွာ - BBC News မြန်မာ",
+                "long": "မြန်မာစစ်တပ်နဲ့ ကိုးကန့်တပ်ကြား တိုက်ပွဲဖြစ်မှာစိုးလို့ လောက်ကိုင်မြို့ကနေ ပြည်သူအများအပြား စတင်ထွက်ခွာ"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dmdjv7",
+                  "types": ["Podcast"],
+                  "duration": 741,
+                  "durationISO8601": "PT12M21S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672965420000,
+                  "availableFrom": 1670373420000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "စစ်ပွဲအန္တရာယ်ကြောင့် လောက်ကိုင်မြို့ကနေ လူအများအပြား ထွက်ခွာ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1670371200000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dmdk3t",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dm1x73", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dm1x73",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "တရုတ်မြန်မာနယ်စပ် ဂိတ်၅ခုအနက် ၁ခုဘဲဖွင့်ထားလို့ ကုန်သွယ်ရေးနှောက်နှေးနေတယ်လို့ ဆိုကြပြီ",
+                "medium": "KBC ဥက္ကဋ္ဌဟောင်းကိုဖမ်းဆီးတာဟာ ဘာသာရေးအပေါ် အနိုင်ကျင့်မှုသက်သက်ဘဲလို့ KIO မီဒီယာ တာ၀န်ခံပြော",
+                "long": "- ရခိုင်မှာ လူမှုကယ်ဆယ်ရေးအကူအညီတွေလမ်းဖွင့်ပေးဖို့ အပစ်ရပ်ခဲ့ပေမယ့် အကူအညီမရသေးလို့ အငတ်ဆိုက်နေတဲ့ အခြေအနေကို စစ်ရှောင်စခန်းတာ၀န်ခံတွေပြောပြ\n- ရုရှားဒုံးကျည်တိုက်ခိုက်မှုတွေကြောင့် ယူကရိန်းဓါတ်အားပေးလိုင်းတွေ ထိမှန်ပြီး မြို့တော်တော်များများ မီးပြတ်ကာ ဆောင်းအ၀င် အနွေးပေးစက်တွေလည်း အသုံးပြုမရဖြစ်နေ\n- တလောက ပစ်ခတ်တိုက်ခိုက်ခံရလို့ ပျက်စီးသွားတဲ့ ခရိုင်းမီးယား တံတားကို ရုရှားသမ္မတပူတင် လာရောက်စစ်ဆေး\n- မနှစ်က စစ်အာဏာသိမ်းပြီးနောက်ပဋိပက္ခတွေဖြစ်ခဲ့တဲ့ ဆူဒန်မှာ စစ်တပ်နဲ့သဘောတူညီချက်ယူလို့ ဆန္ဒပြကြပြီ\n- အိမ်ထောင်ရှိရက်နဲ့ဖောက်ပြန်သူတွေ ၊ လက်မထပ်ဘဲအတူနေသူတွေကို အပြစ်ပေးမယ့် ဥပဒေတွေ အင်ဒိုနီးရှားမှာ ပြင်ဆင်ပြဌာန်းတော့မယ်\n- ဂျပန်ကို ပန်နယ်တီမှာ နိုင်တဲ့ ခရိုအေးရှားနဲ့ တောင်ကိုရီးယားကို ၄ဂိုး-၁ဂိုးနဲ့ နိုင်တဲ့ ဘရာဇီးတို့ ဒီဇင်ဘာ၉ရက်မှာ ကွာတားဖိုင်နယ် ကန်ကြမယ့် အကြောင်း အပါအ၀င် အင်္ဂါ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dm1x6s",
+                  "types": ["Podcast"],
+                  "duration": 636,
+                  "durationISO8601": "PT10M36S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672885380000,
+                  "availableFrom": 1670293380000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ဒီပဲယင်းဘက်ကရွာတွေမှာ စစ်ကောင်စီတပ်တွေ မီးရှို့နေတာ ၃ရက်ရှိပြီလို့ ဒေသခံပြော",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1670284800000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dm1x73",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dlt8qt", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dlt8qt",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "တာ၀န်ပြီးဆုံးလို့ တရုတ်အာကာသယာဥ်မှူးတွေ ကမ္ဘာမြေပေါ် ပြန်လည်ဆင်းသက်လာကြ",
+                "medium": "ဆီးရီးယားမှာ ကုန်စျေးနှုန်းကြီးမြင့်မှု၊အစိုးရအဖွဲ့ လာဘ်စားမှုတွေကြောင့် အစိုးရအဆောက်အအုံကို ဆန္ဒပြသူတွေ ၀င်ရောက်စီးနင်း",
+                "long": "- မန္တလေးတိုင်းမြို့နယ် ၅ ခုမှာ စစ်ကောင်စီအဖွဲ့ဝင်တွေက မီးရှို့ရာမှာ နိုဝင်ဘာ တစ်လအတွင်း နေအိမ် ၃၀၀ နီးပါး မီးလောင်ဆုံးရှုံးခဲ့တယ်လို့ NUG ထုတ်ပြန်\n- စစ်ကိုင်းတိုင်း ထီးချိုင့်ဘက်မှာတော့ နိုဝင်ဘာလကုန်ကနေ ခုဒီဇင်ဘာလဆန်းအထိ ကျေးရွာ ၇ရွာလောက်မှာ စစ်ကောင်စီတပ်တွေ၀င်မီးရှို့လို့ ‌နေအိမ်ရာနဲ့ချီ မီးလောင်ပျက်စီးထားပြီလို့ ဒေသခံတွေကပြောသလို KIA နဲ့ PDF တပ်ဖွဲ့တွေ ဆုတ်ခွာရင်းမီးရှို့ခဲ့လို့ နေအိမ်ရာနဲ့ချီ ဆုံးရှုံးတယ်လို့ စစ်ကောင်စီကထုတ်ပြန်\n- ရခိုင်ပြည်နယ် ပုဏ္ဏားကျွန်း ဆင်အင်းကြီးရွာမှာ စစ်ကောင်စီတပ်ဖွဲ့တွေက လက်ချက်ကြောင့် အရပ်သား ၁၀ ယောက်သေဆုံးခဲ့ပြီး ဒါဇင်နဲ့ချီ ဒဏ်ရာရရှိခဲ့တဲ့အကြောင်း ဒေသခံရဲ့ ပြောပြချက်\n- ကိုဗစ်ကာလ နေရပ်ပြန်လိုသူတွေကို အခကြေးငွေယူပြီး ကယ်ဆယ်ရေးလေကြောင်းခရီးစဥ်တွေပေါ် တင်ပေးတဲ့ ဗီယက်နမ်သံအရာရှိတွေ ဖမ်းဆီး ခံရ\n- ဆီနီဂေါကို နိုင်တဲ့ အင်္ဂလန် နဲ့ ပိုလန်ကိုနိုင်တဲ့ ပြင်သစ်တို့ ကွာတားဖိုင်နယ် တက်သွားပြီး လာမယ့် ဒီဇင်ဘာမှာ ကစားမယ့်  အကြောင်း အပါအ၀င် တနင်္လာ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dlt8n7",
+                  "types": ["Podcast"],
+                  "duration": 534,
+                  "durationISO8601": "PT8M54S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672798620000,
+                  "availableFrom": 1670206620000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ဘင်္ဂလားဒေ့ရှ်မှာ လေထုညစ်ညမ်းမှုကြောင့် နိုင်ငံစီးပွားရေးကို ထိခိုက်လာစေတယ်လို့ ကမ္ဘာဘဏ်ထုတ်ပြန်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1670198400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dlt8qt",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dlp9z8", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dlp9z8",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "အစိုးရနဲ့ အပစ်ရပ်မှု ရပ်ဆိုင်းထားတဲ့ ပါကစ္စတန်တာလီဘန်တွေ ချုံခိုတိုက်ခိုက်လို့ ရဲတွေသေ",
+                "medium": "အသတ်ခံရတဲ့ ငါးဖမ်းဌာနအရာရှိကိစ္စနဲ့ပတ်သက်လို့ ဖုံးကွယ်ထားတယ်ဆိုပြီး တောင်ကိုရီးယား လုံခြုံရေးအကြံပေးဟောင်း ဖမ်းဆီးခံရ",
+                "long": "- ကန့်ဘလူနဲ့ကျွန်းလှ တ၀ိုက် ဒေသခံတွေကို စစ်ကောင်စီတပ်ဖွဲ့တွေက ပျူစောထီးသင်တန်း တက်ခိုင်းနေပြီး မတက်တဲ့သူတွေကို တအိမ် ကျပ်သုံးသောင်းတစ်ထောင် ကောက်ခံလျက်ရှိတယ်လို့ ဆိုပြီ\n- တမူးကိစ္စ ဗီဒီယိုဖိုင်နဲ့ ပတ်သက်လို့ စုံစမ်းနေပြီး ကျူးလွန်တာမှန်ရင် ထိရောက်တဲ့အရေးယူတွေ လုပ်ဆောင်သွားမယ်လို့ အမျိုးသားညီညွတ်ရေးအစိုးရ လူ့အခွင့်အရေး၀န်ကြီးပြောကြား\n- ၂၀၀၈ ဖွဲ့စည်းပုံ အခြေခံဥပဒေ ပြင်ဆင်ရေး နိုင်ငံရေးပါတီ ၁၆ခုက ဆွေးနွေးနေတာ ပုဒ်မပေါင်း ၅၀ကျော်ရှိပြီလို့ ဦးစိုင်းအိုက်ပေါင်းပြော\n- အဂတိလိုက်စားမှု ကင်းအောင်လုပ်မယ်ဆိုပြီး အာဏာရလာတဲ့ တောင်အာဖရိက သမ္မတ အိမ်မှာ ဒေါ်လာသန်းချီ ငွေသားတွေ ၀ှက်ထားတဲ့ကိစ္စပေါ်ပေါက်ခဲ့လို့ သမ္မတ ရာထူးက ဆင်းပေးဖို့ တောင်းဆိုနေကြပြီ\n- ဂန္ဓ၀င်ဘောလုံးသမားကြီး ပီလီ အူမကြီးကင်ဆာနဲ့ ခွဲစိတ်ထားရာက ဆေးရုံပြန်တက်နေရပြီး သူနေပြန်ကောင်းဖို့ ဆုတောင်းနေကြပြီ\n- အမေရိကန်ကို နိုင်တဲ့ နယ်သာလန်နဲ့ သြစတြေးလျကို နိုင်တဲ့ အာဂျင်တီးနား တို့ ကွာတားဖိုင်နယ် အဆင့် တက်လှမ်းကြတဲ့ အကြောင်း အပါအ၀င် တနင်္ဂနွေ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dlp9yp",
+                  "types": ["Podcast"],
+                  "duration": 644,
+                  "durationISO8601": "PT10M44S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672713960000,
+                  "availableFrom": 1670121960000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "တစ်စင်းကို ဒေါ်လာသန်း ၇၀၀တန် ရေဒါနဲ့ဖမ်းလို့မရတဲ့ B 21 ဗုံးကြဲလေယာဥ် အမေရိကန် မိတ်ဆက်ပြသ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1670112000000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dlp9z8",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dljrzc", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dljrzc",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ဘရာဇီးလ်နဲ့ ဆွစ်ဇာလန် နောက်တဆင့်တက်",
+                "long": "စနေနေ့ မနက်ခင်း သတင်းများ ( ၃ ဒီဇင်ဘာ၊ ၂၀၂၂)\n\nထီးချိုင့်မြို့နယ်ထဲမှာ စစ်ကောင်စီက လေကြောင်းနဲ့ ဗုံးကြဲတာ ရွာတွေကို မီးရှို့ခဲ့တာကြောင့်  ဒေသခံတွေ ဘယ်လို ရင်ဆိုင်နေရပါသလဲ။ \n\nတရုတ်နှစ်ကူးနီးလာပေမဲ့ ကျောက်စိမ်းအရောင်းအဝယ်အေး။ \n\nယူကရိန်းရဲ့ အခြေခံအဆောက်အအုံတွေကို ရုရှားက ပစ်မှတ်ထား တိုက်ခိုက်တာ အခြေခံ လူ့အခွင့်အရေးကို ချိုးဖောက်လို့ စိုးရိမ်လို့ ကုလပြော။ \n\nနိုဝင်ဘာတလတည်း အလုပ်အကိုင် နှစ်သိန်းခြောက်သောင်းကျော်ဖန်တီးလို့ အမေရိကန် အလုပ်သမားဌာနပြော။ \n\nတရုတ်ရဲ့ ကိုဗစ် ကန့်သတ်ချက်လျော့ချမှု ကမ္ဘာ့ကျန်းမာရေးအဖွဲ့ အပြုသဘော တုံ့ပြန်။ \n\nစန္ဒယားတီးတာက ဦးနှောက်အလုပ်လုပ်ပုံကို ပိုကောင်းစေ။\n\nကမ္ဘာဖလားပြိုင်ပွဲရလဒ်။ \n\nဘရာဇီးလ်နဲ့ ဆွစ်ဇာလန် နောက်တဆင့်တက်။ \n\nအမေရိကန် နယ်သာလန်၊ အာဂျင်တီးနား သြစတြေးလျ ရှုံးထွက်ကစားမယ်။ \n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dljr4r",
+                  "types": ["Podcast"],
+                  "duration": 665,
+                  "durationISO8601": "PT11M5S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672619040000,
+                  "availableFrom": 1670027040000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "တရုတ်နှစ်ကူးနီးလာပေမဲ့ ကျောက်စိမ်းအရောင်းအဝယ်အေ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1670025600000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dljrzc",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dl8z3m", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dl8z3m",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ဒီမိုကရေစီလိုလားတဲ့ တိုက်ပွဲဝင်သူ ၂၀၀၀ကျော် သေဆုံးခဲ့တယ်လို့ အန်ယူဂျီ ယာယီသမ္မတပြော",
+                "long": "သောကြာနေ့ မနက်ခင်း သတင်းများ (၂ ဒီဇင်ဘာ၊ ၂၀၂၂)\n\nဒီမိုကရေစီလိုလားတဲ့ တိုက်ပွဲဝင်သူ ၂၀၀၀ကျော် သေဆုံးခဲ့တယ်လို့ အန်ယူဂျီ ယာယီသမ္မတပြော။ \n\nရွှေဘိုပေါ်ဆန်း ၂၄ ပြည်ပါတစ်အိတ်ကို ကျပ် လေးထောင်ကျော် စျေးတက်။\n\nထောင်ဒဏ် ၂၄ နှစ်အထိ ချခံထားရတဲ့ ပြည်သူ့လွှတ်တော် ဒုဥက္ကဋ္ဌ ဦးထွန်းထွန်းဟိန်ရဲ့ ကျန်းမာရေး အခြေအနေ ဘယ်လိုရှိနေပါသလဲ။\n\nမတူတာတွေကိုကျော်လွှားပြီး ပြင်သစ်နဲ့ အတူလက်တွဲလုပ်မယ်လို့ အမေရိကန် သမ္မတ ဂျိုးဘိုင်ဒန်ပြော။\n\nကိုဗစ်နဲ့ ပတ်သက်ပြီး အခြေအနေသစ်တမျိုးရင်ဆိုင်နေရတဲ့ တရုတ်။\n\nလျှပ်စစ်နဲ့ သဘာဝဓာတ်ငွေ့သုံး သုံးဘီးတွေကို အိန္ဒိယ လေထုညစ်ညမ်းမှု တိုက်ဖျက်ရေး ကော်မတီက မှတ်ပုံတင်ရန်ညွှန်ကြား။ \n\nကမ္ဘာဖလားပြိုင်ပွဲရလဒ်။\n\nကော့စတာရီကာနဲ့ ဂျာမနီပွဲမှာ ပထမဆုံး အမျိုးသမီး ဒိုင်တွေ တာဝန်ယူ။ \n\nဂျာမနီကမ္ဘာ့ဖလားပြိုင်ပွဲ အုပ်စု အဆင့်ကနေ ထွက်။ \n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dl8yc8",
+                  "types": ["Podcast"],
+                  "duration": 652,
+                  "durationISO8601": "PT10M52S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672532460000,
+                  "availableFrom": 1669940460000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ရွှေဘိုပေါ်ဆန်း ၂၄ပြည်ပါတစ်အိတ် ကျပ်လေးထောင်ကျော် စျေးတက်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669939200000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dl8z3m",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dl0hmg", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dl0hmg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "လျှပ်စစ်မီးမရလို့ မန္တလေးတိုင်းတွင်းက လုပ်ငန်းတချို့ ရပ်ဆိုင်းထားရ",
+                "long": "ရခိုင်ပြည်နယ်တွင်း ဖမ်းဆီးခံထားရတဲ့ အရပ်သားတွေ ပြန်လွှတ်ပေးဖို့ ဒေသခံတွေ တောင်းဆို၊"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dl0gmh",
+                  "types": ["Podcast"],
+                  "duration": 454,
+                  "durationISO8601": "PT7M34S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672444200000,
+                  "availableFrom": 1669852200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "လျှပ်စစ်မီးမရလို့ မန္တလေးတိုင်းတွင်းက လုပ်ငန်းတချို့ ရပ်ဆိုင်းထားရ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669766400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dl0hmg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dkqpgg", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dkqpgg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ခင်ဦးမြို့နယ်တွင်း နေအိမ်အလုံးပေါင်း ၈၀၀ နီးပါး မီးရှို့ဖျက်ဆီးခံရ",
+                "medium": "မန္တလေးတိုင်း မြို့နယ်တချို့မှာ ကျူးကျော်လို့ စွပ်စွဲပြီး နေအိမ်အလုံးပေါင်း ၁၀၀ ကျော် ဖယ်ရှားခံရ",
+                "long": "စစ်ကိုင်းတိုင်းခင်ဦးမြို့နယ်မှာ ဆယ်ရက်အတွင်း နေအိမ်အလုံးပေါင်း ၈၀၀ နီးပါး မီးရှို့ဖျက်ဆီးခံရ"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dkqp35",
+                  "types": ["Podcast"],
+                  "duration": 647,
+                  "durationISO8601": "PT10M47S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672360020000,
+                  "availableFrom": 1669768020000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ခင်ဦးမြို့နယ်တွင်း နေအိမ်အလုံးပေါင်း ၈၀၀ နီးပါး မီးရှို့ဖျက်ဆီးခံရ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669766400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dkqpgg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dkh6p9", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dkh6p9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "WHO က မျောက်ကျောက်ရောဂါကို  MPOX လို့ အမည်ပေး",
+                "medium": "အီရန်မှာ အစိုးရဆန္ဒပြမှုကို ထောက်ခံတဲ့ Rapper အကျင့်ပျက်မှုနဲ့ တရားစွဲခံရပြီး သေဒဏ် ကျခံရနိုင်ဖွယ်ရှိ",
+                "long": "- အမေရိကန်က စျေးသက်သာပြီး ပစ်မှတ်ကို တည့်တည့်ထိနိုင်တဲ့ လက်နက်တွေ ယူကရိန်းကို ထောက်ပံ့ပေးတော့မယ်\n- ပါကစ္စတန်မှာ တာလီဘန်တွေက အစိုးရနဲ့ အပစ်ရပ်ရေး အဆုံးသတ်ပြီး လုံခြုံရေးတပ်ဖွဲ့တွေကို တိုက်ခိုက်သွားတော့မယ်လို့ဆို\n- နိုင်ငံကူးလက်မှတ်သက်တမ်းကုန်တာကို ပွဲစားနဲ့လုပ်ခိုင်းတဲ့ ထိုင်းကမြန်မာသံရုံးအကြောင်း\n- ကပ်ဘေး စစ်ရေးကြားက အမျိုးသမီးနဲ့ ကလေးသူငယ်တွေ အခွင့်အရေးဘယ်လောက်ဆုံးရှုံးနေလဲ\n- ကမ္ဘာဖလားဘောလုံးပွဲက အနိုင်အရှုံး အကြောင်း အပါအ၀င် အင်္ဂါ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dkh6jl",
+                  "types": ["Podcast"],
+                  "duration": 684,
+                  "durationISO8601": "PT11M24S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672282560000,
+                  "availableFrom": 1669690560000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "အိန္ဒိယမှာ ရဲစခန်းကို လူအုပ်ကြီးက၀င်ရောက်စီးနင်း တိုက်ခိုက်ခဲ့တာကြောင့် ရဲအရာရှိ ၃၆ယောက် ဒဏ်ရာရ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669680000000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dkh6p9",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dk616q", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dk616q",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "လူ့အခွင့်အရေးချိုးဖောက်တဲ့ အဆိုးရွားဆုံး ၁၀ နိုင်ငံမှာ မြန်မာနိုင်ငံက ပါဝင်နေတဲ့အကြောင်း",
+                "medium": "ရခိုင်မှာ စစ်ကောင်စီနဲ့ အေအေ အပစ်ရပ်ပြီးနောက် အငူမော် မောင်တောလမ်းပြန်ဖွင့်ဖို့ ဒေသခံတွေမျှော်လင့်နေ",
+                "long": "- ကိုဗစ်လော့ခ်ဒေါင်းချ၊ ကူးစက်မှုစစ်ဆေးတာ ၃နှစ်ကြာရှိခဲ့ပြီးနောက် တရုတ်မြို့ကြီးတွေမှာ ဆန့်ကျင် ဆန္ဒပြ\n- သမီးဖြစ်သူကို ဒုတိယအကြိမ် ထုတ်ပြတဲ့ မြောက်ကိုရီးယားခေါင်းဆောင်နဲ့ Hwasong-17  ဒုံးကျည်စမ်းသပ်မှု\n- အီရန်အလံပုံပေါ်က အမှတ်သင်္ကေကို ဖယ်ရှားပစ်လို့ အမေရိကန်အသင်းကို အီရန်ဘောလုံးအဖွဲ့ချုပ်တိုင်ကြား\n- ဘယ်လ်ဂျီယံကို ၂ဂိုး ဂိုးမရှိနဲ့ အနိုင်ရခဲ့လို့ မော်ရိုကို နိုင်ငံသားတွေ အောင်ပွဲခံနေ\n- ဂျာမနီကို အနိုင်ယူခဲ့တဲ့ ဂျပန်ဘောလုံးအသင်း ကော့စတာရီကာကို ၁ဂိုး ဂိုးမရှိနဲ့ ရှုံးနိမ့်ခဲ့ပြီး စပိန်နဲ့ ဂျာမနီ ပွဲမှာ သရေကျခဲ့ပေမယ့် ခရိုအေးရှားက ကနေဒါကို ၄ဂိုး ၁ဂိုးနဲ့ အနိုင်ရခဲ့တဲ့အကြောင်း အပါအ၀င် တနင်္လာ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dk616b",
+                  "types": ["Podcast"],
+                  "duration": 502,
+                  "durationISO8601": "PT8M22S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672192200000,
+                  "availableFrom": 1669600200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မိုးဗြဲမှာ မိုင်းထိတဲ့ ဆယ်ကျော်သက်ကလေးတွေထဲက ခေါင်းထိထားသူဟာ စိုးရိမ်ရတယ်လို့ ပြော",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669593600000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dk616q",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dk1y76", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dk1y76",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "Squid Game ထဲက အသက်၇၈နှစ် မင်းသား O Yeong-su လိင်ပိုင်းဆိုင်ရာထိပါးမှုနဲ့တရားစွဲခံရ",
+                "medium": "ထိုင်၀မ်ရွေးကောက်ပွဲမှာ အာဏာရပါတီရလဒ်မကောင်းလို့ သမ္မတဆိုင်အင်၀မ်း ပါတီခေါင်းဆောင်အဖြစ်ကနုတ်ထွက်",
+                "long": "- အီတလီရေကြီးမြေပြိုမှု လူတစ်ယောက်သေ ၁၂ယောက်ပျောက်ကာ ရာသီဥတုဆိုးလို့ ကယ်ဆယ်ရေးနှောင့်နှေး\n- ခင်ဦး က မြစ်တော်ကျေးရွာကိုစစ်ကောင်စီတပ် မီး၀င်ရှို့ပြီး သက်ကြီးအမျိုးသားတစ်ယောက်ကို ပစ်သတ်သွားခဲ့တယ်လို့ ဒေသခံပြော\n- ငွေစျေးမတည်ငြိမ်မှု စိုက်ပျိုးသွင်းအားစု စရိတ်ကြီးမြင့်မှုတွေတောင် နှမ်းစိုက်တောင်သူတွေ အရှုံးပေါ်နေတယ်လို့ဆို\n- ပေါ်တူဂီ တိုက်စစ်မှူး ခရစ်တီယာနို ရော်နယ်ဒိုဟာ ထူးခြားတဲ့ ဘောလုံးသမား ပါရမီရှင်ဘဲလို့ ဖီဖာပြော\n- လက်ရှိကမ္ဘာဖလားချန်ပီယံ ပြင်သစ်က ဒိန်းမတ်ကို နိုင်ပြီး ရှုံးထွက်အဆင့်တက် ၊ ပိုလန်နဲ့ ဆော်ဒီကို ၊ အာဂျင်တီးနားက မက်ဆီနဲ့ ဖနန်းဒက်စ် တို့ရဲ့ သွင်းဂိုးတွေနဲ့ မက္ကဆီကို ကို အနိုင်ယူ ၊ သြစတြေးလျက တူနီးရှား တစ်ဂိုး ဂိုးမရှိနဲ့ အနိုင်ရခဲ့တဲ့အကြောင်း အပါအ၀င် တနင်္ဂနွေ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dk1y63",
+                  "types": ["Podcast"],
+                  "duration": 559,
+                  "durationISO8601": "PT9M19S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672108680000,
+                  "availableFrom": 1669516680000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မောင်းသူမဲ့ဘတ်စ်ကားတွေ တောင်ကိုရီးယားနိုင်ငံ ဆိုးလ်မြို့လယ်မှာ စတင်ပြေးဆွဲနေပြီ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669507200000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dk1y76",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0djx8z4", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0djx8z4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ရုရှားသမ္မတ ပူတင် တိုက်ပွဲဝင်စစ်သားမိခင်များနဲ့တွေ့ဆုံ",
+                "long": "စနေနေ့ မနက်ခင်း သတင်းများ (၂၆ နိုဝင်ဘာ၊ ၂၀၂၂)\n\nမြန်မာနိုင်ငံဆိုင်ရာအာဆီယံ အထူးကိုယ်စားလှယ် ပရတ်ဆော့ခွန်းအလွန် စစ်ကောင်စီကို အာဆီယံက ဆက်ဖိအားပေးနိုင်မလား။ \n\nအရာတော်မြို့နယ် နွားမသင်းရွာကို စစ်ကောင်စီတပ်ဖွဲ့ဝင်တွေ မီးရှို့လို့ ဒေသခံတွေ ပြော။\n\nရုရှားသမ္မတ ပူတင် တိုက်ပွဲဝင် စစ်သားမိခင်များနဲ့တွေ့ဆုံ။\n\nရုရှားရဲ့ ဆက်တိုက်တိုက်ခိုက်မှုကြောင့် ယူကရိန်း ခါဆွန်မှာ ဆေးရုံက လူနာတွေ ပြောင်းရွှေ့နေရ။\n\nသောကြာနေ့ ဝတ်ပြုသူများကို အီရန်လုံခြုံရေးတပ်ဖွဲ့ပစ်ခတ်။ \n\nကမ္ဘာဖလားပြိုင်ပွဲရလဒ်။ \n\nဘရာဇီးလ်တိုက်စစ်မှူးနေမာ ဒဏ်ရာကြောင့် နှစ်ပွဲ နားရမယ်။ \n\nအိမ်ရှင် ကာတာအသင်း ကမ္ဘာဖလားကနေ ပထမဆုံးထွက်ရတဲ့ အသင်းဖြစ်လာ။ \n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djx8lj",
+                  "types": ["Podcast"],
+                  "duration": 592,
+                  "durationISO8601": "PT9M52S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672011960000,
+                  "availableFrom": 1669419960000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "အာဆီယံ အထူးကိုယ်စားလှယ် ပရတ်ဆော့ခွန်းအလွန် စစ်ကောင်စီကို အာဆီယံက ဆက်ဖိအားပေးနိုင်မလား",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669334400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0djx8z4",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0djnc83", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0djnc83",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မန္တလေးမြို့မှာ အမျိုးသမီးတစ်ဦးအက်ဆက်နဲ့ အပက်ခံရ",
+                "long": "သောကြာနေ့ မနက်ခင်း သတင်းများ (၂၅ နိုဝင်ဘာ၊ ၂၀၂၂)\n\nအယောင်ဆောင်ဖမ်းဆီးတာတွေများလာချိန်မှာ မြေအောက်လှုပ်ရှားမှုအဖွဲ့တွေရဲ့ ရပ်တည်မှု ဘယ်လောက်ခက်ခဲလာလဲ။\n\nကားတင်သွင်းခွင့်မပြုတာ ကုန်ကျစရိတ်တွေ များတာကြောင့် ကားအရောင်း စင်တာတွေ ပိတ်သိမ်းလာ။ \n\nမန္တလေးမြို့မှာ အမျိုးသမီးတစ်ဦးအက်ဆက်နဲ့ အပက်ခံရ။ \n\nအီရန်မှာ ဆန္ဒပြသူတွေကို အကြမ်းဖက်ဖြိုခွဲတာကို စုံစမ်းဖို့ ကုလလူ့အခွင့်အရေး ကောင်စီအမိန့်ချ။\n\nတရုတ်ထုတ် စောင့်ကြည့် ကင်မရာတွေကို အသုံးမပြုဖို့ ဗြိတိန်အစိုးရ ညွှန်ကြား။ \n\nအမေရိကန်မှာ ငှက်သန်း ၅၀ကျော် ဒီနှစ်အတွင်း ငှက်တုပ်ကွေးကူးစက်ခံရ။\n\nဗြိတိန်က မားစ်ရိုဗာကို အာကာသထဲ ပြန်လွှတ်မယ်။ \n\nကမ္ဘာဖလားပြိုင်ပွဲရလဒ်။\n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djnc2m",
+                  "types": ["Podcast"],
+                  "duration": 667,
+                  "durationISO8601": "PT11M7S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671927720000,
+                  "availableFrom": 1669335720000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ဖမ်းဆီးတာတွေများလာချိန်မှာ မြေအောက်လှုပ်ရှားမှုအဖွဲ့တွေရဲ့ ရပ်တည်မှု ဘယ်လောက်ခက်ခဲလဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669334400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0djnc83",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0djf56z", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0djf56z",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ကိုဗစ်ကြောင့် ကလေး သန်း၄၀ ဒီနှစ်မှာ ဝက်သက်ကာကွယ်ဆေး ထိုးနိုင်မှာ မဟုတ်",
+                "long": "ကြာသပတေးနေ့ မနက်ခင်း သတင်းများ (၂၄ နိုဝင်ဘာ၊ ၂၀၂၂)\n\nခွဲခြားမှုဆန့်ကျင်ရေး လက်ပတ်ဝတ်ဆင်ဖို့ ဖီဖာ တားမြစ်ချက် ဂျာမနီအသင်းသားတွေ ဆန္ဒပြ။ \n\nမကွေးတိုင်း မြိုင်မြို့နယ်ထဲက စစ်ကောင်စီ စစ်ကြောင်းထိုးနေတာကြောင့် ရွာတွေရဲ့ အခြေအနေဘယ်လိုရှိလဲ။ \n\nကြက်သွန်နီနဲ့ ငရုတ်သီးတွေ ထိုင်းနဲ့ ဗီယက်နမ်က တောက်လျှောက်ဝယ်ယူနေလို့ စျေးရ။ \n\nရခိုင်ပြည်နယ် ကျောက်တော်မှာ ရိတ်သိမ်းချိန်တန်တဲ့ စပါးတွေ ရိတ်သိမ်းခွင့်ရဖို့ တောင်သူတွေ သက်ဆိုင်ရာကို တင်ပြ။\nယူကရိန်းက စွမ်းအင် အခြေခံ အဆောက်အအုံတွေကို ရုရှား ဒုံးနဲ့ ဆက်ပစ်။ \nတရုတ်မှာ ကာကွယ်ဆေးထိုးတဲ့နှုန်း ထပ်မြင့်ဖို့ အိုင်အမ်အက်ဖ် တရုတ်ကို တောင်းဆို။ \n\nကိုဗစ်ကြောင့် ကလေး သန်း၄၀ ဒီနှစ်မှာ ဝက်သက်ကာကွယ်ဆေး ထိုးနိုင်မှာ မဟုတ်။ \n\nကမ္ဘာ့ဖလားပြိုင်ပွဲရလဒ်။\n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djf4sr",
+                  "types": ["Podcast"],
+                  "duration": 720,
+                  "durationISO8601": "PT12M",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671843720000,
+                  "availableFrom": 1669251720000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ခွဲခြားမှုဆန့်ကျင်ရေး လက်ပတ်ဝတ်ဆင်ဖို့ ဖီဖာ တားမြစ်ချက် ဂျာမနီအသင်းသားတွေ ဆန္ဒပြ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669248000000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0djf56z",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dj52kv", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dj52kv",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ရှေ့တန်းတိုက်စစ်မှူး ရော်နယ်ဒိုနဲ့ မန်ချက်စတာ ယူနိုက်တက် အသင်းတို့ လမ်းခွဲတော့မယ်",
+                "medium": "အာဂျင်တီးနားကို ၂ဂိုး၁ဂိုးနဲ့နိုင်လို့ ဆော်ဒီမှာ ဒီနေ့အများပြည်သူရုံးပိတ်ရက်အဖြစ် ဘုရင်ဆော်လမန်ကြေညာ",
+                "long": "- ကာတာမှာ OneLove လက်ပတ်၀တ်ပြီး တိုက်ရိုက်ထုတ်လွှင့်တဲ့ ဒိန်းနစ်ရှ် တီဗီသတင်းသမား တားမြစ်ခံရ\n- အမေရိကန်ကိုရောက်နိုင်တဲ့ ဒုံးကျည်ပစ်လွှတ်စမ်းသပ်မှု လုပ်ခဲ့တဲ့မြောက်ကိုရီးယားကို အရေးယူပေးဖို့ လုံခြုံရေးကောင်စီကို အမေရိကန်သံအမတ်တောင်းဆို\n- ကျွဲနွားတွေ လမ်းပေါ်ပစ်ထားမှုနဲ့ အမျိုးသားတစ်ယောက်ကို ဂူဂျာရက်တရားရုံးက ထောင်၆လပြစ်ဒဏ်ချ\n- ရွေးကောက်ပွဲပြီးနောက်မလေးရှား၀န်ကြီးချုပ်သစ်ကို သူ့ဖာသာရွေးတော့မယ်လို့ ဘုရင်အပ္ဗဒူလာ မနေ့က ကြေညာ\n- တရုတ်မှာ စက်ရုံမီးလောင်လို့ လူပေါင်း ၃၈ယောက် အသက်ဆုံးရှုံးခဲ့ရ\n- ပေါက်မြို့နယ် ကျွန်းတိုင်းရွာကို စစ်ကောင်စီတပ် မီး၀င်ရှို့တယ်လို့ ဒေသခံကပြော\n- ကုန်းလမ်း ၊ ရေလမ်း ပိတ်ထားတဲ့အပြင် ရွာချင်း ၊ မြို့ချင်းဆက်လမ်းတွေပါ ဆက်သွယ် သွားလာခွင့် ပိတ်ထားတဲ့ ရခိုင်ပြည်နယ် ရသေ့တောင်မှာ စစ်ရှောင်တွေ စား၀တ်နေရေးအခက်ကြုံနေ\n- လက်ရှိကမ္ဘာဖလားချန်ပီယံ ပြင်သစ်က သြစတြေးလျကို နိုင်ပေမယ့် ပိုလန်နဲ့ မက်ဆီကို ၊ ဒိန်းမတ်နဲ့ တူနီးရှား ပွဲစဥ်တွေမှာ သရေကျခဲ့တဲ့အကြောင်း အပါအ၀င် ဗုဒ္ဓဟူး မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese\n\t\n #ဘီဘီစီမြန်မာပိုင်း #တရုတ်-မြန်မာ ဆက်ဆံရေး #ရုရှား-မြန်မာ #စစ်ကောင်စီ #လုံခြုံရေးကောင်စီ"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dj52g9",
+                  "types": ["Podcast"],
+                  "duration": 515,
+                  "durationISO8601": "PT8M35S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671762180000,
+                  "availableFrom": 1669170180000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မန်ယူကို ထုတ်ရောင်းဖို့ စဥ်းစားနေပြီလို့ အသင်းပိုင်ရှင် ဂလေဇာ မိသားစု ထုတ်ပြန်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669161600000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dj52kv",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhvfvg", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dhvfvg",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "အမေရိကန်မှာ Apple Store ထဲ ကားနဲ့၀င်တိုက်လို့ လူတစ်ယောက်သေ အများအပြားဒဏ်ရာရ",
+                "medium": "သြစတြေးလျက မူလတန်းကျောင်းမှာ သိပ္ပံစမ်းသပ်မှုလုပ်ရင်း ဆရာ၁ယောက်နဲ့ ကလေး ၁၁ယောက် ဒဏ်ရာရ",
+                "long": "- သီရိလင်္ကာမှာ ကလေးတွေ အာဟာရချို့တဲ့နေပြီး လူသန်းနဲ့ချီနှပ်မှန်အောင် မစားရတဲ့အခြေအနေဆိုက်နေတယ်လို့ ကုလသတိပေး\n- အိန္ဒိယမှာ အွန်လိုင်းပေါ် review အတုရေးတာတွေကို တိုက်ဖျက်ဖို့ စည်းမျဥ်းတွေ အစိုးရထုတ်ပြန်\n- မြိုင်က ဗဟင်းရဲစခန်းမီးလောင်နေပြီး အနီးက လူနေအိမ်တွေကို မီးကူးနေတယ်လို့ ဗိုလ်လကျာ်ပြော\n- ပလက်၀မှာ အသက်၅၀ကျော်အမျိုးသား၂ယောက်ကို အေအေတပ်ဖွဲ့အတွက် ငွေကြေးကောက်ခံမှုတွေ ပြုလုပ်ပေးတယ်ဆိုတဲ့ စွပ်စွဲချက်နဲ့ ထောင်၃နှစ်စီ ချမှတ်\n- အမေရိကန်နဲ့ ၀ေလ အသင်းတို့ တစ်ဂိုးစီ သရေကျ အနိုင်ပွဲတွေ ရှိခဲ့တဲ့ ကမ္ဘာ့ဖလား ဘောလုံးပွဲတွေအကြောင်း အပါအ၀င် အင်္ဂါ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhvfn6",
+                  "types": ["Podcast"],
+                  "duration": 475,
+                  "durationISO8601": "PT7M55S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671674280000,
+                  "availableFrom": 1669082280000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "လာမယ့်ဆောင်းရာသီ ယူကရိန်းပြည်သူတွေအသက်အန္တရာယ်ကြုံရနိုင်တယ်လို့ WHO ပြော",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669075200000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhvfvg",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhm11q", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dhm11q",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ကမ္ဘာဖလားအဖွင့်ပွဲစဥ်မှာ အိမ်ရှင်အသင်း ကာတာက အီကွေဒေါကို ၂ဂိုး ဂိုးမရှိနဲ့ ရှုံးနိမ့်သွား",
+                "medium": "- စစ်တွေအကျဥ်းထောင်ထဲ ပြစ်ဒဏ်၁၃နှစ်ချခံထားရတဲ့ ရခိုင်၀န်ကြီးချုပ် ဦးညီပု မျက်စိတဘက် မမြင်ရတော့",
+                "long": "- ပြည်မြို့အကျဥ်းထောင်ထဲမှာလဲ နိုင်ငံရေးအကျဥ်းသားတွေ ထောင်၀င်စာမရ ဆေးကုသမှုခက်ခဲနေပြီး အကြမ်းဖက် အဖွဲ့ဆက်သွယ်မှုနဲ့ ထောင်ချခံထားရတဲ့ ရွှေတောင်အမတ်ကို အကြမ်းဖက်ဆက်သွယ်မှုနဲ့ အမှုထပ်ဖွင့်တဲ့အခြေအနေ\n- အစိုးရဆန့်ကျင်ဆန္ဒပြမှုကိုထောက်ခံလို့ဆိုပြီး အီရန်ကနာမယ်ကြီးမင်းသမီး ဖမ်းဆီးထိန်းသိမ်းခံရ\n- ဘင်္ဂလားဒေ့ရှ်မှာ သေဒဏ်စီရင်ဖို့ပို့ဆောင်စဥ် အစ္စလာမ်မစ် စစ်သွေးကြွနှစ်ယောက် လွတ်မြောက်သွား\n- အစ္စတန်ဘူးလ်မြို့ကို ဗုံးကြဲလို့ဆိုပြီး ကာ့ဒ်သူပုန်တွေရှိရာကို တူရကီအစိုးရ လေကြောင်းကတိုက်ခိုက်ခဲ့တဲ့ အကြောင်း အပါအ၀င်  တနင်္လာ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhm11j",
+                  "types": ["Podcast"],
+                  "duration": 497,
+                  "durationISO8601": "PT8M17S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671587640000,
+                  "availableFrom": 1668995640000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "BTS အဖွဲ့ထဲက ဂျန်ကွတ်ခ်ရဲ့ ဖျော်ဖြေမှုနဲ့ ကမ္ဘာဖလား ဖွင့်ပွဲအခမ်းအနား",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668988800000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhm11q",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhgsk2", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dhgsk2",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မြင်းမူမှာလည်း စစ်ကောင်စီ ယာဥ်တန်းတွေကို နေရာ၅ခုမှာ မိုင်းဆွဲတိုက်ခိုက်ခဲ့တယ်လို့ PDF ပြော",
+                "medium": "ပြီးခဲ့တဲ့တစ်နှစ်အတွင်းကျူးကျော်ဆိုပြီးအိမ်ခြေတစ်သောင်းကျော် အဖျက်ခံရတဲ့ မန္တလေးက အခြေအနေ",
+                "long": "- ပြီးခဲ့တဲ့၂နှစ်အတွင်း မြန်မာပြည်သူတွေ အလွန်ခက်ခဲတဲ့အခြေအနေရင်ဆိုင်နေတဲ့အတွက် သူဆုတောင်းပေး နေတယ်လို့ အောင်လအန်ဆန်ပြော\n- သိန်းရာထောင်ချီ အလုပ်လုပ်နေကြတဲ့ ကျောက်စိမ်းမြေ ဖားကန့်မှာ တစ်သောင်းတန်ငွေစက္ကူအတုတွေပြန့်နှံ့\n - မလေးရှားမှာ ကြားဖြတ်ရွေးကောက်ပွဲပြီးသွားပေးမယ့် ဘယ်ပါတီကမှ ပြတ်ပြတ်သားသား မဲအနိုင်မရ\n- ထိုင်းအိမ်အကူက ဆော်ဒီမင်းသားတစ်ပါးဆီက ဒေါ်လာသန်း၂၀ဖိုးရတနာတွေခိုးသွားပြီးနောက် နှစ်နိုင်ငံ ဆက်ဆံရေးတင်းမာခဲ့ပေမယ့် အခုတော့ စီးပွားရေးပူးပေါင်းဆောင်ရွက်ဖို့ လက်မှတ်ထိုးကြပြီ\n- ဒုံးကျည်စမ်းသပ်ပစ်လွှတ်ရာ လူမြင်ကွင်းကို သမီးဖြစ်သူကိုခေါ်လာတဲ့ မြောက်ကိုရီးယားခေါင်းဆောင် အကြောင်း\n- စီးပွားရေးအခက်ကြုံနေတဲ့ ယူကေက ယူကရိန်းကို နောက်ထပ် ဒေါ်လာသန်း၆၀ ထောက်ပံ့မယ်လို့ ကြေညာ\n- ကမ္ဘာဖလား ဘောလုံးပွဲ ဖွင့်ပွဲ ကျင်းပမယ့် အကြောင်း အပါအ၀င် တနင်္ဂနွေ မနက်ခင်း နောက်ဆုံးရ မြန်မာနဲ့ နိုင်ငံတကာ သတင်းတွေကို ဘီဘီစီမြန်မာပိုင်းရဲ့ ပေါ့ဒ်ကတ်စ်၊ ဝက်ဘ်ဆိုက်၊ ဖေ့စ်ဘုတ်နဲ့ ယူကျုတို့မှာ တင်ဆက်ပေးနေပါတယ်။\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\nဖေ့စ်ဘွတ်ခ် - https://www.facebook.com/BBCnewsBurmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nယူကျု - http://youtube.com/thebbcburmese"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhgsh0",
+                  "types": ["Podcast"],
+                  "duration": 673,
+                  "durationISO8601": "PT11M13S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671502260000,
+                  "availableFrom": 1668910260000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "စစ်ကောင်စီနဲ့ CNDF ၅ရက်တိုက်ပွဲအတွင်း စစ်ကောင်စီ အရာရှိနဲ့ တပ်ဖွဲ့၀င် ၃၀ သေဆုံးတယ်လို့ CNO ထုတ်ပြန်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668902400000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhgsk2",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhb73t", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dhb73t",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မန္တလေးနဲ့ နယ်စပ်ကုန်သွယ်ရေး အခြေအနေဘယ်လိုရှိနေလဲ",
+                "long": "စနေနေ့ မနက်ခင်း သတင်းများ (၁၉ နိုဝင်ဘာ၊ ၂၀၂၂)\n\nကုလသမဂ္ဂ မြန်မာနိုင်ငံဆိုင်ရာလူ့အခွင့်အရေးအထူးကိုယ်စားလှယ် မစ္စတာ တွမ်အင်ဒရူးစ်နဲ့ NUGရဲ့ ကိုရီးယားနိုင်ငံဆိုင်ရာ ကိုယ်စားလှယ်တို့ ဘာဆွေးနွေးကြလဲ။\n\nမန္တလေးနဲ့ နယ်စပ်ကုန်သွယ်ရေး အခြေအနေဘယ်လိုရှိနေလဲ။\n\nရုရှားရဲ့ တိုက်ခိုက်မှုကြောင့် ယူကရိန်းရဲ့ စွမ်းအင်စနစ် တဝက်နီးပါးပြိုလဲ။\n\nဆင်းရဲတဲ့ နိုင်ငံတွေအတွက် ရန်ပုံငွေနဲ့ ပတ်သက်ပြီး ညှိနှိုင်းဆွေးနွေးဖို့ ရာသီဥတု ထိပ်သီးဆွေးနွေးပွဲ တရက်ထပ်တိုး။ \n\nမြောက်ကိုရီးယားရဲ့ နောက်ဆုံးစမ်းသပ် ပစ်ခတ်တဲ့ ပဲ့ထိန်း ဒုံးကျည် ခြိမ်းခြောက်မှု အမေရိကန် လျော့ချ။\n\nစွမ်းအင် လျော့သုံးဖို့ ဆောင်းတွင်းမှာ လည်ရှည်ခေါင်းစွပ်အကျီတွေ ဝတ်ဖို့ တိုကျို အုပ်ချုပ်ရေးမှူး တိုက်တွန်း။ \n\nကမ္ဘာဖလားကျင်းပမယ့် ဘောလုံးကွင်းမှာ အရက်မရောင်းဖို့ ဖီဖာတားမြစ်။\n\nရော်နယ်ဒိုနဲ့ စာချုပ် အဆုံးသတ်ဖို့ မန်ယူ ဥပဒေကြောင်းအရ ဆွေးနွေး။ \n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhb4xy",
+                  "types": ["Podcast"],
+                  "duration": 514,
+                  "durationISO8601": "PT8M34S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671412320000,
+                  "availableFrom": 1668820320000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ကုလမြန်မာ့လူ့အခွင့်အရေးအထူးကိုယ်စားလှယ်နဲ့ NUGကိုရီးယားနိုင်ငံကိုယ်စားလှယ်တို့ ဘာဆွေးနွေးကြလဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668816000000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhb73t",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dh0tdl", "brandPid": "p02p9f6q" },
+            "media": {
+              "id": "p0dh0tdl",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ကြံစျေးကောင်းလို့ ကြံတောင်သူတွေ အဆင်ပြေ",
+                "long": "သောကြာနေ့ မနက်ခင်း သတင်းများ (၁၈ နိုဝင်ဘာ၊ ၂၀၂၂)\n\nစစ်ကောင်စီရဲ့ လွှတ်ငြိမ်းချမ်းသာခွင့်အပေါ် နိုင်ငံရေးသမားတွေ ဘာပြောလဲ။ \n\nမတ္တရာမှာ စစ်ကောင်စီနဲ့ ဒေသခံကာကွယ်ရေး တပ်ဖွဲ့အကြား ထိတွေ့မှုတွေ ဆက်ဖြစ်။\n\nကြံစျေးကောင်းလို့ ကြံတောင်သူတွေ အဆင်ပြေ။ \n\nအောက်လွှတ်တော် ဥက္ကဋ္ဌအဖြစ် အရွေးခံမှာ မဟုတ်ဘူးလို့ လက်ရှိဥက္ကဋ္ဌ နန်စီပါလိုစီ ပြော။ \n\nယူကရိန်းစွမ်းအင် အခြေခံအဆောက်အအုံတွေ အရေးပေါ် အခြေအနေကို ရောက်လို့ ဥရောပသမဂ္ဂ တာဝန်ရှိသူပြော။ \n\nမလေးရှားလေကြောင်းလိုင်းက လေယာဥ်ပစ်ချလို့ အမျိုးသား ၃ဦးကို နယ်သာလန် တရားရုံးက ထောင်ဒဏ်ချ။\n\nကိုလံဘီယာမှာ အစိုးရနဲ့ သူပုန် ငြိမ်းချမ်းရေး ပြန်ဆွေးနွေးမယ်။ \n\nအပူချိန်ကြောင့် ကမ္ဘာ့ဖလားပြိုင်ပွဲဝင် ဝေးလ်အသင်း အချိန်ပြောင်း လေ့ကျင်ရ။\n\nဖီဖာဥက္ကဋ္ဌ အင်ဖာတီနို တတိယသက်တမ်း ဥက္ကဋ္ဌအဖြစ် အရွေးခံမယ်။\n\nမနက်ပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်း ပေါ့ဒ်ကတ်စ် ရယူရန် - https://www.bbc.com/burmese/media-45625858\nယူကျု - http://youtube.com/thebbcburmese\nအင်စတာဂရမ် - https://www.instagram.com/bbcburmese/\nဝက်ဘ်ဆိုက် - https://www.bbcburmese.com\n#ဘီဘီစီမြန်မာပိုင်း #မနက်ခင်းသတင်း #ကိုရိုနာဗိုင်းရပ်စ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dh0shn",
+                  "types": ["Podcast"],
+                  "duration": 738,
+                  "durationISO8601": "PT12M18S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671324240000,
+                  "availableFrom": 1668732240000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "စစ်ကောင်စီရဲ့ လွှတ်ငြိမ်းချမ်းသာခွင့်အပေါ် နိုင်ငံရေးသမားတွေ ဘာပြောလဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02p90fw.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668729600000,
+            "brand": {
+              "pid": "p02p9f6q",
+              "title": "ဘီဘီစီမြန်မာပိုင်း မနက်ခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dh0tdl",
+            "type": "ws_radio"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/burmese/podcasts/p02pc9lh.json
+++ b/data/burmese/podcasts/p02pc9lh.json
@@ -1,96 +1,98 @@
 {
   "metadata": {
     "id": "urn:bbc:ares:ws_media:brand:bbc_burmese_radio/p02pc9lh",
-    "locators": { "pid": "p096cz7m", "brandPid": "p02pc9lh" },
+    "locators": { "pid": "p0dmlmvq", "brandPid": "p02pc9lh" },
     "type": "WSRADIO",
     "createdBy": "bbc_burmese_radio",
     "language": "my",
-    "lastUpdated": 1612888589635,
-    "firstPublished": 1612794267000,
-    "lastPublished": 1612794267000,
-    "timestamp": 1612794267000,
+    "lastUpdated": 1670498346579,
+    "firstPublished": 1670425403000,
+    "lastPublished": 1670425403000,
+    "timestamp": 1670425403000,
     "options": {},
     "analyticsLabels": {
-      "pageTitle": "Burmese Evening Broadcast - BBC News မြန်မာ",
-      "pageIdentifier": "burmese.bbc_burmese_radio.programmes.p02pc9lh.page",
+      "pageTitle": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ် - BBC News မြန်မာ",
+      "pageIdentifier": "burmese.bbc_burmese_radio.podcasts.programmes.p02pc9lh.page",
       "producerId": "35",
       "contentType": "player-episode",
       "producer": "BURMESE"
     },
+    "passport": { "home": "", "taggings": [] },
     "tags": {},
-    "version": "v1.3.11",
+    "version": "v1.4.8",
     "blockTypes": ["media"],
-    "title": "Burmese Evening Broadcast",
-    "releaseDateTimeStamp": 1612742400000,
-    "atiAnalytics": {}
+    "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်",
+    "releaseDateTimeStamp": 1670371200000
   },
   "content": {
     "blocks": [
       {
-        "id": "p096cz7m",
+        "id": "p0dmlmvq",
         "subType": "episode",
         "format": "Audio",
         "title": "",
         "synopses": {
-          "short": "Coup leader Min Aung Hlaing gives a speech while night curfew is declared in cities."
+          "short": "ဖားကန့်မြို့နယ် လုံးခင်းကျေးရွာအုပ်စုထဲမှာ တိုက်ပွဲဖြစ်",
+          "long": "ဒီဇင်ဘာ ၇ ရက် ဗုဒ္ဓဟူး ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ်\n\n- ကျောင်းသား ၇ ဦးကို သေဒဏ်စီရင်မယ် ဆိုတဲ့ သတင်းတွေ ကျယ်ကျယ်ပြန့်ပြန့် ထွက်ပေါ်ခဲ့ပေမဲ့ ဒီကနေ့ စီရင်မှု မရှိဘူးလို့ အကျဉ်းဦးစီးဌာန တာဝန်ရှိသူပြော၊ \n\n- ဖားကန့်မြို့နယ် လုံးခင်းကျေးရွာအုပ်စုထဲက ဘုန်းကြီးကျောင်းကို ဝင်စီးနင်းတဲ့ စစ်ကောင်စီတပ်တွေနဲ့ KIA နဲ့ PDF ပူးပေါင်းအဖွဲ့တွေကြား တိုက်ပွဲဖြစ်၊  \n\n- ဂျာမနီ အစိုးရကို ဖြုတ်ချဖို့ ကြံစည်တယ်ဆိုတဲ့ သံသယနဲ့ နိုင်ငံတဝန်း စီးနင်း ပြီး လူ၂၅ ယောက်ကို ဖမ်းဆီး၊ \n\n- တရုတ်နိုင်ငံမှာ ကိုဗစ် စည်းကမ်းတချို့ လျှော့ပေါ့ပေး၊ \n\n စတဲ့ သတင်းတွေ အပြင် နိုင်ငံတကာထိပ်တန်းသတင်းတွေ ကို နားဆင်ရပါမယ်။ \n-----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင် နိုင်ပါတယ်။ \nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် - \nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို"
         },
         "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
         "embedding": false,
         "advertising": false,
         "versions": [
           {
-            "versionId": "p096cyj3",
+            "versionId": "p0dmkx8l",
             "types": ["Podcast"],
-            "duration": 905,
-            "durationISO8601": "PT15M5S",
+            "duration": 954,
+            "durationISO8601": "PT15M54S",
             "warnings": {},
             "availableTerritories": {
               "uk": true,
               "nonUk": true,
               "world": false
             },
-            "availableUntil": 1615386120000,
-            "availableFrom": 1612794120000,
+            "availableUntil": 1673014500000,
+            "availableFrom": 1670422500000,
             "availabilityStatus": "available"
           }
         ],
         "availability": "available",
         "smpKind": "radioProgramme",
-        "episodeTitle": "Monday Evening",
+        "episodeTitle": "ကျောင်းသား ၇ ဦးကို သေဒဏ်စီရင်မယ် ဆိုတဲ့သတင်းတွေ ထွက်ပေါ်ခဲ့ပေမဲ့ ဒီကနေ့ စီရင်မှု မရှိဘူးလို့ အကျဉ်းဦးစီးဌာန တာဝန်ရှိသူပြော",
         "type": "media"
       }
     ]
   },
   "promo": {
-    "headlines": { "headline": "Burmese Evening Broadcast" },
-    "locators": { "pid": "p096cz7m", "brandPid": "p02pc9lh" },
+    "headlines": { "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်" },
+    "locators": { "pid": "p0dmlmvq", "brandPid": "p02pc9lh" },
     "media": {
-      "id": "p096cz7m",
+      "id": "p0dmlmvq",
       "subType": "episode",
       "format": "Audio",
       "title": "",
       "synopses": {
-        "short": "Coup leader Min Aung Hlaing gives a speech while night curfew is declared in cities."
+        "short": "ဖားကန့်မြို့နယ် လုံးခင်းကျေးရွာအုပ်စုထဲမှာ တိုက်ပွဲဖြစ်",
+        "long": "ဒီဇင်ဘာ ၇ ရက် ဗုဒ္ဓဟူး ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ်\n\n- ကျောင်းသား ၇ ဦးကို သေဒဏ်စီရင်မယ် ဆိုတဲ့ သတင်းတွေ ကျယ်ကျယ်ပြန့်ပြန့် ထွက်ပေါ်ခဲ့ပေမဲ့ ဒီကနေ့ စီရင်မှု မရှိဘူးလို့ အကျဉ်းဦးစီးဌာန တာဝန်ရှိသူပြော၊ \n\n- ဖားကန့်မြို့နယ် လုံးခင်းကျေးရွာအုပ်စုထဲက ဘုန်းကြီးကျောင်းကို ဝင်စီးနင်းတဲ့ စစ်ကောင်စီတပ်တွေနဲ့ KIA နဲ့ PDF ပူးပေါင်းအဖွဲ့တွေကြား တိုက်ပွဲဖြစ်၊  \n\n- ဂျာမနီ အစိုးရကို ဖြုတ်ချဖို့ ကြံစည်တယ်ဆိုတဲ့ သံသယနဲ့ နိုင်ငံတဝန်း စီးနင်း ပြီး လူ၂၅ ယောက်ကို ဖမ်းဆီး၊ \n\n- တရုတ်နိုင်ငံမှာ ကိုဗစ် စည်းကမ်းတချို့ လျှော့ပေါ့ပေး၊ \n\n စတဲ့ သတင်းတွေ အပြင် နိုင်ငံတကာထိပ်တန်းသတင်းတွေ ကို နားဆင်ရပါမယ်။ \n-----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင် နိုင်ပါတယ်။ \nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် - \nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို"
       },
       "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
       "embedding": false,
       "advertising": false,
       "versions": [
         {
-          "versionId": "p096cyj3",
+          "versionId": "p0dmkx8l",
           "types": ["Podcast"],
-          "duration": 905,
-          "durationISO8601": "PT15M5S",
+          "duration": 954,
+          "durationISO8601": "PT15M54S",
           "warnings": {},
           "availableTerritories": { "uk": true, "nonUk": true, "world": false },
-          "availableUntil": 1615386120000,
-          "availableFrom": 1612794120000,
+          "availableUntil": 1673014500000,
+          "availableFrom": 1670422500000,
           "availabilityStatus": "available"
         }
       ],
       "availability": "available",
       "smpKind": "radioProgramme",
-      "episodeTitle": "Monday Evening",
+      "episodeTitle": "ကျောင်းသား ၇ ဦးကို သေဒဏ်စီရင်မယ် ဆိုတဲ့သတင်းတွေ ထွက်ပေါ်ခဲ့ပေမဲ့ ဒီကနေ့ စီရင်မှု မရှိဘူးလို့ အကျဉ်းဦးစီးဌာန တာဝန်ရှိသူပြော",
       "type": "media"
     },
     "indexImage": {
@@ -104,9 +106,12 @@
       "copyrightHolder": null,
       "type": "image"
     },
-    "releaseDateTimestamp": 1612742400000,
-    "brand": { "pid": "p02pc9lh", "title": "Burmese Evening Broadcast" },
-    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p096cz7m",
+    "releaseDateTimestamp": 1670371200000,
+    "brand": {
+      "pid": "p02pc9lh",
+      "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+    },
+    "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dmlmvq",
     "type": "ws_radio"
   },
   "relatedContent": {
@@ -121,40 +126,42 @@
         "type": "other-episode",
         "promos": [
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p0969mdh", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dm5pw0", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p0969mdh",
+              "id": "p0dm5pw0",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "More than 70 cities in Burma have held anti-military protests on the streets.",
-                "medium": "Up to one hundred thousand demonstrators have gathered on the streets of Myanmar's largest city, Yangon."
+                "short": "ဒီးမောဆိုမှာ စစ်ကောင်စီ အပြင်းအထန် ထိုးစစ်ဆင်",
+                "long": "ဒီဇင်ဘာ ၆ရက် အင်္ဂါနေ့ညချမ်း ဘီဘီစီမြန်မာပိုင်း ရေဒီယိုအစီအစဉ်\n-ဒေါ်အောင်ဆန်းစုကြည် လက်ကျန်အမှုတွေ ပြီးပြတ်ရင် ဘာဆက်ဖြစ်မလဲ။\n- ဒီးမောဆိုမှာ စစ်ကောင်စီ အပြင်းအထန် ထိုးစစ်ဆင်။ \n-ကုလားတန်စီမံကိန်းရဲ့ အစိတ်အပိုင်း စစ်တွေဆိပ်ကမ်းကို နိုင်ငံတကာ ကုန်သွယ်ရေး ဆိပ်ကမ်း အဖြစ်တိုးမြှင့်ဖို့ အိန္ဒိယနဲ့ မြန်မာ အစိုးရ သဘောတူ။ \n-အင်ဒိုနီးရှားမှာ လက်မထပ်ဘဲ လိင်ကိစ္စလွန်လွန်ကျူးကျူး ဖြစ်ရင် ထောင်ဒဏ်တနှစ်ထိ ပြစ်ဒဏ်ချမှတ်နိုင်တဲ့ ဉပဒေ ပြဋ္ဌာန်း။\n-ကွယ်လွန်တဲ့ သမ္မတ ကျန်ဇီမင်းကို တရုတ်သမ္မတ ရှီကျင့်ဖျင် ချီးကျူး\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင်နိုင်ပါ တယ်။\nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\nမနက်ပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် - https://www.bbc.com/burmese/bbc_burmese_radio/w3csxsf3\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nBBC.COM\nဘီဘီစီ မြန်မာပိုင်း ရေဒီယို - BBC News မြန်မာ\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ...."
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p0969l7f",
+                  "versionId": "p0dm5f0p",
                   "types": ["Podcast"],
-                  "duration": 939,
-                  "durationISO8601": "PT15M39S",
+                  "duration": 885,
+                  "durationISO8601": "PT14M45S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": true,
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1615300560000,
-                  "availableFrom": 1612708560000,
+                  "availableUntil": 1672927980000,
+                  "availableFrom": 1670335980000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Sunday Evening",
+              "episodeTitle": "ဒေါ်အောင်ဆန်းစုကြည် လက်ကျန်အမှုတွေ ပြီးပြတ်ရင် ဘာဆက်ဖြစ်မလဲ",
               "type": "media"
             },
             "indexImage": {
@@ -168,48 +175,51 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1612656000000,
+            "releaseDateTimestamp": 1670284800000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0969mdh",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dm5pw0",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p0967thw", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dlyf4l", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p0967thw",
+              "id": "p0dlyf4l",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "Myanmar coup: Internet shutdown as thousands of people protest against military"
+                "short": "ဒီဇင်ဘာလ ၅ ရက်၊ တနင်းလာ ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ်",
+                "long": "ဒီဇင်ဘာလ ၅ ရက်၊ တနင်းလာ ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ် \n\n- လှည်းကူက လမ်းမဘေးမှာ ကလေးလူငယ် အလောင်း ၁၃ လောင်း စုပြုံတွေ့ရှိ\n\n- ပင်လယ်လမ်းကြောင်းကဝင်တဲ့ ရုရှား ရေနံတင်သွင်းမှုကို ဥရောပသမဂ္ဂ ပိတ်ပင်\n\nစတဲ့ သတင်းတွေအပါအဝင် နောက်ဆုံးရ သတင်းတွေကို နားဆင်ကြရမှာပါ\n-----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေကနေလည်း နားဆင်နိုင်ပါ တယ်။ \nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် - \nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\nမနက်ပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် - https://www.bbc.com/burmese/bbc_burmese_radio/w3csxsf3\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p0967t2j",
+                  "versionId": "p0dlyd5x",
                   "types": ["Podcast"],
-                  "duration": 931,
-                  "durationISO8601": "PT15M31S",
+                  "duration": 933,
+                  "durationISO8601": "PT15M33S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": true,
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1613225580000,
-                  "availableFrom": 1612620780000,
+                  "availableUntil": 1670856360000,
+                  "availableFrom": 1670251560000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Saturday Evening",
+              "episodeTitle": "လှည်းကူက လမ်းမဘေးမှာ ကလေးလူငယ် အလောင်း ၁၃ လောင်း စုပြုံတွေ့ရှိ",
               "type": "media"
             },
             "indexImage": {
@@ -223,49 +233,51 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1612569600000,
+            "releaseDateTimestamp": 1670198400000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0967thw",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dlyf4l",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p0965f5d", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dlrg3q", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p0965f5d",
+              "id": "p0dlrg3q",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "Hundreds of teachers, students and workers in Yangon, protested against military coup.",
-                "medium": "Hundreds of teachers, students and workers in Yangon, Myanmar, protested against military coup."
+                "short": "တမူးမြို့ပေါ်က အမျိုးသမီးတဦးအသတ်ခံရမှု ဖြစ်စဥ် ဒေသကာကွယ်ရေးအဖွဲ့ တုံ့ပြန်ချက်",
+                "long": "NUG အစိုးရဘက်က စုံစမ်းစစ်ဆေးနေတဲ့ တမူးမြို့က အမျိုးသမီးတဦး ရိုက်နှက်သတ်ခံရမှုနဲ့ ပတ်သက်လို့ အဲဒီအမျိုးသမီးဟာ ပျူစောထီးအဖွဲ့တွေနဲ့ ဆက်စပ်မှုရှိပြီး ဒီဖြစ်ရပ်ဟာ လွန်ခဲ့တဲ့ ၆ လလောက် ဖြစ်ခဲ့တာလို့ တုံ့ပြန်ပြောဆို"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p0965ck7",
+                  "versionId": "p0dlrd6k",
                   "types": ["Podcast"],
-                  "duration": 936,
-                  "durationISO8601": "PT15M36S",
+                  "duration": 935,
+                  "durationISO8601": "PT15M35S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": true,
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1615127160000,
-                  "availableFrom": 1612535160000,
+                  "availableUntil": 1672755300000,
+                  "availableFrom": 1670163300000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Burmese Evening Broadcast",
+              "episodeTitle": "တမူးမြို့ပေါ်က အမျိုးသမီးတဦးအသတ်ခံရမှု ဖြစ်စဥ် ဒေသကာကွယ်ရေးအဖွဲ့ တုံ့ပြန်ချက်",
               "type": "media"
             },
             "indexImage": {
@@ -279,142 +291,34 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1612483200000,
+            "releaseDateTimestamp": 1670112000000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0965f5d",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dlrg3q",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p0961yr1", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dlmdjh", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p0961yr1",
+              "id": "p0dlmdjh",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "Myanmar blocks access to Facebook. UN chief says coup must fail."
+                "short": "စစ်ကိုင်းတိုင်းမြို့နယ် ၃ ခုမှာတပတ်အတွင်း စစ်ကောင်စီက အိမ် ၂၀၀၀ နီးပါးမီးရှို့ဖျက်ဆီးခဲ့",
+                "long": "ရုရှားရေနံကို ရေနံတစည် ဒေါ်လာ ၆၀ ထက်ပိုမပေးဖို့ ဥရောပနိုင်ငံတွေရဲ့ဆုံးဖြတ်ချက်ဟာ ကိုယ့်စွမ်းအင်လုံခြုံရေးကို ကိုယ့်ဘာသာဖျက်ဆီးသလိုဖြစ်လိမ့်မယ်လို့ ရုရှားတုံ့ပြန်"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p0961v9r",
-                  "types": ["Podcast"],
-                  "duration": 928,
-                  "durationISO8601": "PT15M28S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1615041780000,
-                  "availableFrom": 1612449780000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Thursday Evening",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1612396800000,
-            "brand": {
-              "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0961yr1",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p095xqj5", "brandPid": "p02pc9lh" },
-            "media": {
-              "id": "p095xqj5",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Myanmar coup: Detained Daw Aung San Suu Kyi and U Win Myint face charges."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p095xnyn",
-                  "types": ["Podcast"],
-                  "duration": 934,
-                  "durationISO8601": "PT15M34S",
-                  "warnings": {},
-                  "availableTerritories": {
-                    "uk": true,
-                    "nonUk": true,
-                    "world": false
-                  },
-                  "availableUntil": 1614953520000,
-                  "availableFrom": 1612361520000,
-                  "availabilityStatus": "available"
-                }
-              ],
-              "availability": "available",
-              "smpKind": "radioProgramme",
-              "episodeTitle": "Wednesday Evening",
-              "type": "media"
-            },
-            "indexImage": {
-              "id": "",
-              "subType": "index",
-              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "height": 0,
-              "width": 0,
-              "altText": null,
-              "copyrightHolder": null,
-              "type": "image"
-            },
-            "releaseDateTimestamp": 1612310400000,
-            "brand": {
-              "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
-            },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p095xqj5",
-            "type": "ws_radio"
-          },
-          {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p095nlr9", "brandPid": "p02pc9lh" },
-            "media": {
-              "id": "p095nlr9",
-              "subType": "episode",
-              "format": "Audio",
-              "title": "",
-              "synopses": {
-                "short": "Thousands of people protests to demand the release of Alexei Navalny.",
-                "medium": "Thousands of people across Russia have been taking part in unauthorised protests to demand the release of the jailed opposition activist Alexei Navalny."
-              },
-              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
-              "embedding": false,
-              "advertising": false,
-              "versions": [
-                {
-                  "versionId": "p095nlgb",
+                  "versionId": "p0dlmcg2",
                   "types": ["Podcast"],
                   "duration": 938,
                   "durationISO8601": "PT15M38S",
@@ -424,14 +328,14 @@
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1614694080000,
-                  "availableFrom": 1612102080000,
+                  "availableUntil": 1672669920000,
+                  "availableFrom": 1670077920000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Sunday Evening",
+              "episodeTitle": "ကမ္ဘာ့ဖလားဝတ်စုံတွေကို ဒေါ်လာ ၁၀၀၊ ၁၅၀ နဲ့ရောင်းနေချိန်မှာ မြန်မာနိုင်ငံကဝတ်စုံချုပ်အလုပ်သမားတွေ တနေ့ ၂ ဒေါ်လာအောက်ပဲလုပ်ခရရှိ",
               "type": "media"
             },
             "indexImage": {
@@ -445,49 +349,51 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1612051200000,
+            "releaseDateTimestamp": 1670025600000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p095nlr9",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dlmdjh",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p095lwty", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dldzjq", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p095lwty",
+              "id": "p0dldzjq",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "Army says chief's constitution abrogation remark was taken out of context.",
-                "medium": "Army says chief's constitution abrogation remark was misinterpreted and pledged to abide by it. WHO urges nations which started vaccination for fair share of doses."
+                "short": "ရုရှားတပ်တွေပြန်ဆုတ်ပေးရင် စေ့စပ်ဆွေးနွေးရေးကို စဉ်းစားမယ်လို့ အမေရိကန်သမ္မတဘိုင်ဒန်ပြော",
+                "long": "နှင်ထုတ်ခံထားရတဲ့အိမ်တွေမှာ ပြန်ဝင်ရောက်နေထိုင်ကြတဲ့ စီဒီအမ်ဝန်ထမ်းတွေကို ထပ်မံမောင်းထုတ်တင်းကျပ်"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p095lwj9",
+                  "versionId": "p0dldwms",
                   "types": ["Podcast"],
-                  "duration": 937,
-                  "durationISO8601": "PT15M37S",
+                  "duration": 939,
+                  "durationISO8601": "PT15M39S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": true,
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1614607560000,
-                  "availableFrom": 1612015560000,
+                  "availableUntil": 1672582800000,
+                  "availableFrom": 1669990800000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Saturday Evening",
+              "episodeTitle": "၂၀၀၈ အခြေခံဥပဒေဖျက်သိမ်းဖို့အပါအဝင် အချက် ၅ ချက်လက်ခံရင် စစ်တပ်နဲ့ဆွေးနွေးဖို့စဉ်းစားမယ်လို့ NUG ယာယီသမ္မတ ဒူးဝါးလရှီးလပြော",
               "type": "media"
             },
             "indexImage": {
@@ -501,48 +407,51 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1611964800000,
+            "releaseDateTimestamp": 1669939200000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p095lwty",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dldzjq",
             "type": "ws_radio"
           },
           {
-            "headlines": { "headline": "Burmese Evening Broadcast" },
-            "locators": { "pid": "p095j7yr", "brandPid": "p02pc9lh" },
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dl5j3z", "brandPid": "p02pc9lh" },
             "media": {
-              "id": "p095j7yr",
+              "id": "p0dl5j3z",
               "subType": "episode",
               "format": "Audio",
               "title": "",
               "synopses": {
-                "short": "United Nations and a dozen foreign embassies have urged the army to respect democracy."
+                "short": "ထီးချိုင့်မြို့နယ် လေသာရွာမှာ တိုက်ပွဲဆက်ဖြစ်နေ",
+                "long": "ဒဂုံတက္ကသိုလ်ကျောင်းသားတွေ အပါအဝင် လူငယ် ၁၀ ဦး သေဒဏ်ချမှတ်ခံရ၊ ထီးချိုင့် လေသာရွာမှာ တိုက်ပွဲဆက်ဖြစ်နေ၊ အမေရိကန် ဒေါ်လာနဲ့တင်မက ယွမ်နဲ့ ဘတ် စတဲ့ နိုင်ငံခြားငွေတွေနဲ့ ပို့ကုန်ရငွေ ရှင်းလင်းခွင့် ပြုလိုက်တဲ့အတွက် ပို့ကုန်လုပ်ငန်းရှင်တွေအပေါ် ဘယ်လို သက်ရောက်မှုတွေ ရှိလာနိုင်မလဲ၊ တရုတ်နိုင်ငံမှာ ကိုဗစ်ကန့်သတ်မှုတွေအပေါ် ကန့်ကွက် ဆန္ဒပြနေကြချိန်မှာပဲ မြို့ကြီးတချို့မှာ ကန့်သတ်မှုတွေ လျှော့ချပေးဖို့ ပြင်နေ၊ တာလီဘန်အာဏာပိုင်တွေရဲ့ အမိန့်ကြောင့် အာဖဂန်နစ္စတန်မှာ VOA သတင်းဌာန အသံလွှင့်နေတာ ရပ်ဆိုင်းလိုက်ရ"
               },
               "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
               "embedding": false,
               "advertising": false,
               "versions": [
                 {
-                  "versionId": "p095j7vx",
+                  "versionId": "p0dl59fw",
                   "types": ["Podcast"],
-                  "duration": 2057,
-                  "durationISO8601": "PT34M17S",
+                  "duration": 928,
+                  "durationISO8601": "PT15M28S",
                   "warnings": {},
                   "availableTerritories": {
                     "uk": true,
                     "nonUk": true,
                     "world": false
                   },
-                  "availableUntil": 1614523320000,
-                  "availableFrom": 1611931320000,
+                  "availableUntil": 1672498920000,
+                  "availableFrom": 1669906920000,
                   "availabilityStatus": "available"
                 }
               ],
               "availability": "available",
               "smpKind": "radioProgramme",
-              "episodeTitle": "Friday Evening",
+              "episodeTitle": "ဒဂုံတက္ကသိုလ်ကျောင်းသားတွေ အပါအဝင် လူငယ် ၁၀ ဦး သေဒဏ်ချမှတ်ခံရ",
               "type": "media"
             },
             "indexImage": {
@@ -556,12 +465,822 @@
               "copyrightHolder": null,
               "type": "image"
             },
-            "releaseDateTimestamp": 1611878400000,
+            "releaseDateTimestamp": 1669852800000,
             "brand": {
               "pid": "p02pc9lh",
-              "title": "Burmese Evening Broadcast"
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
             },
-            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p095j7yr",
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dl5j3z",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dkw87p", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dkw87p",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "တရုတ်ခေါင်းဆောင်ဟောင်း ကျန်ဇီမင်းကွယ်လွန်၊ တရုတ်ကို မှီခိုတာလျှော့ဖို့ နေတိုး သတိပေး"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dkw6yc",
+                  "types": ["Podcast"],
+                  "duration": 905,
+                  "durationISO8601": "PT15M5S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672413900000,
+                  "availableFrom": 1669821900000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "နေပြည်တော်ရောက် ရုရှား စစ်ဦးစီးချုပ်ရုံးအကြီးအကဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669766400000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dkw87p",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dklqcq", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dklqcq",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ပါကစ္စတန်နိုင်ငံ စစ်တပ်အကြီးအကဲသစ် တရားဝင် ကျမ်းသစ္စာကျိန်",
+                "long": "နိုဝင်ဘာ ၂၉ ရက် အင်္ဂါနေ့ညချမ်း ဘီဘီစီမြန်မာပိုင်း ရေဒီယိုအစီအစဉ် \n-ဆက်သွယ်ရေးဌာနက အသိပေးနေတဲ့ မိုဘိုင်းဖုန်းဆင်းကဒ်တွေ မှတ်ပုံတင်ရင် ဘာတွေ ဖြစ်လာနိုင်လဲ။ မတင်ရင်ရော ဘယ်လို သက်ရောက်မှုတွေ ရှိမလဲ။  \n-ကယားပြည်နယ်ထဲမှာ မြေမြုပ်မိုင်းကြောင့် အသက်အန္တရာယ်ရှိနေပေမဲ့ စစ်ဘေးရှောင်တွေ ဘာကြောင့် နေရပ်ပြန်နေကြရတာလဲ။   \n-ရခိုင်ပြည်နယ်ထဲမှာ စပါးရိတ်သိမ်းနေတဲ့ တောင်သူတွေ ဘယ်လို အခက်အခဲတွေ ရှိနေလဲ။  \n-ကိုဗစ် စည်းမျဉ်းတွေ တင်းကျပ်လို့ ဆန္ဒပြတဲ့သူတွေကို ဥပဒေနဲ့အညီ နေထိုင်ဖို့ တရုတ်အစိုးရသတိပေး။ \n-ပါကစ္စတန်နိုင်ငံ စစ်တပ်အကြီးအကဲသစ် တရားဝင် ကျမ်းသစ္စာကျိန်။  \n -----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင်နိုင်ပါ တယ်။\nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\nမနက်ပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် - https://www.bbc.com/burmese/bbc_burmese_radio/w3csxsf3\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nBBC.COM\nဘီဘီစီ မြန်မာပိုင်း ရေဒီယို - BBC News မြန်မာ\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ...."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dklmz0",
+                  "types": ["Podcast"],
+                  "duration": 917,
+                  "durationISO8601": "PT15M17S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672322700000,
+                  "availableFrom": 1669730700000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မိုဘိုင်းဖုန်းဆင်းကဒ်တွေ မှတ်ပုံတင်ရင် ဘာတွေ ဖြစ်လာနိုင်လဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669680000000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dklqcq",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dk41x4", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dk41x4",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ကရင်နဲ့စစ်ကိုင်းထဲတိုက်ပွဲတွေပြင်းထန်၊ ရှီကျင်းပင်ဆန့်ကျင်ရေးဆန္ဒပြပွဲဘေဂျင်းမှာပေါ်ပေါက်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dk405v",
+                  "types": ["Podcast"],
+                  "duration": 975,
+                  "durationISO8601": "PT16M15S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672150260000,
+                  "availableFrom": 1669558260000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "အယာတိုလာခါမေနီရဲ့ တူမကိုယ်တိုင် အီရန်အစိုးရကို ဆန့်ကျင်နေ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669507200000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dk41x4",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dk02nr", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dk02nr",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "အေအေနဲ့ အပစ်ရပ်လိုက်ချိန်မှာ သီပေါမြို့နယ်မှာ SSPP/SSA နဲ့တိုက်ပွဲဖြစ်ပွား",
+                "medium": "တရုတ်ပြည်မှာ ကိုဗစ်လော့ဒေါင်းဆန့်ကျင်ဆန္ဒပြသူတွေကို ရဲကပစ်ခတ်လို့ ၁၀ ယောက်သေဆုံး"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djzv1k",
+                  "types": ["Podcast"],
+                  "duration": 940,
+                  "durationISO8601": "PT15M40S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1672067280000,
+                  "availableFrom": 1669475280000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ရခိုင်တပ်တော်အေအေနဲ့ စစ်ကောင်စီအပစ်ရပ်သဘောတူညီချက်ယူလိုက်ပြီ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669420800000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dk02nr",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0djt4t0", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0djt4t0",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မင်္ဂလာဒုံမြို့နယ် စံသမာဓိရပ်ကွက်ထဲက ကျူးကျော်အိမ်တွေကို စစ်ကောင်စီက ဘူဒိုဇာတွေနဲ့ဖျက်ဆီး",
+                "long": "ရုရှားရဲ့တိုက်ခိုက်မှုကြောင့် ယူကရိန်းနေရာအနှံ့အပြားလျှပ်စစ်မီးပြတ်တောက်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djstkb",
+                  "types": ["Podcast"],
+                  "duration": 939,
+                  "durationISO8601": "PT15M39S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671980520000,
+                  "availableFrom": 1669388520000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ဖားကန့်ဆိုင်းတောင်မှာ ကေအိုင်အေစုပေါင်းတပ်နဲ့ စစ်ကောင်စီတိုက်ပွဲကြောင့် ဒေသခံတွေထွက်ပြေးတိမ်းရှောင်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669334400000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0djt4t0",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0djk5m9", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0djk5m9",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မြို့ပြပြောက်ကျား အဖွဲ့ဝင်တွေ အခုရက်ပိုင်းအတွင်း ခပ်စိပ်စိပ် ဖမ်းဆီးခံရမှုတွေရှိလာနေ",
+                "long": "မြို့ပြပြောက်ကျား အဖွဲ့ဝင်တွေ အခုရက်ပိုင်းအတွင်း ခပ်စိပ်စိပ် ဖမ်းဆီးခံရမှုတွေရှိလာနေ၊ စစ်ကောင်စီတပ်ဖွဲ့တွေရဲ့ လက်ချက်ကြောင့် မြောင်နဲ့ ရေစကြိုမြို့နယ်တွေမှာ တပတ်အတွင်း အိမ်ခြေ တစ်ထောင်ကျော် မီးလောင်ဆုံးရှုံးခဲ့တယ်လို့ ဒေသခံတွေပြော၊ စစ်အာဏာသိမ်းပြီးတဲ့နောက် ပြည်တွင်းမှာ စစ်တပ်က လူသတ် နင်းမိုင်းတွေကို အသုံးပြုတာ တိုးလာ၊ အာဖဂန်နစ္စတန်နိုင်ငံမှာ သမီးငယ်တွေကို ရောင်းစားပြီး ငွေရှာရတဲ့အထိ အငတ်ဘေး ကြုံနေရ၊ တရုတ်နိုင်ငံမှာ ကိုဗစ်ပိုး လုံးဝကင်းစင်ရေး မူဝါဒတွေ တင်းတင်းကျပ်ကျပ် ချပြီး ဆောင်ရွက်နေတဲ့ကြားက ကိုဗစ်ရောဂါ နေ့စဉ် ကူးစက်မှုနှုန်းက အမြင့်ဆုံးအဆင့် ရောက်နေ"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0djk1f1",
+                  "types": ["Podcast"],
+                  "duration": 926,
+                  "durationISO8601": "PT15M26S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671894120000,
+                  "availableFrom": 1669302120000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "အာဖဂန်နစ္စတန်နိုင်ငံမှာ သမီးငယ်တွေကို ရောင်းစားပြီး ငွေရှာရတဲ့အထိ အငတ်ဘေး ကြုံနေရ၊",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669248000000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0djk5m9",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dj90ks", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dj90ks",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "စစ်ကိုင်းတိုင်း မြို့နယ်တချို့မှာ တိုက်ပွဲတွေ ဆက်တိုက်ဖြစ်၊ ဒေသခံတွေ ထွက်ပြေးနေရ",
+                "long": "နိုဝင်ဘာ ၂၃ ရက် ဗုဒ္ဓဟူး ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ်\n\n- စစ်ကိုင်းတိုင်း ခင်ဦးအပါအဝင် မြို့နယ်တချို့မှာ စစ်ကောင်စီတပ်နဲ့ ဒေသကာကွယ်ရေး အဖွဲ့တွေကြား တိုက်ပွဲတွေ ဆက်တိုက်ဖြစ်၊ ဒေသခံတွေ ထွက်ပြေးနေရ၊\n\n- အမေရိကန်၊ တရုတ်၊ အိန္ဒိယတို့ပါ ပါဝင်တဲ့ အာဆီယံကာကွယ်ရေး ဝန်ကြီးများ အစည်းအဝေး စစ်ကောင်စီဝန်ကြီး တက်ရောက်ခွင့် မရ၊\n\n- အာဏာသိမ်းပြီးနောက် မြန်မာနိုင်ငံမှာ အလုပ်သမားအခွင့်အရေးချိုးဖောက်ခံရမှု ကမ္ဘာ့အဆိုးဆုံး ၁၀ နိုင်ငံထဲရောက်၊\n\n- ယူကရိန်းနိုင်ငံ Vilnyansk မြို့ ဆေးရုံက သားဖွားဆောင်မှာ ဒုံးလက်နက် ကျလို့ မွေးကင်းစ ကလေးငယ် သေဆုံး၊\n\n စတဲ့ သတင်းတွေ အပြင် နိုင်ငံတကာထိပ်တန်းသတင်းတွေ ကို နားဆင်ရပါမယ်။ \n-----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင် နိုင်ပါတယ်။ \nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် - \nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dj8wrd",
+                  "types": ["Podcast"],
+                  "duration": 919,
+                  "durationISO8601": "PT15M19S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671804660000,
+                  "availableFrom": 1669212660000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "အမေရိကန် ပါတဲ့ အာဆီယံကာကွယ်ရေး ဝန်ကြီးများ အစည်းအဝေး စစ်ကောင်စီဝန်ကြီး တက်ခွင့် မရ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669161600000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dj90ks",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhz2gf", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dhz2gf",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "နာမည်ကြီး အာဂျင်တီးနားဘောလုံးအသင်း ဆော်ဒီကိုရှုံ",
+                "long": "နိုဝင်ဘာ ၂၂ ရက် အင်္ဂါနေ့ညချမ်း ဘီဘီစီမြန်မာပိုင်း ရေဒီယိုအစီအစဉ် \n-စစ်ရေးတင်းမာမှုပြင်းထန်တဲ့ စစ်ကိုင်းတိုင်းထဲကို ကြံ့ခိုင်ရေးပါတီဥက္ကဋ္ဌ ဦးခင်ရီ ဘာကြောင့်သွားတာပါလဲ။ \n-ထိုင်းမှာ အလုပ်လုပ်ခွင့်ရဖို့ စောင့်နေတဲ့ ထောင်နဲ့ချီတဲ့ မြန်မာအလုပ်သမားတွေ ဘယ်လို ရင်ဆိုင်နေရပါသလဲ။ \n- စစ်ကောင်စီလက်‌အောက် တက္ကသိုလ်တွေ ပြန်ဖွင့်လှစ်လိုက်ပါပြီ။ ကျောင်းသားတွေဘက်ကရော ဘယ်လိုတုံ့ပြန်ပါသလဲဆိုတာတွေကို \n-အင်ဒိုနီးရှားငလျင်ကြောင့် သေဆုံးသူ ၂၆ဝကျော်ရှိလာ။\n-နာမည်ကြီး အာဂျင်တီးနားဘောလုံးအသင်း ဆော်ဒီကိုရှုံး။\n -----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင်နိုင်ပါ တယ်။\nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\nမနက်ပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် - https://www.bbc.com/burmese/bbc_burmese_radio/w3csxsf3\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nBBC.COM\nဘီဘီစီ မြန်မာပိုင်း ရေဒီယို - BBC News မြန်မာ\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ...."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhz0t6",
+                  "types": ["Podcast"],
+                  "duration": 909,
+                  "durationISO8601": "PT15M9S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671717960000,
+                  "availableFrom": 1669125960000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "စစ်ရေးတင်းမာမှုပြင်းထန်တဲ့ စစ်ကိုင်းတိုင်းကို ကြံ့ခိုင်ရေးပါတီဥက္ကဋ္ဌဦးခင်ရီ ဘာကြောင့်သွားတာလဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1669075200000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhz2gf",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhk275", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dhk275",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ကျူးကျော်လို့စွပ်စွဲပြီး နေအိမ်တွေကို ဖျက်ဆီးမှု အခွင့်အရေးချိုးဖောက်တာလို့ ဝေဖန်",
+                "long": "ရာသီဥတုပြောင်းလဲမှုကြောင့် ထိခိုက်ဆုံးရှုံးခဲ့ရတဲ့ ဆင်းရဲတဲ့ နိုင်ငံတွေကို ငွေကြေးအကူအညီပေးတော့မယ်လို့ ကုလသမဂ္ဂ ညီလာခံကနေ သမိုင်းဝင်သဘောတူညီမှုတရပ် ချမှတ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhjy13",
+                  "types": ["Podcast"],
+                  "duration": 936,
+                  "durationISO8601": "PT15M36S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671545460000,
+                  "availableFrom": 1668953460000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ကျူးကျော်လို့စွပ်စွဲပြီး နေအိမ်တွေကို ဖျက်ဆီးမှု အခွင့်အရေးချိုးဖောက်တာလို့ ဝေဖန်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668902400000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhk275",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dhdzlr", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dhdzlr",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ခင်ဦးမြို့နယ်ပေါင်းလဲကျေးရွာ ၂ ရက်ဆက်တိုက်မီးရှို့ခံရ",
+                "medium": "ရခိုင်ပြည်နယ်မှာ စပါးရိတ်သိမ်းတဲ့လယ်သမားတွေကို လိုက်လံပစ်ခတ်"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dhdv9q",
+                  "types": ["Podcast"],
+                  "duration": 940,
+                  "durationISO8601": "PT15M40S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671463500000,
+                  "availableFrom": 1668871500000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ယူကရိန်းနိုင်ငံမှာ လျှပ်စစ်ဓာတ်အားပြတ်တောက်မဲ့ အန္တရာယ်ရှိနေပြီလို့ သတိပေး",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668816000000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dhdzlr",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dh5ncp", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dh5ncp",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "အာဆီယံအထူးသံတမန်ကမြန်မာအတွက်အကြံပြုချက်ထုတ်ပြန်",
+                "long": "ရွေးကောက်ပွဲအတွက် အကြမ်းဖက်တိုက်ဖျက်ရေးအရှိန်မြှင့်မယ်လို့ ဗိုလ်ချုပ်ဇော်မင်းထွန်းကပြော"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dh5hf2",
+                  "types": ["Podcast"],
+                  "duration": 938,
+                  "durationISO8601": "PT15M38S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671374280000,
+                  "availableFrom": 1668782280000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မန္တလေးတိုင်း မတ္တရာမြို့နယ်မှာ စစ်ကောင်စီနဲ့ ပီဒီအက်ဖ်ပြောက်ကျားတွေ ၂ ရက်ကြာတိုက်ပွဲဖြစ်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668729600000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dh5ncp",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dgtx1v", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dgtx1v",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "အမျိုးသားနေ့အထိမ်းအမှတ် စစ်ကောင်စီက အကျဉ်းသား ၆၀၀၀ နီးပါးကို လွတ်ငြိမ်းချမ်းသာခွင့်ပြု",
+                "long": "အမျိုးသားနေ့အထိမ်းအမှတ်အဖြစ် စစ်ကောင်စီက အကျဉ်းသား ၆၀၀၀ နီးပါးကို လွတ်ငြိမ်းချမ်းသာခွင့်ပြု၊ စစ်ကောင်စီရဲ့ လွတ်ငြိမ်းချမ်းသာခွင့် ပြုတဲ့အထဲမှာ ထင်ရှားတဲ့ နိုင်ငံရေးသမားတွေ၊ NLD ပါတီဝင်တွေနဲ့ နိုင်ငံခြားသားအကျဉ်းသားတွေ ပါဝင်၊ စစ်အာဏာသိမ်းပြီး နောက်ပိုင်းကစလို့ လက်နက်ကိုင်ဆန့်ကျင်မှုတွေ အများဆုံး ဖြစ်နေတဲ့ စစ်ကိုင်းတိုင်းနဲ့ မကွေးတိုင်းထဲက စစ်ရေးအခြေအနေ၊ ယူကရိန်းရဲ့ အခြေခံအဆောက်အအုံတွေကို ပစ်မှတ်ထားပြီး ရုရှားက မစ်ဆိုင်းဒုံးတွေနဲ့ ထပ်မံ တိုက်ခိုက်၊ တောင်ကိုရီးယားမှာ ဟော်လိုဝင်းပွဲတော် လူအုပ်ကြီးထဲ တိုးဝှေ့ပိမိတဲ့ ဖြစ်စဉ်အပေါ် ရဲရဲ့ စုံစမ်းစစ်ဆေးမှုကို အယုံအကြည် မရှိဘူးလို့ ကျန်ရစ်သူ မိသားစုတချို့ကပြော"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dgtr11",
+                  "types": ["Podcast"],
+                  "duration": 925,
+                  "durationISO8601": "PT15M25S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671286200000,
+                  "availableFrom": 1668694200000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "စစ်ကောင်စီရဲ့ လွတ်ငြိမ်းချမ်းသာခွင့်ထဲမှာ ထင်ရှားတဲ့ နိုင်ငံရေးသမားတွေ၊ NLD ပါတီဝင်တွေနဲ့ နိုင်ငံခြားသားအကျဉ်းသားတွေ ပါဝင်",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668643200000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dgtx1v",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dgm818", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dgm818",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "မောင်တောနဲ့ ကျောက်တော်မှာ လက်နက်ကြီးကျလို့ အရပ်သား ဆယ်ယောက်ကျော် သေဆုံး",
+                "long": "နိုဝင်ဘာ ၁၆ ရက် ဗုဒ္ဓဟူး ညချမ်း ဘီဘီစီမြန်မာပိုင်း အစီအစဉ်\n\n- မောင်တောနဲ့ ကျောက်တော်မှာ လက်နက်ကြီးကျလို့ အရပ်သား ဆယ်ယောက်ကျော် သေဆုံး၊ \n\n-ကရင်ပြည်နယ် KNU နယ်မြေ၊ ဘုရားသုံးဆူမြို့နယ်ထဲက သတ္ထုမိုင်းကို စစ်ကောင်စီက လေယာဉ်နဲ့ပစ်ခတ်လို့ အရပ်သား ၃ ယောက် သေဆုံး၊ \n\n\n- စစ်ကိုင်းတိုင်းနဲ့ ရခိုင်ပြည်နယ်မှာ ရွှေ့ပြောင်းအလုပ်လုပ်ချင်သူတွေကိုပစ်မှတ်ထားပြီး ငွေလိမ်လည်မှုတွေ ဆက်တိုက်ဖြစ်လာ၊ \n\n\n- ပိုလန်နိုင်ငံဘက်ကို ကျလာတဲ့ လက်နက်က ရုရှားဘက်က ပစ်တာ မဟုတ်နိုင်ဘူးလို့ တွေ့ရ၊\n\n စတဲ့ သတင်းတွေ အပြင် နိုင်ငံတကာထိပ်တန်းသတင်းတွေ ကို နားဆင်ရပါမယ်။ \n-----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင် နိုင်ပါတယ်။ \nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် - \nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို"
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dglw5j",
+                  "types": ["Podcast"],
+                  "duration": 907,
+                  "durationISO8601": "PT15M7S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671200100000,
+                  "availableFrom": 1668608100000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "ဘုရားသုံးဆူမြို့နယ်ထဲက သတ္ထုမိုင်းကို စစ်ကောင်စီက လေယာဉ်နဲ့ပစ်ခတ်လို့ အရပ်သား ၃ ယောက် သေဆုံး",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668556800000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dgm818",
+            "type": "ws_radio"
+          },
+          {
+            "headlines": {
+              "headline": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "locators": { "pid": "p0dgd4k1", "brandPid": "p02pc9lh" },
+            "media": {
+              "id": "p0dgd4k1",
+              "subType": "episode",
+              "format": "Audio",
+              "title": "",
+              "synopses": {
+                "short": "ဒီကနေ့ ကမ္ဘာ့လူဦးရေ ၈ ဘီလီယံပြည့်မယ်လို့ ကုလသမဂ္ဂပြော",
+                "long": "နိုဝင်ဘာ ၁၅ ရက် အင်္ဂါနေ့ညချမ်း ဘီဘီစီမြန်မာပိုင်း ရေဒီယိုအစီအစဉ် \n-မော်လမြိုင်မြို့မှာ နာရီနဲ့ချီကြာတဲ့ ပစ်ခတ်မှုတွေ ဘယ်လိုဖြစ်ခဲ့ပါသလဲ။ \n- ကုလသမဂ္ဂရဲ့ တတိယကော်မတီမှာ အတည်ပြုနိုင်ခဲ့တဲ့ သေဒဏ်ပြစ်ဒဏ်ချမှတ်မှု တရားဝင်ဆိုင်းငံ့ခြင်းဆိုင်ရာ အဆိုမူကြမ်းကို စစ်ကောင်စီက လက်ခံနိုင်မလား။ \n- လျှပ်စစ်ကားတွေကို အခွန်မကောက်ဘူးဆိုတာကြောင့် ပြည်တွင်းမှာ စိတ်ဝင်စားမှု ပိုလာနိုင်ပါသလား။ \n-ဒီကနေ့ ကမ္ဘာ့လူဦးရေ ၈ ဘီလီယံပြည့်မယ်လို့ ကုလသမဂ္ဂပြော။ \n-ယူကရိန်းကို ရုရှားကျူးကျော်မှု နောက်ဆက်တွဲ အကျိုးသက်ရောက်မှု ဂျီ ၂ဝ ထိပ်သီးဆွေးနွေးပွဲမှာ ဆွေးနွေး\n -----\nဘီဘီစီရဲ့ ရေဒီယိုအစီအစဉ်တွေကို အင်တာနက်ဝက်ဘ်ဆိုက်နဲ့ ပေါ့ဒ်ကတ်စ်တွေ ကနေလည်း နားဆင်နိုင်ပါ တယ်။\nအသံလွှင့်နေစဉ် တိုက်ရိုက်နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/liveradio\n-----\nညပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် -\nhttps://www.bbc.com/burmese/bbc_burmese_radio/w3csxs4j\nမနက်ပိုင်း ထုတ်လွှင့်မှု နားဆင်ရန် - https://www.bbc.com/burmese/bbc_burmese_radio/w3csxsf3\n-----\nမနက်ပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625862\nညပိုင်းအစီအစဉ် ပေါ့ဒ်ကတ် နားဆင်ရန် - https://www.bbc.com/burmese/media-45625858\n#ဘီဘီစီမြန်မာပိုင်း #ရေဒီယို\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nBBC.COM\nဘီဘီစီ မြန်မာပိုင်း ရေဒီယို - BBC News မြန်မာ\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ....\nနေ့စဉ် ပြည်တွင်း ပြည်ပ သတင်းနဲ့ သုံးသပ်ချက်များ၊ ပညာရေး၊ ကျန်းမာရေး၊ အားကစား၊ နည်းပညာ အစီအစဉ်များ နဲ့ မျက်မှောက်ရေးရာ အဖြာဖြာ...."
+              },
+              "imageUrl": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "embedding": false,
+              "advertising": false,
+              "versions": [
+                {
+                  "versionId": "p0dgd3b7",
+                  "types": ["Podcast"],
+                  "duration": 915,
+                  "durationISO8601": "PT15M15S",
+                  "warnings": {},
+                  "availableTerritories": {
+                    "uk": true,
+                    "nonUk": true,
+                    "world": false
+                  },
+                  "availableUntil": 1671113700000,
+                  "availableFrom": 1668521700000,
+                  "availabilityStatus": "available"
+                }
+              ],
+              "availability": "available",
+              "smpKind": "radioProgramme",
+              "episodeTitle": "မော်လမြိုင်မြို့မှာ နာရီနဲ့ချီကြာတဲ့ ပစ်ခတ်မှုတွေ ဘယ်လိုဖြစ်ခဲ့ပါသလဲ",
+              "type": "media"
+            },
+            "indexImage": {
+              "id": "",
+              "subType": "index",
+              "href": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "path": "ichef.bbci.co.uk/images/ic/$recipe/p02pc2n5.jpg",
+              "height": 0,
+              "width": 0,
+              "altText": null,
+              "copyrightHolder": null,
+              "type": "image"
+            },
+            "releaseDateTimestamp": 1668470400000,
+            "brand": {
+              "pid": "p02pc9lh",
+              "title": "ဘီဘီစီမြန်မာပိုင်း ညနေခင်းသတင်းအစီအစဉ်"
+            },
+            "id": "urn:bbc:ares:ws_media:page:bbc_burmese_radio/p0dgd4k1",
             "type": "ws_radio"
           }
         ]

--- a/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -219,6 +219,33 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
           </span>
         </a>
       </li>
+      <li
+        class="emotion-6 emotion-7"
+        dir="ltr"
+      >
+        <a
+          aria-labelledby="externalLinkId-Download"
+          class="emotion-8 emotion-9"
+          dir="ltr"
+          href="https://bbc.com"
+        >
+          <span
+            id="externalLinkId-Download"
+            role="text"
+          >
+            <span
+              lang="en-GB"
+            >
+              Download
+            </span>
+            <span
+              class="emotion-10 emotion-11"
+            >
+              , A brand podcast, внешняя
+            </span>
+          </span>
+        </a>
+      </li>
     </ul>
   </aside>
 </div>

--- a/src/app/legacy/containers/PodcastExternalLinks/index.stories.jsx
+++ b/src/app/legacy/containers/PodcastExternalLinks/index.stories.jsx
@@ -3,7 +3,7 @@ import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 import { withKnobs } from '@storybook/addon-knobs';
 import { ServiceContextProvider } from '../../../contexts/ServiceContext';
 import { ToggleContextProvider } from '#contexts/ToggleContext';
-import PodcastExternalLinksComponent from '.';
+import PodcastExternalLinkComponent from '.';
 
 // eslint-disable-next-line react/prop-types
 const Component = ({ service, variant }) => (
@@ -15,23 +15,32 @@ const Component = ({ service, variant }) => (
     }}
   >
     <ServiceContextProvider service={service} variant={variant}>
-      <PodcastExternalLinksComponent
+      <PodcastExternalLinkComponent
         links={[
           {
             linkUrl: 'https://bbc.com',
             linkText: 'Apple',
+            linkType: 'apple'
           },
           {
             linkUrl: 'https://bbc.com',
             linkText: 'Google',
+            linkType: 'google'
           },
           {
             linkUrl: 'https://bbc.com',
             linkText: 'Spotify',
+            linkType: 'spotify'
           },
           {
             linkUrl: 'https://bbc.com',
             linkText: 'RSS',
+            linkType: 'rss'
+          },
+          {
+            linkUrl: 'https://bbc.com',
+            linkText: 'Download',
+            linkType: 'download'
           },
         ]}
       />

--- a/src/app/legacy/containers/PodcastExternalLinks/index.test.jsx
+++ b/src/app/legacy/containers/PodcastExternalLinks/index.test.jsx
@@ -25,14 +25,22 @@ const links = [
   {
     linkUrl: 'https://bbc.com',
     linkText: 'Apple',
+    linkType: 'apple',
   },
   {
     linkUrl: 'https://bbc.com',
     linkText: 'Spotify',
+    linkType: 'spotify',
   },
   {
     linkUrl: 'https://bbc.com',
     linkText: 'RSS',
+    linkType: 'rss',
+  },
+  {
+    linkUrl: 'https://bbc.com',
+    linkText: 'Download',
+    linkType: 'download',
   },
 ];
 
@@ -48,8 +56,8 @@ describe('PodcastExternalLinks', () => {
     const listElements = container.getElementsByTagName('li');
     const list = getByRole('list');
 
-    expect(elements.length).toBe(3);
-    expect(listElements.length).toBe(3);
+    expect(elements.length).toBe(4);
+    expect(listElements.length).toBe(4);
     expect(list).toBeInTheDocument();
 
     const { container: emptyContainer } = render(<Component links={[]} />);
@@ -85,7 +93,7 @@ describe('PodcastExternalLinks', () => {
   it('should render hidden text in the links with external text', () => {
     const { getAllByText } = render(<Component links={links} />);
     const visuallyHiddenText = getAllByText(', A brand podcast, внешняя');
-    expect(visuallyHiddenText.length).toEqual(3);
+    expect(visuallyHiddenText.length).toEqual(4);
   });
 
   it('should contain the correct lang attribute', async () => {
@@ -101,7 +109,7 @@ describe('Event Tracking', () => {
     render(<Component links={links} />);
 
     expect(viewTrackerSpy).toHaveBeenCalledWith({
-      componentName: 'third-party',
+      componentName: `third-party`,
       campaignID: 'player-episode-podcast',
     });
   });
@@ -111,7 +119,7 @@ describe('Event Tracking', () => {
     render(<Component links={links} />);
 
     expect(clickTrackerSpy).toHaveBeenCalledWith({
-      componentName: 'third-party',
+      componentName: `third-party-${links[0].linkType}`,
       campaignID: 'player-episode-podcast',
     });
   });

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -259,6 +259,7 @@ export const service: DefaultServiceConfig = {
         duration: 'ကြာမြင့်ချိန်',
         recentEpisodes: 'ထုတ်လွှင့်ပြီး အစီအစဉ်မျာ',
         podcastExternalLinks: 'ဒီပေါ့ဒ်ကတ်စ်ကို နောက်ထပ်ရနိုင်သည့်နေရာ',
+        download: 'ဒေါင်းလုပ်လုပ် ရယူရန်',
       },
       socialEmbed: {
         caption: {

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -147,6 +147,7 @@ export interface Translations {
     duration?: string;
     recentEpisodes?: string;
     podcastExternalLinks?: string;
+    download?: string;
   };
   socialEmbed: {
     caption?: {

--- a/src/app/routes/onDemandAudio/getInitialData/index.js
+++ b/src/app/routes/onDemandAudio/getInitialData/index.js
@@ -112,8 +112,10 @@ export default async ({
       get(['content', 'blocks', 0, 'synopses', 'medium']) || shortSynopsis;
     const summary = isPodcast ? mediumSynopsis : shortSynopsis;
 
+    const versionId = get(['promo', 'media', 'versions', 0, 'versionId']);
+
     const externalLinks = isPodcast
-      ? await getPodcastExternalLinks(service, brandId, variant)
+      ? await getPodcastExternalLinks(service, brandId, variant, versionId)
       : [];
 
     return {

--- a/src/app/routes/onDemandAudio/getInitialData/index.test.js
+++ b/src/app/routes/onDemandAudio/getInitialData/index.test.js
@@ -75,7 +75,9 @@ describe('Get initial data for on demand radio', () => {
       {
         linkText: 'RSS',
         linkUrl: 'https://podcasts.files.bbci.co.uk/p02pc9qc.rss',
+        linkType: 'rss',
       },
+      [],
     ]);
   });
 

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/arabic.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/arabic.js
@@ -4,98 +4,116 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3k7pugwtP9ZouNIj2x97I6',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl: 'https://podcasts.apple.com/us/podcast/bbc-xtra/id262251878',
+        linkType: 'apple',
       },
     ],
     p08z9x26: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3X9hcuWajnQ1QytkmvmV5k',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/ae/podcast/%D8%AE%D8%B1%D8%A7%D9%81%D8%A7%D8%AA/id1541601477',
+        linkType: 'apple',
       },
     ],
     p086jpqy: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1Ipw9UySbhZvZgEBAPKnYK',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%A7%D9%84%D9%86%D8%B4%D8%B1%D8%A9-%D8%A7%D9%84%D9%8A%D9%88%D9%85%D9%8A%D8%A9-%D9%84%D9%81%D9%8A%D8%B1%D9%88%D8%B3-%D9%83%D9%88%D8%B1%D9%88%D9%86%D8%A7/id1502996667',
+        linkType: 'apple',
       },
     ],
     p08gp8wx: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2Hd2doehQOTkRsRni0rICY',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%D8%AE%D8%B1%D8%A7%D9%81%D8%A7%D8%AA-%D9%83%D9%88%D8%B1%D9%88%D9%86%D8%A7/id1518556307',
+        linkType: 'apple',
       },
     ],
     p09cgw89: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3E1HIl16xfaFG6RXImxpVI',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%D8%A3%D8%A8%D8%B9%D8%A7%D8%AF-%D8%A7%D9%84%D8%B5%D9%88%D8%B1%D8%A9/id1561146726',
+        linkType: 'apple',
       },
     ],
     p09m6x31: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3VsAmuPq7qHIRofC5biK8c',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%A8%D9%88%D8%AF%D9%83%D8%A7%D8%B3%D8%AA-%D8%B9-%D9%84%D8%A7%D9%82%D8%A7%D8%AA/id1573549106',
+        linkType: 'apple',
       },
     ],
     p09w8yvk: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0dyrgq9nQMdZ5b7Hfcz6q6',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%A5%D9%83%D8%B3%D8%AA%D8%B1%D8%A7-%D9%84%D9%8A%D9%81%D9%84%D8%B2-xtra-levels/id1586351356',
+        linkType: 'apple',
       },
     ],
     p0b3xdrj: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4Hftvi6T6kjQRogRL1yBVx',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%D9%85%D8%B1%D8%A7%D9%87%D9%82%D8%AA%D9%8A/id1595160361',
+        linkType: 'apple',
       },
     ],
     p0c9wp0l: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3SPVfsKTZ1V6DPvIrvVyAb',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/تغيير-بسيط-a-simple-change/id1626812363',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/burmese.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/burmese.js
@@ -4,22 +4,26 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4SMim5Kg9ex8VwO3D5Kc8n',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/my/podcast/burmese-evening-broadcast/id352604027',
+        linkType: 'apple',
       },
     ],
     p02p9f6q: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/6okAEFPPbfms2Ik4ZoAD3t',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/burmese-morning-broadcast/id352604028',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/gahuza.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/gahuza.js
@@ -4,55 +4,65 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3X2EmcD5e9YZjbLgX9SZls',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/baza-muganga/id1492445243',
+        linkType: 'apple',
       },
     ],
     p02pcb5c: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4WIzS3ZAXxw1fxUx4FCTBY',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/imvo-nimvano/id981906761',
+        linkType: 'apple',
       },
     ],
     p07yjlmf: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/5cW7niDjkEF35hGC4rOUlD',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/ikiganiro-cyabagore/id1492486017',
+        linkType: 'apple',
       },
     ],
     p07yhgwh: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1HWMG5MGbcsGOVKkHeTiof',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/amakuru-kuri-bbc-gahuzamiryango/id1492454113',
+        linkType: 'apple',
       },
     ],
     p07yjfjq: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/5RVTKebCVwCBvC0zHnCKfz',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/ikinamico-urunana/id1492479210',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hausa.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hausa.js
@@ -4,11 +4,13 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1JGid3GVGVdab0FycTUY4L',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/korona-ina-mafita/id1526116287',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/hindi.js
@@ -4,107 +4,128 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1eqTGd8QFThO8jOOl7zWoY',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%E0%A4%B5-%E0%A4%B5-%E0%A4%9A%E0%A4%A8/id1245120783',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%B5%E0%A4%BF%E0%A4%B5%E0%A5%87%E0%A4%9A%E0%A4%A8%E0%A4%BE/1/pkViS6nFvD0_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2019-2019',
+        linkType: 'gaana',
       },
     ],
     p055260j: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0SDaLngHehBulm5LXpyqSV',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%E0%A4%AC-%E0%A4%AC-%E0%A4%B8-%E0%A4%8F%E0%A4%95-%E0%A4%AE-%E0%A4%B2-%E0%A4%95-%E0%A4%A4/id1244954195',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%AC%E0%A5%80%E0%A4%AC%E0%A5%80%E0%A4%B8%E0%A5%80-%E0%A4%8F%E0%A4%95-%E0%A4%AE%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%95%E0%A4%BE%E0%A4%A4/1/9x-ipVkS1f8_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2020',
+        linkType: 'gaana',
       },
     ],
     p05528hs: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1izS1hnTt4hDVwysWQ8HYi',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%AC-%E0%A4%AC-%E0%A4%B8-%E0%A4%A8-%E0%A4%AF-%E0%A4%9C-%E0%A4%AE-%E0%A4%95%E0%A4%B0-%E0%A4%B8/id1245120209',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%AC%E0%A5%80%E0%A4%AC%E0%A5%80%E0%A4%B8%E0%A5%80-%E0%A4%A8%E0%A5%8D%E0%A4%AF%E0%A5%82%E0%A4%9C%E0%A4%BC-%E0%A4%AE%E0%A5%87%E0%A4%95%E0%A4%B0%E0%A5%8D%E0%A4%B8/1/d8gj1oPueo4_',
+        linkType: 'jiosaavn',
       },
     ],
     p05523zq: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4NwNiuICPqNRfGsg4Qm9wH',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%AC-%E0%A4%AC-%E0%A4%B8-70-%E0%A4%8F%E0%A4%AE%E0%A4%8F%E0%A4%AE/id1244939385',
+        linkType: 'apple',
       },
     ],
     p05525mc: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4ZERQGr2e0byGAtbTa76dR',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%A6-%E0%A4%A8-%E0%A4%AF-%E0%A4%9C%E0%A4%B9-%E0%A4%A8/id1244954172',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A4%BE-%E0%A4%9C%E0%A4%B9%E0%A4%BE%E0%A4%A8/1/,2RtKVyy0fI_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2020-3',
+        linkType: 'gaana',
       },
     ],
     p08s9wv2: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2J22D8PZYQdvx4zICcRGon',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/se/podcast/%E0%A4%95%E0%A4%B9-%E0%A4%A8-%E0%A4%9C-%E0%A4%A6%E0%A4%97-%E0%A4%95/id1533103067',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%95%E0%A4%B9%E0%A4%BE%E0%A4%A8%E0%A5%80-%E0%A4%9C%E0%A4%BC%E0%A4%BF%E0%A4%82%E0%A4%A6%E0%A4%97%E0%A5%80-%E0%A4%95%E0%A5%80/1/UTAeq5YqNqw_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2021-4',
+        linkType: 'gaana',
       },
     ],
     p09ds7zx: [
@@ -112,20 +133,24 @@ const externalLinks = {
         linkText: 'Spotify',
         linkUrl:
           'https://open.spotify.com/show/6BGVmN2D82U8hGgDBA4N07?si=9_IClv8KTQyFS4N9jQiSpw',
+        linkType: 'spotify',
       },
       {
-        linkText: 'Apple Podcasts',
+        linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%A6-%E0%A4%A8%E0%A4%AD%E0%A4%B0-%E0%A4%AA-%E0%A4%B0-%E0%A4%A6-%E0%A4%A8-%E0%A4%AA-%E0%A4%B0-%E0%A4%96-%E0%A4%AC%E0%A4%B0-dinbhar/id1563251973',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%A6%E0%A4%BF%E0%A4%A8-%E0%A4%AD%E0%A4%B0/1/ZBludb0NoRM_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2019',
+        linkType: 'gaana',
       },
     ],
 
@@ -133,44 +158,53 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/02iGEmdv3do4InPguSE1cs',
+        linkType: 'spotify',
       },
       {
-        linkText: 'Apple Podcasts',
+        linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%A1-%E0%A4%B0-%E0%A4%AE-%E0%A4%95-%E0%A4%B5-%E0%A4%A8-drama-queen/id1618467926',
+        linkType: 'apple',
       },
       {
         linkText: 'अपने दिल की बात हमसे शेयर करें',
         linkUrl: 'https://www.bbc.com/hindi/send/u107107375',
+        linkType: 'form',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/season/drama-queen-season-1-2022',
+        linkType: 'gaana',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.saavn.com/s/show/ड्रामा-क्वीन-drama-queen/1/dZOptt08D4A_',
+        linkType: 'jiosaavn',
       },
     ],
     p0clc83k: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0sgucaqSDSOg30tyDdq960',
+        linkType: 'spotify',
       },
       {
-        linkText: 'Apple Podcasts',
+        linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%AC-%E0%A4%A4-%E0%A4%B8%E0%A4%B0%E0%A4%B9%E0%A4%A6-%E0%A4%AA-%E0%A4%B0/id1634185584',
+        linkType: 'apple',
       },
       {
         linkText: 'Jio Saavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%AC%E0%A4%BE%E0%A4%A4-%E0%A4%B8%E0%A4%B0%E0%A4%B9%E0%A4%A6-%E0%A4%AA%E0%A4%BE%E0%A4%B0/1/BzW104mU9GQ_',
+        linkType: 'jiosaavn',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2022-159',
+        linkType: 'gaana',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.js
@@ -26,20 +26,33 @@ const podcastExternalLinks = {
 const getRssLink = brandPid => ({
   linkUrl: `https://podcasts.files.bbci.co.uk/${brandPid}.rss`,
   linkText: 'RSS',
+  linkType: 'rss',
+});
+
+// Burmese podcast experiment - remove hardcoded linkText when rolling out to other services
+const getDownloadLink = versionId => ({
+  linkUrl: `https://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download-low/proto/https/vpid/${versionId}.mp3`,
+  linkText: 'ဒေါင်းလုပ်လုပ် ရယူရန်',
+  linkType: 'download',
 });
 
 export const getPodcastExternalLinks = async (
   service,
   brandPid,
   variant = 'default',
+  versionId,
 ) => {
   try {
     const linkData = await podcastExternalLinks[service]();
     if (!linkData) return [];
     if (!brandPid) return [];
+    let downloadLink = [];
+    // Burmese podcast experiment
+    if (service === 'burmese' && brandPid === 'p02pc9lh')
+      downloadLink = getDownloadLink(versionId);
 
     const links = pathOr([], ['default', variant, brandPid], linkData);
-    return [...links, getRssLink(brandPid)];
+    return [...links, getRssLink(brandPid), downloadLink];
   } catch (err) {
     logger.warn(PODCAST_SERVICE_MISSING, {
       service,

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.test.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/index.test.js
@@ -10,7 +10,9 @@ describe('getPodcastExternalLinks', () => {
       {
         linkText: 'RSS',
         linkUrl: 'https://podcasts.files.bbci.co.uk/p08mlgcb.rss',
+        linkType: 'rss',
       },
+      [],
     ];
     expect(links).toEqual(expectedLinks);
   });
@@ -26,12 +28,14 @@ describe('getPodcastExternalLinks', () => {
   });
 
   it('should return rss feed when brand is not found', async () => {
-    const otherLinks = await getPodcastExternalLinks('hausa', 'bar');
+    const otherLinks = await getPodcastExternalLinks('hausa', 'bar', 'default');
     expect(otherLinks).toEqual([
       {
         linkText: 'RSS',
         linkUrl: 'https://podcasts.files.bbci.co.uk/bar.rss',
+        linkType: 'rss',
       },
+      [],
     ]);
   });
 
@@ -42,8 +46,22 @@ describe('getPodcastExternalLinks', () => {
       {
         linkText: 'RSS',
         linkUrl: 'https://podcasts.files.bbci.co.uk/p02pc9xp.rss',
+        linkType: 'rss',
       },
+      [],
     ];
     expect(links).toEqual(expectedLinks);
+  });
+
+  it('should return the correct download link', async () => {
+    const links = await getPodcastExternalLinks(
+      'burmese',
+      'p02pc9lh',
+      undefined,
+      'p0967t2j',
+    );
+    expect(links[3].linkUrl).toEqual(
+      'https://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download-low/proto/https/vpid/p0967t2j.mp3',
+    );
   });
 });

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/indonesia.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/indonesia.js
@@ -4,44 +4,52 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1llyU19J1zhNgK6cc6m3K6',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/bbc-indonesia/id434812049',
+        linkType: 'apple',
       },
     ],
     p08wdlfl: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1d4NQ20PkCliBnJn4NHeHO',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/global-newsbeat/id1537379741',
+        linkType: 'apple',
       },
     ],
     p0btnmzx: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4bSkrXP20pPmiF4Mjb2Wuw',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/investigasi-skandal-adopsi/id1613760117',
+        linkType: 'apple',
       },
     ],
     p0dbsl80: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/43zcFT0Ac70PogTlN8v8jU',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/flora-carita/id1652325843',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/kyrgyz.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/kyrgyz.js
@@ -4,22 +4,26 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0Ns5LMWc959Cummte0k9Q1',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/25-%D0%B6%D1%8B%D0%BB-%D0%BE%D0%B1%D0%BE%D0%B4%D0%BE/id1568103058',
+        linkType: 'apple',
       },
     ],
     p0c80v81: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/7nYFDxTuJnmWtS5lhxtjmB',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/би-би-си-дүрбүсүндө/id1625319429',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/marathi.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/marathi.js
@@ -4,58 +4,70 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4f0yoffmGYYqaTAwI4Ngal',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%A4-%E0%A4%A8-%E0%A4%97-%E0%A4%B7-%E0%A4%9F/id1550093946',
+        linkType: 'apple',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2021-17',
+        linkType: 'gaana',
       },
       {
         linkText: 'JioSaavn',
         linkUrl: 'https://www.jiosaavn.com/shows/तीन-गोष्टी/1/5k2iS6,xzZc_',
+        linkType: 'jiosaavn',
       },
     ],
     p09437hm: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0LK47dXlIqm0Gm1DLeYAIS',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%B8-%E0%A4%AA-%E0%A4%97-%E0%A4%B7-%E0%A4%9F/id1550094137',
+        linkType: 'apple',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2021-18',
+        linkType: 'gaana',
       },
       {
         linkText: 'JioSaavn',
         linkUrl: 'https://www.jiosaavn.com/shows/सोपी-गोष्ट/1/kVtGnMWt4kE_',
+        linkType: 'jiosaavn',
       },
     ],
     p0b1s4nm: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2HlWdNCZ3DpwUMXL4FlHs6',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%E0%A4%97-%E0%A4%B7-%E0%A4%9F-%E0%A4%A6-%E0%A4%A8-%E0%A4%AF-%E0%A4%9A/id1595097031',
+        linkType: 'apple',
       },
       {
         linkText: 'Gaana',
         linkUrl: 'https://gaana.com/podcast/-season-1-2021-271',
+        linkType: 'gaana',
       },
       {
         linkText: 'JioSaavn',
         linkUrl:
           'https://www.jiosaavn.com/shows/%E0%A4%97%E0%A5%8B%E0%A4%B7%E0%A5%8D%E0%A4%9F-%E0%A4%A6%E0%A5%81%E0%A4%A8%E0%A4%BF%E0%A4%AF%E0%A5%87%E0%A4%9A%E0%A5%80/1/NeVi8wudirQ_',
+        linkType: 'jiosaavn',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/nepali.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/nepali.js
@@ -4,11 +4,13 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2oE8PaJfhvymftvgAxHP2d',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%E0%A4%AC-%E0%A4%AC-%E0%A4%B8-%E0%A4%A8-%E0%A4%AA-%E0%A4%B2-%E0%A4%AA%E0%A4%A1%E0%A4%95-%E0%A4%B8-%E0%A4%9F/id475748640',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/persian.js
@@ -4,85 +4,101 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2z6NRjAYvSaInglrZOfawC',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl: 'https://podcasts.apple.com/us/podcast/pargar/id634850665',
+        linkType: 'apple',
       },
     ],
     p036kbdd: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1y5MuXLzLPJsw1YbtPNMe6',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/in/podcast/be-ebarat-e-digar/id1055378813',
+        linkType: 'apple',
       },
     ],
     p05gyy09: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/08dvs0rLyyNni2I3lhteen',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%B5%D9%81%D8%AD%D9%87-%DB%B2-page-2/id1288618875',
+        linkType: 'apple',
       },
     ],
     p0703hz7: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/5oMeCbKkRkqx8X7IKpAZzB',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%AF%D8%A7%D8%B3%D8%AA%D8%A7%D9%86-%D8%A7%D9%86%D9%82%D9%84%D8%A7%D8%A8-%D8%A8%D9%87-%D8%B1%D9%88%D8%A7%DB%8C%D8%AA-%D8%A8%DB%8C-%D8%A8%DB%8C-%D8%B3%DB%8C/id1451707438',
+        linkType: 'apple',
       },
     ],
     p02pc9mc: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0cHK9mp72ixQv8PVd7Bb3N',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/bbc-persian-radio/id262741509',
+        linkType: 'apple',
       },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/رادیو-فارسی-بیبیسی-id574405?utm_source=website&utm_medium=dlink&utm_campaign=web_share&utm_content=%D8%B1%D8%A7%D8%AF%DB%8C%D9%88%20%D9%81%D8%A7%D8%B1%D8%B3%DB%8C%20%D8%A8%DB%8C%E2%80%8C%D8%A8%DB%8C%E2%80%8C%D8%B3%DB%8C-CastBox_FM',
+        linkType: 'castbox',
       },
     ],
     p09v5lgp: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4k2EWdvmGiWLgXpUrm8VMS',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D8%A8%DB%8C%D9%86-%D8%B3%D8%B7%D9%88%D8%B1/id1584665242',
+        linkType: 'apple',
       },
     ],
     p0bw80rj: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4kInUtgdsMnUxlA7sBKxLL',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl: 'https://podcasts.apple.com/us/podcast/بین-سطور/id1615070108',
+        linkType: 'apple',
       },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/%D8%B4%DB%8C%D8%B1%D8%A7%D8%B2%D9%87-id4841117?country=us',
+        linkType: 'castbox',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/portuguese.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/portuguese.js
@@ -4,48 +4,57 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4KqTMEWcOUzHFHAPCt54Uk',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/br/podcast/que-hist%C3%B3ria/id1492686435',
+        linkType: 'apple',
       },
     ],
     p09qw1cn: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/54YV8Rd6zmvq9Ry55q9HQw',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/bbc-l%C3%AA/id1586358051',
+        linkType: 'apple',
       },
       {
         linkText: 'Arquivo completo',
         linkUrl: 'https://www.bbc.com/portuguese/topics/cxndrr1qgllt',
+        linkType: 'arquivocompleto',
       },
     ],
     p0cx5pt6: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/5OZrG0afS38YHeaCnBQbBz',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/as-estranhas-origens-das-guerras-culturais/id1642483075',
+        linkType: 'apple',
       },
     ],
     p0cyhvny: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4909a8iZAdJ01DLyJxiwcd',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/brasil-partido/id1643515422',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
@@ -4,73 +4,102 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4J0FwkJYlSvkqZrJWdG9nt',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D1%80%D0%B0%D0%B4%D0%B8%D0%BE%D0%B0%D1%80%D1%85%D0%B8%D0%B2-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%BE%D0%B9-%D1%81%D0%BB%D1%83%D0%B6%D0%B1%D1%8B-%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8/id1248943501',
+        linkType: 'apple',
       },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/%D0%A0%D0%B0%D0%B4%D0%B8%D0%BE%D0%B0%D1%80%D1%85%D0%B8%D0%B2-%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%BE%D0%B9-%D1%81%D0%BB%D1%83%D0%B6%D0%B1%D1%8B-%D0%91%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8-id933314?country=us',
+        linkType: 'castbox',
       },
     ],
     p076qqzl: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/2CR7Wn6IzBVXPxQ5uzkkz1',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/%D1%87%D1%82%D0%BE-%D1%8D%D1%82%D0%BE-%D0%B1%D1%8B%D0%BB%D0%BE/id1460240829?l=en',
+        linkType: 'apple',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.com/album/7330688' },
-      { linkText: 'Castbox', linkUrl: 'https://castbox.fm/vc/2092482' },
+      {
+        linkText: 'Yandex',
+        linkUrl: 'https://music.yandex.com/album/7330688',
+        linkType: 'yandex',
+      },
+      {
+        linkText: 'Castbox',
+        linkUrl: 'https://castbox.fm/vc/2092482',
+        linkType: 'castbox',
+      },
     ],
     p08pxjzf: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0g5kVHIpOM8V4qtgCqFppm',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D0%B0%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9-%D0%BF%D0%B8%D1%80%D0%BE%D0%B3/id1529622434',
+        linkType: 'apple',
       },
       {
         linkText: 'Yandex',
         linkUrl: 'https://music.yandex.com/album/11965335',
+        linkType: 'yandex',
       },
-      { linkText: 'Castbox', linkUrl: 'https://castbox.fm/vc/3283439' },
+      {
+        linkText: 'Castbox',
+        linkUrl: 'https://castbox.fm/vc/3283439',
+        linkType: 'castbox',
+      },
     ],
     p075ydnq: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3vu4FSOf79BHsVQ5sV0LmV',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/us/podcast/%D1%80%D0%B0%D0%B7%D0%B3%D0%BE%D0%B2%D0%BE%D1%80%D1%8B-%D1%81-%D0%B0%D1%80%D0%B1%D0%B8%D1%82%D1%80%D0%BE%D0%BC/id1459245691',
+        linkType: 'apple',
       },
     ],
     p08l9l66: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/1mflnDxXdhrxp2BKC782Im',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D0%B1%D0%B8-%D0%B1%D0%B8-%D1%81%D0%B8-doc/id1524273697',
+        linkType: 'apple',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.ru/album/11522254' },
+      {
+        linkText: 'Yandex',
+        linkUrl: 'https://music.yandex.ru/album/11522254',
+        linkType: 'yandex',
+      },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/id3130703?utm_campaign=i_share_ch&utm_medium=dlink&utm_source=i_share&country=us',
+        linkType: 'yandex',
       },
     ],
     p09nx6zm: [
@@ -78,32 +107,42 @@ const externalLinks = {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/%D0%BF%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%B9%D0%BE%D0%BC%D0%B5%D0%B9-%D0%BC%D0%B0%D1%80%D1%83/id1575896140',
+        linkType: 'apple',
       },
       {
         linkText: 'Yandex',
         linkUrl: 'https://music.yandex.com/album/16801020',
+        linkType: 'yandex',
       },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/%D0%9F%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%99%D0%BE%D0%BC%D0%B5%D0%B9-%D0%9C%D0%B0%D1%80%D1%83-id4407848',
+        linkType: 'castbox',
       },
     ],
     p082h9l8: [
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/0gNOG2xiadfkRrBJnubfHT',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/8-%D0%B8%D1%81%D1%82%D0%BE%D1%80%D0%B8%D0%B9-%D0%B8%D0%B7-90-%D1%85/id1470221669',
+        linkType: 'apple',
       },
-      { linkText: 'Yandex', linkUrl: 'https://music.yandex.ru/album/9875407' },
+      {
+        linkText: 'Yandex',
+        linkUrl: 'https://music.yandex.ru/album/9875407',
+        linkType: 'yandex',
+      },
       {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/\u041a\u043e\u043c\u0430\u043d\u0434\u0438\u0440\u043e\u0432\u043a\u0430-\u0432-\u0414\u043e\u043d\u0435\u0446\u043a-id2616795',
+        linkType: 'castbox',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/ukrainian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/ukrainian.js
@@ -4,11 +4,13 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/3q7550hSqicRIJSFsQ5BVr',
+        linkType: 'spotify',
       },
       {
         linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D1%89%D0%BE-%D1%86%D0%B5-%D0%B1%D1%83%D0%BB%D0%BE/id1569801762',
+        linkType: 'apple',
       },
     ],
   },

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/urdu.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/urdu.js
@@ -4,19 +4,23 @@ const externalLinks = {
       {
         linkText: 'Spotify',
         linkUrl: 'https://open.spotify.com/show/4izrTfBmEKZHYCAUiuc4gw',
+        linkType: 'spotify',
       },
       {
-        linkText: 'Apple Podcasts',
+        linkText: 'Apple',
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%DA%88%D8%B1%D8%A7%D9%85%DB%81-%DA%A9%D9%88%D8%A6%DB%8C%D9%86-drama-queen/id1618467017',
+        linkType: 'apple',
       },
       {
         linkText: 'Patari',
         linkUrl: 'https://patari.pk/home/song/625a05eb4950df5b58b97a4a',
+        linkType: 'patari',
       },
       {
         linkText: 'اپنے دل کی بات ہمارے ساتھ شیئر کیجیے',
         linkUrl: 'https://www.bbc.com/urdu/send/u106609198',
+        linkType: 'form',
       },
     ],
   },
@@ -24,11 +28,13 @@ const externalLinks = {
     {
       linkText: 'Spotify',
       linkUrl: 'https://open.spotify.com/show/7iOhf64Hu8wBCZDQSm0Dod',
+      linkType: 'spotify',
     },
     {
-      linkText: 'Apple Podcasts',
+      linkText: 'Apple',
       linkUrl:
         'https://podcasts.apple.com/gb/podcast/%D8%A8%D8%A7%D8%AA-%D8%B3%D8%B1%D8%AD%D8%AF-%D9%BE%D8%A7%D8%B1/id1634186835',
+      linkType: 'apple',
     },
   ],
 };

--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/zhongwen.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/zhongwen.js
@@ -3,11 +3,13 @@ const common = {
     {
       linkText: 'Spotify',
       linkUrl: 'https://open.spotify.com/show/0HCq2CZEdD5egLoE4t4C8t',
+      linkType: 'spotify',
     },
     {
       linkText: 'Apple',
       linkUrl:
         'https://podcasts.apple.com/us/podcast/bbc-%E6%99%82%E4%BA%8B%E4%B8%80%E5%91%A8-newsweek-cantonese/id415474539',
+      linkType: 'apple',
     },
   ],
 };


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAM1-188

**Overall change:**
_Part 2 of the Podcast Download Experiment (on Burmese)_
Adds tracking to the podcast download


**Code changes:**

- update tests
- add tracking to `PodcastExternalLink`

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
