### PR TITLE
Fix E2E hitting invalid .json endpoint for Articles

### DIFF
--- a/cypress/integration/pages/testsForAllPages.js
+++ b/cypress/integration/pages/testsForAllPages.js
@@ -4,7 +4,11 @@
 import topicTagsTest from '../../support/helpers/topicTagsTest';
 import checkA11y from '../../support/helpers/checkA11y';
 
-export const testsThatAlwaysRunForAllPages = ({ service, pageType }) => {
+export const testsThatAlwaysRunForAllPages = ({
+  service,
+  variant,
+  pageType,
+}) => {
   describe(`testsToAlwaysRunForAllPages to run for ${service} ${pageType}`, () => {
     it('should have no detectable a11y violations on page load', () => {
       checkA11y();
@@ -17,7 +21,7 @@ export const testsThatAlwaysRunForAllPages = ({ service, pageType }) => {
         service !== 'news' &&
         Cypress.env('APP_ENV') !== 'local'
       ) {
-        topicTagsTest();
+        topicTagsTest(service, variant, pageType);
       } else {
         cy.log('Topic tags currently disabled on Sport and Newsround');
       }

--- a/cypress/support/helpers/topicTagsTest.js
+++ b/cypress/support/helpers/topicTagsTest.js
@@ -32,7 +32,7 @@ const getPageData = (url, service, variant, pageType) => {
 };
 
 export default (service, variant, pageType) => {
-  cy.url().then(async url => {
+  cy.url().then(url => {
     const urlForData = url.replace('.amp', '');
 
     const firstVisitedPage = url;
@@ -94,33 +94,5 @@ export default (service, variant, pageType) => {
         cy.log('No topic tags in json');
       }
     });
-    // const env = Cypress.env('APP_ENV');
-
-    // if (env !== 'local' && pageType === 'article') {
-    //   const articleId =
-    //     Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
-
-    //   const bffUrl = `https://web-cdn.${
-    //     env === 'live' ? '' : `${env}.`
-    //   }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${
-    //     variant ? `&variant=${variant}` : ''
-    //   }`;
-
-    //   cy.log(bffUrl);
-    //   await cy
-    //     .request({
-    //       url: bffUrl,
-    //       headers: { 'ctx-service-env': env },
-    //     })
-    //     .then(({ body }) => {
-    //       pageBody = body;
-    //     });
-    // } else {
-    //   console.log('hit else');
-    //   cy.request(getDataUrl(urlForData)).then(({ body }) => {
-    //     pageBody = body;
-    //     console.log('request', body);
-    //   });
-    // }
   });
 };

--- a/cypress/support/helpers/topicTagsTest.js
+++ b/cypress/support/helpers/topicTagsTest.js
@@ -1,15 +1,52 @@
 import getDataUrl from './getDataUrl';
 import visitPage from './visitPage';
 
-export default () => {
-  cy.url().then(url => {
+const getPageData = (url, service, variant, pageType) => {
+  const env = Cypress.env('APP_ENV');
+  let pageBody;
+
+  const isBffFetch = pageType === 'articles';
+
+  if (!isBffFetch) {
+    pageBody = cy.request(getDataUrl(url)).then(({ body }) => body);
+  } else {
+    const articleId =
+      Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
+
+    const bffUrl = `https://web-cdn.${
+      env === 'live' ? '' : `${env}.`
+    }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${
+      variant ? `&variant=${variant}` : ''
+    }`;
+
+    cy.log(bffUrl);
+    pageBody = cy
+      .request({
+        url: bffUrl,
+        headers: { 'ctx-service-env': env },
+      })
+      .then(({ body }) => body);
+  }
+
+  return pageBody;
+};
+
+export default (service, variant, pageType) => {
+  cy.url().then(async url => {
     const urlForData = url.replace('.amp', '');
 
     const firstVisitedPage = url;
+    getPageData(urlForData, service, variant, pageType).then(body => {
+      let pageBody;
 
-    cy.request(getDataUrl(urlForData)).then(({ body }) => {
+      if (pageType === 'articles') {
+        pageBody = body.data.article;
+      } else {
+        pageBody = body;
+      }
+
       // Check if data has topic tags
-      const topicTagsPresent = body.metadata.topics;
+      const topicTagsPresent = pageBody.metadata.topics;
       let topicTagsLength = 0;
 
       // Get number of topic tags expected
@@ -57,5 +94,33 @@ export default () => {
         cy.log('No topic tags in json');
       }
     });
+    // const env = Cypress.env('APP_ENV');
+
+    // if (env !== 'local' && pageType === 'article') {
+    //   const articleId =
+    //     Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
+
+    //   const bffUrl = `https://web-cdn.${
+    //     env === 'live' ? '' : `${env}.`
+    //   }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${
+    //     variant ? `&variant=${variant}` : ''
+    //   }`;
+
+    //   cy.log(bffUrl);
+    //   await cy
+    //     .request({
+    //       url: bffUrl,
+    //       headers: { 'ctx-service-env': env },
+    //     })
+    //     .then(({ body }) => {
+    //       pageBody = body;
+    //     });
+    // } else {
+    //   console.log('hit else');
+    //   cy.request(getDataUrl(urlForData)).then(({ body }) => {
+    //     pageBody = body;
+    //     console.log('request', body);
+    //   });
+    // }
   });
 };


### PR DESCRIPTION
**Overall change:**
- Updates the topics tags E2E test suite to point to the BFF for Article pages, as the `.json` for them is in the process of being removed.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
