### PR TITLE
WSTEAMA-399: Do not exclude new components from component health

### DIFF
--- a/.storybook/helpers/healthFactors/index.tsx
+++ b/.storybook/helpers/healthFactors/index.tsx
@@ -21,7 +21,6 @@ export const isExempt = context => {
     'simorgh structure',
     'cypress',
     'coding standards',
-    'new components',
   ];
 
   const kind = path(['kind'], context) as string;

--- a/src/app/components/VisuallyHiddenText/README.md
+++ b/src/app/components/VisuallyHiddenText/README.md
@@ -1,4 +1,3 @@
-# Visually Hidden Text
 ## Description
 
 Adds non-visible text to the page, to be utilised by screen-readers and other assistive technology.

--- a/src/app/components/VisuallyHiddenText/index.stories.tsx
+++ b/src/app/components/VisuallyHiddenText/index.stories.tsx
@@ -4,6 +4,7 @@ import { withServicesKnob } from '#psammead/psammead-storybook-helpers/src';
 import { Services } from '../../models/types/global';
 import notes from './README.md';
 import VisuallyHiddenText from './index';
+import metadata from './metadata.json';
 
 interface Props {
   service: Services;
@@ -20,7 +21,7 @@ export default {
   title: 'New Components/VisuallyHiddenText',
   Component,
   decorators: [withKnobs, withServicesKnob()],
-  parameters: { docs: { page: notes } },
+  parameters: { metadata, docs: { page: notes } },
 };
 
 export const Example = ({ service, text }: Props) => (


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-399

Overall changes
======
Ensure that component health can be displayed for all relevant components in Storybook

Code changes
======
- Remove new components from the exempt list in storybook health factor config

Testing
======
- [x] Ensure component health displayed for components which have metdata.json in the src/app/components directory, and the metadata.json file has been hooked into the stories.tsx file
- [x] Ensure missing component health displayed for new components without a metadata.json file

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
