### PR TITLE
Suppress React hydration warning for timestamps

### DIFF
--- a/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-timestamp/src/index.jsx
@@ -44,6 +44,7 @@ const Timestamp = ({
     service={service}
     darkMode={darkMode}
     className={className}
+    suppressHydrationWarning
   >
     {children}
   </StyledTimestamp>


### PR DESCRIPTION
**Overall change:**
- Attempts to fix hydration errors for timestamps, as they can change between the server render and client hydration. This error is more announced with React 18 and may have been happening all along: https://beta.reactjs.org/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
