### PR TITLE
Update Arabic and Persian podcast promo and Azeri navigation

### DIFF
--- a/src/app/lib/config/services/arabic.ts
+++ b/src/app/lib/config/services/arabic.ts
@@ -49,7 +49,7 @@ export const service: DefaultServiceConfig = {
       title: 'البودكاست',
       brandTitle: 'بي بي سي إكسترا',
       brandDescription:
-        'بي بي سي إكسترا بودكاست يناقش كل أمور حياتنا اليومية، يأتيكم ثلاثة أيام أسبوعياً',
+        'بودكاست أسبوعي يقدم  قصصا إنسانية عن العالم العربي وشبابه.',
       image: {
         src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09t98w8.jpg',
         alt: 'بي بي سي إكسترا',

--- a/src/app/lib/config/services/azeri.ts
+++ b/src/app/lib/config/services/azeri.ts
@@ -322,10 +322,6 @@ export const service: DefaultServiceConfig = {
         title: 'Beynəlxalq',
         url: '/azeri/topics/cde15l4vn02t',
       },
-      {
-        title: 'Video',
-        url: '/azeri/media/video',
-      },
     ],
   },
 };

--- a/src/app/lib/config/services/persian.ts
+++ b/src/app/lib/config/services/persian.ts
@@ -48,16 +48,16 @@ export const service: DefaultServiceConfig = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'پادکست',
-      brandTitle: 'رادیو فارسی بی‌بی‌سی',
+      brandTitle: 'پرگار',
       brandDescription:
-        'پادکست چشم‌انداز بامدادی رادیو بی‌بی‌سی – دوشنبه ۱۹ اردیبهشت ۱۴۰۱',
+        'برنامه‌ای که در آن مهمانان برنامه به پرسش‌های چالشی مربوط به جامعه امروز پاسخ می‌دهند',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0bq9rkk.jpg',
-        alt: 'پادکست چشم‌انداز بامدادی رادیو بی‌بی‌سی',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p02swnpg.jpg',
+        alt: 'پرگار',
       },
       linkLabel: {
         text: 'پادکست',
-        href: 'https://www.bbc.com/persian/podcasts/p02pc9mc',
+        href: 'https://www.bbc.com/persian/podcasts/p02pc9wf',
       },
       skipLink: {
         text: 'از %title% رد شوید و به خواندن ادامه دهید',

--- a/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/kyrgyz/__snapshots__/canonical.test.js.snap
@@ -120,7 +120,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Сүрөт
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <img
   alt="social media"
-  class="e3vrtyk0 bbc-15pa1ki-StyledImg-StyledImage e1mo64ex0"
+  class="e3vrtyk0 bbc-rb7xa0 e1mo64ex0"
   height="351"
   sizes="(min-width: 1008px) 645px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsdevpb/11D53/test/_63734037_socialmedia.jpg"

--- a/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/storyPage/mundo/__snapshots__/canonical.test.js.snap
@@ -162,7 +162,7 @@ exports[`Canonical Story Page Image Caption should match text 1`] = `"Pie de fot
 exports[`Canonical Story Page Image should match snapshot 1`] = `
 <img
   alt="A person holding a union jack umbrella in front of Big Ben"
-  class="e3vrtyk0 bbc-15pa1ki-StyledImg-StyledImage e1mo64ex0"
+  class="e3vrtyk0 bbc-rb7xa0 e1mo64ex0"
   height="549"
   sizes="(min-width: 1008px) 645px, 100vw"
   src="https://ichef.bbci.co.uk/news/640/cpsprodpb/17D42/production/_110620679_gettyimages-542984918.jpg"


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Changed Persian podcast promo, fixed mistake in Arabic's podcast promo descirption and removed Video for Azeir nav.

Code changes
======

- edited podcastPromo section of src/app/lib/config/services/persian.ts
- edited description in podcastPromo section of src/app/lib/config/services/arabic.ts
- edited navigation section of src/app/lib/config/services/azeri.ts
- updated snapshots

Testing
======
1. manual testing changes in localhost
2. run unit and integration tests

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
