### PR TITLE
Enable ATI event tracking for the tipohome page

### DIFF
--- a/src/app/contexts/EventTrackingContext/index.tsx
+++ b/src/app/contexts/EventTrackingContext/index.tsx
@@ -18,6 +18,7 @@ import {
   TOPIC_PAGE,
   LIVE_PAGE,
   MEDIA_ARTICLE_PAGE,
+  HOME_PAGE,
 } from '#app/routes/utils/pageTypes';
 import { PageTypes, Platforms } from '#app/models/types/global';
 import { ServiceContext } from '../ServiceContext';
@@ -36,7 +37,7 @@ export const EventTrackingContext = createContext<EventTrackingContextProps>(
   {} as EventTrackingContextProps,
 );
 
-type CampaignPageTypes = Exclude<PageTypes, 'error' | 'home'>;
+type CampaignPageTypes = Exclude<PageTypes, 'error'>;
 
 const getCampaignID = (pageType: CampaignPageTypes) => {
   const campaignID = {
@@ -54,6 +55,7 @@ const getCampaignID = (pageType: CampaignPageTypes) => {
     [CORRESPONDENT_STORY_PAGE]: 'article-csp',
     [TOPIC_PAGE]: 'topic-page',
     [LIVE_PAGE]: 'live-page',
+    [HOME_PAGE]: 'index-home'
   }[pageType];
 
   if (!campaignID) {

--- a/src/app/contexts/EventTrackingContext/index.tsx
+++ b/src/app/contexts/EventTrackingContext/index.tsx
@@ -55,7 +55,7 @@ const getCampaignID = (pageType: CampaignPageTypes) => {
     [CORRESPONDENT_STORY_PAGE]: 'article-csp',
     [TOPIC_PAGE]: 'topic-page',
     [LIVE_PAGE]: 'live-page',
-    [HOME_PAGE]: 'index-home'
+    [HOME_PAGE]: 'index-home',
   }[pageType];
 
   if (!campaignID) {

--- a/src/app/legacy/containers/ATIAnalytics/params/index.js
+++ b/src/app/legacy/containers/ATIAnalytics/params/index.js
@@ -1,4 +1,20 @@
 import {
+  HOME_PAGE,
+  STORY_PAGE,
+  MEDIA_ASSET_PAGE,
+  CORRESPONDENT_STORY_PAGE,
+  ARTICLE_PAGE,
+  FRONT_PAGE,
+  TOPIC_PAGE,
+  MEDIA_ARTICLE_PAGE,
+  FEATURE_INDEX_PAGE,
+  MOST_READ_PAGE,
+  MOST_WATCHED_PAGE,
+  INDEX_PAGE,
+  PHOTO_GALLERY_PAGE,
+  MEDIA_PAGE,
+} from '#app/routes/utils/pageTypes';
+import {
   buildArticleATIParams,
   buildArticleATIUrl,
 } from './article/buildParams';
@@ -32,75 +48,77 @@ const ARTICLE_PHOTO_GALLERY = 'article-photo-gallery';
 const ARTICLE_CORRESPONDENT_PIECE = 'article-correspondent';
 
 const pageTypeUrlBuilders = {
-  article: buildArticleATIUrl,
-  mediaArticle: (data, requestContext, serviceContext) =>
+  [ARTICLE_PAGE]: buildArticleATIUrl,
+  [MEDIA_ARTICLE_PAGE]: (data, requestContext, serviceContext) =>
     buildArticleATIUrl(data, requestContext, serviceContext, 'article-sfv'),
-  STY: (data, requestContext, serviceContext) =>
+  [STORY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIUrl(data, requestContext, serviceContext, 'article'),
-  frontPage: buildIndexPageATIUrl,
-  media: buildTvRadioATIUrl,
-  mostRead: buildMostReadATIUrl,
-  mostWatched: buildMostWatchedATIUrl,
-  IDX: buildIndexPageATIUrl,
-  FIX: buildIndexPageATIUrl,
-  TOPIC: buildTopicPageATIUrl,
-  MAP: (data, requestContext, serviceContext) =>
+  [FRONT_PAGE]: buildIndexPageATIUrl,
+  [MEDIA_PAGE]: buildTvRadioATIUrl,
+  [MOST_READ_PAGE]: buildMostReadATIUrl,
+  [MOST_WATCHED_PAGE]: buildMostWatchedATIUrl,
+  [INDEX_PAGE]: buildIndexPageATIUrl,
+  [FEATURE_INDEX_PAGE]: buildIndexPageATIUrl,
+  [TOPIC_PAGE]: buildTopicPageATIUrl,
+  [MEDIA_ASSET_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIUrl(
       data,
       requestContext,
       serviceContext,
       ARTICLE_MEDIA_ASSET,
     ),
-  PGL: (data, requestContext, serviceContext) =>
+  [PHOTO_GALLERY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIUrl(
       data,
       requestContext,
       serviceContext,
       ARTICLE_PHOTO_GALLERY,
     ),
-  CSP: (data, requestContext, serviceContext) =>
+  [CORRESPONDENT_STORY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIUrl(
       data,
       requestContext,
       serviceContext,
       ARTICLE_CORRESPONDENT_PIECE,
     ),
+  [HOME_PAGE]: buildIndexPageATIUrl,
 };
 
 const pageTypeParamBuilders = {
-  article: buildArticleATIParams,
-  mediaArticle: (data, requestContext, serviceContext) =>
+  [ARTICLE_PAGE]: buildArticleATIParams,
+  [MEDIA_ARTICLE_PAGE]: (data, requestContext, serviceContext) =>
     buildArticleATIParams(data, requestContext, serviceContext, 'article-sfv'),
-  frontPage: buildIndexPageATIParams,
-  media: buildTvRadioATIParams,
-  mostRead: buildMostReadATIParams,
-  mostWatched: buildMostWatchedATIParams,
-  IDX: buildIndexPageATIParams,
-  FIX: buildIndexPageATIParams,
-  TOPIC: buildTopicPageATIParams,
-  MAP: (data, requestContext, serviceContext) =>
+  [FRONT_PAGE]: buildIndexPageATIParams,
+  [MEDIA_PAGE]: buildTvRadioATIParams,
+  [MOST_READ_PAGE]: buildMostReadATIParams,
+  [MOST_WATCHED_PAGE]: buildMostWatchedATIParams,
+  [INDEX_PAGE]: buildIndexPageATIParams,
+  [FEATURE_INDEX_PAGE]: buildIndexPageATIParams,
+  [TOPIC_PAGE]: buildTopicPageATIParams,
+  [MEDIA_ASSET_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIParams(
       data,
       requestContext,
       serviceContext,
       ARTICLE_MEDIA_ASSET,
     ),
-  PGL: (data, requestContext, serviceContext) =>
+  [PHOTO_GALLERY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIParams(
       data,
       requestContext,
       serviceContext,
       ARTICLE_PHOTO_GALLERY,
     ),
-  CSP: (data, requestContext, serviceContext) =>
+  [CORRESPONDENT_STORY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIParams(
       data,
       requestContext,
       serviceContext,
       ARTICLE_CORRESPONDENT_PIECE,
     ),
-  STY: (data, requestContext, serviceContext) =>
+  [STORY_PAGE]: (data, requestContext, serviceContext) =>
     buildCpsAssetPageATIParams(data, requestContext, serviceContext, 'article'),
+  [HOME_PAGE]: buildIndexPageATIParams,
 };
 
 const createBuilderFactory = (requestContext, pageTypeHandlers) => {

--- a/src/app/legacy/containers/ATIAnalytics/params/index.test.js
+++ b/src/app/legacy/containers/ATIAnalytics/params/index.test.js
@@ -8,6 +8,7 @@ import {
   MEDIA_ASSET_PAGE,
   PHOTO_GALLERY_PAGE,
   MEDIA_ARTICLE_PAGE,
+  HOME_PAGE,
 } from '#app/routes/utils/pageTypes';
 import { buildATIUrl, buildATIEventTrackingParams } from '.';
 
@@ -195,6 +196,17 @@ describe('ATIAnalytics params', () => {
       );
     });
 
+    it('should return the correct homePage url', () => {
+      const url = buildATIUrl(
+        frontPage,
+        { ...requestContext, pageType: HOME_PAGE },
+        serviceContext,
+      );
+      expect(url).toMatchInlineSnapshot(
+        `"s=598285&s2=atiAnalyticsProducerId&p=service.page&r=0x0x24x24&re=1024x768&hl=00-00-00&lng=en-US&x1=[urn%3Abbc%3Acps%3A00000000-0000-0000-0000-000000000000]&x2=[responsive]&x3=[atiAnalyticsAppName]&x4=[language]&x5=[http%253A%252F%252Flocalhost%252F]&x7=[index-home]&x8=[simorgh]&x9=[title%2520-%2520brandName]&x11=[1970-01-01T00%3A00%3A00.000Z]&x12=[1970-01-01T00%3A00%3A00.000Z]"`,
+      );
+    });
+
     it('should return the right IDX page url', () => {
       const url = buildATIUrl(
         idxPage,
@@ -342,6 +354,29 @@ describe('ATIAnalytics params', () => {
       const params = buildATIEventTrackingParams(
         frontPage,
         { ...requestContext, pageType: FRONT_PAGE },
+        serviceContext,
+      );
+      expect(params).toEqual({
+        appName: 'atiAnalyticsAppName',
+        contentId: 'urn:bbc:cps:00000000-0000-0000-0000-000000000000',
+        contentType: 'index-home',
+        language: 'language',
+        pageIdentifier: 'service.page',
+        pageTitle: 'title - brandName',
+        libraryVersion: 'simorgh',
+        platform: 'platform',
+        producerId: 'atiAnalyticsProducerId',
+        service: 'service',
+        statsDestination: 'statsDestination',
+        timePublished: '1970-01-01T00:00:00.000Z',
+        timeUpdated: '1970-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('should return the correct homePage params', () => {
+      const params = buildATIEventTrackingParams(
+        frontPage,
+        { ...requestContext, pageType: HOME_PAGE },
         serviceContext,
       );
       expect(params).toEqual({

--- a/src/app/lib/analyticsUtils/indexPage/index.js
+++ b/src/app/lib/analyticsUtils/indexPage/index.js
@@ -3,6 +3,7 @@ import {
   FRONT_PAGE,
   INDEX_PAGE,
   FEATURE_INDEX_PAGE,
+  HOME_PAGE,
 } from '#app/routes/utils/pageTypes';
 
 export const getPageIdentifier = (indexPageData, service) => {
@@ -51,6 +52,7 @@ export const getPageTitle = (indexPageData, brandName) => {
 export const getContentType = pageType => {
   switch (pageType) {
     case FRONT_PAGE:
+    case HOME_PAGE:
       return 'index-home';
     case INDEX_PAGE:
       return 'index-section';


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Enables ATI Event Tracking for Home Page.

This also fixes the following errors in the browser console:
![Screenshot 2023-03-22 at 12 23 09](https://user-images.githubusercontent.com/58214768/226907711-ea486d18-5f54-4b94-bc3b-d0689ad8d183.png)


Code changes
======
- Add same configuration as front page for home page  
- Add a test to check ATI tracking is correct for home page
- Refactor - use page type constants, instead of hardcoding.  

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
