### PR TITLE
WSTEAM1-306: Remove secondary column and most read

### DIFF
--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -6,25 +6,15 @@ import path from 'ramda/src/path';
 import pathOr from 'ramda/src/pathOr';
 import styled from '@emotion/styled';
 import { jsx, useTheme } from '@emotion/react';
-import { string, node } from 'prop-types';
+import { string } from 'prop-types';
 import useToggle from '#hooks/useToggle';
 
+import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '#psammead/gel-foundations/src/breakpoints';
 import {
-  GEL_GROUP_1_SCREEN_WIDTH_MAX,
-  GEL_GROUP_2_SCREEN_WIDTH_MIN,
-  GEL_GROUP_3_SCREEN_WIDTH_MAX,
-  GEL_GROUP_4_SCREEN_WIDTH_MIN,
-  GEL_GROUP_4_SCREEN_WIDTH_MAX,
-  GEL_GROUP_5_SCREEN_WIDTH_MIN,
-} from '#psammead/gel-foundations/src/breakpoints';
-import {
-  GEL_MARGIN_ABOVE_400PX,
-  GEL_MARGIN_BELOW_400PX,
   GEL_SPACING,
   GEL_SPACING_DBL,
   GEL_SPACING_TRPL,
   GEL_SPACING_QUAD,
-  GEL_SPACING_QUIN,
 } from '#psammead/gel-foundations/src/spacings';
 
 import { articleDataPropTypes } from '#models/propTypes/article';
@@ -43,9 +33,6 @@ import OptimizelyPageViewTracking from '#containers/OptimizelyPageViewTracking';
 import OptimizelyArticleCompleteTracking from '#containers/OptimizelyArticleCompleteTracking';
 import ArticleMediaPlayer from '#containers/ArticleMediaPlayer';
 import LinkedData from '#containers/LinkedData';
-import MostReadContainer from '#containers/MostRead';
-import MostReadSection from '#containers/MostRead/section';
-import MostReadSectionLabel from '#containers/MostRead/label';
 import SocialEmbedContainer from '#containers/SocialEmbed';
 import fauxHeadline from '#containers/FauxHeadline';
 import CpsRecommendations from '#containers/CpsRecommendations';
@@ -84,27 +71,6 @@ const Wrapper = styled.div`
   background-color: ${props => props.theme.palette.GREY_2};
 `;
 
-const MediaArticlePageMostReadSection = styled(MostReadSection)`
-  @media (max-width: ${GEL_GROUP_1_SCREEN_WIDTH_MAX}) {
-    margin: 0 ${GEL_MARGIN_BELOW_400PX} 0 ${GEL_MARGIN_BELOW_400PX};
-    padding-bottom: ${GEL_SPACING_TRPL};
-  }
-  @media (min-width: ${GEL_GROUP_2_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_3_SCREEN_WIDTH_MAX}) {
-    margin: 0 ${GEL_MARGIN_ABOVE_400PX} 0 ${GEL_MARGIN_ABOVE_400PX};
-    padding-bottom: ${GEL_SPACING_QUAD};
-  }
-  @media (min-width: ${GEL_GROUP_4_SCREEN_WIDTH_MIN}) and (max-width: ${GEL_GROUP_4_SCREEN_WIDTH_MAX}) {
-    margin: 0 ${GEL_MARGIN_ABOVE_400PX} 0 ${GEL_MARGIN_ABOVE_400PX};
-    padding-bottom: ${GEL_SPACING_QUIN};
-  }
-  @media (min-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN}) {
-    width: 100%; /* Needed for IE11 */
-    margin: 0 auto;
-    padding: 0 ${GEL_SPACING_DBL} ${GEL_SPACING_TRPL};
-    max-width: ${GEL_GROUP_5_SCREEN_WIDTH_MIN};
-  }
-`;
-
 const Main = styled.main`
   padding-bottom: ${GEL_SPACING_TRPL};
 `;
@@ -118,7 +84,7 @@ const StyledRelatedTopics = styled(RelatedTopics)`
   }
 `;
 
-const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
+const MediaArticlePage = ({ pageData }) => {
   const { articleAuthor, isTrustProjectParticipant, showRelatedTopics } =
     useContext(ServiceContext);
   const { enabled: preloadLeadImageToggle } = useToggle('preloadLeadImage');
@@ -220,17 +186,6 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
     filterForBlockType(promoImageBlocks, 'rawImage'),
   );
 
