### PR TITLE
WSTEAM1-429 - Lambda app start-up script and config

### DIFF
--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -69,19 +69,20 @@ const fileLogger = createLogger({
     }),
   ),
   transports: [
-    new transports.File(loggerOptions.file),
+    new transports.Console(loggerOptions.console),
+    // new transports.File(loggerOptions.file),
 
-    // console output is sent to syslog - this can consume a lot of disk space in instances that
-    // handle a lot of traffic, so we only enable console output in some environments
-    ...(process.env.LOG_TO_CONSOLE === 'true'
-      ? [new transports.Console(loggerOptions.console)]
-      : []),
+    // // console output is sent to syslog - this can consume a lot of disk space in instances that
+    // // handle a lot of traffic, so we only enable console output in some environments
+    // ...(process.env.LOG_TO_CONSOLE === 'true'
+    //   ? [new transports.Console(loggerOptions.console)]
+    //   : []),
   ],
 });
 
 class Logger {
   constructor(callingFile) {
-    createLogDirectory(LOG_DIR);
+    // createLogDirectory(LOG_DIR);
     const file = folderAndFilename(callingFile);
 
     this.error = (event, message) => {

--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -17,7 +17,7 @@ const {
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 const LOG_FILE = 'app.log';
 const LOG_DIR = process.env.LOG_DIR || 'log';
-const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE || 'false';
+const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE === 'true';
 
 const createLogDirectory = (dirName = 'log') => {
   if (!fs.existsSync(dirName)) {
@@ -71,7 +71,7 @@ const fileLogger = createLogger({
   ),
   transports: [
     // handle a lot of traffic, so we only enable console output in some environments
-    ...(LOG_TO_CONSOLE === 'true'
+    ...(LOG_TO_CONSOLE
       ? [new transports.Console(loggerOptions.console)]
       : [new transports.File(loggerOptions.file)]),
   ],

--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -17,7 +17,6 @@ const {
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 const LOG_FILE = 'app.log';
 const LOG_DIR = process.env.LOG_DIR || 'log';
-const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE || 'false';
 
 const createLogDirectory = (dirName = 'log') => {
   if (!fs.existsSync(dirName)) {
@@ -70,19 +69,20 @@ const fileLogger = createLogger({
     }),
   ),
   transports: [
-    // handle a lot of traffic, so we only enable console output in some environments
-    ...(LOG_TO_CONSOLE === 'true'
-      ? [new transports.Console(loggerOptions.console)]
-      : [new transports.File(loggerOptions.file)]),
+    new transports.Console(loggerOptions.console),
+    // new transports.File(loggerOptions.file),
+
+    // // console output is sent to syslog - this can consume a lot of disk space in instances that
+    // // handle a lot of traffic, so we only enable console output in some environments
+    // ...(process.env.LOG_TO_CONSOLE === 'true'
+    //   ? [new transports.Console(loggerOptions.console)]
+    //   : []),
   ],
 });
 
 class Logger {
   constructor(callingFile) {
-    if (!LOG_TO_CONSOLE) {
-      createLogDirectory(LOG_DIR);
-    }
-
+    // createLogDirectory(LOG_DIR);
     const file = folderAndFilename(callingFile);
 
     this.error = (event, message) => {

--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -17,6 +17,7 @@ const {
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 const LOG_FILE = 'app.log';
 const LOG_DIR = process.env.LOG_DIR || 'log';
+const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE || 'false';
 
 const createLogDirectory = (dirName = 'log') => {
   if (!fs.existsSync(dirName)) {
@@ -69,20 +70,19 @@ const fileLogger = createLogger({
     }),
   ),
   transports: [
-    new transports.Console(loggerOptions.console),
-    // new transports.File(loggerOptions.file),
-
-    // // console output is sent to syslog - this can consume a lot of disk space in instances that
-    // // handle a lot of traffic, so we only enable console output in some environments
-    // ...(process.env.LOG_TO_CONSOLE === 'true'
-    //   ? [new transports.Console(loggerOptions.console)]
-    //   : []),
+    // handle a lot of traffic, so we only enable console output in some environments
+    ...(LOG_TO_CONSOLE === 'true'
+      ? [new transports.Console(loggerOptions.console)]
+      : [new transports.File(loggerOptions.file)]),
   ],
 });
 
 class Logger {
   constructor(callingFile) {
-    // createLogDirectory(LOG_DIR);
+    if (!LOG_TO_CONSOLE) {
+      createLogDirectory(LOG_DIR);
+    }
+
     const file = folderAndFilename(callingFile);
 
     this.error = (event, message) => {

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -116,7 +116,7 @@ describe('Logger node - for the server', () => {
 
       it('does not create a console transport when process.LOG_TO_CONSOLE is false', () => {
         process.env.LOG_DIR = 'foobarDir';
-        process.env.LOG_TO_CONSOLE = 'false';
+        process.env.LOG_TO_CONSOLE = false;
         require('./logger.node');
 
         expect(winston.transports.Console).not.toHaveBeenCalled();
@@ -124,7 +124,7 @@ describe('Logger node - for the server', () => {
 
       it('sets up console transport when process.LOG_TO_CONSOLE is true', () => {
         process.env.LOG_DIR = 'foobarDir';
-        process.env.LOG_TO_CONSOLE = 'true';
+        process.env.LOG_TO_CONSOLE = true;
         require('./logger.node');
 
         expect(winston.transports.Console).toHaveBeenCalledWith({

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -178,7 +178,7 @@ describe('Logger node - for the server', () => {
           });
           expect(winston.createLogger).toHaveBeenCalledWith({
             format: 'Combine Mock',
-            transports: [{}, {}],
+            transports: [{}],
           });
         });
       });

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -178,7 +178,7 @@ describe('Logger node - for the server', () => {
           });
           expect(winston.createLogger).toHaveBeenCalledWith({
             format: 'Combine Mock',
-            transports: [{}],
+            transports: [{}, {}],
           });
         });
       });

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -116,7 +116,7 @@ describe('Logger node - for the server', () => {
 
       it('does not create a console transport when process.LOG_TO_CONSOLE is false', () => {
         process.env.LOG_DIR = 'foobarDir';
-        process.env.LOG_TO_CONSOLE = false;
+        process.env.LOG_TO_CONSOLE = 'false';
         require('./logger.node');
 
         expect(winston.transports.Console).not.toHaveBeenCalled();
@@ -124,7 +124,7 @@ describe('Logger node - for the server', () => {
 
       it('sets up console transport when process.LOG_TO_CONSOLE is true', () => {
         process.env.LOG_DIR = 'foobarDir';
-        process.env.LOG_TO_CONSOLE = true;
+        process.env.LOG_TO_CONSOLE = 'true';
         require('./logger.node');
 
         expect(winston.transports.Console).toHaveBeenCalledWith({

--- a/src/server/utilities/getAgent/certs.js
+++ b/src/server/utilities/getAgent/certs.js
@@ -11,7 +11,7 @@ const getCert = async () => {
   const caPath = process.env.CA_PATH || '/etc/pki/tls/certs/ca-bundle.crt';
   const certChainPath =
     process.env.CERT_CHAIN_PATH || '/etc/pki/tls/certs/client.crt';
-  const keyPath = process.KEY_PATH || '/etc/pki/tls/private/client.key';
+  const keyPath = process.env.KEY_PATH || '/etc/pki/tls/private/client.key';
 
   try {
     const [ca, certChain, key] = await loadFiles({

--- a/src/server/utilities/getAgent/certs.js
+++ b/src/server/utilities/getAgent/certs.js
@@ -8,9 +8,10 @@ const loadFiles = ({ caPath, certChainPath, keyPath }) =>
   ]);
 
 const getCert = async () => {
-  const caPath = '/etc/pki/tls/certs/ca-bundle.crt';
-  const certChainPath = '/etc/pki/tls/certs/client.crt';
-  const keyPath = '/etc/pki/tls/private/client.key';
+  const caPath = process.env.CA_PATH || '/etc/pki/tls/certs/ca-bundle.crt';
+  const certChainPath =
+    process.env.CERT_CHAIN_PATH || '/etc/pki/tls/certs/client.crt';
+  const keyPath = process.KEY_PATH || '/etc/pki/tls/private/client.key';
 
   try {
     const [ca, certChain, key] = await loadFiles({

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -24,7 +24,7 @@ module.exports = {
   experimental: {
     externalDir: true,
   },
-  env: { ...clientEnvVars, LOG_TO_CONSOLE: 'true' },
+  env: clientEnvVars,
   compiler: {
     emotion: true,
   },

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -24,7 +24,7 @@ module.exports = {
   experimental: {
     externalDir: true,
   },
-  env: clientEnvVars,
+  env: { ...clientEnvVars, LOG_TO_CONSOLE: 'true' },
   compiler: {
     emotion: true,
   },

--- a/ws-nextjs-app/run.sh
+++ b/ws-nextjs-app/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Execute server.js, which is output using "next build"
+exec node server.js


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/WSTEAM1-429

Overall changes
======
Adds startup script for the Next.JS app to run on Lambda. Also configures the cert location to allow Lambda to provide the location via env variables and sets the log output to 'console' for the Next.JS app.

Code changes
======
- Adds `run.sh` script to start the app on the Lambda
- Adds `process.env` checks for the cert locations, so that the Lambda can provide these values due to its different filesystem setup
- Sets the `LOG_TO_CONSOLE` env variable in the Next app to ensure that the `Console` Winston transport is used for logging, rather than the file based transport

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
