### PR TITLE
FIX: `hasStoryRecommendations` was missing from Archive config

### DIFF
--- a/src/app/lib/config/services/archive.ts
+++ b/src/app/lib/config/services/archive.ts
@@ -218,6 +218,9 @@ export const service: DefaultServiceConfig = {
     radioSchedule: {
       hasRadioSchedule: false,
     },
+    recommendations: {
+      hasStoryRecommendations: false,
+    },
     footer: {
       externalLink: {
         href: 'https://www.bbc.co.uk/editorialguidelines/guidance/feeds-and-links',


### PR DESCRIPTION
missing `hasStoryRecommendations` leads to 500 errors on live
