### PR TITLE
Fix Topic E2E page navigation bug

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -9,7 +9,7 @@ export default ({ service, pageType, variant }) => {
   const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
   let otherVariant;
   describe(`Tests for ${service} ${pageType}`, () => {
-    before(() => {
+    beforeEach(() => {
       cy.log(Cypress.env('currentPath'));
       cy.log(service);
       const env = Cypress.env('APP_ENV');

--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -9,7 +9,7 @@ export default ({ service, pageType, variant }) => {
   const scriptSwitchServices = ['serbian', 'ukchina', 'zhongwen'];
   let otherVariant;
   describe(`Tests for ${service} ${pageType}`, () => {
-    beforeEach(() => {
+    before(() => {
       cy.log(Cypress.env('currentPath'));
       cy.log(service);
       const env = Cypress.env('APP_ENV');
@@ -93,27 +93,31 @@ export default ({ service, pageType, variant }) => {
             cy.get('a')
               .should('have.attr', 'href')
               .then($href => {
-                cy.visit($href);
-                cy.window().then(win => {
-                  const jsonData = win.SIMORGH_DATA.pageData;
+                cy.get('a').click();
+                cy.url()
+                  .should('eq', $href)
+                  .then(() => {
+                    cy.window().then(win => {
+                      const jsonData = win.SIMORGH_DATA.pageData;
 
-                  if (jsonData.metadata.locators.cpsUrn) {
-                    cy.log('cps article');
-                    const { shortHeadline } = jsonData.promo.headlines;
-                    expect(shortHeadline).to.equal(firstItemHeadline);
-                  }
-                  if (jsonData.metadata.locators.optimoUrn) {
-                    cy.log('optimo article');
-                    const headline =
-                      jsonData.promo.headlines.promoHeadline.blocks[0].model
-                        .blocks[0].model.text;
-                    cy.log(
-                      jsonData.promo.headlines.promoHeadline.blocks[0].model
-                        .blocks[0].model.text,
-                    );
-                    expect(headline).to.equal(firstItemHeadline);
-                  }
-                });
+                      if (jsonData.metadata.locators.cpsUrn) {
+                        cy.log('cps article');
+                        const { shortHeadline } = jsonData.promo.headlines;
+                        expect(shortHeadline).to.equal(firstItemHeadline);
+                      }
+                      if (jsonData.metadata.locators.optimoUrn) {
+                        cy.log('optimo article');
+                        const headline =
+                          jsonData.promo.headlines.promoHeadline.blocks[0].model
+                            .blocks[0].model.text;
+                        cy.log(
+                          jsonData.promo.headlines.promoHeadline.blocks[0].model
+                            .blocks[0].model.text,
+                        );
+                        expect(headline).to.equal(firstItemHeadline);
+                      }
+                    });
+                  });
               });
           });
       });


### PR DESCRIPTION
Fixes a navigation bug that was introduced in https://github.com/bbc/simorgh/pull/10632, so this puts it back to the old navigation approach, but still making use of the `win.SIMORGH_DATA.pageData` object instead of fetching the page data manually

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
