### PR TITLE
Skip failing topics test (first item headline test)

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -74,7 +74,7 @@ export default ({ service, pageType, variant }) => {
           .its('length')
           .should('eq', numberOfItems);
       });
-      it('First item has correct headline', () => {
+      it.skip('First item has correct headline', () => {
         cy.log(firstItemHeadline);
         // Goes down into the first item's h2 text and compares to title
         cy.get('[data-testid="topic-promos"]')


### PR DESCRIPTION
Test is very flakey due to caching. Also with video items in the promos, the video duration is included in the rendered headline, and not in the headline in the data it matches to. So the test will fail even more often with video promos being present.

The risk for removing this test is not too high: the only thing that can slip through without it is new promos not rendering when they should. This would be a big bad thing, but the test that checks the number of items on the page would sometime catch if promos were not rendering. It would not catch this always though as the page that is checked is page 1, which should always fill up with 24 items, even if these are not the most recent ones expected. 

To check if new promos are not rendering at all we would probably need to count the items on the LAST page, but this is likely to be as flakey as the test this PR is disabling because of the caching reason!

@paruchurisilpa @noagb any thoughts?

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
