### PR TITLE
NWS-1654: Improve Podcast image

### DIFF
--- a/src/app/legacy/containers/OnDemandImage/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/OnDemandImage/__snapshots__/index.test.jsx.snap
@@ -60,10 +60,10 @@ exports[`AudioPlayer blocks OnDemandHeading should render correctly 1`] = `
       <img
         alt="BBC News"
         class="emotion-4 emotion-5 emotion-6"
-        height="240"
+        height="256"
         sizes="(min-width: 1008px) 228px, 30vw"
         src="https://mock-url"
-        width="240"
+        width="256"
       />
     </div>
   </div>

--- a/src/app/legacy/containers/OnDemandImage/index.jsx
+++ b/src/app/legacy/containers/OnDemandImage/index.jsx
@@ -28,7 +28,7 @@ const getSrcSet = ({ imageUrl, sizes }) =>
   sizes.map(size => `${getSrc({ imageUrl, size })} ${size}w`).join(',');
 
 const smallImageSize = 128;
-const mediumImageSize = 240;
+const mediumImageSize = 256;
 const largeImageSize = 480;
 
 const OnDemandImage = ({ imageUrl, alt: altFromProps, dir }) => {
@@ -36,7 +36,7 @@ const OnDemandImage = ({ imageUrl, alt: altFromProps, dir }) => {
 
   const alt = is(String, altFromProps) ? altFromProps : defaultImageAltText;
 
-  const src = getSrc({ imageUrl, size: smallImageSize });
+  const src = getSrc({ imageUrl, size: mediumImageSize });
   const srcset = getSrcSet({
     imageUrl,
     sizes: [smallImageSize, mediumImageSize, largeImageSize],

--- a/src/app/legacy/containers/OnDemandImage/index.test.jsx
+++ b/src/app/legacy/containers/OnDemandImage/index.test.jsx
@@ -36,7 +36,7 @@ describe('AudioPlayer blocks OnDemandHeading', () => {
     );
     const img = getByAltText('BBC News پښتو');
     expect(img.src).toEqual(
-      'https://ichef.bbci.co.uk/images/ic/128x128/p063j1dv.jpg',
+      'https://ichef.bbci.co.uk/images/ic/256x256/p063j1dv.jpg',
     );
     expect(img.alt).toEqual('BBC News پښتو');
   });
@@ -63,7 +63,7 @@ describe('AudioPlayer blocks OnDemandHeading', () => {
     );
     const img = container.querySelector('amp-img');
     expect(img.getAttribute('src')).toEqual(
-      'https://ichef.bbci.co.uk/images/ic/128x128/p063j1dv.jpg',
+      'https://ichef.bbci.co.uk/images/ic/256x256/p063j1dv.jpg',
     );
     expect(img.getAttribute('alt')).toEqual('BBC News Afaan Oromoo');
     expect(img.getAttribute('layout')).toEqual('responsive');

--- a/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/OnDemandAudioPage/__snapshots__/index.test.jsx.snap
@@ -854,11 +854,11 @@ exports[`OnDemand Radio Page  should match snapshot for AMP 1`] = `
                 alt="BBC News پښتو"
                 attribution=""
                 fallback=""
-                height="240"
+                height="256"
                 layout="responsive"
-                src="https://ichef.bbci.co.uk/images/ic/128x128/p08b23c8.png"
+                src="https://ichef.bbci.co.uk/images/ic/256x256/p08b23c8.png"
                 style="background-color: rgb(253, 253, 253);"
-                width="240"
+                width="256"
               />
             </div>
           </div>
@@ -1784,10 +1784,10 @@ exports[`OnDemand Radio Page  should match snapshot for Canonical 1`] = `
               <img
                 alt="BBC News پښتو"
                 class="emotion-29 emotion-30 emotion-31"
-                height="240"
+                height="256"
                 sizes="(min-width: 1008px) 228px, 30vw"
-                src="https://ichef.bbci.co.uk/images/ic/128x128/p08b23c8.png"
-                width="240"
+                src="https://ichef.bbci.co.uk/images/ic/256x256/p08b23c8.png"
+                width="256"
               />
             </div>
           </div>
@@ -2677,10 +2677,10 @@ exports[`OnDemand Radio Page  should show the 'content not yet available' messag
               <img
                 alt="BBC News 코리아"
                 class="emotion-29 emotion-30 emotion-31"
-                height="240"
+                height="256"
                 sizes="(min-width: 1008px) 228px, 30vw"
-                src="https://ichef.bbci.co.uk/images/ic/128x128/p08b8lzc.png"
-                width="240"
+                src="https://ichef.bbci.co.uk/images/ic/256x256/p08b8lzc.png"
+                width="256"
               />
             </div>
           </div>
@@ -3531,10 +3531,10 @@ exports[`OnDemand Radio Page  should show the expired content message if episode
               <img
                 alt="BBC News 코리아"
                 class="emotion-29 emotion-30 emotion-31"
-                height="240"
+                height="256"
                 sizes="(min-width: 1008px) 228px, 30vw"
-                src="https://ichef.bbci.co.uk/images/ic/128x128/p08b8lzc.png"
-                width="240"
+                src="https://ichef.bbci.co.uk/images/ic/256x256/p08b8lzc.png"
+                width="256"
               />
             </div>
           </div>


### PR DESCRIPTION
Resolves[ #1654](https://jira.dev.bbc.co.uk/browse/NEWSWORLDSERVICE-1654)

**Overall change:**
Improve the quality of the podcast promo image by Increasing its intrinsic size from 128x128px to 256x256px.

**Code changes:**

- Change the intrinsic image size by changing the image size variables in the the image URL
- Increase the medium size from 240px to 256px (nearest size allowed by ichef, recommended by Jira ticket)
- Update test and snapshot.
- 
You can see this update in [this Chromatic link.](https://5d28eb3fe163f6002046d6fa-ohplervkcg.chromatic.com/?path=/story/pages-ondemand-radio-page--page)

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
