### PR TITLE
WSTEAM1-352: Add latestMediaTitle translations to service config files

### DIFF
--- a/src/app/lib/config/services/afaanoromoo.ts
+++ b/src/app/lib/config/services/afaanoromoo.ts
@@ -252,6 +252,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Isin hin darbiin',
       featuresAnalysisTitle: `Maaltu haasa'ama?`,
+      latestMediaTitle: 'Haaraa',
     },
     mostRead: {
       header: "Baay'ee kan dubbifame",

--- a/src/app/lib/config/services/amharic.ts
+++ b/src/app/lib/config/services/amharic.ts
@@ -240,6 +240,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'እንዳያመልጥዎ',
       featuresAnalysisTitle: 'ከየፈርጁ',
+      latestMediaTitle: 'የቅርብ ጊዜ',
     },
     mostRead: {
       header: 'ብዙ የተነበቡ',

--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -248,6 +248,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'প্রধান খবর',
       featuresAnalysisTitle: 'চিঠিপত্র ও মতামত',
+      latestMediaTitle: 'সর্বশেষ',
     },
     mostRead: {
       header: 'সর্বাধিক পঠিত',

--- a/src/app/lib/config/services/burmese.ts
+++ b/src/app/lib/config/services/burmese.ts
@@ -279,6 +279,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'ထိပ်တန်း သတင်းများ',
       featuresAnalysisTitle: 'ဆောင်းပါး',
+      latestMediaTitle: 'နောက်ဆုံးရ',
     },
     mostRead: {
       header: 'အဖတ်အများဆုံး',

--- a/src/app/lib/config/services/gahuza.ts
+++ b/src/app/lib/config/services/gahuza.ts
@@ -267,6 +267,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: "Inkuru iri kw'isonga",
       featuresAnalysisTitle: 'Ivyo BBC Gahuza ibahitiramwo',
+      latestMediaTitle: 'Ibiheruka',
     },
     mostRead: {
       header: 'Ibisomwa cane',

--- a/src/app/lib/config/services/gujarati.ts
+++ b/src/app/lib/config/services/gujarati.ts
@@ -252,6 +252,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'નવાજૂની',
       featuresAnalysisTitle: 'બીબીસી વિશેષ',
+      latestMediaTitle: 'લેટેસ્ટ',
     },
     mostRead: {
       header: 'સૌથી વધારે વંચાયેલા સમાચાર',

--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -284,6 +284,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'टॉप स्टोरी',
       featuresAnalysisTitle: 'ज़रूर पढ़ें',
+      latestMediaTitle: 'ताज़ा',
     },
     mostRead: {
       header: 'सबसे अधिक पढ़ी गईं',

--- a/src/app/lib/config/services/igbo.ts
+++ b/src/app/lib/config/services/igbo.ts
@@ -252,6 +252,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Isi akụkọ',
       featuresAnalysisTitle: 'Kọwaara m isi akụkọ',
+      latestMediaTitle: 'Kachasị ọhụrụ',
     },
     mostRead: {
       header: 'Akachasị Gụọ',

--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -273,6 +273,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Berita Utama',
       featuresAnalysisTitle: 'Majalah',
+      latestMediaTitle: 'Terbaru',
     },
     mostRead: {
       header: 'Paling banyak dibaca',

--- a/src/app/lib/config/services/korean.ts
+++ b/src/app/lib/config/services/korean.ts
@@ -247,6 +247,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: '주요뉴스',
       featuresAnalysisTitle: '이 시간 이슈',
+      latestMediaTitle: '최신',
     },
     mostRead: {
       header: 'TOP 뉴스',

--- a/src/app/lib/config/services/kyrgyz.ts
+++ b/src/app/lib/config/services/kyrgyz.ts
@@ -254,6 +254,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Башкы кабарлар',
       featuresAnalysisTitle: 'Редактордун тандоосу',
+      latestMediaTitle: 'Соңку',
     },
     mostRead: {
       header: 'Эң көп окулгандар',

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -264,6 +264,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'मोठ्या बातम्या',
       featuresAnalysisTitle: 'Features',
+      latestMediaTitle: 'नवीनतम',
     },
     mostRead: {
       header: 'सर्वाधिक वाचलेले',

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -290,6 +290,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'مهمترین خبرها',
       featuresAnalysisTitle: 'گزارش و تحلیل',
+      latestMediaTitle: 'تازه ترین',
     },
     mostRead: {
       header: 'پربیننده‌ترین‌ها',

--- a/src/app/lib/config/services/pidgin.ts
+++ b/src/app/lib/config/services/pidgin.ts
@@ -243,6 +243,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Top Tori',
       featuresAnalysisTitle: 'Informate me',
+      latestMediaTitle: 'New things',
     },
     mostRead: {
       header: 'De one we dem de read well well',

--- a/src/app/lib/config/services/punjabi.ts
+++ b/src/app/lib/config/services/punjabi.ts
@@ -247,6 +247,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'ਤਾਜ਼ਾ ਘਟਨਾਕ੍ਰਮ',
       featuresAnalysisTitle: 'ਦ੍ਰਿਸ਼ਟੀਕੋਣ',
+      latestMediaTitle: 'ਬਿਲਕੁਲ ਨਵਾਂ',
     },
     mostRead: {
       header: 'ਸਭ ਤੋਂ ਵੱਧ ਪੜ੍ਹਿਆ ਗਿਆ',

--- a/src/app/lib/config/services/serbian.ts
+++ b/src/app/lib/config/services/serbian.ts
@@ -350,6 +350,7 @@ export const service: SerbianConfig = {
       },
       topStoriesTitle: 'Najvažnije',
       featuresAnalysisTitle: 'Reportaže',
+      latestMediaTitle: 'Najnovije',
     },
   },
   cyr: {
@@ -667,6 +668,7 @@ export const service: SerbianConfig = {
       },
       topStoriesTitle: 'Најважније',
       featuresAnalysisTitle: 'Репортаже',
+      latestMediaTitle: 'Најновије',
     },
   },
 };

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -246,6 +246,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'ප්‍රධාන පුවත',
       featuresAnalysisTitle: 'දැක්ම',
