### PR TITLE
WSTEAMA-255: Simple homepage component 😮 

### DIFF
--- a/src/app/models/types/global.ts
+++ b/src/app/models/types/global.ts
@@ -18,7 +18,8 @@ export type PageTypes =
   | 'STY'
   | 'PGL'
   | 'CSP'
-  | 'TOPIC';
+  | 'TOPIC'
+  | 'HOME';
 
 export type SerbianService = {
   service: 'serbian';

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -3,6 +3,6 @@
 import { jsx } from '@emotion/react';
 
 const HomePage = () => {
-  return <div>Hi, I am a Home Page component</div>;
+  return <div>Hi, I am a Home Page component!</div>;
 };
 export default HomePage;

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -1,0 +1,8 @@
+/** @jsx jsx */
+/* @jsxFrag React.Fragment */
+import { jsx } from '@emotion/react';
+
+const HomePage = () => {
+  return <div>Hi, I am a Home Page component</div>;
+};
+export default HomePage;

--- a/src/app/pages/HomePage/index.stories.tsx
+++ b/src/app/pages/HomePage/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { withKnobs } from '@storybook/addon-knobs';
+import { HOME_PAGE } from '#app/routes/utils/pageTypes';
 import { ServiceContextProvider } from '../../contexts/ServiceContext';
 import { withServicesKnob } from '../../legacy/psammead/psammead-storybook-helpers/src';
 import ThemeProvider from '../../components/ThemeProvider';
@@ -16,7 +17,15 @@ const Component = ({ service, variant }: Props) => {
   return (
     <ThemeProvider service={service} variant={variant}>
       <ServiceContextProvider service={service} variant={variant}>
-        <HomePage />
+        <HomePage
+          service={service}
+          variant={variant}
+          pageType={HOME_PAGE}
+          status={200}
+          isAmp={false}
+          pathname="/kyrgyz"
+          pageData={{ status: 200 }}
+        />
       </ServiceContextProvider>
     </ThemeProvider>
   );

--- a/src/app/pages/HomePage/index.stories.tsx
+++ b/src/app/pages/HomePage/index.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { withKnobs } from '@storybook/addon-knobs';
+import { ServiceContextProvider } from '../../contexts/ServiceContext';
+import { withServicesKnob } from '../../legacy/psammead/psammead-storybook-helpers/src';
+import ThemeProvider from '../../components/ThemeProvider';
+import { Services, Variants } from '../../models/types/global';
+import HomePage from '.';
+
+interface Props {
+  service: Services;
+  variant: Variants;
+}
+
+const Component = ({ service, variant }: Props) => {
+  return (
+    <ThemeProvider service={service} variant={variant}>
+      <ServiceContextProvider service={service} variant={variant}>
+        <HomePage />
+      </ServiceContextProvider>
+    </ThemeProvider>
+  );
+};
+
+export default {
+  Component,
+  title: 'Pages/Home Page',
+  decorators: [withKnobs, withServicesKnob()],
+};
+
+export const Example = Component;

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -1,0 +1,1 @@
+export default () => {};

--- a/src/app/pages/HomePage/index.test.tsx
+++ b/src/app/pages/HomePage/index.test.tsx
@@ -1,1 +1,13 @@
-export default () => {};
+import React from 'react';
+import { render } from '../../components/react-testing-library-with-providers';
+import HomePage from './HomePage';
+
+describe('Home Page', () => {
+  it('should render a hello message', () => {
+    const { container } = render(<HomePage />);
+    expect(container).not.toBeEmptyDOMElement();
+    expect(container.firstChild?.textContent).toBe(
+      'Hi, I am a Home Page component!',
+    );
+  });
+});

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,6 +1,9 @@
+import pipe from 'ramda/src/pipe';
 import HomePage from './HomePage';
 import applyBasicPageHandlers from '../utils/applyBasicPageHandlers';
 
-export default applyBasicPageHandlers({
-  addVariantHandling: true,
-})(HomePage);
+export default pipe(
+  applyBasicPageHandlers({
+    addVariantHandling: true,
+  }),
+)(HomePage);

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,8 +1,6 @@
-/** @jsx jsx */
-/* @jsxFrag React.Fragment */
-import { jsx } from '@emotion/react';
+import HomePage from './HomePage';
+import applyBasicPageHandlers from '../utils/applyBasicPageHandlers';
 
-const HomePage = () => {
-  return <div>Hi, I am a Home Page component</div>;
-};
-export default HomePage;
+export default applyBasicPageHandlers({
+  addVariantHandling: true,
+})(HomePage);

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,0 +1,8 @@
+/** @jsx jsx */
+/* @jsxFrag React.Fragment */
+import { jsx } from '@emotion/react';
+
+const HomePage = () => {
+  return <div>Hi, I am a Home Page component</div>;
+};
+export default HomePage;

--- a/src/app/routes/utils/pageTypes.js
+++ b/src/app/routes/utils/pageTypes.js
@@ -12,3 +12,4 @@ export const PHOTO_GALLERY_PAGE = 'PGL';
 export const CORRESPONDENT_STORY_PAGE = 'CSP';
 export const TOPIC_PAGE = 'TOPIC';
 export const LIVE_PAGE = 'LIVE';
+export const HOME_PAGE = 'HOME';


### PR DESCRIPTION
Resolves WSTEAMA-255

**Overall change:**
Simple Homepage Component

**Code changes:**
- New component written in Typescript, for the HomePage, which has navigation and footer, and displays the text "Hi, I am a HomePage Component!"
- Example on Storybook

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
