### PR TITLE
Update African sites navs to link to Tipo video topics

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -323,7 +323,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Viidiyoo',
-        url: '/afaanoromoo/media/video',
+        url: '/afaanoromoo/topics/ck0dg7dpjwwt',
       },
       {
         title: 'Jajjaboo',

--- a/src/app/lib/config/services/afrique.ts
+++ b/src/app/lib/config/services/afrique.ts
@@ -360,7 +360,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Vidéos',
-        url: '/afrique/media/video',
+        url: '/afrique/topics/cz4vn9gyd6rt',
       },
       {
         title: 'Nos émissions',

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -310,7 +310,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'ቪዲዮ',
-        url: '/amharic/media/video',
+        url: '/amharic/topics/c917ezk2pmvt',
       },
       {
         title: 'በጣም የተወደዱ',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -350,7 +350,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Amajwi n’amashusho',
-        url: '/gahuza/media/video',
+        url: '/gahuza/topics/crldzm936jmt',
       },
     ],
   },

--- a/src/app/lib/config/services/hausa.ts
+++ b/src/app/lib/config/services/hausa.ts
@@ -354,7 +354,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Bidiyo',
-        url: '/hausa/media/video',
+        url: '/hausa/topics/cn09qmz4jryt',
       },
       {
         title: 'Shirye-shirye na Musamman',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -281,7 +281,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Ihe nkiri',
-        url: '/igbo/media/video',
+        url: '/igbo/topics/c3l19z3qjmyt',
       },
       {
         title: 'Nke ka ewuewu',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -284,7 +284,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Video',
-        url: '/pidgin/media/video',
+        url: '/pidgin/topics/c3l19z3k1ert',
       },
       {
         title: 'Sport',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -332,7 +332,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Muuqaal',
-        url: '/somali/media/video',
+        url: '/somali/topics/c7pl4k5r9xxt',
       },
       {
         title: 'Barnaamijyada Idaacadda',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -294,7 +294,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'ቪድዮ',
-        url: '/tigrinya/media/video',
+        url: '/tigrinya/topics/crldzm9n4rdt',
       },
       {
         title: 'ኣመና ፍቱዋት',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -307,7 +307,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Fídíò',
-        url: '/yoruba/media/video',
+        url: '/yoruba/topics/ck5rznlk6k3t',
       },
       {
         title: 'Èyí to gbajúmọ̀ jù',

--- a/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/amp.test.js.snap
@@ -350,7 +350,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "about": Array [
         Object {
           "@type": "Thing",

--- a/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/news/__snapshots__/canonical.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Canonical Articles A11y I can see the skip to content link 1`] = `"Skip to content"`;
 
-exports[`Canonical Articles Analytics ATI 1`] = `"<img height=\\"1px\\" width=\\"1px\\" alt=\\"\\" style=\\"position:absolute\\" src=\\"https://logws1363.ati-host.net?s=598286&amp;s2=64&amp;p=news.articles.c0g992jmmkko.page&amp;x2=[responsive]&amp;x3=[news]&amp;x4=[en-gb]&amp;x7=[article]&amp;x8=[simorgh-nojs]&amp;x9=[Royal%2520wedding%2520flowers%2520given%2520to%2520Hackney%2520hospice]&amp;x11=[2019-05-28T13%3A38%3A19.412Z]&amp;x12=[2019-05-28T13%3A38%3A19.412Z]&amp;x13=[Wedding%2520of%2520Prince%2520Harry%2520and%2520Meghan%2520Markle~Duchess%2520of%2520Sussex~Hackney~Windsor]&amp;x14=[2351f2b2-ce36-4f44-996d-c3c4f7f90eaa~803eaeb9-c0c3-4f1b-9a66-90efac3df2dc~dba7dfeb-87d3-4801-80ba-fa8be6c9555e~f94940f0-476c-4ec7-b48d-e58120bb1956]\\"/>"`;
+exports[`Canonical Articles Analytics ATI 1`] = `"<img height=\\"1px\\" width=\\"1px\\" alt=\\"\\" style=\\"position:absolute\\" src=\\"https://logws1363.ati-host.net?s=598286&amp;s2=64&amp;p=news.articles.c0g992jmmkko.page&amp;x2=[responsive]&amp;x3=[news]&amp;x4=[en-gb]&amp;x7=[article]&amp;x8=[simorgh-nojs]&amp;x9=[Royal%2520wedding%2520flowers%2520given%2520to%2520Hackney%2520hospice]&amp;x11=[2019-05-28T13%3A38%3A19.412Z]&amp;x12=[2019-05-28T13%3A38%3A19.412Z]&amp;x13=[Wedding%2520of%2520Prince%2520Harry%2520and%2520Meghan%2520Markle~Duchess%2520of%2520Sussex~Hackney~Windsor]&amp;x14=[2351f2b2-ce36-4f44-996d-c3c4f7f90eaa~803eaeb9-c0c3-4f1b-9a66-90efac3df2dc~dba7dfeb-87d3-4801-80ba-fa8be6c9555e~f94940f0-476c-4ec7-b48d-e58120bb1956]&amp;x17=[Wedding%2520of%2520Prince%2520Harry%2520and%2520Meghan%2520Markle~Duchess%2520of%2520Sussex~Hackney~Windsor]\\"/>"`;
 
 exports[`Canonical Articles Footer Anchors should match text and url 1`] = `
 Object {
@@ -258,7 +258,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "about": Array [
         Object {
           "@type": "Thing",

--- a/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/amp.test.js.snap
@@ -364,7 +364,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "author": Object {
         "@type": "NewsMediaOrganization",
         "logo": Object {

--- a/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/persian/__snapshots__/canonical.test.js.snap
@@ -272,7 +272,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "author": Object {
         "@type": "NewsMediaOrganization",
         "logo": Object {

--- a/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/amp.test.js.snap
@@ -266,7 +266,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "author": Object {
         "@type": "Organization",
         "logo": Object {

--- a/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/articles/scotland/__snapshots__/canonical.test.js.snap
@@ -174,7 +174,7 @@ Object {
   "@context": "http://schema.org",
   "@graph": Array [
     Object {
-      "@type": "Article",
+      "@type": "NewsArticle",
       "author": Object {
         "@type": "Organization",
         "logo": Object {

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/amp.test.js.snap
@@ -273,7 +273,7 @@ Object {
 exports[`AMP Feature Index page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Vidéos",
-  "url": "/afrique/media/video",
+  "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 

--- a/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/afrique/__snapshots__/canonical.test.js.snap
@@ -139,7 +139,7 @@ Object {
 exports[`Canonical Feature Index page Header Navigation link should match text and url 10`] = `
 Object {
   "text": "Vidéos",
-  "url": "/afrique/media/video",
+  "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 

--- a/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/frontPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -104,7 +104,7 @@ Object {
 exports[`Canonical Front Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Video",
-  "url": "/pidgin/media/video",
+  "url": "/pidgin/topics/c3l19z3k1ert",
 }
 `;
 

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/amp.test.js.snap
@@ -245,7 +245,7 @@ Object {
 exports[`AMP Live Radio Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Amajwi n’amashusho",
-  "url": "/gahuza/media/video",
+  "url": "/gahuza/topics/crldzm936jmt",
 }
 `;
 

--- a/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/gahuza/__snapshots__/canonical.test.js.snap
@@ -111,7 +111,7 @@ Object {
 exports[`Canonical Live Radio Header Navigation link should match text and url 6`] = `
 Object {
   "text": "Amajwi n’amashusho",
-  "url": "/gahuza/media/video",
+  "url": "/gahuza/topics/crldzm936jmt",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/amp.test.js.snap
@@ -238,7 +238,7 @@ Object {
 exports[`AMP Media Asset Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Video",
-  "url": "/pidgin/media/video",
+  "url": "/pidgin/topics/c3l19z3k1ert",
 }
 `;
 

--- a/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaAssetPage/pidgin/__snapshots__/canonical.test.js.snap
@@ -104,7 +104,7 @@ Object {
 exports[`Canonical Media Asset Page Header Navigation link should match text and url 5`] = `
 Object {
   "text": "Video",
-  "url": "/pidgin/media/video",
+  "url": "/pidgin/topics/c3l19z3k1ert",
 }
 `;
 

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/amp.test.js.snap
@@ -261,8 +261,8 @@ Object {
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 10`] = `
 Object {
-  "text": "Page en cours, Vidéos",
-  "url": "/afrique/media/video",
+  "text": "Vidéos",
+  "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 

--- a/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/afrique/__snapshots__/canonical.test.js.snap
@@ -138,8 +138,8 @@ Object {
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 10`] = `
 Object {
-  "text": "Page en cours, Vidéos",
-  "url": "/afrique/media/video",
+  "text": "Vidéos",
+  "url": "/afrique/topics/cz4vn9gyd6rt",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
@@ -224,7 +224,7 @@ Object {
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "Muuqaal",
-  "url": "/somali/media/video",
+  "url": "/somali/topics/c7pl4k5r9xxt",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
@@ -97,7 +97,7 @@ Object {
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 4`] = `
 Object {
   "text": "Muuqaal",
-  "url": "/somali/media/video",
+  "url": "/somali/topics/c7pl4k5r9xxt",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Replaced link to Most popular video page with link to video topic page and the African Services navigation bars. 

Code changes
======

1. Edited Video link in the navigation sections of the following config files: 
- Afaanoromoo
- Afrique
- Amharic
- Gahuza
- Hausa
- Igbo
- Pidgin
- Somali
- TIgrinya
- Yoruba
2. Updated snapshots


Testing
======
1. Run _yarn run dev_ and manually tested the links
2. Run Unit and Integration tests with update snapshots option 

Helpful Links
======


[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
