### PR TITLE
WSTEAM1-298: Restrict recommendations requests for sfv articles.

### DIFF
--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -16,6 +16,7 @@ const bffArticleJson = {
       content: {},
       metadata: {
         allowAdvertising: true,
+        consumableAsSFV: true,
       },
       promo: {},
       relatedContent: {},
@@ -134,6 +135,7 @@ describe('Articles - BFF Fetching', () => {
       pathname: '/kyrgyz/articles/c0000000000o.amp?renderer_env=live',
       service: 'kyrgyz',
       isAdvertising: true,
+      isArticleSfv: true,
       agent,
       variant: undefined,
     });

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Agent } from 'https';
 import pipe from 'ramda/src/pipe';
-import pathOr from 'ramda/src/pathOr';
 import Url from 'url-parse';
 import getAdditionalPageData from '#app/routes/cpsAsset/utils/getAdditionalPageData';
 import nodeLogger from '../../../lib/logger.node';
@@ -10,6 +9,7 @@ import { BFF_FETCH_ERROR } from '../../../lib/logger.const';
 import fetchPageData from '../../utils/fetchPageData';
 import { Services, Variants } from '../../../models/types/global';
 import getOnwardsPageData from '../utils/getOnwardsData';
+import { advertisingAllowed, isSfv } from '../utils/paramChecks';
 
 const logger = nodeLogger(__filename);
 
@@ -127,17 +127,8 @@ export default async ({
       data: { article, secondaryData },
     } = json;
 
-    let isAdvertising = false;
-    if (pageType === 'cpsAsset') {
-      isAdvertising = pathOr(
-        false,
-        ['metadata', 'options', 'allowAdvertising'],
-        article,
-      );
-    } else {
-      isAdvertising = pathOr(false, ['metadata', 'allowAdvertising'], article);
-    }
-
+    const isAdvertising = advertisingAllowed(pageType, article);
+    const isArticleSfv = isSfv(article);
     let wsojData = [];
     try {
       wsojData = await getOnwardsPageData({
@@ -145,6 +136,7 @@ export default async ({
         service,
         variant,
         isAdvertising,
+        isArticleSfv,
         agent,
       });
     } catch (error) {

--- a/src/app/routes/article/utils/getOnwardsData.test.ts
+++ b/src/app/routes/article/utils/getOnwardsData.test.ts
@@ -39,6 +39,20 @@ describe('WSOJ data', () => {
 
     expect(additionalPageData).toEqual(expectedOutput);
   });
+
+  it('should NOT return recommendations data for sfv articles', async () => {
+    const expectedOutput = {};
+
+    const additionalPageData = await getOnwardsPageData({
+      pathname: '/kyrgyz/articles/c0000000000o.amp?renderer_env=live',
+      service: 'kyrgyz',
+      isAdvertising: true,
+      isArticleSfv: true,
+      agent,
+    });
+
+    expect(additionalPageData).toEqual(expectedOutput);
+  });
 });
 
 describe('Optimizely Experiments', () => {

--- a/src/app/routes/article/utils/getOnwardsData.ts
+++ b/src/app/routes/article/utils/getOnwardsData.ts
@@ -93,12 +93,14 @@ const getOnwardsPageData = async ({
   service,
   variant,
   isAdvertising,
+  isArticleSfv = false,
   agent,
 }: {
   pathname: string;
   service: string;
   variant?: string;
   isAdvertising: boolean;
+  isArticleSfv?: boolean;
   agent: Agent | null;
 }) => {
   const recommendationsAllowed = await hasArticleRecommendations(
@@ -107,7 +109,7 @@ const getOnwardsPageData = async ({
     variant,
   );
 
-  if (!recommendationsAllowed || agent == null) return {};
+  if (!recommendationsAllowed || agent == null || isArticleSfv) return {};
 
   const removeAmpAndRenderSuffixes = /(\.|\?).*/g;
   const urlsToFetch = await getRecommendationsURLs(

--- a/src/app/routes/article/utils/paramChecks.test.ts
+++ b/src/app/routes/article/utils/paramChecks.test.ts
@@ -1,0 +1,59 @@
+import { ARTICLE_PAGE } from '#app/routes/utils/pageTypes';
+import { advertisingAllowed, isSfv, ArticleType } from './paramChecks';
+
+describe('advertisingAllowed', () => {
+  it('returns true when advertising is allowed on CPS Assets', () => {
+    const articleDataSample = {
+      metadata: {
+        options: {
+          allowAdvertising: true,
+        },
+      },
+    };
+    const actual = advertisingAllowed(
+      'cpsAsset',
+      articleDataSample as unknown as ArticleType,
+    );
+    expect(actual).toBe(true);
+  });
+
+  it('returns true when advertising is allowed on Optimo articles', () => {
+    const articleDataSample = {
+      metadata: {
+        allowAdvertising: true,
+      },
+    };
+    const actual = advertisingAllowed(
+      ARTICLE_PAGE,
+      articleDataSample as unknown as ArticleType,
+    );
+    expect(actual).toBe(true);
+  });
+
+  it('returns false otherwise', () => {
+    const articleDataSample = {};
+    const actual = advertisingAllowed(
+      ARTICLE_PAGE,
+      articleDataSample as unknown as ArticleType,
+    );
+    expect(actual).toBe(false);
+  });
+});
+
+describe('isSfv', () => {
+  it('returns true when consumableAsSFV is true', () => {
+    const articleDataSample = {
+      metadata: {
+        consumableAsSFV: true,
+      },
+    };
+    const actual = isSfv(articleDataSample as unknown as ArticleType);
+    expect(actual).toBe(true);
+  });
+
+  it('returns false otherwise', () => {
+    const articleDataSample = {};
+    const actual = isSfv(articleDataSample as unknown as ArticleType);
+    expect(actual).toBe(false);
+  });
+});

--- a/src/app/routes/article/utils/paramChecks.ts
+++ b/src/app/routes/article/utils/paramChecks.ts
@@ -1,0 +1,16 @@
+import pathOr from 'ramda/src/pathOr';
+import { InferProps } from 'prop-types';
+import { articleDataPropTypes } from '../../../models/propTypes/article';
+
+export type ArticleType = InferProps<typeof articleDataPropTypes>;
+
+export const advertisingAllowed = (pageType: string, article: ArticleType) => {
+  if (pageType === 'cpsAsset') {
+    return pathOr(false, ['metadata', 'options', 'allowAdvertising'], article);
+  }
+  return pathOr(false, ['metadata', 'allowAdvertising'], article);
+};
+
+export const isSfv = (article: ArticleType) => {
+  return pathOr(false, ['metadata', 'consumableAsSFV'], article);
+};


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-298](https://jira.dev.bbc.co.uk/browse/WSTEAM1-298)

Overall changes
======
Prevents WSOJ from rendering on Article SFV pages.

Regular Article Page:
![Screenshot 2023-03-08 at 15 36 02](https://user-images.githubusercontent.com/32307964/223758105-5858ae12-197a-41e7-aa58-bd090965f399.png)

Article SFV Page: 
![Screenshot 2023-03-08 at 15 37 26](https://user-images.githubusercontent.com/32307964/223758207-83d42294-72d4-4587-96e9-2e79fdc64445.png)

Code changes
======

- _getInitialData has been refactored to pull out the consumableAsSFV flag._
- _getOnwardsData has been modified to NOT request WSOJ data when consumableAsSFV is true._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
