### PR TITLE
Retry ATI test

### DIFF
--- a/cypress/integration/pages/testsForAllCanonicalPages.js
+++ b/cypress/integration/pages/testsForAllCanonicalPages.js
@@ -18,11 +18,17 @@ export const testsThatFollowSmokeTestConfigForAllCanonicalPages = ({
   if (pageType !== 'errorPage404') {
     describe(`Running testsForAllCanonicalPages for ${service} ${pageType}`, () => {
       if (Cypress.env('SMOKE')) {
-        describe('ATI', () => {
-          it('should have a noscript img tag with the ati url', () => {
-            cy.hasNoscriptImgAtiUrl(envConfig.atiUrl);
-          });
-        });
+        describe(
+          'ATI',
+          {
+            retries: 3,
+          },
+          () => {
+            it('should have a noscript img tag with the ati url', () => {
+              cy.hasNoscriptImgAtiUrl(envConfig.atiUrl);
+            });
+          },
+        );
       }
     });
   }


### PR DESCRIPTION
We keep getting errors like this:


 1) storyPage - /ukchina/trad/52836902 - Canonical
       Running testsForAllCanonicalPages for ukchinaTrad storyPage
         ATI
           should have a noscript img tag with the ati url:
     AssertionError: Timed out retrying after 10000ms: expected '[ <noscript>, 17 more... ]' to contain '<img height="1px" width="1px" alt="" style="position:absolute" src="https://a1.api.bbc.co.uk/hit.xiti?'
      at Context.eval (https://www.bbc.com/__cypress/tests?p=cypress/support/index.js:12:22)

This adds code to retry the test 3 times.

We are not sure why this now fails sometimes.