### PR TITLE
Fix Topics E2E article page data fetch

### DIFF
--- a/cypress/integration/pages/articles/helpers.js
+++ b/cypress/integration/pages/articles/helpers.js
@@ -50,3 +50,25 @@ export const getVideoEmbedUrl = (body, language, isAmp = false) => {
 
   return isAmp ? `${embedUrl}/amp` : embedUrl;
 };
+
+export const fetchArticlePageData = async (service, variant, urlOverride) => {
+  const env = Cypress.env('APP_ENV');
+  if (env !== 'local') {
+    const articleId =
+      urlOverride ||
+      Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
+
+    const bffUrl = `https://web-cdn.${
+      env === 'live' ? '' : `${env}.`
+    }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${
+      variant ? `&variant=${variant}` : ''
+    }`;
+
+    cy.log(bffUrl);
+    return cy.request({
+      url: bffUrl,
+      headers: { 'ctx-service-env': env },
+    });
+  }
+  return cy.request(`${urlOverride || Cypress.env('currentPath')}.json`);
+};

--- a/cypress/integration/pages/articles/tests.js
+++ b/cypress/integration/pages/articles/tests.js
@@ -5,6 +5,7 @@ import {
   getBlockData,
   getAllBlocksDataByType,
   getAllSocialBlocksByProviderName,
+  fetchArticlePageData,
 } from './helpers';
 
 // TODO: Remove after https://github.com/bbc/simorgh/issues/2959
