### PR TITLE
Add better ATI beacon error logging

### DIFF
--- a/src/app/lib/analyticsUtils/sendBeacon/index.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.js
@@ -1,5 +1,6 @@
 import onClient from '../../utilities/onClient';
 import nodeLogger from '../../logger.node';
+import { ATI_LOGGING_ERROR } from '../../logger.const';
 import 'isomorphic-fetch';
 
 const logger = nodeLogger(__filename);
@@ -8,8 +9,10 @@ const sendBeacon = async url => {
   if (onClient()) {
     try {
       await fetch(url, { credentials: 'include' }).then(res => res.text());
-    } catch (e) {
-      logger.error(e);
+    } catch (error) {
+      logger.error(ATI_LOGGING_ERROR, {
+        error,
+      });
     }
   }
 };

--- a/src/app/lib/analyticsUtils/sendBeacon/index.test.js
+++ b/src/app/lib/analyticsUtils/sendBeacon/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 import loggerMock from '#testHelpers/loggerMock';
+import { ATI_LOGGING_ERROR } from '#app/lib/logger.const';
 
 let fetchResponse;
 let isOnClient;
@@ -54,7 +55,9 @@ describe('sendBeacon', () => {
 
       await sendBeacon('https://foobar.com');
 
-      expect(loggerMock.error).toHaveBeenCalledWith(error);
+      expect(loggerMock.error).toHaveBeenCalledWith(ATI_LOGGING_ERROR, {
+        error,
+      });
     });
   });
 });

--- a/src/app/lib/logger.const.js
+++ b/src/app/lib/logger.const.js
@@ -87,6 +87,9 @@ const logCodes = {
 
   // Recommendations
   RECOMMENDATIONS_MISSING_DATA: 'recommendations_missing_data',
+
+  // Logging
+  ATI_LOGGING_ERROR: 'ati_logging_error',
 };
 
 module.exports = logCodes;


### PR DESCRIPTION
Resolves NEWSWORLDSERVICE-1678

**Overall change:**
Improves the error logging of the ATI beacon with by adding more filterable parameters

**Code changes:**
- Updates the ATI beacon `catch` to log errors more cleanly
- Adds a new `ATI_LOGGING_ERROR` const value

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
