### PR TITLE
Update links in the GPG Signing Guide

### DIFF
--- a/docs/GPG-Signing-Guide.md
+++ b/docs/GPG-Signing-Guide.md
@@ -29,27 +29,27 @@ Setting up GPG on a MacOS is actually quite simple. Please follow the links for 
 2. [Uninstall GPG Tools Mail](https://gpgtools.tenderapp.com/kb/faq/uninstall-gpg-suite#2-uninstall-gpgmail)
 3. Open the app and create a new key pair
    - The application will automatically prompt you
-4. [Add your public GPG key to GitHub](https://help.github.com/en/articles/adding-a-new-gpg-key-to-your-github-account)
-5. [Tell git about the gpg sign](https://help.github.com/en/articles/telling-git-about-your-signing-key)
-6. [Turn on commit signing](https://help.github.com/en/articles/signing-commits)
+4. [Add your public GPG key to GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account)
+5. [Tell git about the gpg sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
+6. [Turn on commit signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
 ## Automatic Signing
 
 In your local repository you can turn on automatic signing with this command:
 
-```
+```sh
 git config commit.gpgsign true
 ```
 
 If you want git to globally sign all commits that you make use this command:
 
-```
+```sh
 git config --global commit.gpgsign true
 ```
 
 ## Signing failures
 
-1. Make sure you follow the following step: https://help.github.com/en/articles/telling-git-about-your-signing-key
+1. Make sure you follow the following steps: https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key
 2. Install Pineentry from [link](https://www.gnupg.org/related_software/pinentry/index.en.html) or `homebrew`
 
 ```

--- a/docs/GPG-Signing-Guide.md
+++ b/docs/GPG-Signing-Guide.md
@@ -9,7 +9,7 @@ Please familiarise yourself with our:
 - [Contributing guidelines](https://github.com/bbc/simorgh/blob/latest/CONTRIBUTING.md)
 - [Guide to Code Reviews](https://github.com/bbc/simorgh/blob/latest/docs/Code-Reviews.md)
 - [Github Project Board Guide](https://github.com/bbc/simorgh/blob/latest/docs/Project-Board-Guide.md)
-- [GPG Signing Guide](docs/GPG-Signing-Guide.md) (you are here)
+- [GPG Signing Guide](./GPG-Signing-Guide.md#gpg-signing-guide) (you are here)
 - [Primary README](https://github.com/bbc/simorgh/blob/latest/README.md)
 - [Recommended Tools](https://github.com/bbc/simorgh/blob/latest/docs/Recommended-Tools.md)
 - [Troubleshooting](https://github.com/bbc/simorgh/blob/latest/docs/Troubleshooting.md)


### PR DESCRIPTION
Resolves #N/A

**Overall change:**
Fixing broken links in the GPG Signing Guide

**Code changes:**

- Docs changes only

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
