### PR TITLE
Ensure visual style of COLLECTION and visual prominence of HIGH is rendered as a hierarchical grid on the homepage

### DIFF
--- a/data/kyrgyz/homePage/index.json
+++ b/data/kyrgyz/homePage/index.json
@@ -132,7 +132,8 @@
         "curationId": "urn:bbc:tipo:list:905b0f54-c03d-426f-9d3b-cb31f00c0d8f",
         "curationType": "tipo-curation",
         "position": 0,
-        "visualProminence": "HIGH"
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
       },
       {
         "summaries": [

--- a/src/app/components/Curation/getComponentName/index.test.ts
+++ b/src/app/components/Curation/getComponentName/index.test.ts
@@ -5,7 +5,7 @@ import {
 import getComponentName, { COMPONENT_NAMES } from '.';
 
 const { MINIMUM, LOW, NORMAL, HIGH, MAXIMUM } = VISUAL_PROMINENCE;
-const { NONE, BANNER } = VISUAL_STYLE;
+const { NONE, BANNER, COLLECTION } = VISUAL_STYLE;
 const {
   MESSAGE_BANNER,
   SIMPLE_CURATION_GRID,
@@ -23,6 +23,7 @@ describe('getComponentName', () => {
     ${BANNER}       | ${MAXIMUM}           | ${NOT_SUPPORTED}
     ${NONE}         | ${NORMAL}            | ${SIMPLE_CURATION_GRID}
     ${NONE}         | ${HIGH}              | ${HIERARCHICAL_CURATION_GRID}
+    ${COLLECTION}   | ${HIGH}              | ${HIERARCHICAL_CURATION_GRID}
     ${'fake-style'} | ${'fake-prominence'} | ${null}
   `(
     'should return $expected when visual style is $visualStyle and visual prominence is $visualProminence',

--- a/src/app/components/Curation/getComponentName/index.ts
+++ b/src/app/components/Curation/getComponentName/index.ts
@@ -12,7 +12,7 @@ export const COMPONENT_NAMES = {
   NOT_SUPPORTED: 'not-supported',
 } as const;
 
-const { NONE, BANNER } = VISUAL_STYLE;
+const { NONE, BANNER, COLLECTION } = VISUAL_STYLE;
 const { MINIMUM, LOW, NORMAL, HIGH, MAXIMUM } = VISUAL_PROMINENCE;
 const {
   MESSAGE_BANNER,
@@ -33,6 +33,7 @@ export default (
     [`${BANNER}_${MAXIMUM}`]: NOT_SUPPORTED,
     [`${NONE}_${NORMAL}`]: SIMPLE_CURATION_GRID,
     [`${NONE}_${HIGH}`]: HIERARCHICAL_CURATION_GRID,
+    [`${COLLECTION}_${HIGH}`]: HIERARCHICAL_CURATION_GRID,
   };
 
   const visualStyleAndProminence = `${visualStyle}_${visualProminence}`;


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Updates the logic in the curation component to determine which type of component to render based on visual style and visual prominence

Code changes
======
Return a hierarchical curation grid if the visual style is COLLECTION and visual prominence is HIGH

Testing
======
- [x] Unit test(s)
- [ ] Manual test - update local data for kyrgyz homepage to set first curation's visualStyle to COLLECTION. Ensures that a hierarchical grid is rendered.

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