-  const MostReadWrapper = ({ children }) => (
-    <MediaArticlePageMostReadSection>
-      <MostReadSectionLabel mobileDivider={showRelatedTopics && topics} />
-      {children}
-    </MediaArticlePageMostReadSection>
-  );
-
-  MostReadWrapper.propTypes = {
-    children: node.isRequired,
-  };
-
   return (
     <Wrapper>
       <ATIAnalytics data={pageData} />
@@ -266,6 +221,7 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
       <MediaArticlePageGrid>
         <Primary>
           <Main role="main">
+            <h1>MEDIA PAGE</h1>
             <Blocks blocks={blocks} componentsToRender={componentsToRender} />
           </Main>
           {showRelatedTopics && topics && (
@@ -280,10 +236,6 @@ const MediaArticlePage = ({ pageData, mostReadEndpointOverride }) => {
         </Primary>
         <SecondaryColumn pageData={pageData} />
       </MediaArticlePageGrid>
-      <MostReadContainer
-        mostReadEndpointOverride={mostReadEndpointOverride}
-        wrapper={MostReadWrapper}
-      />
       <OptimizelyPageViewTracking />
       <OptimizelyArticleCompleteTracking />
     </Wrapper>

--- a/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.jsx
@@ -221,7 +221,6 @@ const MediaArticlePage = ({ pageData }) => {
       <MediaArticlePageGrid>
         <Primary>
           <Main role="main">
-            <h1>MEDIA PAGE</h1>
             <Blocks blocks={blocks} componentsToRender={componentsToRender} />
           </Main>
           {showRelatedTopics && topics && (

--- a/src/app/pages/MediaArticlePage/SecondaryColumn.jsx
+++ b/src/app/pages/MediaArticlePage/SecondaryColumn.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import path from 'ramda/src/path';
 import styled from '@emotion/styled';
-import { useTheme } from '@emotion/react';
 
 import { GEL_GROUP_4_SCREEN_WIDTH_MIN } from '#psammead/gel-foundations/src/breakpoints';
 import {
@@ -12,9 +11,7 @@ import {
 
 import { articleDataPropTypes } from '#models/propTypes/article';
 
-import FeaturesAnalysis from '#containers/CpsFeaturesAnalysis';
-import TopStoriesSection from './PagePromoSections/TopStoriesSection';
-import { Secondary, gridColumnsSecondary } from './MediaArticlePageGrid';
+import { Secondary } from './MediaArticlePageGrid';
 
 const ResponsiveComponentWrapper = styled.div`
   margin-bottom: ${GEL_SPACING_TRPL};
@@ -25,31 +22,13 @@ const ResponsiveComponentWrapper = styled.div`
 `;
 
 const SecondaryColumn = ({ pageData }) => {
-  const topStoriesContent = path(['secondaryColumn', 'topStories'], pageData);
-  const featuresContent = path(['secondaryColumn', 'features'], pageData);
+  const latestMedia = path(['secondaryColumn', 'latestMedia'], pageData);
 
-  const {
-    palette: { GREY_2 },
-  } = useTheme();
-
-  if (!topStoriesContent && !featuresContent) return null;
+  if (!latestMedia) return null;
 
   return (
     <Secondary>
-      {topStoriesContent && (
-        <ResponsiveComponentWrapper data-testid="top-stories">
-          <TopStoriesSection content={topStoriesContent} />
-        </ResponsiveComponentWrapper>
-      )}
-      {featuresContent && (
-        <ResponsiveComponentWrapper data-testid="features">
-          <FeaturesAnalysis
-            content={featuresContent}
-            parentColumns={gridColumnsSecondary}
-            sectionLabelBackground={GREY_2}
-          />
-        </ResponsiveComponentWrapper>
-      )}
+      <ResponsiveComponentWrapper data-testid="features" />
     </Secondary>
   );
 };

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
@@ -859,9 +859,6 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
           class="emotion-8 emotion-9"
           role="main"
         >
-          <h1>
-            MEDIA PAGE
-          </h1>
           <h1
             class="emotion-10 emotion-11"
             id="content"

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
@@ -859,6 +859,9 @@ exports[`MediaArticlePage should render a news article correctly 1`] = `
           class="emotion-8 emotion-9"
           role="main"
         >
+          <h1>
+            MEDIA PAGE
+          </h1>
           <h1
             class="emotion-10 emotion-11"
             id="content"


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-306](https://jira.dev.bbc.co.uk/browse/WSTEAM1-306)

Overall changes
======
Secondary column and most read have been removed: 
![Screenshot 2023-03-28 at 17 20 43](https://user-images.githubusercontent.com/32307964/228305111-78239d01-4b87-4a5b-b62a-d7abc56da3ee.png)


Code changes
======
- _Top stories and Features have been removed, but a place holder has been left in for latestMedia column._
- _Most read section has been removed completely._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
