### PR TITLE
Update social media embed disclaimer text for BBC Brasil

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -271,8 +271,8 @@ export const service: DefaultServiceConfig = {
           endTextVisuallyHidden: 'Final de %provider_name% post',
         },
         consentBanner: {
-          heading: `Aceita conteúdo de [social_media_site]?`,
-          body: `Este item inclui conteúdo extraído de [social_media_site]. Pedimos sua autorzação antes que algo seja carregado, pois eles podem estar utilizando cookies e outras tecnologias. Você pode consultar a [link] política de uso de cookies [/link] e [link] os termos de privacidade  [/link] do [social_media_site] antes de concordar. Para acessar o conteúdo clique em "aceitar e continuar".`,
+          heading: `Aceita conteúdo do [social_media_site]?`,
+          body: `Este item inclui conteúdo extraído do [social_media_site]. Pedimos sua autorização antes que algo seja carregado, pois eles podem estar utilizando cookies e outras tecnologias. Você pode consultar a [link] política de uso de cookies [/link] e [link] os termos de privacidade [/link] do [social_media_site] antes de concordar. Para acessar o conteúdo clique em "aceitar e continuar".`,
           button: 'Aceite e continue',
         },
       },


### PR DESCRIPTION
Resolves #n/a

**Overall change:**
FIx some typos on BBC Brasil's social media embed disclaimer.

**Code changes:**

- Edited heading and body in the ConsentBanner section of src/app/lib/config/services/portuguese.ts



![screengrab](https://user-images.githubusercontent.com/10046386/217268743-9b5fe0bc-f685-4867-aa7d-e6313056bbb2.jpg)



---

- [x] I have assigned myself to this PR and the corresponding issues
- [x] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [x] I have assigned this PR to the Simorgh project
- [x] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