+      latestMediaTitle: 'අලුත්ම',
     },
     mostRead: {
       header: 'වැඩිපුරම කියැවූ',

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -256,6 +256,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Wararka ugu waaweyn',
       featuresAnalysisTitle: 'Xul',
+      latestMediaTitle: 'Arrimhii u danbeeyey',
     },
     mostRead: {
       header: 'Ugu akhris badan',

--- a/src/app/lib/config/services/tamil.ts
+++ b/src/app/lib/config/services/tamil.ts
@@ -265,6 +265,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'முக்கிய செய்திகள்',
       featuresAnalysisTitle: 'சிறப்புச் செய்திகள்',
+      latestMediaTitle: 'மிகச் சமீபத்தியது',
     },
     mostRead: {
       header: 'அதிகம் படிக்கப்பட்டது',

--- a/src/app/lib/config/services/telugu.ts
+++ b/src/app/lib/config/services/telugu.ts
@@ -255,6 +255,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'ముఖ్యమైన కథనాలు',
       featuresAnalysisTitle: 'ఫీచర్లు',
+      latestMediaTitle: 'తాజా వార్తలు',
     },
     mostRead: {
       header: 'ఎక్కువమంది చదివినవి',

--- a/src/app/lib/config/services/tigrinya.ts
+++ b/src/app/lib/config/services/tigrinya.ts
@@ -228,6 +228,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'ዜናታት',
       featuresAnalysisTitle: 'ኣዘራረብቲ ዛዕባታት',
+      latestMediaTitle: 'ናይ መወዳእታ',
     },
     mostRead: {
       header: 'ብብዝሒ ዝተነበ',

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -269,6 +269,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'اہم خبریں',
       featuresAnalysisTitle: 'فیچر اور تجزیے',
+      latestMediaTitle: 'تازہ ترین',
     },
     mostRead: {
       header: 'سب سے زیادہ پڑھی جانے والی',

--- a/src/app/lib/config/services/uzbek.ts
+++ b/src/app/lib/config/services/uzbek.ts
@@ -251,6 +251,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Бош мақола',
       featuresAnalysisTitle: 'Муҳаррир танлови',
+      latestMediaTitle: 'Сўнгги',
     },
     mostRead: {
       header: 'Энг кўп ўқилган',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -247,6 +247,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Tin chính',
       featuresAnalysisTitle: 'Góc nhìn và chuyên mục',
+      latestMediaTitle: 'Mới nhất',
     },
     mostRead: {
       header: 'Đọc nhiều nhất',

--- a/src/app/lib/config/services/yoruba.ts
+++ b/src/app/lib/config/services/yoruba.ts
@@ -237,6 +237,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Ìròyìn tó ṣe kókó',
       featuresAnalysisTitle: 'Ìwádìí kíkún lóríi kókó ìròyìn ',
+      latestMediaTitle: 'Èyí tí ó ṣẹ̀ṣẹ̀dé',
     },
     mostRead: {
       header: 'Èyítí A Ń Kà Jùlọ',

--- a/src/app/lib/config/services/zhongwen.ts
+++ b/src/app/lib/config/services/zhongwen.ts
@@ -335,7 +335,7 @@ export const service: ZhongwenConfig = {
         },
         consentBanner: {
           heading: `允许[social_media_site]内容`,
-          body: `此文包含[social_media_site}提供的内容。由于这些内容会使用曲奇或小甜饼等科技，我们在加载任何内容前会寻求您的认可。  您可能在给与许可前愿意阅读[social_media_site][link]小甜饼政策[/link]和[link]隐私政策[/link]。 希望阅读上述内容，请点击“接受并继续”。`,
+          body: `此文包含[social_media_site]提供的内容。由于这些内容会使用曲奇或小甜饼等科技，我们在加载任何内容前会寻求您的认可。  您可能在给与许可前愿意阅读[social_media_site][link]小甜饼政策[/link]和[link]隐私政策[/link]。 希望阅读上述内容，请点击“接受并继续”。`,
         },
       },
       include: {
@@ -345,6 +345,7 @@ export const service: ZhongwenConfig = {
       },
       topStoriesTitle: '头条新闻',
       featuresAnalysisTitle: '特别推荐',
+      latestMediaTitle: '最新',
     },
   },
   trad: {
@@ -627,7 +628,7 @@ export const service: ZhongwenConfig = {
         },
         consentBanner: {
           heading: `允許[social_media_site]内容`,
-          body: `此文包含[social_media_site}提供的内容。由於這些内容會使用曲奇或小甜餅等科技，我們在加載任何内容前會尋求您的認可。  您可能在給予許可前希望閲讀[social_media_site][link]曲奇政策[/link]和[link]隱私政策[/link]。希望閲讀上述内容，請點擊“接受並繼續”。`,
+          body: `此文包含[social_media_site]提供的内容。由於這些内容會使用曲奇或小甜餅等科技，我們在加載任何内容前會尋求您的認可。  您可能在給予許可前希望閲讀[social_media_site][link]曲奇政策[/link]和[link]隱私政策[/link]。希望閲讀上述内容，請點擊“接受並繼續”。`,
         },
       },
       include: {
@@ -637,6 +638,7 @@ export const service: ZhongwenConfig = {
       },
       topStoriesTitle: '頭條新聞',
       featuresAnalysisTitle: '特別推薦',
+      latestMediaTitle: '最新',
     },
   },
 };

--- a/src/app/models/types/translations.ts
+++ b/src/app/models/types/translations.ts
@@ -178,6 +178,7 @@ export interface Translations {
   };
   topStoriesTitle?: string;
   featuresAnalysisTitle?: string;
+  latestMediaTitle?: string;
 }
 
 export interface TranslationsError {


### PR DESCRIPTION
Resolves JIRA WSTEAM1-352 (Subtask of WSTEAM1-307)

Overall changes
======
Add 'Latest' heading translation to the translation config for each service.

Code changes
======

- Add 'latestMediaTitle' field to translations model.
- Add 'latestMediaTitle' key-value pair to service config files where a translation has been provided. (See ticket 307 for translations spreadsheet).
- Fix bracket typo in Zhongwen service config file.

Testing
======
N/A

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
