### PR TITLE
Disable Newsround Test env E2Es

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -4726,7 +4726,7 @@ module.exports = () => ({
           },
           test: {
             paths: ['/newsround/23212028'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/newsround/56331357'],


### PR DESCRIPTION
Overall changes
======
- Disables the Newsround E2Es on Test as the `.json` route for the pageData is now switched off.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
