### PR TITLE
E2E fix - articles data now from BFF

### DIFF
--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -152,7 +152,7 @@ export const testsThatFollowSmokeTestConfig = ({
 
       it('should have an inline link', () => {
         if (articlesData.data.article.metadata.language === 'en-gb') {
-          cy.get('main a');
+          cy.get('main a').should('exist');
         }
       });
 

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -52,7 +52,7 @@ export const testsThatFollowSmokeTestConfig = ({
           env === 'live' ? '' : `${env}.`
         }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
 
-        console.log(bffUrl);
+        cy.log(bffUrl);
         cy.request({
           url: bffUrl,
           headers: { 'ctx-service-env': env },
@@ -86,7 +86,6 @@ export const testsThatFollowSmokeTestConfig = ({
     describe(`Article Body`, () => {
       it('should render a H1, which contains/displays a styled headline', () => {
         const headlineData = getBlockData('headline', articlesData);
-        console.log(headlineData);
         cy.get('h1').should(
           'contain',
           headlineData.model.blocks[0].model.blocks[0].model.text,

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -31,7 +31,40 @@ export const testsThatFollowSmokeTestConfig = ({
   pageType,
   variant,
 }) => {
+  let articlesData;
   describe(`Running tests for ${service} ${pageType}`, () => {
+    before(() => {
+      const env = Cypress.env('APP_ENV');
+      if (env !== 'local') {
+        const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
+        let appendVariant = '';
+
+        // eslint-disable-next-line prefer-destructuring
+        const articleId = Cypress.env('currentPath')
+          .split('articles/')
+          .pop()
+          .split('?')[0];
+        cy.log(articleId);
+        if (scriptSwitchServices.includes(service)) {
+          appendVariant = `&variant=${variant}`;
+        }
+        const bffUrl = `https://web-cdn.${
+          env === 'live' ? '' : `${env}.`
+        }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
+
+        console.log(bffUrl);
+        cy.request({
+          url: bffUrl,
+          headers: { 'ctx-service-env': env },
+        }).then(({ body }) => {
+          articlesData = body;
+        });
+      } else {
+        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
+          articlesData = body;
+        });
+      }
+    });
     describe(`Metadata`, () => {
       // Here we should only have metadata tests that are unique to articles pages
       it('should have the correct articles metadata', () => {
@@ -52,35 +85,30 @@ export const testsThatFollowSmokeTestConfig = ({
 
     describe(`Article Body`, () => {
       it('should render a H1, which contains/displays a styled headline', () => {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const headlineData = getBlockData('headline', body);
-          cy.get('h1').should(
-            'contain',
-            headlineData.model.blocks[0].model.blocks[0].model.text,
-          );
-        });
+        const headlineData = getBlockData('headline', articlesData);
+        console.log(headlineData);
+        cy.get('h1').should(
+          'contain',
+          headlineData.model.blocks[0].model.blocks[0].model.text,
+        );
       });
 
       it('should render an H2, which contains/displays a styled subheading', () => {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          if (body.data.article.metadata.language === 'en-gb') {
-            const subheadingData = getBlockData('subheadline', body);
-            cy.get('h2').should(
-              'contain',
-              subheadingData.model.blocks[0].model.blocks[0].model.text,
-            );
-          }
-        });
+        if (articlesData.data.article.metadata.language === 'en-gb') {
+          const subheadingData = getBlockData('subheadline', articlesData);
+          cy.get('h2').should(
+            'contain',
+            subheadingData.model.blocks[0].model.blocks[0].model.text,
+          );
+        }
       });
 
       it('should render a paragraph, which contains/displays styled text', () => {
         if (serviceHasCorrectlyRenderedParagraphs(service)) {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const paragraphData = getBlockData('text', body);
-            const { text } = paragraphData.model.blocks[0].model;
+          const paragraphData = getBlockData('text', articlesData);
+          const { text } = paragraphData.model.blocks[0].model;
 
-            cy.get('p').should('contain', text);
-          });
+          cy.get('p').should('contain', text);
         }
       });
 
@@ -101,38 +129,34 @@ export const testsThatFollowSmokeTestConfig = ({
         }
 
         it('should have an image copyright label with styling', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const copyrightData = getBlockData('image', body);
-            const rawImageblock = getBlockByType(
-              copyrightData.model.blocks,
-              'rawImage',
-            );
-            const { copyrightHolder } = rawImageblock.model;
+          const copyrightData = getBlockData('image', articlesData);
+          const rawImageblock = getBlockByType(
+            copyrightData.model.blocks,
+            'rawImage',
+          );
+          const { copyrightHolder } = rawImageblock.model;
 
-            cy.get('figure')
-              .eq(0)
-              .within(() => {
-                if (copyrightHolder === 'BBC') {
-                  // If an image has a BBC copyright, the copyright holder (<p>) does not appear on images.
-                  // This is why we're asserting the value. If the copyright does not appear and is not
-                  // 'BBC' then it is clear there is an error with this component.
-                  cy.get('p[role="text"]').should('not.exist');
-                } else {
-                  cy.get('p[role="text"]')
-                    .should('be.visible')
-                    .and('contain', copyrightHolder);
-                }
-              });
-          });
+          cy.get('figure')
+            .eq(0)
+            .within(() => {
+              if (copyrightHolder === 'BBC') {
+                // If an image has a BBC copyright, the copyright holder (<p>) does not appear on images.
+                // This is why we're asserting the value. If the copyright does not appear and is not
+                // 'BBC' then it is clear there is an error with this component.
+                cy.get('p[role="text"]').should('not.exist');
+              } else {
+                cy.get('p[role="text"]')
+                  .should('be.visible')
+                  .and('contain', copyrightHolder);
+              }
+            });
         });
       }
 
       it('should have an inline link', () => {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          if (body.data.article.metadata.language === 'en-gb') {
-            cy.get('main a');
-          }
-        });
+        if (articlesData.data.article.metadata.language === 'en-gb') {
+          cy.get('main a');
+        }
       });
 
       if (serviceHasInlineLink(service) && Cypress.env('APP_ENV') !== 'live') {
@@ -163,156 +187,137 @@ export const testsThatFollowSmokeTestConfig = ({
 
       describe('Media Player', () => {
         it('should have a visible caption beneath a mediaplayer', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const media = getBlockData('video', body);
-            if (media) {
-              const captionBlock = getBlockByType(
-                media.model.blocks,
-                'caption',
-              );
+          const media = getBlockData('video', articlesData);
+          if (media) {
+            const captionBlock = getBlockByType(media.model.blocks, 'caption');
 
-              if (captionBlock) {
-                const { text } =
-                  captionBlock.model.blocks[0].model.blocks[0].model;
+            if (captionBlock) {
+              const { text } =
+                captionBlock.model.blocks[0].model.blocks[0].model;
 
-                cy.get('figcaption')
-                  .eq(1)
-                  .within(() => {
-                    cy.get('p')
-                      .eq(0)
-                      .should('be.visible')
-                      .should('contain', text);
-                  });
-              }
+              cy.get('figcaption')
+                .eq(1)
+                .within(() => {
+                  cy.get('p')
+                    .eq(0)
+                    .should('be.visible')
+                    .should('contain', text);
+                });
             }
-          });
+          }
         });
       });
 
       describe('Social Embeds', () => {
         it('Youtube embed is redered when it exists on page', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const youtubeSocialEmbedsData = getAllSocialBlocksByProviderName(
-              'YouTube',
-              body,
-            );
-            if (youtubeSocialEmbedsData.length > 0) {
-              youtubeSocialEmbedsData.forEach(content => {
-                const youtubeUrl = content.model.source;
-                cy.get(`[data-e2e="youtube-embed-${youtubeUrl}"]`)
-                  .scrollIntoView()
-                  .within(() => {
-                    cy.get(`[data-testid="consentBanner"]`).should('exist');
-                    cy.get(`iframe`).should('not.exist');
-                    cy.get(`[data-testid="banner-button"]`).click();
-                    cy.get(`iframe`).should('exist');
-                    cy.get(`[href^="#end-of-youtube-content"]`).should('exist');
-                  });
-              });
-            } else {
-              cy.log('There is no Youtube embed in this page!');
-              cy.get(`[href^="#end-of-youtube-content"]`).should('not.exist');
-            }
-          });
+          const youtubeSocialEmbedsData = getAllSocialBlocksByProviderName(
+            'YouTube',
+            articlesData,
+          );
+          if (youtubeSocialEmbedsData.length > 0) {
+            youtubeSocialEmbedsData.forEach(content => {
+              const youtubeUrl = content.model.source;
+              cy.get(`[data-e2e="youtube-embed-${youtubeUrl}"]`)
+                .scrollIntoView()
+                .within(() => {
+                  cy.get(`[data-testid="consentBanner"]`).should('exist');
+                  cy.get(`iframe`).should('not.exist');
+                  cy.get(`[data-testid="banner-button"]`).click();
+                  cy.get(`iframe`).should('exist');
+                  cy.get(`[href^="#end-of-youtube-content"]`).should('exist');
+                });
+            });
+          } else {
+            cy.log('There is no Youtube embed in this page!');
+            cy.get(`[href^="#end-of-youtube-content"]`).should('not.exist');
+          }
         });
 
         it('Instagram embed is redered when it exists on page', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const instagramSocialEmbedsData = getAllSocialBlocksByProviderName(
-              'Instagram',
-              body,
-            );
-            if (instagramSocialEmbedsData.length > 0) {
-              instagramSocialEmbedsData.forEach(content => {
-                const instagramUrl = content.model.source;
-                cy.get(`[data-e2e="instagram-embed-${instagramUrl}"]`)
-                  .scrollIntoView()
-                  .within(() => {
-                    cy.get(`[href^="#end-of-instagram-content"]`).should(
-                      'exist',
-                    );
-                    cy.get(`iframe`).should('exist');
-                  });
-              });
-            } else {
-              cy.log('There is no Instagram embed in this page!');
-              cy.get(`[href^="#end-of-instagram-content"]`).should('not.exist');
-            }
-          });
+          const instagramSocialEmbedsData = getAllSocialBlocksByProviderName(
+            'Instagram',
+            articlesData,
+          );
+          if (instagramSocialEmbedsData.length > 0) {
+            instagramSocialEmbedsData.forEach(content => {
+              const instagramUrl = content.model.source;
+              cy.get(`[data-e2e="instagram-embed-${instagramUrl}"]`)
+                .scrollIntoView()
+                .within(() => {
+                  cy.get(`[href^="#end-of-instagram-content"]`).should('exist');
+                  cy.get(`iframe`).should('exist');
+                });
+            });
+          } else {
+            cy.log('There is no Instagram embed in this page!');
+            cy.get(`[href^="#end-of-instagram-content"]`).should('not.exist');
+          }
         });
 
         it('Tiktok embed is redered when it exists on page', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const tiktokSocialEmbedsData = getAllSocialBlocksByProviderName(
-              'TikTok',
-              body,
-            );
-            if (tiktokSocialEmbedsData.length > 0) {
-              tiktokSocialEmbedsData.forEach(content => {
-                const tiktokUrl = content.model.source;
-                cy.get(`[data-e2e="tiktok-embed-${tiktokUrl}"]`)
-                  .scrollIntoView()
-                  .within(() => {
-                    cy.get(`[data-testid="consentBanner"]`).should('exist');
-                    cy.get(`iframe`).should('not.exist');
-                    cy.get(`[data-testid="banner-button"]`).click();
-                    cy.get(`iframe`).should('exist');
-                    cy.get(`[href^="#end-of-tiktok-content"]`).should('exist');
-                  });
-              });
-            } else {
-              cy.log('There is no Tiktok embed in this page!');
-              cy.get(`[href^="#end-of-tiktok-content"]`).should('not.exist');
-            }
-          });
+          const tiktokSocialEmbedsData = getAllSocialBlocksByProviderName(
+            'TikTok',
+            articlesData,
+          );
+          if (tiktokSocialEmbedsData.length > 0) {
+            tiktokSocialEmbedsData.forEach(content => {
+              const tiktokUrl = content.model.source;
+              cy.get(`[data-e2e="tiktok-embed-${tiktokUrl}"]`)
+                .scrollIntoView()
+                .within(() => {
+                  cy.get(`[data-testid="consentBanner"]`).should('exist');
+                  cy.get(`iframe`).should('not.exist');
+                  cy.get(`[data-testid="banner-button"]`).click();
+                  cy.get(`iframe`).should('exist');
+                  cy.get(`[href^="#end-of-tiktok-content"]`).should('exist');
+                });
+            });
+          } else {
+            cy.log('There is no Tiktok embed in this page!');
+            cy.get(`[href^="#end-of-tiktok-content"]`).should('not.exist');
+          }
         });
 
         it('Twitter embed is redered when it exists on page', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const twitterSocialEmbedsData = getAllSocialBlocksByProviderName(
-              'Twitter',
-              body,
-            );
-            if (twitterSocialEmbedsData.length > 0) {
-              twitterSocialEmbedsData.forEach(content => {
-                const twitterUrl = content.model.source;
-                cy.get(`[data-e2e="twitter-embed-${twitterUrl}"]`)
-                  .scrollIntoView()
-                  .within(() => {
-                    cy.get(`iframe`).should('exist');
-                    cy.get(`[href^="#end-of-twitter-content"]`).should('exist');
-                  });
-              });
-            } else {
-              cy.log('There is no Twitter embed in this page!');
-              cy.get(`[href^="#end-of-twitter-content"]`).should('not.exist');
-            }
-          });
+          const twitterSocialEmbedsData = getAllSocialBlocksByProviderName(
+            'Twitter',
+            articlesData,
+          );
+          if (twitterSocialEmbedsData.length > 0) {
+            twitterSocialEmbedsData.forEach(content => {
+              const twitterUrl = content.model.source;
+              cy.get(`[data-e2e="twitter-embed-${twitterUrl}"]`)
+                .scrollIntoView()
+                .within(() => {
+                  cy.get(`iframe`).should('exist');
+                  cy.get(`[href^="#end-of-twitter-content"]`).should('exist');
+                });
+            });
+          } else {
+            cy.log('There is no Twitter embed in this page!');
+            cy.get(`[href^="#end-of-twitter-content"]`).should('not.exist');
+          }
         });
 
         it('Facebook embed is redered when it exists on page', () => {
-          cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-            const facebookSocialEmbedsData = getAllSocialBlocksByProviderName(
-              'Facebook',
-              body,
-            );
-            if (facebookSocialEmbedsData.length > 0) {
-              facebookSocialEmbedsData.forEach(content => {
-                const facebookUrl = content.model.source;
-                cy.get(`[data-e2e="facebook-embed-${facebookUrl}"]`)
-                  .scrollIntoView()
-                  .within(() => {
-                    cy.get(`iframe`).should('exist');
-                    cy.get(`[href^="#end-of-facebook-content"]`).should(
-                      'exist',
-                    );
-                  });
-              });
-            } else {
-              cy.log('There is no Facebook embed in this page!');
-              cy.get(`[href^="#end-of-facebook-content"]`).should('not.exist');
-            }
-          });
+          const facebookSocialEmbedsData = getAllSocialBlocksByProviderName(
+            'Facebook',
+            articlesData,
+          );
+          if (facebookSocialEmbedsData.length > 0) {
+            facebookSocialEmbedsData.forEach(content => {
+              const facebookUrl = content.model.source;
+              cy.get(`[data-e2e="facebook-embed-${facebookUrl}"]`)
+                .scrollIntoView()
+                .within(() => {
+                  cy.get(`iframe`).should('exist');
+                  cy.get(`[href^="#end-of-facebook-content"]`).should('exist');
+                });
+            });
+          } else {
+            cy.log('There is no Facebook embed in this page!');
+            cy.get(`[href^="#end-of-facebook-content"]`).should('not.exist');
+          }
         });
       });
     });

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -40,11 +40,9 @@ export const testsThatFollowSmokeTestConfig = ({
         let appendVariant = '';
 
         // eslint-disable-next-line prefer-destructuring
-        const articleId = Cypress.env('currentPath')
-          .split('articles/')
-          .pop()
-          .split('?')[0];
-        cy.log(articleId);
+        const articleId =
+          Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
+
         if (scriptSwitchServices.includes(service)) {
           appendVariant = `&variant=${variant}`;
         }

--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -29,11 +29,9 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
         let appendVariant = '';
 
         // eslint-disable-next-line prefer-destructuring
-        const articleId = Cypress.env('currentPath')
-          .split('articles/')
-          .pop()
-          .split('?')[0];
-        cy.log(articleId);
+        const articleId =
+          Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
+
         if (scriptSwitchServices.includes(service)) {
           appendVariant = `&variant=${variant}`;
         }
@@ -41,7 +39,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
           env === 'live' ? '' : `${env}.`
         }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
 
-        console.log(bffUrl);
+        cy.log(bffUrl);
         cy.request({
           url: bffUrl,
           headers: { 'ctx-service-env': env },

--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -19,8 +19,41 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
   service,
   pageType,
   variant,
-}) =>
+}) => {
+  let articlesData;
   describe(`Running testsForAMPOnly for ${service} ${pageType}`, () => {
+    before(() => {
+      const env = Cypress.env('APP_ENV');
+      if (env !== 'local') {
+        const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
+        let appendVariant = '';
+
+        // eslint-disable-next-line prefer-destructuring
+        const articleId = Cypress.env('currentPath')
+          .split('articles/')
+          .pop()
+          .split('?')[0];
+        cy.log(articleId);
+        if (scriptSwitchServices.includes(service)) {
+          appendVariant = `&variant=${variant}`;
+        }
+        const bffUrl = `https://web-cdn.${
+          env === 'live' ? '' : `${env}.`
+        }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
+
+        console.log(bffUrl);
+        cy.request({
+          url: bffUrl,
+          headers: { 'ctx-service-env': env },
+        }).then(({ body }) => {
+          articlesData = body;
+        });
+      } else {
+        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
+          articlesData = body;
+        });
+      }
+    });
     it('should contain an amp-img', () => {
       if (serviceHasFigure(service)) {
         cy.get('figure')
@@ -34,33 +67,29 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
 
     describe('Media Player: AMP', () => {
       it('should render a placeholder image', () => {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const media = getBlockData('video', body);
-          if (media && media.type === 'video') {
-            cy.get('[data-e2e="media-player"]').within(() => {
-              cy.get('div')
-                .should('have.attr', 'data-e2e')
-                .should('not.be.empty');
-            });
-          }
-        });
+        const media = getBlockData('video', articlesData);
+        if (media && media.type === 'video') {
+          cy.get('[data-e2e="media-player"]').within(() => {
+            cy.get('div')
+              .should('have.attr', 'data-e2e')
+              .should('not.be.empty');
+          });
+        }
       });
 
       it('should render an iframe with a valid URL', () => {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          const media = getBlockData('video', body);
-          if (media && media.type === 'video') {
-            const { lang } = appConfig[service][variant];
-            const embedUrl = getVideoEmbedUrl(body, lang, true);
-            cy.get(`amp-iframe[src="${embedUrl}"]`).should('be.visible');
-            cy.testResponseCodeAndTypeRetry({
-              path: embedUrl,
-              responseCode: 200,
-              type: 'text/html',
-              allowFallback: true,
-            });
-          }
-        });
+        const media = getBlockData('video', articlesData);
+        if (media && media.type === 'video') {
+          const { lang } = appConfig[service][variant];
+          const embedUrl = getVideoEmbedUrl(articlesData, lang, true);
+          cy.get(`amp-iframe[src="${embedUrl}"]`).should('be.visible');
+          cy.testResponseCodeAndTypeRetry({
+            path: embedUrl,
+            responseCode: 200,
+            type: 'text/html',
+            allowFallback: true,
+          });
+        }
       });
     });
 
@@ -164,7 +193,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
       }
     });
   });
-
+};
 // For testing low priority things e.g. cosmetic differences, and a safe place to put slow tests.
 export const testsThatNeverRunDuringSmokeTestingForAMPOnly = ({
   service,

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -25,10 +25,12 @@ export default ({ service, pageType, variant }) => {
           otherVariant = variant === 'simp' ? 'trad' : 'simp';
         }
       }
-
+      const env = Cypress.env('APP_ENV');
       // Gets the topic page data for all the tests
       cy.request(
-        `https://web-cdn.api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}`,
+        `https://web-cdn.${
+          env === 'live' ? '' : `${env}.`
+        }api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}`,
       ).then(({ body }) => {
         topicTitle = body.data.title;
         variantTopicId = body.data.variantTopicId;

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -12,33 +12,38 @@ export default ({ service, pageType, variant }) => {
     beforeEach(() => {
       cy.log(Cypress.env('currentPath'));
       cy.log(service);
-
-      // eslint-disable-next-line prefer-destructuring
-      topicId = Cypress.env('currentPath').split('topics/').pop().split('?')[0];
-
-      if (scriptSwitchServices.includes(service)) {
-        appendVariant = `&variant=${variant}`;
-        if (service === 'serbian') {
-          otherVariant = variant === 'lat' ? 'cyr' : 'lat';
-        }
-        if (service === 'ukchina' || service === 'zhongwen') {
-          otherVariant = variant === 'simp' ? 'trad' : 'simp';
-        }
-      }
       const env = Cypress.env('APP_ENV');
-      // Gets the topic page data for all the tests
-      cy.request(
-        `https://web-cdn.${
-          env === 'live' ? '' : `${env}.`
-        }api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}`,
-      ).then(({ body }) => {
-        topicTitle = body.data.title;
-        variantTopicId = body.data.variantTopicId;
-        pageCount = body.data.pageCount;
-        numberOfItems = body.data.curations[0].summaries.length;
-        firstItemHeadline = body.data.curations[0].summaries[0].title;
-      });
-      cy.log(`topic id ${topicId}`);
+      if (env !== 'local') {
+        // eslint-disable-next-line prefer-destructuring
+        topicId = Cypress.env('currentPath')
+          .split('topics/')
+          .pop()
+          .split('?')[0];
+
+        if (scriptSwitchServices.includes(service)) {
+          appendVariant = `&variant=${variant}`;
+          if (service === 'serbian') {
+            otherVariant = variant === 'lat' ? 'cyr' : 'lat';
+          }
+          if (service === 'ukchina' || service === 'zhongwen') {
+            otherVariant = variant === 'simp' ? 'trad' : 'simp';
+          }
+        }
+
+        // Gets the topic page data for all the tests
+        cy.request(
+          `https://web-cdn.${
+            env === 'live' ? '' : `${env}.`
+          }api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}`,
+        ).then(({ body }) => {
+          topicTitle = body.data.title;
+          variantTopicId = body.data.variantTopicId;
+          pageCount = body.data.pageCount;
+          numberOfItems = body.data.curations[0].summaries.length;
+          firstItemHeadline = body.data.curations[0].summaries[0].title;
+        });
+        cy.log(`topic id ${topicId}`);
+      }
     });
     describe(`Page content`, () => {
       it('should render a H1, which contains/displays topic title', () => {


### PR DESCRIPTION
Changed the source of the data the test acts on from requesting the json to requesting the BFF data with appropriate header.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
