### PR TITLE
[WSTEAM1-265] Add focus styling to external links on podcast page

### DIFF
--- a/src/app/legacy/containers/PodcastExternalLinks/Link.jsx
+++ b/src/app/legacy/containers/PodcastExternalLinks/Link.jsx
@@ -23,7 +23,7 @@ const Link = styled.a`
     color: ${C_METAL};
   }
 
-  &:focus,
+  &:focus > span,
   &:hover > span {
     text-decoration: underline;
   }

--- a/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/PodcastExternalLinks/__snapshots__/index.test.jsx.snap
@@ -105,7 +105,7 @@ exports[`PodcastExternalLinks Should render external links 1`] = `
   color: #6E6E73;
 }
 
-.emotion-8:focus,
+.emotion-8:focus>span,
 .emotion-8:hover>span {
   -webkit-text-decoration: underline;
   text-decoration: underline;


### PR DESCRIPTION
Resolves #[[WSTEAM1-265]](https://jira.dev.bbc.co.uk/browse/WSTEAM1-265)

**Overall change:**
Applies focus styling to the external links (e.g, Spotify, Apple, RSS etc) on podcast pages
(This fixes a P1 a11y bug)

**Code changes:**
- Add `> span` to target the nested external link with focus styling

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [x] This PR requires manual testing
