### PR TITLE
Integration tests should fail on outdated snapshots

### DIFF
--- a/.github/workflows/simorgh-integration-tests.yml
+++ b/.github/workflows/simorgh-integration-tests.yml
@@ -42,4 +42,4 @@ jobs:
         run: ./scripts/installNodeModules.sh
 
       - name: Integration Tests
-        run: yarn test:integration -- --ci
+        run: yarn test:integration:ci

--- a/src/integration/utils/runTests/index.js
+++ b/src/integration/utils/runTests/index.js
@@ -55,7 +55,7 @@ const runTests = () =>
   new Promise((resolve, reject) => {
     const child = spawn(
       'jest',
-      [filesToTest, '-u', '--runInBand', '--colors', ...getJestArgs()],
+      [filesToTest, '--runInBand', '--colors', ...getJestArgs()],
       { stdio: 'inherit' },
     );
     child.on('exit', code => {


### PR DESCRIPTION
Overall changes
======
Ensures that integration tests fail on CI if there are out of date snapshots

Code changes
======
- Remove `-u` flag from integration test runner, as this will update the snapshots and let the tests pass
- Ensure that the Run Integration Test github action runs the correct command 

Testing
======
- [ ] Automated PR checks passing

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
