### PR TITLE
Update Japanese and Turkish navs

### DIFF
--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -304,10 +304,6 @@ export const service: DefaultServiceConfig = {
         url: '/japanese/60631515',
       },
       {
-        title: 'コロナウイルス',
-        url: '/japanese/52137815',
-      },
-      {
         title: '気候変動',
         url: '/japanese/58771282',
       },

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -314,6 +314,10 @@ export const service: DefaultServiceConfig = {
         url: '/turkce',
       },
       {
+        title: '14 Mayıs Seçimleri',
+        url: '/turkce/topics/cg5mgyyvjd0t',
+      },
+      {
         title: '6 Şubat Depremi',
         url: '/turkce/topics/c383emwewmqt',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Remove link to Coronavirus topic page from the Japanese site navigation and add link to 2023 Election topic page to the nav bar on BBC Turkce


Code changes
======
- remove corona link form the navigation section of src/app/lib/config/services/japanese.ts
- add election to the navigation section of src/app/lib/config/services/turkce.ts


Testing
======
1. Open bbc.com/japanese check that the Coronavirus topic link (コロナウイルス) is no longer on the Nav
2.  Open bbc.com/turkce the second item in the nav should be 14 Mayıs Seçimleri and when clicked should open  https://www.bbc.com/turkce/topics/cg5mgyyvjd0t





Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