@@ -34,35 +35,10 @@ export const testsThatFollowSmokeTestConfig = ({
 }) => {
   let articlesData;
   describe(`Running tests for ${service} ${pageType}`, () => {
-    before(() => {
-      const env = Cypress.env('APP_ENV');
-      if (env !== 'local') {
-        const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
-        let appendVariant = '';
-
-        // eslint-disable-next-line prefer-destructuring
-        const articleId =
-          Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
-
-        if (scriptSwitchServices.includes(service)) {
-          appendVariant = `&variant=${variant}`;
-        }
-        const bffUrl = `https://web-cdn.${
-          env === 'live' ? '' : `${env}.`
-        }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
-
-        cy.log(bffUrl);
-        cy.request({
-          url: bffUrl,
-          headers: { 'ctx-service-env': env },
-        }).then(({ body }) => {
-          articlesData = body;
-        });
-      } else {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          articlesData = body;
-        });
-      }
+    before(async () => {
+      articlesData = await fetchArticlePageData(service, variant).then(
+        ({ body }) => body,
+      );
     });
     describe(`Metadata`, () => {
       // Here we should only have metadata tests that are unique to articles pages

--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -1,6 +1,10 @@
 import path from 'ramda/src/path';
 import appConfig from '../../../../src/server/utilities/serviceConfigs';
-import { getBlockData, getVideoEmbedUrl } from './helpers';
+import {
+  getBlockData,
+  getVideoEmbedUrl,
+  fetchArticlePageData,
+} from './helpers';
 import config from '../../../support/config/services';
 import { serviceNumerals } from '../../../../src/app/legacy/containers/MostRead/Canonical/Rank';
 
@@ -22,35 +26,10 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
 }) => {
   let articlesData;
   describe(`Running testsForAMPOnly for ${service} ${pageType}`, () => {
-    before(() => {
-      const env = Cypress.env('APP_ENV');
-      if (env !== 'local') {
-        const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
-        let appendVariant = '';
-
-        // eslint-disable-next-line prefer-destructuring
-        const articleId =
-          Cypress.env('currentPath').match(/(c[a-zA-Z0-9]{10}o)/)?.[1];
-
-        if (scriptSwitchServices.includes(service)) {
-          appendVariant = `&variant=${variant}`;
-        }
-        const bffUrl = `https://web-cdn.${
-          env === 'live' ? '' : `${env}.`
-        }api.bbci.co.uk/fd/simorgh-bff?pageType=article&id=${articleId}&service=${service}${appendVariant}`;
-
-        cy.log(bffUrl);
-        cy.request({
-          url: bffUrl,
-          headers: { 'ctx-service-env': env },
-        }).then(({ body }) => {
-          articlesData = body;
-        });
-      } else {
-        cy.request(`${Cypress.env('currentPath')}.json`).then(({ body }) => {
-          articlesData = body;
-        });
-      }
+    before(async () => {
+      articlesData = await fetchArticlePageData(service, variant).then(
+        ({ body }) => body,
+      );
     });
     it('should contain an amp-img', () => {
       if (serviceHasFigure(service)) {

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -1,3 +1,5 @@
+import { fetchArticlePageData } from '../articles/helpers';
+
 export default ({ service, pageType, variant }) => {
   let topicId;
   let variantTopicId;
@@ -99,29 +101,33 @@ export default ({ service, pageType, variant }) => {
                 cy.get('a').click();
                 cy.url()
                   .should('eq', $href)
-                  .then(url => {
+                  .then(async url => {
                     // Check the page navigated to has the short headline that was on the topic item
-                    cy.request(`${url}.json`).then(({ body }) => {
-                      if (body.metadata.locators.cpsUrn) {
-                        cy.log('cps article');
-                        const { shortHeadline } = body.promo.headlines;
-                        expect(shortHeadline).to.equal(firstItemHeadline);
-                      }
-                      if (body.promo.locators.optimoUrn) {
-                        cy.log('optimo article');
-                        cy.window().then(win => {
-                          const jsonData = win.SIMORGH_DATA.pageData;
-                          const headline =
-                            jsonData.promo.headlines.promoHeadline.blocks[0]
-                              .model.blocks[0].model.text;
-                          cy.log(
-                            jsonData.promo.headlines.promoHeadline.blocks[0]
-                              .model.blocks[0].model.text,
-                          );
-                          expect(headline).to.equal(firstItemHeadline);
-                        });
-                      }
-                    });
+                    const articleBody = await fetchArticlePageData(
+                      service,
+                      variant,
+                      url,
+                    ).then(({ body }) => body);
+
+                    if (articleBody.metadata.locators.cpsUrn) {
+                      cy.log('cps article');
+                      const { shortHeadline } = articleBody.promo.headlines;
+                      expect(shortHeadline).to.equal(firstItemHeadline);
+                    }
+                    if (articleBody.promo.locators.optimoUrn) {
+                      cy.log('optimo article');
+                      cy.window().then(win => {
+                        const jsonData = win.SIMORGH_DATA.pageData;
+                        const headline =
+                          jsonData.promo.headlines.promoHeadline.blocks[0].model
+                            .blocks[0].model.text;
+                        cy.log(
+                          jsonData.promo.headlines.promoHeadline.blocks[0].model
+                            .blocks[0].model.text,
+                        );
+                        expect(headline).to.equal(firstItemHeadline);
+                      });
+                    }
                   });
               });
           });

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -1,5 +1,3 @@
-import { fetchArticlePageData } from '../articles/helpers';
-
 export default ({ service, pageType, variant }) => {
   let topicId;
   let variantTopicId;
@@ -95,40 +93,27 @@ export default ({ service, pageType, variant }) => {
             cy.get('a')
               .should('have.attr', 'href')
               .then($href => {
-                cy.log($href);
+                cy.visit($href);
+                cy.window().then(win => {
+                  const jsonData = win.SIMORGH_DATA.pageData;
 
-                // Clicks the first item, then checks the page navigates to has the expected url
-                cy.get('a').click();
-                cy.url()
-                  .should('eq', $href)
-                  .then(async url => {
-                    // Check the page navigated to has the short headline that was on the topic item
-                    const articleBody = await fetchArticlePageData(
-                      service,
-                      variant,
-                      url,
-                    ).then(({ body }) => body);
-
-                    if (articleBody.metadata.locators.cpsUrn) {
-                      cy.log('cps article');
-                      const { shortHeadline } = articleBody.promo.headlines;
-                      expect(shortHeadline).to.equal(firstItemHeadline);
-                    }
-                    if (articleBody.promo.locators.optimoUrn) {
-                      cy.log('optimo article');
-                      cy.window().then(win => {
-                        const jsonData = win.SIMORGH_DATA.pageData;
-                        const headline =
-                          jsonData.promo.headlines.promoHeadline.blocks[0].model
-                            .blocks[0].model.text;
-                        cy.log(
-                          jsonData.promo.headlines.promoHeadline.blocks[0].model
-                            .blocks[0].model.text,
-                        );
-                        expect(headline).to.equal(firstItemHeadline);
-                      });
-                    }
-                  });
+                  if (jsonData.metadata.locators.cpsUrn) {
+                    cy.log('cps article');
+                    const { shortHeadline } = jsonData.promo.headlines;
+                    expect(shortHeadline).to.equal(firstItemHeadline);
+                  }
+                  if (jsonData.metadata.locators.optimoUrn) {
+                    cy.log('optimo article');
+                    const headline =
+                      jsonData.promo.headlines.promoHeadline.blocks[0].model
+                        .blocks[0].model.text;
+                    cy.log(
+                      jsonData.promo.headlines.promoHeadline.blocks[0].model
+                        .blocks[0].model.text,
+                    );
+                    expect(headline).to.equal(firstItemHeadline);
+                  }
+                });
               });
           });
       });


### PR DESCRIPTION
**Overall change:**
- Updates the Topics E2E to check the `win.SIMORGH_DATA.pageData` object when extracting the headline values, instead of fetching from the `.json` endpoint which is now defunct for Article pages
- Extracts the Article page BFF fetch into a helper function that can be reused

---

- [x] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
