### PR TITLE
WSTEAMA-288: Ensure page type is passed as a parameter to the simorgh BFF

### DIFF
--- a/src/app/routes/topic/getInitialData/index.js
+++ b/src/app/routes/topic/getInitialData/index.js
@@ -27,6 +27,7 @@ export default async ({ getAgent, service, path: pathname, variant, page }) => {
       ...(page && {
         page,
       }),
+      pageType: 'topic',
     });
     const optHeaders = { 'ctx-service-env': env };
     const { status, json } = await fetchPageData({

--- a/src/app/routes/topic/getInitialData/index.test.js
+++ b/src/app/routes/topic/getInitialData/index.test.js
@@ -108,7 +108,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&pageType=topic',
       agent,
       optHeaders,
     });
@@ -125,7 +125,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=serbian&variant=cyr',
+      path: 'https://mock-bff-path/?id=54321&service=serbian&variant=cyr&pageType=topic',
       agent,
       optHeaders,
     });
@@ -141,7 +141,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&pageType=topic',
       agent,
       optHeaders,
     });
@@ -157,7 +157,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&pageType=topic',
       agent,
       optHeaders,
     });
@@ -173,7 +173,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&pageType=topic',
       agent,
       optHeaders,
     });
@@ -191,7 +191,7 @@ describe('get initial data for topic', () => {
     const testHeader = { 'ctx-service-env': 'test' };
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&pageType=topic',
       agent,
       optHeaders: testHeader,
     });
@@ -208,7 +208,7 @@ describe('get initial data for topic', () => {
     });
 
     expect(fetchDataSpy).toHaveBeenCalledWith({
-      path: 'https://mock-bff-path/?id=54321&service=pidgin&page=20',
+      path: 'https://mock-bff-path/?id=54321&service=pidgin&page=20&pageType=topic',
       agent,
       optHeaders,
     });


### PR DESCRIPTION
Resolves #WSTEAMA-288

**Overall change:**
Ensures that pageType is set to topic when invoking the simorgh-bff, because it will become a mandatory parameter in future

**Code changes:**
- set pageType=topic when invoking the bff for topic pages
- Update tests

---

- [ ] I have assigned myself to this PR and the corresponding issues
- [ ] I have added the `cross-team` label to this PR if it requires visibility across World Service teams
- [ ] I have assigned this PR to the Simorgh project
- [ ] (BBC contributors only) This PR follows the [repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)

**Testing:**

- [ ] Automated (jest and/or cypress) tests added (for new features) or updated (for existing features)
- [ ] If necessary, I have run the local E2E non-smoke tests relevant to my changes (`CYPRESS_APP_ENV=local CYPRESS_SMOKE=false yarn test:e2e:interactive`)
- [ ] This PR requires manual testing
