### PR TITLE
Adds `pageType` to the CDN request for Cypress Topic Page tests

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -35,7 +35,7 @@ export default ({ service, pageType, variant }) => {
           method: 'GET',
           url: `https://web-cdn.${
             env === 'live' ? '' : `${env}.`
-          }api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}`,
+          }api.bbci.co.uk/fd/simorgh-bff?page=1&id=${topicId}&service=${service}${appendVariant}&pageType=topic`,
         };
 
         if (Cypress.env('currentPath').includes('?renderer_env=test')) {


### PR DESCRIPTION
Resolves broken CI/CD pipeline ([Slack Thread](https://bbc-tpg.slack.com/archives/C03RCUN9MD1/p1679579449124279))

Overall changes
======
Adds pageType as a param to the CDN request for the Cypress topic page tests, as it is now a mandatory parameter to the BFF

Code changes
======

As above.

Testing
======
- [x] Run Cypress tests against live environment with these changes, and the tests pass

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
