### PR TITLE
Add Symbol polyfill for legacy browsers

### DIFF
--- a/src/poly/legacy.js
+++ b/src/poly/legacy.js
@@ -2,10 +2,7 @@
 // IE10
 import 'core-js/es/map';
 import 'core-js/es/set';
-
-// Needed by Styled Components
-// IE11, IE10
-// import 'core-js/es/symbol';
+import 'core-js/es/symbol';
 
 // Needed by React Loadable
 // IE11, IE10


### PR DESCRIPTION
**Overall change:**
- Polyfills `symbol` in an attempt to fix Opera Mini analytics issues after the React 18 upgrade.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
