### PR TITLE
WSTEAM1-196 - Adds fauxHeadline for new MediaArticlePage BFF response

### DIFF
--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
-import propEq from 'ramda/src/propEq';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 import { string, node } from 'prop-types';
@@ -25,7 +24,6 @@ import {
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
 } from '#psammead/gel-foundations/src/spacings';
-import { singleTextBlock } from '#app/models/blocks';
 import { articleDataPropTypes } from '#models/propTypes/article';
 import ArticleMetadata from '#containers/ArticleMetadata';
 import { RequestContext } from '#contexts/RequestContext';
@@ -148,7 +146,6 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const aboutTags = getAboutTags(pageData);
   const topics = path(['metadata', 'topics'], pageData);
   const blocks = pathOr([], ['content', 'model', 'blocks'], pageData);
-  const startsWithHeading = propEq('type', 'headline')(blocks[0] || {});
 
   const bylineBlock = blocks.find(block => block.type === 'byline');
   const bylineContribBlocks = pathOr([], ['model', 'blocks'], bylineBlock);
@@ -203,16 +200,6 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <CpsRecommendations {...props} items={recommendationsData} />
     ),
   };
-
-  const visuallyHiddenBlock = {
-    id: null,
-    model: { blocks: [singleTextBlock(headline)] },
-    type: 'visuallyHiddenHeadline',
-  };
-
-  const articleBlocks = startsWithHeading
-    ? blocks
-    : [visuallyHiddenBlock, ...blocks];
 
   const promoImageBlocks = pathOr(
     [],
@@ -281,7 +268,7 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
         <Primary>
           <Main role="main">
             <Blocks
-              blocks={articleBlocks}
+              blocks={blocks}
               componentsToRender={componentsToRender}
             />
           </Main>

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -267,10 +267,7 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <MediaArticlePageGrid>
         <Primary>
           <Main role="main">
-            <Blocks
-              blocks={blocks}
-              componentsToRender={componentsToRender}
-            />
+            <Blocks blocks={blocks} componentsToRender={componentsToRender} />
           </Main>
           {showRelatedTopics && topics && (
             <StyledRelatedTopics

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -49,6 +49,7 @@ import MostReadSectionLabel from '#containers/MostRead/label';
 import SocialEmbedContainer from '#containers/SocialEmbed';
 import AdContainer from '#containers/Ad';
 import CanonicalAdBootstrapJs from '#containers/Ad/Canonical/CanonicalAdBootstrapJs';
+import fauxHeadline from '#containers/FauxHeadline';
 
 import {
   getArticleId,
@@ -167,6 +168,7 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   );
 
   const componentsToRender = {
+    fauxHeadline,
     visuallyHiddenHeadline,
     headline: headings,
     subheadline: headings,

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -1,11 +1,15 @@
-import React, { useContext } from 'react';
+/** @jsxRuntime classic */
+/** @jsx jsx */
+
+import { useContext } from 'react';
 import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
+import propEq from 'ramda/src/propEq';
 import styled from '@emotion/styled';
-import { useTheme } from '@emotion/react';
+import { jsx, useTheme } from '@emotion/react';
 import { string, node } from 'prop-types';
 import useToggle from '#hooks/useToggle';
-import CpsRecommendations from '#containers/CpsRecommendations';
+import isLive from '#app/lib/utilities/isLive';
 
 import {
   GEL_GROUP_1_SCREEN_WIDTH_MAX,
@@ -24,6 +28,7 @@ import {
   GEL_SPACING_QUAD,
   GEL_SPACING_QUIN,
 } from '#psammead/gel-foundations/src/spacings';
+import { singleTextBlock } from '#app/models/blocks';
 import { articleDataPropTypes } from '#models/propTypes/article';
 import ArticleMetadata from '#containers/ArticleMetadata';
 import { RequestContext } from '#contexts/RequestContext';
@@ -39,7 +44,7 @@ import ChartbeatAnalytics from '#containers/ChartbeatAnalytics';
 import ComscoreAnalytics from '#containers/ComscoreAnalytics';
 import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
 import OptimizelyArticleCompleteTracking from '#containers/OptimizelyArticleCompleteTracking';
-import articleMediaPlayer from '#containers/ArticleMediaPlayer';
+import ArticleMediaPlayer from '#containers/ArticleMediaPlayer';
 import LinkedData from '#containers/LinkedData';
 import MostReadContainer from '#containers/MostRead';
 import MostReadSection from '#containers/MostRead/section';
@@ -48,6 +53,7 @@ import SocialEmbedContainer from '#containers/SocialEmbed';
 import AdContainer from '#containers/Ad';
 import CanonicalAdBootstrapJs from '#containers/Ad/Canonical/CanonicalAdBootstrapJs';
 import fauxHeadline from '#containers/FauxHeadline';
+import CpsRecommendations from '#containers/CpsRecommendations';
 
 import {
   getArticleId,
@@ -76,6 +82,8 @@ import RelatedContentSection from './PagePromoSections/RelatedContentSection';
 import SecondaryColumn from './SecondaryColumn';
 
 import MediaArticlePageGrid, { Primary } from './MediaArticlePageGrid';
+
+import styles from './MediaArticlePage.styles';
 
 const Wrapper = styled.div`
   background-color: ${props => props.theme.palette.GREY_2};
@@ -146,6 +154,7 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
   const aboutTags = getAboutTags(pageData);
   const topics = path(['metadata', 'topics'], pageData);
   const blocks = pathOr([], ['content', 'model', 'blocks'], pageData);
+  const startsWithHeading = propEq('type', 'headline')(blocks[0] || {});
 
   const bylineBlock = blocks.find(block => block.type === 'byline');
   const bylineContribBlocks = pathOr([], ['model', 'blocks'], bylineBlock);
@@ -169,8 +178,24 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
     visuallyHiddenHeadline,
     headline: headings,
     subheadline: headings,
-    audio: articleMediaPlayer,
-    video: articleMediaPlayer,
+    audio: props => (
+      /**
+       * TODO: Consolate the styling into a single stylesheet for the media player
+       * - The media player needs padding top applied, but is also inheriting styles from other components
+       */
+      <div css={!isLive() && styles.mediaPlayer}>
+        <ArticleMediaPlayer {...props} />
+      </div>
+    ),
+    video: props => (
+      /**
+       * TODO: Consolate the styling into a single stylesheet for the media player
+       * - The media player needs padding top applied, but is also inheriting styles from other components
+       */
+      <div css={!isLive() && styles.mediaPlayer}>
+        <ArticleMediaPlayer {...props} />
+      </div>
+    ),
     text,
     byline: props =>
       hasByline ? (
@@ -200,6 +225,16 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <CpsRecommendations {...props} items={recommendationsData} />
     ),
   };
+
+  const visuallyHiddenBlock = {
+    id: null,
+    model: { blocks: [singleTextBlock(headline)] },
+    type: 'visuallyHiddenHeadline',
+  };
+
+  const articleBlocks = startsWithHeading
+    ? blocks
+    : [visuallyHiddenBlock, ...blocks];
 
   const promoImageBlocks = pathOr(
     [],
@@ -267,7 +302,15 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <MediaArticlePageGrid>
         <Primary>
           <Main role="main">
-            <Blocks blocks={blocks} componentsToRender={componentsToRender} />
+            <Blocks
+              /**
+               * TODO: Remove isLive check when a11y swarm is complete
+               * - Live will continue to work as it does now, using the visuallyHiddenHeadline block inserted manually
+               * - Test will use the BFF to format the ordering of the blocks, so no work is needed in Simorgh
+               */
+              blocks={isLive() ? articleBlocks : blocks}
+              componentsToRender={componentsToRender}
+            />
           </Main>
           {showRelatedTopics && topics && (
             <StyledRelatedTopics

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.styles.ts
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.styles.ts
@@ -1,0 +1,8 @@
+import { css, Theme } from '@emotion/react';
+
+export default {
+  mediaPlayer: ({ spacings }: Theme) =>
+    css({
+      paddingTop: `${spacings.TRIPLE}rem`,
+    }),
+};

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
@@ -212,51 +212,55 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   margin: 0;
 }
 
+.emotion-12 {
+  padding-top: 1.5rem;
+}
+
 @media (max-width: 14.9375rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 20%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-12 {
+  .emotion-13 {
     margin-left: 40%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-12 {
+  .emotion-13 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -264,7 +268,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -272,7 +276,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -280,7 +284,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 1;
@@ -288,7 +292,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -296,7 +300,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-12 {
+    .emotion-13 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -304,19 +308,19 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-14 {
+.emotion-15 {
   margin: 0;
   padding-bottom: 1.5rem;
   width: 100%;
 }
 
-.emotion-16 {
+.emotion-17 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.emotion-18 {
+.emotion-19 {
   position: absolute;
   top: 0;
   left: 0;
@@ -325,12 +329,12 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   cursor: default;
 }
 
-.emotion-18:hover .emotion-24,
-.emotion-18:focus .emotion-24 {
+.emotion-19:hover .emotion-25,
+.emotion-19:focus .emotion-25 {
   background-color: #B80000;
 }
 
-.emotion-20 {
+.emotion-21 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -344,31 +348,31 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-20 {
+  .emotion-21 {
     font-size: 0.875rem;
   }
 }
 
-.no-js .emotion-20 {
+.no-js .emotion-21 {
   background-color: rgba(34, 34, 34, 0.75);
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .no-js .emotion-20 {
+  .no-js .emotion-21 {
     background-color: transparent;
   }
 }
 
-.no-js .emotion-20 .guidance-message {
+.no-js .emotion-21 .guidance-message {
   display: none;
 }
 
-.emotion-22 {
+.emotion-23 {
   position: absolute;
   bottom: 0;
 }
 
-.emotion-25 {
+.emotion-26 {
   background-color: #222222;
   border: none;
   color: #FFFFFF;
@@ -389,18 +393,18 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   left: 0;
 }
 
-.emotion-25:hover,
-.emotion-25:focus {
+.emotion-26:hover,
+.emotion-26:focus {
   background-color: #B80000;
   -webkit-transition: background-color 300ms;
   transition: background-color 300ms;
 }
 
-.no-js .emotion-25 {
+.no-js .emotion-26 {
   display: none;
 }
 
-.emotion-25:focus-visible::before {
+.emotion-26:focus-visible::before {
   content: '';
   position: absolute;
   left: 0;
@@ -411,7 +415,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   border: 0.1875rem solid #000000;
 }
 
-.emotion-29>svg {
+.emotion-30>svg {
   color: #FFFFFF;
   fill: currentColor;
   height: 1.5rem;
@@ -419,7 +423,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   width: 1.5rem;
 }
 
-.emotion-31 {
+.emotion-32 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -428,17 +432,17 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   height: 0.75rem;
 }
 
-.emotion-33 {
+.emotion-34 {
   display: block;
   margin-top: 0.5rem;
 }
 
-.emotion-35 {
+.emotion-36 {
   display: block;
   width: 100%;
 }
 
-.emotion-37 {
+.emotion-38 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -455,37 +459,37 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-37 {
+  .emotion-38 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-37 {
+  .emotion-38 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-38 {
     width: 100%;
     margin: 0.5rem 0 0;
   }
 }
 
-.emotion-37>p {
+.emotion-38>p {
   padding-bottom: 1.5rem;
   margin: 0;
 }
 
-.emotion-37>p:last-child {
+.emotion-38>p:last-child {
   padding-bottom: 0;
 }
 
 @media (min-width: 25rem) and (max-width: 62.9375rem) {
-  .emotion-37 {
+  .emotion-38 {
     width: calc(100% - 1rem);
     margin-left: 1rem;
     padding-right: 1rem;
@@ -494,61 +498,61 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 63rem) {
-  .emotion-37 {
+  .emotion-38 {
     padding-right: 0;
     padding-left: 0.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-41 {
+  .emotion-42 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-41 {
+  .emotion-42 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-41 {
+  .emotion-42 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-41 {
+  .emotion-42 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-41 {
+  .emotion-42 {
     margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-41 {
+  .emotion-42 {
     margin-left: 33.333333333333336%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-41 {
+  .emotion-42 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -557,7 +561,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -566,7 +570,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -575,7 +579,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -584,7 +588,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 2;
@@ -592,7 +596,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-41 {
+    .emotion-42 {
       grid-template-columns: repeat(12, 1fr);
       grid-column-end: span 12;
       grid-column-start: 5;
@@ -600,7 +604,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-44 {
+.emotion-45 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
@@ -613,86 +617,86 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-44 {
+  .emotion-45 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-44 {
+  .emotion-45 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-44 {
+  .emotion-45 {
     padding: 2.5rem 0;
   }
 }
 
 @media (max-width: 62.9375rem) {
-  .emotion-44 {
+  .emotion-45 {
     padding: 0.5rem 0 2rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-44 {
+  .emotion-45 {
     padding: 1rem 0 2.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-46 {
+  .emotion-47 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-46 {
+  .emotion-47 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-46 {
+  .emotion-47 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-46 {
+  .emotion-47 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-46 {
+  .emotion-47 {
     margin-left: 20%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-46 {
+  .emotion-47 {
     margin-left: 40%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-46 {
+  .emotion-47 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -701,7 +705,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -710,7 +714,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -719,7 +723,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       padding: 0 1rem;
@@ -728,7 +732,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -736,7 +740,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-46 {
+    .emotion-47 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -744,7 +748,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-48 {
+.emotion-49 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #545658;
@@ -756,24 +760,24 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-48 {
+  .emotion-49 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-48 {
+  .emotion-49 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-48:last-child {
+.emotion-49:last-child {
   padding-bottom: 1rem;
 }
 
-.emotion-52 {
+.emotion-53 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -785,26 +789,26 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-52 {
+  .emotion-53 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-52 {
+  .emotion-53 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-52 {
+  .emotion-53 {
     padding-top: 2rem;
   }
 }
 
-.emotion-56 {
+.emotion-57 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -816,21 +820,21 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-56 {
+  .emotion-57 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-56 {
+  .emotion-57 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-56 {
+  .emotion-57 {
     padding-right: 2.5rem;
   }
 }
@@ -863,120 +867,124 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
             WS Media (1) -Media above title
           </h1>
           <div
-            class="emotion-12 emotion-4"
-            dir="ltr"
+            class="emotion-12"
           >
-            <figure
-              class="emotion-14 emotion-15"
+            <div
+              class="emotion-13 emotion-4"
+              dir="ltr"
             >
-              <div
-                class="emotion-16 emotion-17"
-                data-e2e="media-player"
+              <figure
+                class="emotion-15 emotion-16"
               >
                 <div
-                  class="emotion-18 emotion-19"
-                  data-e2e="media-player__placeholder"
+                  class="emotion-17 emotion-18"
+                  data-e2e="media-player"
                 >
                   <div
-                    class="emotion-20 emotion-21"
-                    data-e2e="media-player__guidance"
+                    class="emotion-19 emotion-20"
+                    data-e2e="media-player__placeholder"
                   >
-                    <noscript
-                      class="emotion-22 emotion-23"
+                    <div
+                      class="emotion-21 emotion-22"
+                      data-e2e="media-player__guidance"
+                    >
+                      <noscript
+                        class="emotion-23 emotion-24"
+                      />
+                    </div>
+                    <button
+                      class="focusIndicatorRemove emotion-25 emotion-26 emotion-27"
+                    >
+                      <span
+                        class="emotion-10 emotion-11"
+                      >
+                        Play video, "BBC launch trailer for We Know Our Place women's sport campaign", Duration 0,54
+                      </span>
+                      <div
+                        aria-hidden="true"
+                        class="emotion-30 emotion-31"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="emotion-32 emotion-33"
+                          focusable="false"
+                          height="12"
+                          viewBox="0 0 12 12"
+                          width="12"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            fill="none"
+                            fill-rule="evenodd"
+                          >
+                            <path
+                              d="M.5.6h12v12H.5z"
+                            />
+                            <path
+                              d="M2.144.96v11.28l8.712-5.64z"
+                              fill="currentColor"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                      <time
+                        aria-hidden="true"
+                        class="emotion-34 emotion-35"
+                        datetime="PT54S"
+                      >
+                        00:54
+                      </time>
+                    </button>
+                    <img
+                      alt=""
+                      class="emotion-36 emotion-37"
+                      src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg"
                     />
                   </div>
-                  <button
-                    class="focusIndicatorRemove emotion-24 emotion-25 emotion-26"
-                  >
-                    <span
-                      class="emotion-10 emotion-11"
-                    >
-                      Play video, "BBC launch trailer for We Know Our Place women's sport campaign", Duration 0,54
-                    </span>
-                    <div
-                      aria-hidden="true"
-                      class="emotion-29 emotion-30"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="emotion-31 emotion-32"
-                        focusable="false"
-                        height="12"
-                        viewBox="0 0 12 12"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M.5.6h12v12H.5z"
-                          />
-                          <path
-                            d="M2.144.96v11.28l8.712-5.64z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                    <time
-                      aria-hidden="true"
-                      class="emotion-33 emotion-34"
-                      datetime="PT54S"
-                    >
-                      00:54
-                    </time>
-                  </button>
-                  <img
-                    alt=""
-                    class="emotion-35 emotion-36"
-                    src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg"
-                  />
                 </div>
-              </div>
-              <figcaption
-                class="emotion-37 emotion-38"
-                dir="ltr"
-              >
-                <span
-                  class="emotion-10 emotion-11"
+                <figcaption
+                  class="emotion-38 emotion-39"
+                  dir="ltr"
                 >
-                  Video caption, 
-                </span>
-                <p>
-                  BBC launch trailer for We Know Our Place women's sport campaign"
-                </p>
-              </figcaption>
-            </figure>
+                  <span
+                    class="emotion-10 emotion-11"
+                  >
+                    Video caption, 
+                  </span>
+                  <p>
+                    BBC launch trailer for We Know Our Place women's sport campaign"
+                  </p>
+                </figcaption>
+              </figure>
+            </div>
           </div>
           <div
-            class="emotion-41 emotion-4"
+            class="emotion-42 emotion-4"
             dir="ltr"
           >
             <strong
-              class="emotion-43 emotion-44 emotion-45"
+              class="emotion-44 emotion-45 emotion-46"
             >
               WS Media (1) -Media above title
             </strong>
           </div>
           <div
-            class="emotion-46 emotion-4"
+            class="emotion-47 emotion-4"
             dir="ltr"
           >
             <time
-              class="emotion-48 emotion-49"
+              class="emotion-49 emotion-50"
               datetime="2023-01-17"
             >
               17 January 2023
             </time>
           </div>
           <div
-            class="emotion-46 emotion-4"
+            class="emotion-47 emotion-4"
             dir="ltr"
           >
             <h2
-              class="emotion-52 emotion-53"
+              class="emotion-53 emotion-54"
               id="Headline"
               tabindex="-1"
             >
@@ -984,11 +992,11 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
             </h2>
           </div>
           <div
-            class="emotion-46 emotion-4"
+            class="emotion-47 emotion-4"
             dir="ltr"
           >
             <p
-              class="emotion-56 emotion-57"
+              class="emotion-57 emotion-58"
               dir="ltr"
             >
               Page Text

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
@@ -201,188 +201,62 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   padding-bottom: 1.5rem;
 }
 
-@media (max-width: 14.9375rem) {
-  .emotion-10 {
-    padding: 0 0.5rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-10 {
-    padding: 0 0.5rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
-    padding: 0 1rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-10 {
-    padding: 0 1rem;
-    margin-left: 0%;
-  }
-}
-
-@media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-10 {
-    margin-left: 16.666666666666668%;
-  }
-}
-
-@media (min-width: 80rem) {
-  .emotion-10 {
-    margin-left: 33.333333333333336%;
-  }
-}
-
-@supports (display: grid) {
-  .emotion-10 {
-    display: block;
-    width: initial;
-    margin: 0;
-  }
-
-  @media (max-width: 14.9375rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      padding: 0 0.5rem;
-      grid-column-start: 1;
-    }
-  }
-
-  @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      padding: 0 0.5rem;
-      grid-column-start: 1;
-    }
-  }
-
-  @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      padding: 0 1rem;
-      grid-column-start: 1;
-    }
-  }
-
-  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      padding: 0 1rem;
-      grid-column-start: 1;
-    }
-  }
-
-  @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(6, 1fr);
-      grid-column-end: span 6;
-      grid-column-start: 2;
-    }
-  }
-
-  @media (min-width: 80rem) {
-    .emotion-10 {
-      grid-template-columns: repeat(12, 1fr);
-      grid-column-end: span 12;
-      grid-column-start: 5;
-    }
-  }
-}
-
-.emotion-12 {
-  font-size: 1.75rem;
-  line-height: 2rem;
-  font-family: ReithSerif,Helvetica,Arial,sans-serif;
-  font-weight: 500;
-  font-style: normal;
-  color: #141414;
-  display: block;
+.emotion-10 {
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
   margin: 0;
-  padding: 2rem 0;
-  overflow-wrap: anywhere;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-12 {
-    font-size: 2rem;
-    line-height: 2.25rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    font-size: 2.75rem;
-    line-height: 3rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-12 {
-    padding: 2.5rem 0;
-  }
-}
-
-.emotion-12:focus {
-  outline: none;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 20%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-14 {
+  .emotion-12 {
     margin-left: 40%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-14 {
+  .emotion-12 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -390,7 +264,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -398,7 +272,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 1;
@@ -406,7 +280,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 1;
@@ -414,7 +288,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -422,7 +296,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-14 {
+    .emotion-12 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -430,19 +304,19 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-16 {
+.emotion-14 {
   margin: 0;
   padding-bottom: 1.5rem;
   width: 100%;
 }
 
-.emotion-18 {
+.emotion-16 {
   padding-top: 56.25%;
   position: relative;
   overflow: hidden;
 }
 
-.emotion-20 {
+.emotion-18 {
   position: absolute;
   top: 0;
   left: 0;
@@ -451,12 +325,12 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   cursor: default;
 }
 
-.emotion-20:hover .emotion-26,
-.emotion-20:focus .emotion-26 {
+.emotion-18:hover .emotion-24,
+.emotion-18:focus .emotion-24 {
   background-color: #B80000;
 }
 
-.emotion-22 {
+.emotion-20 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: normal;
@@ -470,31 +344,31 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-22 {
+  .emotion-20 {
     font-size: 0.875rem;
   }
 }
 
-.no-js .emotion-22 {
+.no-js .emotion-20 {
   background-color: rgba(34, 34, 34, 0.75);
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .no-js .emotion-22 {
+  .no-js .emotion-20 {
     background-color: transparent;
   }
 }
 
-.no-js .emotion-22 .guidance-message {
+.no-js .emotion-20 .guidance-message {
   display: none;
 }
 
-.emotion-24 {
+.emotion-22 {
   position: absolute;
   bottom: 0;
 }
 
-.emotion-27 {
+.emotion-25 {
   background-color: #222222;
   border: none;
   color: #FFFFFF;
@@ -515,18 +389,18 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   left: 0;
 }
 
-.emotion-27:hover,
-.emotion-27:focus {
+.emotion-25:hover,
+.emotion-25:focus {
   background-color: #B80000;
   -webkit-transition: background-color 300ms;
   transition: background-color 300ms;
 }
 
-.no-js .emotion-27 {
+.no-js .emotion-25 {
   display: none;
 }
 
-.emotion-27:focus-visible::before {
+.emotion-25:focus-visible::before {
   content: '';
   position: absolute;
   left: 0;
@@ -537,18 +411,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   border: 0.1875rem solid #000000;
 }
 
-.emotion-29 {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  width: 1px;
-  margin: 0;
-}
-
-.emotion-31>svg {
+.emotion-29>svg {
   color: #FFFFFF;
   fill: currentColor;
   height: 1.5rem;
@@ -556,7 +419,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   width: 1.5rem;
 }
 
-.emotion-33 {
+.emotion-31 {
   vertical-align: middle;
   margin: 0 0.25rem;
   color: #222222;
@@ -565,17 +428,17 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   height: 0.75rem;
 }
 
-.emotion-35 {
+.emotion-33 {
   display: block;
   margin-top: 0.5rem;
 }
 
-.emotion-37 {
+.emotion-35 {
   display: block;
   width: 100%;
 }
 
-.emotion-39 {
+.emotion-37 {
   font-size: 0.9375rem;
   line-height: 1.125rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -592,37 +455,37 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 0.9375rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-39 {
+  .emotion-37 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-39 {
+  .emotion-37 {
     width: 100%;
     margin: 0.5rem 0 0;
   }
 }
 
-.emotion-39>p {
+.emotion-37>p {
   padding-bottom: 1.5rem;
   margin: 0;
 }
 
-.emotion-39>p:last-child {
+.emotion-37>p:last-child {
   padding-bottom: 0;
 }
 
 @media (min-width: 25rem) and (max-width: 62.9375rem) {
-  .emotion-39 {
+  .emotion-37 {
     width: calc(100% - 1rem);
     margin-left: 1rem;
     padding-right: 1rem;
@@ -631,61 +494,61 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 63rem) {
-  .emotion-39 {
+  .emotion-37 {
     padding-right: 0;
     padding-left: 0.5rem;
   }
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-43 {
+  .emotion-41 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-43 {
+  .emotion-41 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-43 {
-    margin-left: 20%;
+  .emotion-41 {
+    margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-43 {
-    margin-left: 40%;
+  .emotion-41 {
+    margin-left: 33.333333333333336%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-43 {
+  .emotion-41 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -694,7 +557,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -703,7 +566,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-43 {
+    .emotion-41 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -712,7 +575,151 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-43 {
+    .emotion-41 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      padding: 0 1rem;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 63rem) and (max-width: 79.9375rem) {
+    .emotion-41 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      grid-column-start: 2;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .emotion-41 {
+      grid-template-columns: repeat(12, 1fr);
+      grid-column-end: span 12;
+      grid-column-start: 5;
+    }
+  }
+}
+
+.emotion-44 {
+  font-size: 1.75rem;
+  line-height: 2rem;
+  font-family: ReithSerif,Helvetica,Arial,sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  color: #141414;
+  display: block;
+  margin: 0;
+  padding: 2rem 0;
+}
+
+@media (min-width: 20rem) and (max-width: 37.4375rem) {
+  .emotion-44 {
+    font-size: 2rem;
+    line-height: 2.25rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-44 {
+    font-size: 2.75rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width: 37.5rem) {
+  .emotion-44 {
+    padding: 2.5rem 0;
+  }
+}
+
+@media (max-width: 62.9375rem) {
+  .emotion-44 {
+    padding: 0.5rem 0 2rem;
+  }
+}
+
+@media (min-width: 63rem) {
+  .emotion-44 {
+    padding: 1rem 0 2.5rem;
+  }
+}
+
+@media (max-width: 14.9375rem) {
+  .emotion-46 {
+    padding: 0 0.5rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 15rem) and (max-width: 24.9375rem) {
+  .emotion-46 {
+    padding: 0 0.5rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 25rem) and (max-width: 37.4375rem) {
+  .emotion-46 {
+    padding: 0 1rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+  .emotion-46 {
+    padding: 0 1rem;
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 63rem) and (max-width: 79.9375rem) {
+  .emotion-46 {
+    margin-left: 20%;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-46 {
+    margin-left: 40%;
+  }
+}
+
+@supports (display: grid) {
+  .emotion-46 {
+    display: block;
+    width: initial;
+    margin: 0;
+  }
+
+  @media (max-width: 14.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      padding: 0 0.5rem;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 15rem) and (max-width: 24.9375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      padding: 0 0.5rem;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 25rem) and (max-width: 37.4375rem) {
+    .emotion-46 {
+      grid-template-columns: repeat(6, 1fr);
+      grid-column-end: span 6;
+      padding: 0 1rem;
+      grid-column-start: 1;
+    }
+  }
+
+  @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
+    .emotion-46 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       padding: 0 1rem;
@@ -721,7 +728,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-43 {
+    .emotion-46 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -729,7 +736,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-43 {
+    .emotion-46 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -737,7 +744,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
   }
 }
 
-.emotion-45 {
+.emotion-48 {
   font-size: 0.875rem;
   line-height: 1.125rem;
   color: #545658;
@@ -749,24 +756,24 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-45 {
+  .emotion-48 {
     font-size: 0.875rem;
     line-height: 1.125rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-45 {
+  .emotion-48 {
     font-size: 0.8125rem;
     line-height: 1rem;
   }
 }
 
-.emotion-45:last-child {
+.emotion-48:last-child {
   padding-bottom: 1rem;
 }
 
-.emotion-49 {
+.emotion-52 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -778,26 +785,26 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-49 {
+  .emotion-52 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-49 {
+  .emotion-52 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-49 {
+  .emotion-52 {
     padding-top: 2rem;
   }
 }
 
-.emotion-53 {
+.emotion-56 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -809,21 +816,21 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-53 {
+  .emotion-56 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-53 {
+  .emotion-56 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-53 {
+  .emotion-56 {
     padding-right: 2.5rem;
   }
 }
@@ -848,56 +855,51 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
           class="emotion-8 emotion-9"
           role="main"
         >
-          <div
-            class="emotion-10 emotion-4"
-            dir="ltr"
+          <h1
+            class="emotion-10 emotion-11"
+            id="content"
+            tabindex="-1"
           >
-            <h1
-              class="emotion-12 emotion-13"
-              id="content"
-              tabindex="-1"
-            >
-              WS Media (1) -Media above title
-            </h1>
-          </div>
+            WS Media (1) -Media above title
+          </h1>
           <div
-            class="emotion-14 emotion-4"
+            class="emotion-12 emotion-4"
             dir="ltr"
           >
             <figure
-              class="emotion-16 emotion-17"
+              class="emotion-14 emotion-15"
             >
               <div
-                class="emotion-18 emotion-19"
+                class="emotion-16 emotion-17"
                 data-e2e="media-player"
               >
                 <div
-                  class="emotion-20 emotion-21"
+                  class="emotion-18 emotion-19"
                   data-e2e="media-player__placeholder"
                 >
                   <div
-                    class="emotion-22 emotion-23"
+                    class="emotion-20 emotion-21"
                     data-e2e="media-player__guidance"
                   >
                     <noscript
-                      class="emotion-24 emotion-25"
+                      class="emotion-22 emotion-23"
                     />
                   </div>
                   <button
-                    class="focusIndicatorRemove emotion-26 emotion-27 emotion-28"
+                    class="focusIndicatorRemove emotion-24 emotion-25 emotion-26"
                   >
                     <span
-                      class="emotion-29 emotion-30"
+                      class="emotion-10 emotion-11"
                     >
                       Play video, "BBC launch trailer for We Know Our Place women's sport campaign", Duration 0,54
                     </span>
                     <div
                       aria-hidden="true"
-                      class="emotion-31 emotion-32"
+                      class="emotion-29 emotion-30"
                     >
                       <svg
                         aria-hidden="true"
-                        class="emotion-33 emotion-34"
+                        class="emotion-31 emotion-32"
                         focusable="false"
                         height="12"
                         viewBox="0 0 12 12"
@@ -920,7 +922,7 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
                     </div>
                     <time
                       aria-hidden="true"
-                      class="emotion-35 emotion-36"
+                      class="emotion-33 emotion-34"
                       datetime="PT54S"
                     >
                       00:54
@@ -928,17 +930,17 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
                   </button>
                   <img
                     alt=""
-                    class="emotion-37 emotion-38"
+                    class="emotion-35 emotion-36"
                     src="https://ichef.test.bbci.co.uk/images/ic/512xn/p01thw3g.jpg"
                   />
                 </div>
               </div>
               <figcaption
-                class="emotion-39 emotion-40"
+                class="emotion-37 emotion-38"
                 dir="ltr"
               >
                 <span
-                  class="emotion-29 emotion-30"
+                  class="emotion-10 emotion-11"
                 >
                   Video caption, 
                 </span>
@@ -949,22 +951,32 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
             </figure>
           </div>
           <div
-            class="emotion-43 emotion-4"
+            class="emotion-41 emotion-4"
+            dir="ltr"
+          >
+            <strong
+              class="emotion-43 emotion-44 emotion-45"
+            >
+              WS Media (1) -Media above title
+            </strong>
+          </div>
+          <div
+            class="emotion-46 emotion-4"
             dir="ltr"
           >
             <time
-              class="emotion-45 emotion-46"
+              class="emotion-48 emotion-49"
               datetime="2023-01-17"
             >
               17 January 2023
             </time>
           </div>
           <div
-            class="emotion-43 emotion-4"
+            class="emotion-46 emotion-4"
             dir="ltr"
           >
             <h2
-              class="emotion-49 emotion-50"
+              class="emotion-52 emotion-53"
               id="Headline"
               tabindex="-1"
             >
@@ -972,11 +984,11 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
             </h2>
           </div>
           <div
-            class="emotion-43 emotion-4"
+            class="emotion-46 emotion-4"
             dir="ltr"
           >
             <p
-              class="emotion-53 emotion-54"
+              class="emotion-56 emotion-57"
               dir="ltr"
             >
               Page Text

--- a/src/app/pages/MediaArticlePage/fixtureData.js
+++ b/src/app/pages/MediaArticlePage/fixtureData.js
@@ -3,23 +3,23 @@ const pidginPageData = {
     model: {
       blocks: [
         {
-          id: 'fd03416f',
-          type: 'headline',
+          id: '2484b596',
+          type: 'visuallyHiddenHeadline',
           model: {
             blocks: [
               {
-                id: 'e91a3127',
+                id: '5ecf3620',
                 type: 'text',
                 model: {
                   blocks: [
                     {
-                      id: 'fa2fdac4',
+                      id: '3b9abb26',
                       type: 'paragraph',
                       model: {
                         text: 'WS Media (1) -Media above title',
                         blocks: [
                           {
-                            id: 'b679fd57',
+                            id: 'ebf8d803',
                             type: 'fragment',
                             model: {
                               text: 'WS Media (1) -Media above title',
@@ -40,29 +40,29 @@ const pidginPageData = {
           position: [1],
         },
         {
-          id: 'c8048f31',
+          id: 'd3d6bfd8',
           type: 'video',
           model: {
             locator: 'urn:bbc:pips:pid:p01thw20',
             blocks: [
               {
-                id: 'e92b193b',
+                id: '58e40776',
                 type: 'caption',
                 model: {
                   blocks: [
                     {
-                      id: 'edd2f8de',
+                      id: '114d678b',
                       type: 'text',
                       model: {
                         blocks: [
                           {
-                            id: '9ef3953b',
+                            id: '9a21a54a',
                             type: 'paragraph',
                             model: {
                               text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
                               blocks: [
                                 {
-                                  id: '31fc56b9',
+                                  id: 'dee173c5',
                                   type: 'fragment',
                                   model: {
                                     text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
@@ -83,12 +83,12 @@ const pidginPageData = {
                 position: [2, 1],
               },
               {
-                id: 'cafbaa21',
+                id: 'e1ede8f7',
                 type: 'aresMedia',
                 model: {
                   blocks: [
                     {
-                      id: '3652279b',
+                      id: 'ac79d69f',
                       blockId: 'urn:bbc:ares::clip:p01thw20',
                       type: 'aresMediaMetadata',
                       model: {
@@ -127,12 +127,12 @@ const pidginPageData = {
                       position: [2, 2, 1],
                     },
                     {
-                      id: '5b6bcc8c',
+                      id: '9aed1eb7',
                       type: 'image',
                       model: {
                         blocks: [
                           {
-                            id: 'db7954e3',
+                            id: '4a56948a',
                             type: 'rawImage',
                             model: {
                               width: 1428,
@@ -144,23 +144,23 @@ const pidginPageData = {
                             position: [2, 2, 2, 1],
                           },
                           {
-                            id: '08c303ea',
+                            id: 'c51e6bae',
                             type: 'altText',
                             model: {
                               blocks: [
                                 {
-                                  id: 'f3ad262f',
+                                  id: '22b766bb',
                                   type: 'text',
                                   model: {
                                     blocks: [
                                       {
-                                        id: '3c60dd58',
+                                        id: '4d434bcb',
                                         type: 'paragraph',
                                         model: {
                                           text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
                                           blocks: [
                                             {
-                                              id: 'f1a9d7d7',
+                                              id: '5d45d744',
                                               type: 'fragment',
                                               model: {
                                                 text: 'BBC launch trailer for We Know Our Place women\'s sport campaign"',
@@ -193,68 +193,77 @@ const pidginPageData = {
           position: [2],
         },
         {
-          id: 'f36890f3',
+          id: 'c66579d3',
+          type: 'fauxHeadline',
+          model: {
+            blocks: [
+              {
+                id: '4fe12ad6',
+                type: 'text',
+                model: {
+                  blocks: [
+                    {
+                      id: '89a8aca0',
+                      type: 'paragraph',
+                      model: {
+                        text: 'WS Media (1) -Media above title',
+                        blocks: [
+                          {
+                            id: 'ce185601',
+                            type: 'fragment',
+                            model: {
+                              text: 'WS Media (1) -Media above title',
+                              attributes: [],
+                            },
+                            position: [3, 1, 1, 1],
+                          },
+                        ],
+                      },
+                      position: [3, 1, 1],
+                    },
+                  ],
+                },
+                position: [3, 1],
+              },
+            ],
+          },
+          position: [3],
+        },
+        {
+          id: '0f40aced',
           type: 'timestamp',
           model: {
             firstPublished: 1673964186410,
             lastPublished: 1673964957894,
           },
-          position: [3],
+          position: [4],
         },
         {
-          id: 'e1979b13',
+          id: 'c1d129a8',
           type: 'subheadline',
           model: {
             blocks: [
               {
-                id: 'b9cdd687',
+                id: '6b4b39da',
                 type: 'text',
                 model: {
                   blocks: [
                     {
-                      id: 'a73424f8',
+                      id: '4c816797',
                       type: 'paragraph',
                       model: {
                         text: 'Headline',
                         blocks: [
                           {
-                            id: '2b33bca0',
+                            id: '95335515',
                             type: 'fragment',
                             model: {
                               text: 'Headline',
                               attributes: [],
                             },
-                            position: [4, 1, 1, 1],
+                            position: [5, 1, 1, 1],
                           },
                         ],
-                      },
-                      position: [4, 1, 1],
-                    },
-                  ],
-                },
-                position: [4, 1],
-              },
-            ],
-          },
-          position: [4],
-        },
-        {
-          id: 'bc7c4b90',
-          type: 'text',
-          model: {
-            blocks: [
-              {
-                id: 'c69035e1',
-                type: 'paragraph',
-                model: {
-                  text: 'Page Text',
-                  blocks: [
-                    {
-                      id: 'a8e7dbba',
-                      type: 'fragment',
-                      model: {
-                        text: 'Page Text',
-                        attributes: [],
                       },
                       position: [5, 1, 1],
                     },
@@ -267,13 +276,35 @@ const pidginPageData = {
           position: [5],
         },
         {
-          id: 'b0d7e705',
-          type: 'mpu',
-          model: {},
+          id: 'c57b7f9f',
+          type: 'text',
+          model: {
+            blocks: [
+              {
+                id: '2200c25c',
+                type: 'paragraph',
+                model: {
+                  text: 'Page Text',
+                  blocks: [
+                    {
+                      id: 'cfa9b294',
+                      type: 'fragment',
+                      model: {
+                        text: 'Page Text',
+                        attributes: [],
+                      },
+                      position: [6, 1, 1],
+                    },
+                  ],
+                },
+                position: [6, 1],
+              },
+            ],
+          },
           position: [6],
         },
         {
-          id: '9295a77f',
+          id: 'e094dc5b',
           type: 'wsoj',
           model: {
             type: 'recommendations',


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-196]

Overall changes
======
Adds support for media first MediaArticlePage BFF response

Code changes
======

- Adds fauxHeadline to components to render for new MediaArticlePage BFF response 
- Removes defunct visuallyHiddenHeadline transform logic formed from this issue https://github.com/bbc/simorgh/issues/6243

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
