### PR TITLE
Adding a script to display a list of testable paths

### DIFF
--- a/scripts/testablePaths/index.js
+++ b/scripts/testablePaths/index.js
@@ -1,0 +1,52 @@
+const Table = require('cli-table');
+const allServices = require('../../cypress/support/config/settings/index.js');
+
+let defaultEnvironment = 'all';
+
+if (process.argv.length > 2) {
+  defaultEnvironment = process.argv[2];
+}
+
+const environmentDomainMappings = {
+  local: 'http://localhost:7080',
+  test: 'https://www.test.bbc.com',
+  live: 'https://www.bbc.com',
+};
+
+const getUrls = ({ paths, environment }) => {
+  const domain = environmentDomainMappings[environment];
+
+  if (typeof paths === 'string') {
+    return `${domain}${paths}`;
+  } else {
+    return paths.map(path => `${domain}${path}`).join('\n');
+  }
+};
+
+let testablePaths = [];
+
+const testablePathsTable = new Table({
+  head: ['Service', 'Page Type', 'Environment', 'Path(s)']
+});
+
+Object.values(allServices).forEach(({ name, variant, pageTypes }) => {
+    Object.entries(pageTypes).forEach(([pageType, { environments }]) => {
+
+      if (environments) {
+        let filteredEnvironments = environments;
+
+        if (defaultEnvironment !== 'all') {
+          filteredEnvironments = ({[defaultEnvironment]: environments[defaultEnvironment]});
+        }
+
+        Object.entries(filteredEnvironments).forEach(([environment, { enabled, paths }]) => {
+        if (enabled) {
+          const serviceNameWithVariant = `${name}${variant === 'default' ? '' : `/${variant}`}`;
+          testablePathsTable.push([serviceNameWithVariant, pageType, environment, getUrls({paths, environment})]);
+        }
+      });
+    }
+    });
+});
+
+console.log(testablePathsTable.toString());


### PR DESCRIPTION
Resolves #N/A

**Overall change:**
A script which outputs the services, page types, environments and list of paths which have been enabled in the cypress config file.

**Code changes:**

`node scripts/testablePaths` or `node scripts/testablePaths all` -> displays all enabled URLs for all environments
`node scripts/testablePaths local` -> displays only enabled URLs for local environment
`node scripts/testablePaths test` -> displays only enabled URLs for test environment
`node scripts/testablePaths live` -> displays only enabled URLs for live environment

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
- [ ] TODO: Add a readme to explain how to use this script

**Testing:**

- [ ] This PR requires manual testing
