### PR TITLE
WSTEAMA-352: Disabling front page tests for Hindi on test

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -2501,7 +2501,7 @@ module.exports = () => ({
           },
           test: {
             paths: ['/hindi'],
-            enabled: true,
+            enabled: false,
           },
           local: {
             paths: ['/hindi'],


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-352

Overall changes
======
Do not run Cypress E2E tests for single language services, as they have been migrated to the new HomePage, and Cypress tests are not yet supported

Code changes
======
Disable Hindi FrontPage Cypress tests on the test environment 

Testing
======
- [ ] Cypress E2Es pass against test environment

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
