### PR TITLE
ENH: remove gel.files from calls

### DIFF
--- a/src/app/Layouts/defaultPageWrapper.jsx
+++ b/src/app/Layouts/defaultPageWrapper.jsx
@@ -72,7 +72,7 @@ const PageWrapper = ({ children, pageData, status }) => {
 					head.appendChild(fontStylePlaceholder);
                 };
                 const retrieveAndStoreFont = (font, storageKey, shouldAttachStyle) => {
-                	const fontLocation = font.src ? font.src : 'https://gel.files.bbci.co.uk/'+ font.version + (font.subsets ? '/subsets' : '') + '/' + font.name + '.woff2';
+                	const fontLocation = font.src ? font.src : 'https://static.files.bbci.co.uk/fonts/reith/'+ font.version + (font.subsets ? '/subsets' : '') + '/' + font.name + '.woff2';
                     window.addEventListener("load", (e) => {
                     getFont(fontLocation).then((fontContents) => {
                     	const forStorage = { base64Contents: fontContents, fontFamily: font.fontFamily, fontWeight: font.fontWeight, fontVersion: font.version };

--- a/src/app/components/ThemeProvider/fontFaces.ts
+++ b/src/app/components/ThemeProvider/fontFaces.ts
@@ -1,4 +1,4 @@
-const REITH_FONTS_DIR = 'https://gel.files.bbci.co.uk/r2.512/';
+const REITH_FONTS_DIR = 'https://static.files.bbci.co.uk/fonts/reith/r2.512/';
 
 const NOTO_SERIF_SINHALA_FONTS_DIR =
   'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/';

--- a/src/app/components/ThemeProvider/fontFacesLazy.ts
+++ b/src/app/components/ThemeProvider/fontFacesLazy.ts
@@ -1,4 +1,4 @@
-const REITH_FONTS_DIR = 'https://gel.files.bbci.co.uk/r2.512/';
+const REITH_FONTS_DIR = 'https://static.files.bbci.co.uk/fonts/reith/r2.512/';
 
 const NOTO_SERIF_SINHALA_FONTS_DIR =
   'https://ws-downloads.files.bbci.co.uk/fonts/NotoSerifSinhala/v1.00/';

--- a/src/app/legacy/psammead/README.md
+++ b/src/app/legacy/psammead/README.md
@@ -50,8 +50,8 @@ You can do this in pure CSS:
     font-family: 'ReithSans';
     font-style: normal;
     font-weight: 400;
-    src: url('https://gel.files.bbci.co.uk/r2.511/BBCReithSans_W_Rg.woff2')
-        format('woff2'), url('https://gel.files.bbci.co.uk/r2.511/BBCReithSans_W_Rg.woff')
+    src: url('https://static.files.bbci.co.uk/fonts/reith/r2.512/BBCReithSans_W_Rg.woff2')
+        format('woff2'), url('https://static.files.bbci.co.uk/fonts/reith/r2.512/BBCReithSans_W_Rg.woff')
         format('woff');
   }
   @font-face {
@@ -59,8 +59,8 @@ You can do this in pure CSS:
     font-family: 'ReithSerif';
     font-style: normal;
     font-weight: 600;
-    src: url('https://gel.files.bbci.co.uk/r2.511/BBCReithSerif_W_Md.woff2')
-        format('woff2'), url('https://gel.files.bbci.co.uk/r2.511/BBCReithSerif_W_Md.woff')
+    src: url('https://static.files.bbci.co.uk/fonts/reith/r2.512/BBCReithSerif_W_Md.woff2')
+        format('woff2'), url('https://static.files.bbci.co.uk/fonts/reith/r2.512/BBCReithSerif_W_Md.woff')
         format('woff');
   }
 </style>

--- a/src/integration/common/performance.js
+++ b/src/integration/common/performance.js
@@ -10,7 +10,6 @@ export default ({ service = null, hasScriptFonts = false } = {}) => {
           'https://dataplane.rum.eu-west-1.amazonaws.com',
           ...(hasScriptFonts
             ? [
-                'https://gel.files.bbci.co.uk',
                 'https://ws-downloads.files.bbci.co.uk',
               ]
             : []),

--- a/src/integration/common/performance.js
+++ b/src/integration/common/performance.js
@@ -8,11 +8,7 @@ export default ({ service = null, hasScriptFonts = false } = {}) => {
           'https://ping.chartbeat.net',
           'https://client.rum.us-east-1.amazonaws.com',
           'https://dataplane.rum.eu-west-1.amazonaws.com',
-          ...(hasScriptFonts
-            ? [
-                'https://ws-downloads.files.bbci.co.uk',
-              ]
-            : []),
+          ...(hasScriptFonts ? ['https://ws-downloads.files.bbci.co.uk'] : []),
         ];
 
         resources.forEach(resource => {

--- a/src/server/utilities/getAssetOrigins/index.js
+++ b/src/server/utilities/getAssetOrigins/index.js
@@ -17,9 +17,7 @@ const getAssetOrigins = service => {
     'https://dataplane.rum.eu-west-1.amazonaws.com',
   ];
 
-  const FONTS_ORIGINS = [
-    'https://ws-downloads.files.bbci.co.uk',
-  ];
+  const FONTS_ORIGINS = ['https://ws-downloads.files.bbci.co.uk'];
 
   const assetOrigins = [
     ...COOKIE_ORIGINS,

--- a/src/server/utilities/getAssetOrigins/index.js
+++ b/src/server/utilities/getAssetOrigins/index.js
@@ -18,7 +18,6 @@ const getAssetOrigins = service => {
   ];
 
   const FONTS_ORIGINS = [
-    'https://gel.files.bbci.co.uk',
     'https://ws-downloads.files.bbci.co.uk',
   ];
 

--- a/src/server/utilities/getAssetOrigins/index.test.js
+++ b/src/server/utilities/getAssetOrigins/index.test.js
@@ -29,9 +29,7 @@ const analyticsOrigins = [
   'https://dataplane.rum.eu-west-1.amazonaws.com',
 ];
 
-const fontOrigins = [
-  'https://ws-downloads.files.bbci.co.uk',
-];
+const fontOrigins = ['https://ws-downloads.files.bbci.co.uk'];
 
 describe('getAssetOrigins', () => {
   beforeEach(() => {

--- a/src/server/utilities/getAssetOrigins/index.test.js
+++ b/src/server/utilities/getAssetOrigins/index.test.js
@@ -30,7 +30,6 @@ const analyticsOrigins = [
 ];
 
 const fontOrigins = [
-  'https://gel.files.bbci.co.uk',
   'https://ws-downloads.files.bbci.co.uk',
 ];
 


### PR DESCRIPTION
I noticed that https://static.files.bbci.co.uk/fonts/reith/r2.511/BBCReithSans_W_Rg.woff2 is same font as https://gel.files.bbci.co.uk/r2.512/BBCReithSans_W_Rg.woff2 so we may as well have one less domain lookup...

