### PR TITLE
[WSTEAM1-302] Move Byline below hero image on Optimo Article pages

### DIFF
--- a/data/pidgin/articles/c1j5mz19jdko.json
+++ b/data/pidgin/articles/c1j5mz19jdko.json
@@ -56,6 +56,87 @@
               ]
             },
             {
+              "id": "b264e8e9",
+              "type": "image",
+              "model": {
+                "blocks": [
+                  {
+                    "id": "f6720e42",
+                    "type": "altText",
+                    "model": {
+                      "blocks": [
+                        {
+                          "id": "4fe228df",
+                          "type": "text",
+                          "model": {
+                            "blocks": [
+                              {
+                                "id": "f235c0df",
+                                "type": "paragraph",
+                                "model": {
+                                  "text": "قهوه",
+                                  "blocks": [
+                                    {
+                                      "id": "2906fea8",
+                                      "type": "fragment",
+                                      "model": {
+                                        "text": "قهوه",
+                                        "attributes": []
+                                      },
+                                      "position": [
+                                        2,
+                                        1,
+                                        1,
+                                        1,
+                                        1
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "position": [
+                                  2,
+                                  1,
+                                  1,
+                                  1
+                                ]
+                              }
+                            ]
+                          },
+                          "position": [
+                            2,
+                            1,
+                            1
+                          ]
+                        }
+                      ]
+                    },
+                    "position": [
+                      2,
+                      1
+                    ]
+                  },
+                  {
+                    "id": "7d8f63b9",
+                    "type": "rawImage",
+                    "model": {
+                      "width": 640,
+                      "height": 360,
+                      "locator": "1e4e/test/60a1cf00-814e-11e9-b0be-cb6d2b512d8b.jpg",
+                      "originCode": "cpsdevpb",
+                      "copyrightHolder": "Getty Images"
+                    },
+                    "position": [
+                      2,
+                      2
+                    ]
+                  }
+                ]
+              },
+              "position": [
+                2
+              ]
+            },
+            {
               "id": "3064af08",
               "type": "byline",
               "model": {

--- a/data/pidgin/articles/c1j5mz19jdko.json
+++ b/data/pidgin/articles/c1j5mz19jdko.json
@@ -74,13 +74,13 @@
                                 "id": "f235c0df",
                                 "type": "paragraph",
                                 "model": {
-                                  "text": "قهوه",
+                                  "text": "Coffee",
                                   "blocks": [
                                     {
                                       "id": "2906fea8",
                                       "type": "fragment",
                                       "model": {
-                                        "text": "قهوه",
+                                        "text": "Coffee",
                                         "attributes": []
                                       },
                                       "position": [

--- a/src/app/pages/ArticlePage/ArticlePage.jsx
+++ b/src/app/pages/ArticlePage/ArticlePage.jsx
@@ -158,6 +158,13 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
     audio: articleMediaPlayer,
     video: articleMediaPlayer,
     text,
+    image: props => (
+      <Image
+        {...props}
+        sizes="(min-width: 1008px) 760px, 100vw"
+        shouldPreload={preloadLeadImageToggle}
+      />
+    ),
     byline: props =>
       hasByline ? (
         <Byline {...props}>
@@ -168,13 +175,6 @@ const ArticlePage = ({ pageData, mostReadEndpointOverride }) => {
           />
         </Byline>
       ) : null,
-    image: props => (
-      <Image
-        {...props}
-        sizes="(min-width: 1008px) 760px, 100vw"
-        shouldPreload={preloadLeadImageToggle}
-      />
-    ),
     timestamp: props =>
       hasByline ? null : <Timestamp {...props} popOut={false} />,
     social: SocialEmbedContainer,


### PR DESCRIPTION
Resolves #WSTEAM1-302

**Overall change:**
Moves Byline below the hero image on Optimo Article pages

**Code changes:**
- Moves position of byline 
- Add hero image to `/pidgin/articles/c1j5mz19jdko` fixture data

**Testing:**
- Go to http://localhost:7080/pidgin/articles/c1j5mz19jdko
- Observe position of byline and hero image
