### PR TITLE
Add isDarkUi flag to MediaArticlePage background-color

### DIFF
--- a/src/app/pages/MediaArticlePage/MediaArticlePage.styles.ts
+++ b/src/app/pages/MediaArticlePage/MediaArticlePage.styles.ts
@@ -2,9 +2,9 @@ import { css, Theme } from '@emotion/react';
 import pixelsToRem from '../../utilities/pixelsToRem';
 
 export default {
-  pageWrapper: ({ palette }: Theme) =>
+  pageWrapper: ({ palette, isDarkUi }: Theme) =>
     css({
-      backgroundColor: palette.GREY_10,
+      backgroundColor: isDarkUi ? palette.GREY_10 : palette.GREY_2,
     }),
   grid: ({ mq, gridWidths }: Theme) =>
     css({

--- a/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaArticlePage/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MediaArticlePage should render a news article correctly 1`] = `
 .emotion-0 {
-  background-color: #141414;
+  background-color: #F6F6F6;
 }
 
 .emotion-1 {


### PR DESCRIPTION
Overall changes
======
- Adds the `isDarkUi` flag to the MediaArticlePage background colour check to ensure it gets set to the correct colour depending on the value of `isDarkUi`.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
