### PR TITLE
Fix Cymrufyw service CPS data fetching

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -85,6 +85,18 @@ const transformJson = async (json, pathname, toggles) => {
   }
 };
 
+const getDerivedServiceAndPath = (service, pathname) => {
+  switch (service) {
+    case 'cymrufyw':
+      return {
+        service: 'newyddion',
+        path: pathname.replace('cymrufyw', 'newyddion'),
+      };
+    default:
+      return { service, path: pathname };
+  }
+};
+
 export default async ({
   getAgent,
   path: pathname,
@@ -94,13 +106,16 @@ export default async ({
   toggles,
 }) => {
   try {
+    const { service: derivedService, path: derivedPath } =
+      getDerivedServiceAndPath(service, pathname);
+
     const {
       status,
       pageData: { secondaryColumn, recommendations, ...article },
     } = await bffFetch({
       getAgent,
-      path: pathname,
-      service,
+      path: derivedPath,
+      service: derivedService,
       variant,
       pageType: 'cpsAsset',
     });
@@ -108,7 +123,7 @@ export default async ({
     const processedAdditionalData = processMostWatched({
       data: secondaryColumn,
       service,
-      path: pathname,
+      path: derivedPath,
       toggles,
       page: pageType,
     });


### PR DESCRIPTION
Part of NEWSWORLDSERVICE-1681

**Overall change:**
- Adds a check if the service is `cymrufyw` and converts the service and pathname to use `newyddion` instead for fetching the data from the BFF
- This check will eventually be moved to the BFF

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
