### PR TITLE
FIX: deprecated header

### DIFF
--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -164,6 +164,7 @@ server.get(
     injectResourceHintsHeader,
   ],
   async ({ url, query, headers, path: urlPath }, res) => {
+    res.removeHeader('Expect-CT');
     logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
       url,
       headers: removeSensitiveHeaders(headers),


### PR DESCRIPTION
we're getting some lighthouse fails for deprecated API

https://chromestatus.com/feature/6244547273687040

this comes from default behaviour in helmet prior to version 6 https://github.com/helmetjs/helmet/issues/310#issuecomment-1214144819

This is a hotfix until we upgrade helmet