### PR TITLE
WSTEAM-262: Add additional tracking components to Article Page

### DIFF
--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -40,6 +40,7 @@ import ATIAnalytics from '#containers/ATIAnalytics';
 import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
+import OptimizelyArticleCompleteTracking from '#containers/OptimizelyArticleCompleteTracking';
 import articleMediaPlayer from '#containers/ArticleMediaPlayer';
 import LinkedData from '#containers/LinkedData';
 import MostReadContainer from '#containers/MostRead';
@@ -285,6 +286,7 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
         wrapper={MostReadWrapper}
       />
       <OptimizelyPageViewTracking />
+      <OptimizelyArticleCompleteTracking />
     </Wrapper>
   );
 };

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
@@ -15,6 +15,7 @@ import {
 } from './index.styles';
 import TopStoriesItem from './TopStoriesItem';
 import generatePromoId from '../generatePromoId';
+import { OptimizelyContext } from '@optimizely/react-sdk';
 
 const renderTopStoriesList = (item, index, eventTrackingData, viewRef) => {
   const contentType = pathOr('', ['contentType'], item);
@@ -45,10 +46,11 @@ const renderTopStoriesList = (item, index, eventTrackingData, viewRef) => {
 
 const TopStoriesSection = ({ content }) => {
   const { translations, script, service } = useContext(ServiceContext);
-
+  const { optimizely } = useContext(OptimizelyContext);
   const eventTrackingData = {
     block: {
       componentName: 'top-stories',
+      optimizely,
     },
   };
   const eventTrackingDataSend = path(['block'], eventTrackingData);

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.jsx
@@ -6,6 +6,7 @@ import path from 'ramda/src/path';
 import { C_GREY_2 } from '#psammead/psammead-styles/src/colours';
 import isEmpty from 'ramda/src/isEmpty';
 import useViewTracker from '#hooks/useViewTracker';
+import { OptimizelyContext } from '@optimizely/react-sdk';
 import { ServiceContext } from '../../../../contexts/ServiceContext';
 import {
   StyledSectionLabel,
@@ -15,7 +16,6 @@ import {
 } from './index.styles';
 import TopStoriesItem from './TopStoriesItem';
 import generatePromoId from '../generatePromoId';
-import { OptimizelyContext } from '@optimizely/react-sdk';
 
 const renderTopStoriesList = (item, index, eventTrackingData, viewRef) => {
   const contentType = pathOr('', ['contentType'], item);

--- a/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
+++ b/src/app/pages/ArticlePage/PagePromoSections/TopStoriesSection/index.test.jsx
@@ -76,6 +76,7 @@ describe('Event Tracking', () => {
   it('should implement 3 BLOCK level click trackers(1 for each promo item) and 0 link level click trackers', () => {
     const expected = {
       componentName: 'top-stories',
+      optimizely: null,
       preventNavigation: true,
     };
     const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
@@ -106,6 +107,7 @@ describe('Event Tracking', () => {
   it('should implement 1 BLOCK level view tracker', () => {
     const expected = {
       componentName: 'top-stories',
+      optimizely: null,
     };
     const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
 

--- a/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/ArticlePage/__snapshots__/index.test.jsx.snap
@@ -1695,6 +1695,9 @@ exports[`should render a ltr article (pidgin) with most read correctly 1`] = `
         </li>
       </ol>
     </section>
+    <div
+      aria-hidden="true"
+    />
   </div>
 </div>
 `;
@@ -2214,6 +2217,9 @@ exports[`should render a news article correctly 1`] = `
         </main>
       </div>
     </div>
+    <div
+      aria-hidden="true"
+    />
   </div>
 </div>
 `;
@@ -2760,6 +2766,9 @@ exports[`should render a news article with headline in the middle correctly 1`] 
         </main>
       </div>
     </div>
+    <div
+      aria-hidden="true"
+    />
   </div>
 </div>
 `;
@@ -3148,6 +3157,9 @@ exports[`should render a news article without headline correctly 1`] = `
         </main>
       </div>
     </div>
+    <div
+      aria-hidden="true"
+    />
   </div>
 </div>
 `;
@@ -4847,6 +4859,9 @@ exports[`should render a rtl article (persian) with most read correctly 1`] = `
         </li>
       </ol>
     </section>
+    <div
+      aria-hidden="true"
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
Resolves #NUMBER

**Overall change:**
_A very high-level summary of easily-reproducible changes that can be understood by non-devs._

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
