### PR TITLE
Lower lighthouse baseline score for accessibility

### DIFF
--- a/lighthouse/lighthouserc.js
+++ b/lighthouse/lighthouserc.js
@@ -113,7 +113,7 @@ module.exports = {
         ],
         'categories:accessibility': [
           'error',
-          { aggregationMethod: 'optimistic', minScore: 0.9 },
+          { aggregationMethod: 'optimistic', minScore: 0.85 },
         ],
         'categories:best-practices': [
           'error',


### PR DESCRIPTION
Overall changes
======
Reduces the baseline score for accessibility category in lighthouse tests due to limitations of Lighthouse v6.

[Further Details in Slack Thread](https://bbc-tpg.slack.com/archives/C03RCUN9MD1/p1684235599551929)

Code changes
======
- Reduce score from 0.9 -> 0.85

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
