### PR TITLE
Cypress ignore React #418 hydration error

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,16 +13,25 @@ Cypress.on(`window:before:load`, win => {
   });
 });
 
-// Catches an unexplained error experienced while running the following test:
-// https://github.com/bbc/simorgh/blob/49e5b72db84df57144a92963734bcd080938e45b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js#L14
-// We decided we could not invest any more time in the unexplained error as the test
-// successfully functioned with this specific error caught and discarded.
+const KNOWN_ERRORS = [
+  // Catches an unexplained error experienced while running the following test:
+  // https://github.com/bbc/simorgh/blob/49e5b72db84df57144a92963734bcd080938e45b/cypress/integration/pages/storyPage/testsForCanonicalOnly.js#L14
+  // We decided we could not invest any more time in the unexplained error as the test
+  // successfully functioned with this specific error caught and discarded.
+  "Cannot read property 'postMessage' of undefined",
+  // Catches hydration errors that seem to occassionally occur. This happened since the React 18 upgrade:
+  // https://github.com/bbc/simorgh/pull/10550
+  // React 18 elevates hydration errors from 'warning' to 'error' level. So its likely this issue has
+  // always been present, but was not caught before.
+  'Minified React error #418',
+];
+
 // eslint-disable-next-line consistent-return
 Cypress.on('uncaught:exception', (err, runnable, promise) => {
   // returning false here prevents Cypress from failing the test
   if (
     err.message &&
-    err.message.includes("Cannot read property 'postMessage' of undefined")
+    KNOWN_ERRORS.some(knownErr => err.message.includes(knownErr))
   ) {
     return false;
   }


### PR DESCRIPTION
**Code changes:**
- Tells Cypress to ignore the [React 418 hydration error](https://reactjs.org/docs/error-decoder.html/?invariant=418). Spent a lot of time trying to narrow down the cause of this, but can't find the issue
- The problem has likely always been there, but the upgrade to React 18 causes this hydration message to be elevated from 'warning' to 'error' status, causing tests to fail
- There is no audience/performance impact here, just the error being more loud. I can't see any hydration errors locally and on Test/Live.

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
