### PR TITLE
WSTEAM1-459 - Removes privacy/cookie banners when in `APP` version

### DIFF
--- a/src/app/legacy/containers/ConsentBanner/index.canonical.jsx
+++ b/src/app/legacy/containers/ConsentBanner/index.canonical.jsx
@@ -1,13 +1,11 @@
 import React, { useContext } from 'react';
 import { oneOfType, func, shape, any } from 'prop-types';
 
-import { RequestContext } from '#contexts/RequestContext';
 import { UserContext } from '#contexts/UserContext';
 import Banner from './Banner/index.canonical';
 import useConsentBanners from './useConsentBanners';
 
 const Canonical = ({ onDismissFocusRef }) => {
-  const { isApp } = useContext(RequestContext);
   const { updateCookiePolicy } = useContext(UserContext);
 
   const {
@@ -17,8 +15,6 @@ const Canonical = ({ onDismissFocusRef }) => {
     handleCookieBannerAccepted,
     handleCookieBannerRejected,
   } = useConsentBanners();
-
-  if (isApp) return null;
 
   return (
     <>

--- a/src/app/legacy/containers/ConsentBanner/index.canonical.jsx
+++ b/src/app/legacy/containers/ConsentBanner/index.canonical.jsx
@@ -1,12 +1,15 @@
 import React, { useContext } from 'react';
 import { oneOfType, func, shape, any } from 'prop-types';
 
+import { RequestContext } from '#contexts/RequestContext';
 import { UserContext } from '#contexts/UserContext';
 import Banner from './Banner/index.canonical';
 import useConsentBanners from './useConsentBanners';
 
 const Canonical = ({ onDismissFocusRef }) => {
+  const { isApp } = useContext(RequestContext);
   const { updateCookiePolicy } = useContext(UserContext);
+
   const {
     showPrivacyBanner,
     showCookieBanner,
@@ -14,6 +17,8 @@ const Canonical = ({ onDismissFocusRef }) => {
     handleCookieBannerAccepted,
     handleCookieBannerRejected,
   } = useConsentBanners();
+
+  if (isApp) return null;
 
   return (
     <>

--- a/src/app/legacy/containers/ConsentBanner/index.canonical.test.jsx
+++ b/src/app/legacy/containers/ConsentBanner/index.canonical.test.jsx
@@ -22,13 +22,14 @@ const PRIVACY_BANNER_TEXT =
   "We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.";
 const COOKIE_BANNER_TEXT = 'Let us know you agree to cookies';
 
-const renderFixture = () =>
+const renderFixture = ({ isApp = false } = {}) =>
   render(
     <RequestContextProvider
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       pageType="article"
       isAmp={false}
+      isApp={isApp}
       service="news"
       statusCode={200}
       pathname="/pathname"
@@ -122,6 +123,16 @@ describe('Canonical Consent Banner', () => {
     const agreeButtonEl = screen.queryByText('Yes, I agree');
 
     fireEvent.click(agreeButtonEl);
+
+    const cookieBannerHeadingEl = screen.queryByText(COOKIE_BANNER_TEXT);
+    const privacyBannerHeadingEl = screen.queryByText(PRIVACY_BANNER_TEXT);
+
+    expect(cookieBannerHeadingEl).not.toBeInTheDocument();
+    expect(privacyBannerHeadingEl).not.toBeInTheDocument();
+  });
+
+  it('should render no banners when it is APP version', async () => {
+    renderFixture({ isApp: true });
 
     const cookieBannerHeadingEl = screen.queryByText(COOKIE_BANNER_TEXT);
     const privacyBannerHeadingEl = screen.queryByText(PRIVACY_BANNER_TEXT);

--- a/src/app/legacy/containers/ConsentBanner/index.canonical.test.jsx
+++ b/src/app/legacy/containers/ConsentBanner/index.canonical.test.jsx
@@ -22,14 +22,13 @@ const PRIVACY_BANNER_TEXT =
   "We've made some important changes to our Privacy and Cookies Policy and we want you to know what this means for you and your data.";
 const COOKIE_BANNER_TEXT = 'Let us know you agree to cookies';
 
-const renderFixture = ({ isApp = false } = {}) =>
+const renderFixture = () =>
   render(
     <RequestContextProvider
       bbcOrigin="https://www.test.bbc.co.uk"
       id="c0000000000o"
       pageType="article"
       isAmp={false}
-      isApp={isApp}
       service="news"
       statusCode={200}
       pathname="/pathname"
@@ -123,16 +122,6 @@ describe('Canonical Consent Banner', () => {
     const agreeButtonEl = screen.queryByText('Yes, I agree');
 
     fireEvent.click(agreeButtonEl);
-
-    const cookieBannerHeadingEl = screen.queryByText(COOKIE_BANNER_TEXT);
-    const privacyBannerHeadingEl = screen.queryByText(PRIVACY_BANNER_TEXT);
-
-    expect(cookieBannerHeadingEl).not.toBeInTheDocument();
-    expect(privacyBannerHeadingEl).not.toBeInTheDocument();
-  });
-
-  it('should render no banners when it is APP version', async () => {
-    renderFixture({ isApp: true });
 
     const cookieBannerHeadingEl = screen.queryByText(COOKIE_BANNER_TEXT);
     const privacyBannerHeadingEl = screen.queryByText(PRIVACY_BANNER_TEXT);

--- a/src/app/legacy/containers/Header/index.jsx
+++ b/src/app/legacy/containers/Header/index.jsx
@@ -25,11 +25,11 @@ const Header = ({
 
   const handleBannerBlur = event => {
     const isRejectButton =
-      event.target.getAttribute('data-terms-banner') === 'reject' ||
-      event.target.getAttribute('data-cookie-banner') === 'reject';
+      event.target?.getAttribute('data-terms-banner') === 'reject' ||
+      event.target?.getAttribute('data-cookie-banner') === 'reject';
     const isAcceptButton =
-      event.relatedTarget.getAttribute('data-terms-banner') === 'accept' ||
-      event.relatedTarget.getAttribute('data-cookie-banner') === 'accept';
+      event.relatedTarget?.getAttribute('data-terms-banner') === 'accept' ||
+      event.relatedTarget?.getAttribute('data-cookie-banner') === 'accept';
     const hasMovedToContent = !isAcceptButton && event.relatedTarget !== 'null';
 
     if (isRejectButton && hasMovedToContent) {

--- a/src/app/legacy/containers/Header/index.jsx
+++ b/src/app/legacy/containers/Header/index.jsx
@@ -18,7 +18,6 @@ const Header = ({
   skipLink,
   scriptLink,
   linkId,
-  isApp,
   /* eslint-enable react/prop-types */
 }) => {
   const [showConsentBanner, setShowConsentBanner] = useState(true);
@@ -41,15 +40,13 @@ const Header = ({
   return (
     <div onBlur={handleBannerBlur}>
       {showConsentBanner && <ConsentBanner onDismissFocusRef={brandRef} />}
-      {!isApp && (
-        <BrandContainer
-          borderBottom={borderBottom}
-          skipLink={skipLink}
-          scriptLink={scriptLink}
-          brandRef={brandRef}
-          linkId={linkId || 'topPage'}
-        />
-      )}
+      <BrandContainer
+        borderBottom={borderBottom}
+        skipLink={skipLink}
+        scriptLink={scriptLink}
+        brandRef={brandRef}
+        linkId={linkId || 'topPage'}
+      />
     </div>
   );
 };
@@ -87,6 +84,8 @@ const HeaderContainer = ({ scriptSwitchId, renderScriptSwitch }) => {
 
   const shouldRenderScriptSwitch = scriptLink && renderScriptSwitch;
 
+  if (isApp) return null;
+
   return (
     <header role="banner" lang={serviceLang}>
       {isAmp ? (
@@ -108,10 +107,9 @@ const HeaderContainer = ({ scriptSwitchId, renderScriptSwitch }) => {
               <ScriptLink scriptSwitchId={scriptSwitchId} />
             )
           }
-          isApp={isApp}
         />
       )}
-      {!isApp && showNav && <NavigationContainer />}
+      {showNav && <NavigationContainer />}
     </header>
   );
 };

--- a/src/app/legacy/containers/Header/index.test.jsx
+++ b/src/app/legacy/containers/Header/index.test.jsx
@@ -262,5 +262,27 @@ describe(`Header`, () => {
 
       expect(document.querySelector(`header[role='banner'] nav`)).toBeNull();
     });
+
+    it('should remove the privacy/cookie banner when isApp is set to true', () => {
+      const { container } = HeaderContainerWithContext({
+        renderOptions: {
+          isApp: true,
+          service: 'pidgin',
+          pageType: ARTICLE_PAGE,
+        },
+      });
+
+      const pidginPrivacyAcceptText =
+        pidginServiceConfig.default.translations.consentBanner.privacy.accept;
+      const pidginCookieAcceptText =
+        pidginServiceConfig.default.translations.consentBanner.cookie.canonical
+          .accept;
+
+      const privacyBanner = screen.queryByText(pidginPrivacyAcceptText);
+      const cookieBanner = screen.queryByText(pidginCookieAcceptText);
+
+      expect(container).not.toContainElement(privacyBanner);
+      expect(container).not.toContainElement(cookieBanner);
+    });
   });
 });


### PR DESCRIPTION
Resolves https://jira.dev.bbc.co.uk/browse/WSTEAM1-459

Overall changes
======
Removes the cookie/privacy banner and setting logic when the `isApp` flag is set to `true`

Code changes
======
- Checks for the `isApp` flag before attempting to render the Header component, which also houses the privacy/cookie banners
- Adds optional chaining checks to the `getAttribute` functions used when tabbing in the banners, as this would occasionally throw `null` in tests/dev

Testing
======
1. Clear cookies/local storage when running locally / on Test
2. Visit http://localhost:7080/hausa/articles/cxr0765kxlzo.app?renderer_env=live
3. Confirm that the banner does not appear
4. Visit http://localhost:7080/hausa/articles/cxr0765kxlzo?renderer_env=live
5. Confirm that the banner does appear
6. Visit http://localhost:7080/hausa/articles/cxr0765kxlzo.amp?renderer_env=live
7. Confirm that the banner does appear

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
