### PR TITLE
WSTEAMA-334 - bypasses npm audit ci checks until patched

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,6 +2,7 @@
   "low": true,
   "skip-dev": true,
   "allowlist": [
-    "GHSA-hrpp-h998-j3pp"
+    "GHSA-hrpp-h998-j3pp",
+    "GHSA-f9xv-q969-pqx4"
   ]
 }


### PR DESCRIPTION
Related to WSTEAMA-334

Overall changes
======
- Smol bypass. 
