### PR TITLE
WSTEAM1-347 - Adds view tracking to Latest Media component

### DIFF
--- a/src/app/pages/MediaArticlePage/PagePromoSections/LatestMediaSection/LatestMediaItem/index.tsx
+++ b/src/app/pages/MediaArticlePage/PagePromoSections/LatestMediaSection/LatestMediaItem/index.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+import { forwardRef } from 'react';
 import { jsx } from '@emotion/react';
 import isEmpty from 'ramda/src/isEmpty';
 import Promo from '#components/OptimoPromos';
@@ -7,53 +8,55 @@ import { LatestMediaItemProp } from '../types';
 import LatestMediaIndicator from '../LatestMediaIndicator';
 import styles from './index.styles';
 
-const LatestMediaItem = ({
-  item,
-  ariaLabelledBy,
-  eventTrackingData,
-  ref,
-}: LatestMediaItemProp) => {
-  if (!item || isEmpty(item)) return null;
+const LatestMediaItem = forwardRef<HTMLDivElement, LatestMediaItemProp>(
+  ({ item, ariaLabelledBy, eventTrackingData }, viewRef) => {
+    if (!item || isEmpty(item)) return null;
 
-  const timestamp = item.firstPublished;
+    const timestamp = item.firstPublished;
 
-  const src = item.imageUrl.replace('{width}', '240');
+    const src = item.imageUrl.replace('{width}', '240');
 
-  return (
-    <div ref={ref} css={styles.promoWrapper}>
-      <Promo
-        to={item.link}
-        ariaLabelledBy={ariaLabelledBy}
-        mediaType={item.type}
-        eventTrackingData={eventTrackingData}
-        className="removeBackground"
-        css={styles.promoStyle}
-      >
-        <div css={styles.imageWrapper}>
-          <Promo.Image
-            src={src}
-            altText={item.imageAlt ?? 'Media image placeholder'}
-            width={50}
-            height={50}
-          />
-          <LatestMediaIndicator duration={item.duration} />
-        </div>
-        <div css={styles.textWrapper}>
-          <Promo.Title as="h3" css={styles.promoTitle}>
-            <Promo.Link css={styles.promoLink} className="focusIndicatorInvert">
-              <Promo.Content
-                mediaDuration={item.duration}
-                headline={item.title}
-                isPhotoGallery={false}
-                isLive={false}
-              />
-            </Promo.Link>
-          </Promo.Title>
-          <Promo.Timestamp css={styles.timeStamp}>{timestamp}</Promo.Timestamp>
-        </div>
-      </Promo>
-    </div>
-  );
-};
+    return (
+      <div ref={viewRef} css={styles.promoWrapper}>
+        <Promo
+          to={item.link}
+          ariaLabelledBy={ariaLabelledBy}
+          mediaType={item.type}
+          eventTrackingData={eventTrackingData}
+          className="removeBackground"
+          css={styles.promoStyle}
+        >
+          <div css={styles.imageWrapper}>
+            <Promo.Image
+              src={src}
+              altText={item.imageAlt ?? 'Media image placeholder'}
+              width={50}
+              height={50}
+            />
+            <LatestMediaIndicator duration={item.duration} />
+          </div>
+          <div css={styles.textWrapper}>
+            <Promo.Title as="h3" css={styles.promoTitle}>
+              <Promo.Link
+                css={styles.promoLink}
+                className="focusIndicatorInvert"
+              >
+                <Promo.Content
+                  mediaDuration={item.duration}
+                  headline={item.title}
+                  isPhotoGallery={false}
+                  isLive={false}
+                />
+              </Promo.Link>
+            </Promo.Title>
+            <Promo.Timestamp css={styles.timeStamp}>
+              {timestamp}
+            </Promo.Timestamp>
+          </div>
+        </Promo>
+      </div>
+    );
+  },
+);
 
 export default LatestMediaItem;


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-347]

Overall changes
======
Adds missing ATI view tracking capability for the Latest Media component.

Code changes
======

- Adds missing forward ref, for ref used for view tracking.

Testing
======
1. Visit http://localhost:7080/hausa/articles/cxr0765kxlzo,  and check if an ATI ping occurs for the latest media component.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
