### PR TITLE
Add Welsh and Gaelic translations for Gist and Byline

### DIFF
--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -58,7 +58,7 @@ export const service: DefaultServiceConfig = {
         audioPlayer: 'Audio player',
         videoPlayer: 'Video player',
       },
-      gist: 'At a glance',
+      gist: 'Cipolwg',
       error: {
         404: {
           statusCode: '404',
@@ -88,6 +88,12 @@ export const service: DefaultServiceConfig = {
           callToActionLast: '',
           callToActionLinkUrl: 'https://www.bbc.com/cymrufyw',
         },
+      },
+      byline: {
+        articleInformation: 'Məqalə barədə məlumat',
+        author: 'Müəllif',
+        reportingFrom: 'Məkan',
+        role: 'Vəzifə',
       },
       consentBanner: {
         privacy: {

--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -90,10 +90,10 @@ export const service: DefaultServiceConfig = {
         },
       },
       byline: {
-        articleInformation: 'Məqalə barədə məlumat',
-        author: 'Müəllif',
-        reportingFrom: 'Məkan',
-        role: 'Vəzifə',
+        articleInformation: 'Gwybodaeth am yr erthygl',
+        author: 'Awdur',
+        reportingFrom: 'Yn gohebu o',
+        role: 'Swydd',
       },
       consentBanner: {
         privacy: {

--- a/src/app/lib/config/services/naidheachdan.ts
+++ b/src/app/lib/config/services/naidheachdan.ts
@@ -57,7 +57,7 @@ export const service: DefaultServiceConfig = {
         audioPlayer: 'Audio player',
         videoPlayer: 'Video player',
       },
-      gist: 'At a glance',
+      gist: 'Geàrr-shealladh',
       error: {
         404: {
           statusCode: '404',
@@ -88,6 +88,12 @@ export const service: DefaultServiceConfig = {
           callToActionLast: '',
           callToActionLinkUrl: 'https://www.bbc.com/naidheachdan',
         },
+      },
+      byline: {
+        articleInformation: 'Article information',
+        author: 'Author',
+        reportingFrom: 'Ag aithris às',
+        role: 'Role',
       },
       consentBanner: {
         privacy: {

--- a/src/app/lib/config/services/naidheachdan.ts
+++ b/src/app/lib/config/services/naidheachdan.ts
@@ -90,10 +90,10 @@ export const service: DefaultServiceConfig = {
         },
       },
       byline: {
-        articleInformation: 'Article information',
-        author: 'Author',
+        articleInformation: 'Fiosrachadh mun artaigil',
+        author: 'Ùghdar',
         reportingFrom: 'Ag aithris às',
-        role: 'Role',
+        role: 'Dreuchd',
       },
       consentBanner: {
         privacy: {


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Adds translations for Byline and Gists in Welsh and Gaelic

Code changes
======

- Cymru Fyw service config updated to add translations for Bylines and update translation for Gist header
- Naidheacdan service config updated to add translations for Bylines and update translation for Gist header

Testing
======
1. Visit /naidheachdan/sgeulachdan/c5ynlxj99rvo.amp and /cymrufyw/erthyglau/c0ngdr20ekro.amp on TEST
2. Confirm correct translations rendered in Byline and Gist components

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
