### PR TITLE
add times new roman

### DIFF
--- a/src/app/components/ThemeProvider/fontFamilies.ts
+++ b/src/app/components/ThemeProvider/fontFamilies.ts
@@ -26,5 +26,5 @@ export const PADAUK = 'Padauk, Arial, Verdana, Geneva, Helvetica, sans-serif';
 export const REITH_SANS = 'ReithSans, Helvetica, Arial, sans-serif';
 export const REITH_SERIF = 'ReithSerif, Helvetica, Arial, sans-serif;';
 export const REITH_QALAM =
-  '"BBC Reith Qalam", Arial, Verdana, Geneva, Helvetica, sans-serif';
+  '"Times New Roman", "BBC Reith Qalam", Arial, Verdana, Geneva, Helvetica, sans-serif';
 export const TAHOMA = 'Tahoma, Helmet, freesans, Helvetica, Arial, sans-serif';


### PR DESCRIPTION
Resolves JIRA 1679

Overall changes
======
Add "Times New Roman" before Arial as our first backup font for reith qalam. Our current back upfont is too different from the main font, leading to bad content layout shift scores.

Code changes
======

- add `"Times New Roman"` on line 29 in `fontFamilies.ts`

Testing
======
1. run `yarn test`

Helpful Links
======

[content layout shift](https://web.dev/cls/)

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
