### PR TITLE
NPM Audit: Skip auditing devDependencies 

### DIFF
--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -91,4 +91,4 @@ jobs:
         run: yarn test:lint
 
       - name: NPM Audit
-        run: npx audit-ci --config audit-ci.json
+        run: npx audit-ci --config audit-ci.json --skip-dev

--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -91,4 +91,4 @@ jobs:
         run: yarn test:lint
 
       - name: NPM Audit
-        run: npx audit-ci --config audit-ci.json --skip-dev
+        run: npx audit-ci --config audit-ci.json

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,4 +1,6 @@
 {
   "low": true,
-  "allowlist": ["GHSA-w573-4hg7-7wgq", "GHSA-hrpp-h998-j3pp"]
+  "allowlist": [
+    "GHSA-hrpp-h998-j3pp"
+  ]
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,6 @@
 {
   "low": true,
+  "skip-dev": true,
   "allowlist": [
     "GHSA-hrpp-h998-j3pp"
   ]


### PR DESCRIPTION
Overall changes
======
The NPM Audit PR check should not fail unless there are vulnerabilities found in production dependencies

Code changes
======
- Add skip-dev to the npm audit config file 
- Remove vulnerabilities in dev dependencies from the allow list in the npm audit config file, as they are no longer checked

Testing
======
- [ ] Automated PR checks
- [ ] Run locally to ensure npm audit does not fail

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
