### PR TITLE
WSTEAM1-281: Update identifiers for article-sfv pages

### DIFF
--- a/src/app/legacy/containers/ChartbeatAnalytics/utils/index.js
+++ b/src/app/legacy/containers/ChartbeatAnalytics/utils/index.js
@@ -119,9 +119,6 @@ export const buildSections = ({
     Podcast: 'Podcasts',
   };
 
-  const primaryMediaType =
-    pageType === MEDIA_ARTICLE_PAGE ? getPrimaryMediaType(taggings) : type;
-
   switch (pageType) {
     case STORY_PAGE:
     case MEDIA_ASSET_PAGE:
@@ -139,10 +136,19 @@ export const buildSections = ({
         ...(addProducer ? buildSectionArr(serviceCap, producer, type) : []),
         ...(chapter ? buildSectionArr(serviceCap, chapter, type) : []),
       ].join(', ');
+    case MEDIA_ARTICLE_PAGE:
+      return [
+        serviceCap,
+        ...(pageType
+          ? buildSectionItem(serviceCap, getPrimaryMediaType(taggings))
+          : []),
+        ...(addProducer ? buildSectionArr(serviceCap, producer, type) : []),
+        ...(chapter ? buildSectionArr(serviceCap, chapter, type) : []),
+      ].join(', ');
     default:
       return [
         serviceCap,
-        ...(pageType ? buildSectionItem(serviceCap, primaryMediaType) : []),
+        ...(pageType ? buildSectionItem(serviceCap, type) : []),
         ...(addProducer ? buildSectionArr(serviceCap, producer, type) : []),
         ...(chapter ? buildSectionArr(serviceCap, chapter, type) : []),
       ].join(', ');

--- a/src/app/legacy/containers/ChartbeatAnalytics/utils/index.test.js
+++ b/src/app/legacy/containers/ChartbeatAnalytics/utils/index.test.js
@@ -14,6 +14,7 @@ import {
   PHOTO_GALLERY_PAGE,
   STORY_PAGE,
   TOPIC_PAGE,
+  MEDIA_ARTICLE_PAGE,
 } from '#app/routes/utils/pageTypes';
 import {
   chartbeatUID,
@@ -63,6 +64,11 @@ describe('Chartbeat utilities', () => {
         pageType: ARTICLE_PAGE,
         expectedDefaultType: 'New Article',
         expectedShortType: 'ART',
+      },
+      {
+        pageType: MEDIA_ARTICLE_PAGE,
+        expectedDefaultType: 'article-sfv',
+        expectedShortType: 'article-sfv',
       },
       {
         pageType: 'index',
@@ -610,6 +616,190 @@ describe('Chartbeat utilities', () => {
         uid: 50924,
         useCanonical: true,
         virtualReferrer: 'test.bbc.com/previous-path',
+      };
+
+      expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
+    });
+  });
+
+  describe('Chartbeat Media Article Page - article-sfv', () => {
+    it("should have 'video' in its identifier when the primary media type is video", () => {
+      const fixtureData = {
+        pageType: MEDIA_ARTICLE_PAGE,
+        data: {
+          metadata: {
+            passport: {
+              taggings: [
+                {
+                  predicate: 'http://www.bbc.co.uk/ontologies/bbc/infoClass',
+                  value:
+                    'http://www.bbc.co.uk/things/0db2b959-cbf8-4661-965f-050974a69bb5#id',
+                },
+                {
+                  predicate:
+                    'http://www.bbc.co.uk/ontologies/bbc/primaryMediaType',
+                  value:
+                    'http://www.bbc.co.uk/things/ffc98bca-8cff-4ee6-9beb-a6ff6ef3ef9f#id',
+                },
+              ],
+            },
+          },
+        },
+        service: 'pidgin',
+      };
+
+      const expectedConfig = {
+        domain: 'test.bbc.co.uk',
+        idSync: {
+          bbc_hid: 'foobar',
+        },
+        path: '/',
+        sections: 'Pidgin, Pidgin - video',
+        title: null,
+        type: 'article-sfv',
+        uid: 50924,
+        useCanonical: true,
+        virtualReferrer: null,
+      };
+
+      expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
+    });
+
+    it("should have 'audio' in its identifier when the primary media type is audio", () => {
+      const fixtureData = {
+        pageType: MEDIA_ARTICLE_PAGE,
+        data: {
+          metadata: {
+            passport: {
+              taggings: [
+                {
+                  predicate: 'http://www.bbc.co.uk/ontologies/bbc/infoClass',
+                  value:
+                    'http://www.bbc.co.uk/things/0db2b959-cbf8-4661-965f-050974a69bb5#id',
+                },
+                {
+                  predicate:
+                    'http://www.bbc.co.uk/ontologies/bbc/primaryMediaType',
+                  value:
+                    'http://www.bbc.co.uk/things/fe1fbc8a-bb44-4bf8-8b12-52e58c6345a4#id',
+                },
+              ],
+            },
+          },
+        },
+        service: 'pidgin',
+      };
+
+      const expectedConfig = {
+        domain: 'test.bbc.co.uk',
+        idSync: {
+          bbc_hid: 'foobar',
+        },
+        path: '/',
+        sections: 'Pidgin, Pidgin - audio',
+        title: null,
+        type: 'article-sfv',
+        uid: 50924,
+        useCanonical: true,
+        virtualReferrer: null,
+      };
+
+      expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
+    });
+
+    it("should have 'article-sfv' in its identifier when there are no taggings", () => {
+      const fixtureData = {
+        pageType: MEDIA_ARTICLE_PAGE,
+        data: {
+          metadata: {
+            passport: {},
+          },
+        },
+        service: 'pidgin',
+      };
+
+      const expectedConfig = {
+        domain: 'test.bbc.co.uk',
+        idSync: {
+          bbc_hid: 'foobar',
+        },
+        path: '/',
+        sections: 'Pidgin, Pidgin - article-sfv',
+        title: null,
+        type: 'article-sfv',
+        uid: 50924,
+        useCanonical: true,
+        virtualReferrer: null,
+      };
+
+      expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
+    });
+
+    it("should have 'article-sfv' in its identifier when the primary media type cannot be established", () => {
+      const fixtureData = {
+        pageType: MEDIA_ARTICLE_PAGE,
+        data: {
+          metadata: {
+            passport: {
+              taggings: [
+                {
+                  predicate: 'http://www.bbc.co.uk/ontologies/bbc/infoClass',
+                  value:
+                    'http://www.bbc.co.uk/things/0db2b959-cbf8-4661-965f-050974a69bb5#id',
+                },
+                {
+                  predicate:
+                    'http://www.bbc.co.uk/ontologies/bbc/SOME_OTHER_TAG',
+                  value:
+                    'http://www.bbc.co.uk/things/fe1fbc8a-bb44-4bf8-8b12-52e58c6345a4#id',
+                },
+              ],
+            },
+          },
+        },
+        service: 'pidgin',
+      };
+
+      const expectedConfig = {
+        domain: 'test.bbc.co.uk',
+        idSync: {
+          bbc_hid: 'foobar',
+        },
+        path: '/',
+        sections: 'Pidgin, Pidgin - article-sfv',
+        title: null,
+        type: 'article-sfv',
+        uid: 50924,
+        useCanonical: true,
+        virtualReferrer: null,
+      };
+
+      expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);
+    });
+
+    it('should not intefere with regular article page identifiers', () => {
+      const fixtureData = {
+        pageType: ARTICLE_PAGE,
+        data: {
+          metadata: {
+            passport: {},
+          },
+        },
+        service: 'pidgin',
+      };
+
+      const expectedConfig = {
+        domain: 'test.bbc.co.uk',
+        idSync: {
+          bbc_hid: 'foobar',
+        },
+        path: '/',
+        sections: 'Pidgin, Pidgin - ART',
+        title: 'This is an article title',
+        type: 'New Article',
+        uid: 50924,
+        useCanonical: true,
+        virtualReferrer: null,
       };
 
       expect(getConfig(fixtureData)).toStrictEqual(expectedConfig);


### PR DESCRIPTION
Resolves JIRA: [WSTEAM1-281](https://jira.dev.bbc.co.uk/browse/WSTEAM1-281)

Overall changes
======
Updates the identifiers for Chartbeat so that we can discern audio/video pages:

Request when we have an audio primary media type: 
![Screenshot 2023-03-07 at 17 17 57](https://user-images.githubusercontent.com/32307964/223501458-a6c1c218-533e-46a9-a8ab-4ed76a2e7b5e.png)

Request when we have a video primary media type: 
![Screenshot 2023-03-07 at 17 16 31](https://user-images.githubusercontent.com/32307964/223501472-b9e091a6-6f2d-4535-991f-ad95bdc63731.png)

Request when when we have something other than audio or video: 
![Screenshot 2023-03-07 at 17 18 40](https://user-images.githubusercontent.com/32307964/223501431-34b6430b-23ab-493d-b037-752c14429051.png)


Code changes
======

- _In ChartbeatAnalytics the getConfig function has been updated to process the tagging information in pageData and pull out the primaryMediaType of the article-svf page._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
