### PR TITLE
Update Russian podcasts to remove Yandex links

### DIFF
--- a/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
+++ b/src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js
@@ -32,11 +32,6 @@ const externalLinks = {
         linkType: 'apple',
       },
       {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.com/album/7330688',
-        linkType: 'yandex',
-      },
-      {
         linkText: 'Castbox',
         linkUrl: 'https://castbox.fm/vc/2092482',
         linkType: 'castbox',
@@ -53,11 +48,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/gb/podcast/%D0%B0%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9-%D0%BF%D0%B8%D1%80%D0%BE%D0%B3/id1529622434',
         linkType: 'apple',
-      },
-      {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.com/album/11965335',
-        linkType: 'yandex',
       },
       {
         linkText: 'Castbox',
@@ -91,11 +81,6 @@ const externalLinks = {
         linkType: 'apple',
       },
       {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.ru/album/11522254',
-        linkType: 'yandex',
-      },
-      {
         linkText: 'Castbox',
         linkUrl:
           'https://castbox.fm/channel/id3130703?utm_campaign=i_share_ch&utm_medium=dlink&utm_source=i_share&country=us',
@@ -108,11 +93,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/%D0%BF%D0%B0%D1%81%D1%81%D0%B0%D0%B6%D0%B8%D1%80%D1%8B-%D0%B9%D0%BE%D0%BC%D0%B5%D0%B9-%D0%BC%D0%B0%D1%80%D1%83/id1575896140',
         linkType: 'apple',
-      },
-      {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.com/album/16801020',
-        linkType: 'yandex',
       },
       {
         linkText: 'Castbox',
@@ -132,11 +112,6 @@ const externalLinks = {
         linkUrl:
           'https://podcasts.apple.com/ru/podcast/8-%D0%B8%D1%81%D1%82%D0%BE%D1%80%D0%B8%D0%B9-%D0%B8%D0%B7-90-%D1%85/id1470221669',
         linkType: 'apple',
-      },
-      {
-        linkText: 'Yandex',
-        linkUrl: 'https://music.yandex.ru/album/9875407',
-        linkType: 'yandex',
       },
       {
         linkText: 'Castbox',


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
Removing all BBC Russian podcasts thirs party linkg to Yandex as Yandex is blocking all BBC Russian Podcasts.

**Code changes:**

- removed yandex links from src/app/routes/onDemandAudio/tempData/podcastExternalLinks/russian.js

---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
