### PR TITLE
WSTEAM1-334: Main compartmentalized functionality

### DIFF
--- a/src/app/components/ThemeProvider/paletteInverted.ts
+++ b/src/app/components/ThemeProvider/paletteInverted.ts
@@ -1,5 +1,3 @@
-import { Theme } from '@emotion/react';
-
 export const ARCHIVE_BLUE = '#3A549C';
 export const BLUEJAY = '#0F556C';
 export const BLUEJAY_LHT = '#C3DEE7';

--- a/src/app/components/ThemeProvider/paletteInverted.ts
+++ b/src/app/components/ThemeProvider/paletteInverted.ts
@@ -1,0 +1,104 @@
+import { Theme } from '@emotion/react';
+
+export const ARCHIVE_BLUE = '#3A549C';
+export const BLUEJAY = '#0F556C';
+export const BLUEJAY_LHT = '#C3DEE7';
+export const CHALK = '#ECEAE7';
+export const CONSENT_ACTION = '#F6A21D';
+export const CONSENT_BACKGROUND = '#323232';
+export const CONSENT_FOCUS = '#68A1F8';
+export const DARK_SALTIRE = '#23104C';
+export const KINGFISHER = '#11708C';
+export const LE_TEAL = '#09838B';
+export const NEWSROUND_PURPLE = '#6C22D6';
+export const NEWSROUND_PURPLE_30 = '#9159A8';
+export const POSTBOX = '#B80000';
+export const POSTBOX_30 = '#EAB3B3';
+export const SPORT_MIST = '#F7F7F5';
+export const SPORT_SILVER = '#DBDBDB';
+export const SPORT_YELLOW = '#FFD230';
+export const SPORT_YELLOW_30 = '#BB9A31';
+export const STORM = '#404040';
+export const WEATHER_BLUE = '#067EB3';
+
+export const BLACK = '#FFFFFF';
+export const CLOUD_DARK = '#8A8A8A';
+export const CLOUD_LIGHT = '#454545';
+export const CONSENT_CONTENT = '#414141';
+export const DIM_GREY = '#969696';
+export const EBON = '#DDDDDD';
+export const GHOST = '#020202';
+export const GREY_10 = '#EBEBEB';
+export const GREY_11 = '#454545';
+export const GREY_2 = '#090909';
+export const GREY_3 = '#191715';
+export const GREY_5 = '#757371';
+export const GREY_6 = '#AbA9A7';
+export const GREY_7 = '#C5C3C1';
+export const GREY_8 = '#DFDDDB';
+export const LUNAR = '#0D0D0D';
+export const LUNAR_LIGHT = '#070707';
+export const METAL = '#91918C';
+export const MIDNIGHT_BLACK = '#EDEDED';
+export const OAT_LHT = '#0A0C0E';
+export const ORBIT_GREY = '#B3B3B3';
+export const PEBBLE = '#51514A';
+export const PHILIPPINE_GREY = '#757371';
+export const RHINO = '#A5A5A5';
+export const SHADOW = '#C0C0BD';
+export const STONE = '#2A2F32';
+export const WHITE = '#000000';
+
+const DARK_PALETTE = {
+  palette: {
+    ARCHIVE_BLUE,
+    BLACK,
+    BLUEJAY,
+    BLUEJAY_LHT,
+    CHALK,
+    CLOUD_DARK,
+    CLOUD_LIGHT,
+    CONSENT_ACTION,
+    CONSENT_BACKGROUND,
+    CONSENT_CONTENT,
+    CONSENT_FOCUS,
+    DARK_SALTIRE,
+    DIM_GREY,
+    EBON,
+    GHOST,
+    GREY_10,
+    GREY_11,
+    GREY_2,
+    GREY_3,
+    GREY_5,
+    GREY_6,
+    GREY_7,
+    GREY_8,
+    KINGFISHER,
+    LE_TEAL,
+    LUNAR,
+    LUNAR_LIGHT,
+    METAL,
+    MIDNIGHT_BLACK,
+    NEWSROUND_PURPLE,
+    NEWSROUND_PURPLE_30,
+    OAT_LHT,
+    ORBIT_GREY,
+    PEBBLE,
+    PHILIPPINE_GREY,
+    POSTBOX,
+    POSTBOX_30,
+    RHINO,
+    SHADOW,
+    SPORT_MIST,
+    SPORT_SILVER,
+    SPORT_YELLOW,
+    SPORT_YELLOW_30,
+    STONE,
+    STORM,
+    WEATHER_BLUE,
+    WHITE,
+  },
+};
+
+export default DARK_PALETTE;

--- a/src/app/contexts/ThemeContextPOC/index.tsx
+++ b/src/app/contexts/ThemeContextPOC/index.tsx
@@ -1,0 +1,59 @@
+import { WHITE as WHITE_NORMAL } from '#app/components/ThemeProvider/palette';
+import DARK_PALETTE, {
+  WHITE as WHITE_INVERTED,
+} from '#app/components/ThemeProvider/paletteInverted';
+import { Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+import React, {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useContext,
+  useState,
+} from 'react';
+
+type RequestContextProps = {
+  darkMode: boolean;
+  setDarkMode: Dispatch<SetStateAction<boolean>>;
+};
+
+const Button = styled.button<ButtonType>`
+  border: ${props => (props.mode ? WHITE_NORMAL : WHITE_INVERTED)} 0.3rem solid;
+  background: ${props => (props.mode ? WHITE_INVERTED : WHITE_NORMAL)};
+  color: ${props => (props.mode ? WHITE_NORMAL : WHITE_INVERTED)};
+  font-size: 1.5rem;
+  padding: 1rem;
+`;
+
+type ButtonType = {
+  mode: boolean;
+};
+
+export const ThemeContextPOC = createContext({} as RequestContextProps);
+
+export const ThemeComponent = ({ children }: PropsWithChildren) => {
+  const [darkMode, setDarkMode] = useState(false);
+  return (
+    <ThemeContextPOC.Provider value={{ darkMode, setDarkMode }}>
+      {children}
+    </ThemeContextPOC.Provider>
+  );
+};
+
+export const ToggleButton = () => {
+  const { darkMode, setDarkMode } = useContext(ThemeContextPOC);
+  return (
+    <Button
+      mode={darkMode}
+      type="button"
+      onClick={() => setDarkMode(!darkMode)}
+    >
+      SWITCH TO {darkMode ? 'LIGHT' : 'DARK'}
+    </Button>
+  );
+};
+
+export const applyDarkPalette = (ancestorTheme: Theme): Theme => {
+  return { ...ancestorTheme, ...DARK_PALETTE } as Theme;
+};


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-334](https://jira.dev.bbc.co.uk/browse/WSTEAM1-334)

Overall changes
======

https://user-images.githubusercontent.com/32307964/226679527-d20c1c99-ac33-4863-b5ec-0498d852ee03.mov


Code changes
======

- _A new inverted palette has been added to store colours of respective inverted colours._
- _A dynamic ThemeContext has been added to allow a switch button to be added on any page._

Implementation variations
======
1. _[Applies Dark Mode to the entire App](https://github.com/bbc/simorgh/pull/10723/files)_
1. _[Applies Dark Mode to just Single Pages](https://github.com/bbc/simorgh/pull/10724/files)_
