### PR TITLE
Add `suppressHydrationWarning` to date/time elements

### DIFF
--- a/src/app/legacy/components/Promo/media-icon.jsx
+++ b/src/app/legacy/components/Promo/media-icon.jsx
@@ -35,7 +35,11 @@ const formatChildren = children => {
   const duration = moment.duration(children, 'seconds');
   const durationString = formatDuration({ duration });
   const isoDuration = duration.toISOString();
-  return <StyledTime dateTime={isoDuration}>{durationString}</StyledTime>;
+  return (
+    <StyledTime dateTime={isoDuration} suppressHydrationWarning>
+      {durationString}
+    </StyledTime>
+  );
 };
 
 const MediaIcon = ({ script, service, children, type }) => {

--- a/src/app/legacy/components/RadioSchedule/ProgramCard/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ProgramCard/index.jsx
@@ -119,7 +119,7 @@ const ProgramCard = ({ program, id, ...props }) => {
         <IconWrapper {...programStateConfig[state]}>
           {mediaIcons.audio}
         </IconWrapper>
-        <DurationWrapper dir={dir} dateTime={duration}>
+        <DurationWrapper dir={dir} dateTime={duration} suppressHydrationWarning>
           <span aria-hidden="true">{formatDuration({ duration, locale })}</span>
         </DurationWrapper>
       </ButtonWrapper>

--- a/src/app/legacy/containers/OnDemandFooterTimestamp/index.jsx
+++ b/src/app/legacy/containers/OnDemandFooterTimestamp/index.jsx
@@ -48,6 +48,7 @@ const OnDemandFooterTimestamp = ({ releaseDateTimeStamp, darkMode }) => {
       service={service}
       darkMode={darkMode}
       dateTime={dateTime}
+      suppressHydrationWarning
     >
       {formattedTimestamp}
     </Wrapper>

--- a/src/app/legacy/containers/StoryPromo/MediaIndicator/index.jsx
+++ b/src/app/legacy/containers/StoryPromo/MediaIndicator/index.jsx
@@ -65,7 +65,9 @@ const MediaIndicatorContainer = ({ item, script, service, dir, isInline }) => {
     const isoDuration = duration.toISOString();
     return (
       <MediaIndicator type={type} script={script} service={service} dir={dir}>
-        <StyledTime dateTime={isoDuration}>{durationString}</StyledTime>
+        <StyledTime dateTime={isoDuration} suppressHydrationWarning>
+          {durationString}
+        </StyledTime>
       </MediaIndicator>
     );
   }

--- a/src/app/legacy/psammead/psammead-play-button/src/index.jsx
+++ b/src/app/legacy/psammead/psammead-play-button/src/index.jsx
@@ -88,7 +88,11 @@ const PlayButton = ({
         {mediaIcons[type]}
       </IconWrapper>
       {datetime && duration && durationSpoken && (
-        <TimeDuration dateTime={datetime} aria-hidden="true">
+        <TimeDuration
+          dateTime={datetime}
+          aria-hidden="true"
+          suppressHydrationWarning
+        >
           {duration}
         </TimeDuration>
       )}


### PR DESCRIPTION
**Code changes:**
- Adds `suppressHydrationWarning` flag to various elements that have a `dateTime` attribute and formatted date/time children

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
