### PR TITLE
RUM - ATI beacon resolve response fix

### DIFF
--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -7,7 +7,7 @@ const logger = nodeLogger(__filename);
 const sendBeacon = async url => {
   if (onClient()) {
     try {
-      await fetch(url, { credentials: 'include' });
+      await fetch(url, { credentials: 'include' }).then(res => res.text());
     } catch (e) {
       logger.error(e);
     }


### PR DESCRIPTION
**Overall change:**
Forces a resolve on the `sendBeacon` function for ATI. This could be the cause of the very high Cloudwatch RUM DOMContentLoaded timings.

The fetch request to ATI is potentially just 'hanging', causing the browser to think that the request has not been finished. This could cause RUM to think that the page isn't fully loaded.

Before / current behaviour:
<img width="2254" alt="Screenshot 2023-01-06 at 10 33 14" src="https://user-images.githubusercontent.com/11633031/210992468-1038f90e-1be2-4606-8124-7c0efc02e5b5.png">

After / with this change:
<img width="2253" alt="Screenshot 2023-01-06 at 10 34 19" src="https://user-images.githubusercontent.com/11633031/210992580-c4e7744d-a3ee-4161-b146-16877908e9d2.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
