### PR TITLE
FIX: Fix flaking Most Read test.

### DIFF
--- a/cypress/integration/pages/articles/helpers.js
+++ b/cypress/integration/pages/articles/helpers.js
@@ -1,5 +1,3 @@
-import paths from 'ramda/src/paths';
-// import path from 'ramda/src/path';
 import envConfig from '../../../support/config/envs';
 
 export const getBlockByType = (blocks, blockType) => {
@@ -51,16 +49,4 @@ export const getVideoEmbedUrl = (body, language, isAmp = false) => {
   ].join('/');
 
   return isAmp ? `${embedUrl}/amp` : embedUrl;
-};
-
-export const getMostReadUrl = record => {
-  const [cpsUrl, optimoUrl] = paths(
-    [
-      ['promo', 'locators', 'assetUri'],
-      ['promo', 'locators', 'canonicalUrl'],
-    ],
-    record,
-  );
-
-  return cpsUrl || optimoUrl;
 };

--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -1,6 +1,6 @@
 import path from 'ramda/src/path';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
-import { getBlockData, getVideoEmbedUrl, getMostReadUrl } from './helpers';
+import { getBlockData, getVideoEmbedUrl } from './helpers';
 import config from '../../../support/config/services';
 import { serviceNumerals } from '../../../../src/app/legacy/containers/MostRead/Canonical/Rank';
 
@@ -147,7 +147,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
             });
           });
         });
-        it(`Most read list should contain hrefs`, () => {
+        it(`Most read list should contain hrefs that are not empty`, () => {
           cy.request(mostReadPath).then(({ body: mostReadJson }) => {
             const mostReadRecords = mostReadJson.totalRecords;
             cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
@@ -160,34 +160,10 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
                 cy.get('[data-e2e="most-read"] > amp-list div')
                   .next()
                   .within(() => {
-                    cy.get('a').should('have.attr', 'href');
-                  });
-              }
-            });
-          });
-        });
-
-        it(`Most read list should contain hrefs that match JSON data`, () => {
-          cy.request(mostReadPath).then(({ body: mostReadJson }) => {
-            const mostReadRecords = mostReadJson.totalRecords;
-            cy.fixture(`toggles/${config[service].name}.json`).then(toggles => {
-              const mostReadIsEnabled = path(['mostRead', 'enabled'], toggles);
-              cy.log(
-                `Most read container toggle enabled? ${mostReadIsEnabled}`,
-              );
-              if (mostReadIsEnabled && mostReadRecords >= 5) {
-                const records = path(['records'], mostReadJson);
-                const ListOfMostReadUrlsInOrder = records.map(record =>
-                  getMostReadUrl(record),
-                );
-                cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
-                  .next()
-                  .within(() => {
-                    cy.get('a').each(($el, index) => {
+                    cy.get('a').each($el => {
                       cy.wrap($el)
-                        .invoke('attr', 'href')
-                        .should('contain', ListOfMostReadUrlsInOrder[index]);
+                        .should('have.attr', 'href')
+                        .should('not.be.empty');
                     });
                   });
               }


### PR DESCRIPTION
FIX

**Overall change:**
Fixs flakey test introduced by [NWS-1677](https://github.com/bbc/simorgh/pull/10608)

**Code changes:**

- Removed flakey test and dedicated helper function
- Add condition to existing test so that it checks the href value is not empty.

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
