### PR TITLE
Improve cypress config - keep urls next to page type being tested

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -17,6 +17,7 @@
     "**/pages/testsForAllCanonicalPages.js",
     "**/pages/**/helper.js",
     "**/pages/**/helpers.js",
+    "**/pages/**/urls.js",
     "**/pages/**/getErrorPath.js",
     "**/123PlaygroundForTests/**",
     "**/specialFeatures/utilities/**",

--- a/cypress/integration/pages/articles/index.js
+++ b/cypress/integration/pages/articles/index.js
@@ -15,8 +15,11 @@ import {
   testsThatNeverRunDuringSmokeTestingForCanonicalOnly,
 } from './testsForCanonicalOnly';
 
+import urls from './urls';
+
 const testsForPage = {
   pageType: 'articles',
+  urls,
   testsThatAlwaysRun,
   testsThatAlwaysRunForCanonicalOnly,
   testsThatAlwaysRunForAMPOnly,

--- a/cypress/integration/pages/articles/urls.js
+++ b/cypress/integration/pages/articles/urls.js
@@ -1,11 +1,97 @@
 export default [
   {
     service: 'afaanoromoo',
-    test: ['/afaanoromoo/articles/c4g19kgl85ko'],
+    test: ['https://test.bbc.com/afaanoromoo/articles/c4g19kgl85ko'],
   },
   {
     service: 'afrique',
-    local: ['/afrique/articles/cz216x22106o'],
-    test: ['/afrique/articles/cz216x22106o'],
+    local: ['http://localhost:7080/afrique/articles/cz216x22106o'],
+    test: ['https://test.bbc.com/afrique/articles/cz216x22106o'],
+  },
+  {
+    service: 'azeri',
+    live: ['https://www.bbc.com/azeri/articles/cv0lm08kngmo'],
+  },
+  {
+    service: 'japanese',
+    local: ['http://localhost:7080/japanese/articles/cdd6p3r9g7jo'],
+    test: ['https://www.test.bbc.com/japanese/articles/cdd6p3r9g7jo'],
+    live: ['https://www.bbc.com/japanese/articles/cj4m7n5nrd8o'],
+  },
+  {
+    service: 'kyrgyz',
+    live: ['https://www.bbc.com/kyrgyz/articles/c414v42gy75o'],
+    test: ['https://www.test.bbc.com/kyrgyz/articles/c3xd4xg3rm9o'],
+  },
+  {
+    service: 'mundo',
+    local: ['http://localhost:7080/mundo/articles/ce42wzqr2mko'],
+    test: ['https://www.test.bbc.com/mundo/articles/ce42wzqr2mko'],
+    live: ['https://www.bbc.com/mundo/articles/cdwrpl7qwqqo'],
+  },
+  {
+    service: 'nepali',
+    local: ['http://localhost:7080/nepali/articles/cl90j9m3mn6o'],
+    test: ['https://www.test.bbc.com/nepali/articles/cl90j9m3mn6o'],
+    live: ['https://www.bbc.com/nepali/articles/c16ljg1v008o'],
+  },
+  {
+    service: 'news',
+    local: ['http://localhost:7080/news/articles/cn7k01xp8kxo'],
+    test: ['https://www.test.bbc.com/news/articles/cn7k01xp8kxo'],
+    live: ['https://www.bbc.com/news/articles/cj7xrxz0e8zo'],
+  },
+  {
+    service: 'persian',
+    local: ['http://localhost:7080/persian/articles/cej3lzd5e0go'],
+    test: ['https://www.test.bbc.com/persian/articles/cej3lzd5e0go'],
+    live: ['https://www.bbc.com/persian/articles/c7eel0lmr4do'],
+  },
+  {
+    service: 'pidgin',
+    local: ['http://localhost:7080/pidgin/articles/cwl08rd38l6o'],
+    test: ['https://www.test.bbc.com/pidgin/articles/cwl08rd38l6o'],
+    live: ['https://www.bbc.com/pidgin/articles/cgwk9w4zlg8o'],
+  },
+  {
+    service: 'scotland',
+    local: ['http://localhost:7080/scotland/articles/czwj5l0n210o'],
+    live: ['https://www.bbc.com/scotland/articles/cm49v4x1r9lo'],
+  },
+  {
+    service: 'serbian',
+    variant: 'cyr',
+    local: ['http://localhost:7080/serbian/articles/c805k05kr73o/cyr'],
+  },
+  {
+    service: 'serbian',
+    variant: 'lat',
+    local: ['http://localhost:7080/serbian/articles/c805k05kr73o/lat'],
+  },
+  {
+    service: 'ukchina',
+    variant: 'simp',
+    local: ['http://localhost:7080/ukchina/articles/c0e8weny66ko/simp'],
+  },
+  {
+    service: 'ukchina',
+    variant: 'trad',
+    local: ['http://localhost:7080/ukchina/articles/c0e8weny66ko/trad'],
+  },
+  {
+    service: 'ukrainian',
+    live: ['https://www.bbc.com/ukrainian/articles/c8zv0eed9gko'],
+    test: ['https://www.test.bbc.com/ukrainian/articles/cp4l2mrejvdo'],
+    local: ['http://localhost:7080/ukrainian/articles/cp4l2mrejvdo'],
+  },
+  {
+    service: 'zhongwen',
+    variant: 'simp',
+    local: ['http://localhost:7080/zhongwen/articles/c3xd4x9prgyo/simp'],
+  },
+  {
+    service: 'zhongwen',
+    variant: 'trad',
+    local: ['http://localhost:7080/zhongwen/articles/c3xd4x9prgyo/simp'],
   },
 ];

--- a/cypress/integration/pages/articles/urls.js
+++ b/cypress/integration/pages/articles/urls.js
@@ -1,0 +1,11 @@
+export default [
+  {
+    service: 'afaanoromoo',
+    test: ['/afaanoromoo/articles/c4g19kgl85ko'],
+  },
+  {
+    service: 'afrique',
+    local: ['/afrique/articles/cz216x22106o'],
+    test: ['/afrique/articles/cz216x22106o'],
+  },
+];

--- a/cypress/integration/pages/articles/urls.js
+++ b/cypress/integration/pages/articles/urls.js
@@ -80,9 +80,9 @@ export default [
   },
   {
     service: 'ukrainian',
-    live: ['https://www.bbc.com/ukrainian/articles/c8zv0eed9gko'],
-    test: ['https://www.test.bbc.com/ukrainian/articles/cp4l2mrejvdo'],
     local: ['http://localhost:7080/ukrainian/articles/cp4l2mrejvdo'],
+    test: ['https://www.test.bbc.com/ukrainian/articles/cp4l2mrejvdo'],
+    live: ['https://www.bbc.com/ukrainian/articles/c8zv0eed9gko'],
   },
   {
     service: 'zhongwen',

--- a/cypress/integration/pages/articles/urls.js
+++ b/cypress/integration/pages/articles/urls.js
@@ -92,6 +92,6 @@ export default [
   {
     service: 'zhongwen',
     variant: 'trad',
-    local: ['http://localhost:7080/zhongwen/articles/c3xd4x9prgyo/simp'],
+    local: ['http://localhost:7080/zhongwen/articles/c3xd4x9prgyo/trad'],
   },
 ];

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -27,6 +27,7 @@ import getAmpUrl from './getAmpUrl';
 // Pass arguments in from each page's index.js file
 const runTestsForPage = ({
   pageType,
+  urls,
   testsThatAlwaysRun,
   testsThatAlwaysRunForCanonicalOnly,
   testsThatAlwaysRunForAMPOnly,
@@ -39,11 +40,16 @@ const runTestsForPage = ({
 }) => {
   // For each Service and Page Type in the config file it visits the path and it writes a describe saying this.
 
+  if (urls) {
+    // eslint-disable-next-line no-console
+    console.log(`Urls provided for ${pageType} pageType`);
+  }
+
   Object.keys(config)
     .filter(service => serviceHasPageType(service, pageType))
     .forEach(service => {
-      const paths = getPaths(service, pageType);
       const { variant } = config[service];
+      const paths = getPaths(service, pageType);
 
       const defaultTestArgs = {
         service,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -29,7 +29,12 @@ const getTestablePaths = ({ urls, pageType }) => {
     console.log(`Urls provided for ${pageType} pageType`);
 
     return urls.map(({ service, variant = 'default', ...rest }) => {
-      const paths = rest[getAppEnv()] || [];
+      const pathsWithHost = rest[getAppEnv()] || [];
+
+      // Removes the host from the URL and just returns the path
+      const paths = pathsWithHost.map(
+        pathWithHost => new URL(pathWithHost).pathname,
+      );
 
       return {
         service,

--- a/cypress/support/helpers/runTestsForPage.js
+++ b/cypress/support/helpers/runTestsForPage.js
@@ -43,9 +43,18 @@ const runTestsForPage = ({
     .filter(service => serviceHasPageType(service, pageType))
     .forEach(service => {
       const paths = getPaths(service, pageType);
+      const { variant } = config[service];
+
+      const defaultTestArgs = {
+        service,
+        pageType,
+        variant,
+      };
 
       paths.forEach(currentPath => {
         describe(`${pageType} - ${currentPath} - Canonical`, () => {
+          const testArgs = defaultTestArgs;
+
           before(() => {
             Cypress.env('currentPath', currentPath);
 
@@ -74,12 +83,6 @@ const runTestsForPage = ({
             }
             visitPage(currentPath, pageType);
           });
-
-          const testArgs = {
-            service,
-            pageType,
-            variant: config[service].variant,
-          };
 
           if (!ampOnlyServices.includes(service)) {
             // Enables overriding of the smoke test values in the config/settings.js file
@@ -111,18 +114,16 @@ const runTestsForPage = ({
 
         // Switch to AMP page URL (NB all our pages have AMP variants)
         describe(`${pageType} - ${currentPath} - AMP`, () => {
+          const testArgs = {
+            ...defaultTestArgs,
+            isAmp: true,
+          };
+
           before(() => {
             Cypress.env('currentPath', currentPath);
 
             visitPage(getAmpUrl(currentPath), pageType);
           });
-
-          const testArgs = {
-            service,
-            pageType,
-            variant: config[service].variant,
-            isAmp: true,
-          };
 
           // Enables overriding of the smoke test values in the config/settings.js file
           testsThatAlwaysRunForAllPages(testArgs);


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
