### PR TITLE
Wrap recommendations fetch in `try/catch`

### DIFF
--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -138,13 +138,18 @@ export default async ({
       isAdvertising = pathOr(false, ['metadata', 'allowAdvertising'], article);
     }
 
-    const wsojData = await getOnwardsPageData({
-      pathname,
-      service,
-      variant,
-      isAdvertising,
-      agent,
-    });
+    let wsojData = [];
+    try {
+      wsojData = await getOnwardsPageData({
+        pathname,
+        service,
+        variant,
+        isAdvertising,
+        agent,
+      });
+    } catch (error) {
+      logger.error('Recommendations JSON malformed', error);
+    }
 
     return {
       status,


### PR DESCRIPTION
Overall changes
======
- Wraps the recommendations fetch for articles/cps assets in a `try/catch` so that any errors will not cause the page itself to 4xx/5xx as this is just secondary page data

Testing
======
1. Confirm that article pages and cps pages render correctly on Test
2. Confirm that both page types should recommendations on Live (where applicable)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
