### PR TITLE
Disable Scotland E2E test on Live

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -6210,7 +6210,7 @@ module.exports = () => ({
         environments: {
           live: {
             paths: ['/scotland/articles/cm49v4x1r9lo'],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/scotland/articles/czwj5l0n210o'],


### PR DESCRIPTION
Overall changes
======
- Disables the Scotland articles E2E test as the page its hitting 404s now. Can't seem to find a replacement for it, so disabling.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
