### PR TITLE
Set Node version in E2E GitHub action

### DIFF
--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
     env:
       CI: true
       LOG_LEVEL: 'error'
@@ -25,6 +28,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
       - name: Run Simorgh E2Es
         uses: cypress-io/github-action@v3
         with:


### PR DESCRIPTION
**Overall change:**
- Updates the `simorgh-e2e-tests` workflow to set the Node version to `16.x` as this appeared to be defaulting to a version of Node 18.x from the `cypress-io` Git action.
<img width="294" alt="Screenshot 2023-02-20 at 09 47 46" src="https://user-images.githubusercontent.com/11633031/220070827-584f8521-8d7c-48f7-aa0c-4878a06163b2.png">

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
