### PR TITLE
Add translations in Welsh & Gaelic for OJs and Social Embeds

### DIFF
--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -205,6 +205,8 @@ export const service: DefaultServiceConfig = {
         duration: 'Duration',
       },
       socialEmbed: {},
+      topStoriesTitle: 'Prif Straeon',
+      featuresAnalysisTitle: 'Cylchgrawn',
     },
     mostRead: {
       header: 'Mwyaf poblogaidd',

--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -204,7 +204,30 @@ export const service: DefaultServiceConfig = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
-      socialEmbed: {},
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Disgrifiad, ',
+          text: 'Gallai hysbysebion ymddangos yng nghynnwys',
+          articleText:
+            "Dyw'r BBC ddim yn gyfrifol am gynnwys gwefannau allanol.",
+          articleAdditionalText: 'Gallai hysbysebion ymddangos yng nghynnwys %provider_name%.',
+        },
+        fallback: {
+          text: 'Mae’n flin gennym ein bod yn cael trafferth dangos y post hwn.',
+          linkText: 'Gwylio’r post gwreiddiol ar %provider_name%',
+          linkTextSuffixVisuallyHidden: ', dolen allanol',
+          warningText: "Dyw'r BBC ddim yn gyfrifol am gynnwys gwefannau allanol.",
+        },
+        skipLink: {
+          text: 'I osgoi neges %provider_name%',
+          endTextVisuallyHidden: 'Diwedd neges %provider_name%',
+        },
+        consentBanner: {
+          heading: `Caniatáu cynnwys [social_media_site]?`,
+          body: `Mae’r erthygl hon yn cynnwys deunydd gan [social_media_site]. Gofynnwn am eich caniatâd cyn llwytho unrhyw beth, gan y gallai Twitter ddefnyddio cwcis neu dechnoleg arall. Mae’n bosib eich bod am ddarllen [link] polisi cwcis [/link] [social_media_site] a [link] pholisi preifatrwydd [/link] cyn derbyn. Er mwyn gweld y cynnwys dewiswch ‘derbyn a pharhau’.`,
+          button: 'Derbyn a pharhau',
+        },
+      },
       topStoriesTitle: 'Prif Straeon',
       featuresAnalysisTitle: 'Cylchgrawn',
     },

--- a/src/app/lib/config/services/cymrufyw.ts
+++ b/src/app/lib/config/services/cymrufyw.ts
@@ -210,13 +210,15 @@ export const service: DefaultServiceConfig = {
           text: 'Gallai hysbysebion ymddangos yng nghynnwys',
           articleText:
             "Dyw'r BBC ddim yn gyfrifol am gynnwys gwefannau allanol.",
-          articleAdditionalText: 'Gallai hysbysebion ymddangos yng nghynnwys %provider_name%.',
+          articleAdditionalText:
+            'Gallai hysbysebion ymddangos yng nghynnwys %provider_name%.',
         },
         fallback: {
           text: 'Mae’n flin gennym ein bod yn cael trafferth dangos y post hwn.',
           linkText: 'Gwylio’r post gwreiddiol ar %provider_name%',
           linkTextSuffixVisuallyHidden: ', dolen allanol',
-          warningText: "Dyw'r BBC ddim yn gyfrifol am gynnwys gwefannau allanol.",
+          warningText:
+            "Dyw'r BBC ddim yn gyfrifol am gynnwys gwefannau allanol.",
         },
         skipLink: {
           text: 'I osgoi neges %provider_name%',

--- a/src/app/lib/config/services/naidheachdan.ts
+++ b/src/app/lib/config/services/naidheachdan.ts
@@ -212,13 +212,15 @@ export const service: DefaultServiceConfig = {
           text: 'Dh’fhaodadh sanasan a bhith an lùib stuth',
           articleText:
             'Chan eil am BBC an urra ri na tha air Làraichean-lìn air an taobh a-muigh.',
-          articleAdditionalText: 'Dh’fhaodadh sanasan a bhith an lùib stuth %provider_name%.',
+          articleAdditionalText:
+            'Dh’fhaodadh sanasan a bhith an lùib stuth %provider_name%.',
         },
         fallback: {
           text: 'Chan eil seo ri fhaighinn',
           linkText: 'VFaic tuilleadh %provider_name%',
           linkTextSuffixVisuallyHidden: ', taobh a-muigh',
-          warningText: 'Chan eil am BBC an urra ri na tha air Làraichean-lìn air an taobh a-muigh.',
+          warningText:
+            'Chan eil am BBC an urra ri na tha air Làraichean-lìn air an taobh a-muigh.',
         },
         skipLink: {
           text: 'Leum thairis air %provider_name% teachdaireachd',

--- a/src/app/lib/config/services/naidheachdan.ts
+++ b/src/app/lib/config/services/naidheachdan.ts
@@ -206,7 +206,30 @@ export const service: DefaultServiceConfig = {
         nextRadioShow: 'Next radio show',
         duration: 'Duration',
       },
-      socialEmbed: {},
+      socialEmbed: {
+        caption: {
+          textPrefixVisuallyHidden: 'Fo-thiotal, ',
+          text: 'Dh’fhaodadh sanasan a bhith an lùib stuth',
+          articleText:
+            'Chan eil am BBC an urra ri na tha air Làraichean-lìn air an taobh a-muigh.',
+          articleAdditionalText: 'Dh’fhaodadh sanasan a bhith an lùib stuth %provider_name%.',
+        },
+        fallback: {
+          text: 'Chan eil seo ri fhaighinn',
+          linkText: 'VFaic tuilleadh %provider_name%',
+          linkTextSuffixVisuallyHidden: ', taobh a-muigh',
+          warningText: 'Chan eil am BBC an urra ri na tha air Làraichean-lìn air an taobh a-muigh.',
+        },
+        skipLink: {
+          text: 'Leum thairis air %provider_name% teachdaireachd',
+          endTextVisuallyHidden: 'Deireadh %provider_name% teachdaireachd',
+        },
+        consentBanner: {
+          heading: `Cead do stuth [social_media_site]?`,
+          body: `Tha stuth [social_media_site] an cois an artaigil seo. Tha sinn a’ sireadh cead bhuat mus tèid sìon luchdachadh, oir dh’fhaodadh iad ‘briosgaidean’ agus teicneòlas eile a chur an sàs. ‘S dòcha gum biodh tu airson [link] poileasaidh nam briosgaidean aca [/link] a leughadh agus [link] am poileasaidh prìobhaideachd aca [/link]  mus tèid thu air adhart. Airson sùil a thoirt air an stuth seo, tagh 'Gabh ris agus lean ort'.`,
+          button: 'Gabh ris agus lean ort',
+        },
+      },
       topStoriesTitle: 'Prìomh Sgeulachdan',
       featuresAnalysisTitle: 'Sgeulachdan Aithriseach',
     },


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Adds translations for Welsh and Gaelic

Code changes
======

- Adds Top Stories and Features strapline translations for Welsh
- Adds Social Media Embed translations for Welsh and Gaelic

Testing
======
Visit /naidheachdan/sgeulachdan/cr2r5jn4660o.amp and /cymrufyw/erthyglau/cngvelrj35jo.amp
See no English

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
