### PR TITLE
[NWS-1677] Fix: sets Most Read URL depending on amp or canonical

### DIFF
--- a/src/app/legacy/containers/MostRead/Amp/index.jsx
+++ b/src/app/legacy/containers/MostRead/Amp/index.jsx
@@ -128,7 +128,11 @@ const AmpMostRead = ({ endpoint, size, wrapper: Wrapper }) => {
                 service={service}
                 script={script}
                 title="{{promo.headlines.shortHeadline}}"
-                href="{{promo.locators.assetUri}}"
+                href={
+                  MostReadRank.isAmp
+                    ? '{{promo.locators.canonicalUrl}}'
+                    : '{{promo.locators.assetUri}}'
+                }
                 size={size}
               />
             </MostReadItemWrapper>


### PR DESCRIPTION
Resolves #[NWS-1677](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1677)

**Overall change:**
Sets Most Read href depending on Amp or Canonical page

**Code changes:**

- Add conditional to href to check if on amp / canonical page and sets appropriate url
