### PR TITLE
SPIKE WSTEAMA-203 - MostReadContainer is used by Curation

### DIFF
--- a/src/app/components/Curation/getComponentName/index.ts
+++ b/src/app/components/Curation/getComponentName/index.ts
@@ -6,15 +6,17 @@ import {
 } from '#app/models/types/curationData';
 
 export const COMPONENT_NAMES = {
+  MOST_READ: 'most-read',
   MESSAGE_BANNER: 'message-banner',
   SIMPLE_CURATION_GRID: 'simple-curation-grid',
   HIERARCHICAL_CURATION_GRID: 'hierarchical-curation-grid',
   NOT_SUPPORTED: 'not-supported',
 } as const;
 
-const { NONE, BANNER, COLLECTION } = VISUAL_STYLE;
+const { NONE, BANNER, COLLECTION, RANKED } = VISUAL_STYLE;
 const { MINIMUM, LOW, NORMAL, HIGH, MAXIMUM } = VISUAL_PROMINENCE;
 const {
+  MOST_READ,
   MESSAGE_BANNER,
   SIMPLE_CURATION_GRID,
   HIERARCHICAL_CURATION_GRID,
@@ -34,6 +36,7 @@ export default (
     [`${NONE}_${NORMAL}`]: SIMPLE_CURATION_GRID,
     [`${NONE}_${HIGH}`]: HIERARCHICAL_CURATION_GRID,
     [`${COLLECTION}_${HIGH}`]: HIERARCHICAL_CURATION_GRID,
+    [`${RANKED}_${NORMAL}`]: MOST_READ,
   };
 
   const visualStyleAndProminence = `${visualStyle}_${visualProminence}`;

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -5,6 +5,7 @@ import {
   VISUAL_STYLE,
   VISUAL_PROMINENCE,
 } from '#app/models/types/curationData';
+import MostReadContainer from '#app/legacy/containers/MostRead';
 import VisuallyHiddenText from '../VisuallyHiddenText';
 import CurationGrid from './CurationGrid';
 import HierarchicalGrid from './HierarchicalGrid';
@@ -15,6 +16,7 @@ import MessageBanner from '../MessageBanner';
 const {
   SIMPLE_CURATION_GRID,
   HIERARCHICAL_CURATION_GRID,
+  MOST_READ,
   MESSAGE_BANNER,
   NOT_SUPPORTED,
 } = COMPONENT_NAMES;
@@ -46,9 +48,8 @@ const Curation = ({
   headingLevel = 2,
   position = 0,
   curationLength = 0,
+  mostRead,
 }: CurationProps) => {
-  if (!promos.length) return null;
-
   const componentName = getComponentName(visualStyle, visualProminence);
   const GridComponent = getGridComponent(componentName);
 
@@ -70,6 +71,9 @@ const Curation = ({
           image={promos[0].imageUrl}
         />
       );
+    case MOST_READ:
+      // @ts-expect-error spike ticket
+      return <MostReadContainer initialData={mostRead} />;
     case SIMPLE_CURATION_GRID:
     case HIERARCHICAL_CURATION_GRID:
     default:

--- a/src/app/models/types/curationData.ts
+++ b/src/app/models/types/curationData.ts
@@ -33,17 +33,18 @@ export type VisualProminence = keyof typeof VISUAL_PROMINENCE;
 export interface CurationProps {
   visualStyle: VisualStyle;
   visualProminence: VisualProminence;
-  promos: Summary[];
+  promos?: Summary[];
   title?: string;
   link?: string;
   headingLevel?: number;
   position?: number;
   topStoriesTitle?: string;
   curationLength?: number;
+  mostRead?: object;
 }
 
 export interface CurationData {
-  summaries: Summary[];
+  summaries?: Summary[];
   visualStyle?: VisualStyle | string;
   visualProminence: VisualProminence | string;
   curationId: string;
@@ -53,4 +54,5 @@ export interface CurationData {
   activePage?: number;
   pageCount?: number;
   curationType?: string;
+  mostRead?: object;
 }

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -25,7 +25,6 @@ interface HomePageProps {
 
 const HomePage = ({ pageData }: HomePageProps) => {
   const { curations, description } = pageData;
-  console.log(curations);
 
   const { translations, product, serviceLocalizedName, frontPageTitle, lang } =
     useContext(ServiceContext);

--- a/src/app/pages/HomePage/HomePage.tsx
+++ b/src/app/pages/HomePage/HomePage.tsx
@@ -3,7 +3,6 @@
 import React, { useContext } from 'react';
 import { jsx } from '@emotion/react';
 import VisuallyHiddenText from '#app/components/VisuallyHiddenText';
-import MostReadContainer from '#containers/MostRead';
 import {
   VisualProminence,
   VisualStyle,
@@ -26,6 +25,7 @@ interface HomePageProps {
 
 const HomePage = ({ pageData }: HomePageProps) => {
   const { curations, description } = pageData;
+  console.log(curations);
 
   const { translations, product, serviceLocalizedName, frontPageTitle, lang } =
     useContext(ServiceContext);
@@ -59,9 +59,6 @@ const HomePage = ({ pageData }: HomePageProps) => {
               visualStyle,
               mostRead,
             }) => {
-              if (mostRead) {
-                return <MostReadContainer initialData={mostRead} />;
-              }
               return (
                 <React.Fragment key={`${curationId}-${position}`}>
                   <Curation
@@ -74,6 +71,7 @@ const HomePage = ({ pageData }: HomePageProps) => {
                     position={position}
                     link={link}
                     curationLength={curations && curations.length}
+                    mostRead={mostRead}
                   />
                 </React.Fragment>
               );


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======

Further investigation into how MostReadContainer could be used to display MostRead items on our HomePage. Experimental branch to try using it via Curation like we did with MessageBanner.

Code changes
======

- Adds appropriate references to the required `visualStyle` and `visualProminence` used by `MOST_READ`.
- Adds required fields onto Curation
- Adds a switch case for `MOST_READ` component.
- Removes a line which would prevent the component from rendering.

Testing
======

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
