### PR TITLE
Fix Emotion theming in Next.JS app

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,9 +1,5 @@
-/* eslint-disable no-param-reassign */
 const webpack = require('webpack');
-const path = require('path');
 const { webpackDirAlias } = require('../dirAlias');
-
-const toPath = _path => path.join(process.cwd(), _path);
 
 module.exports = {
   core: {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const webpack = require('webpack');
 const { webpackDirAlias } = require('../dirAlias');
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -67,12 +67,7 @@ module.exports = {
     config.resolve.alias = {
       ...config.resolve.alias,
       ...webpackDirAlias,
-
-      // Storybook 6 does not support emotion 11 - these 3 aliases work around that
-      // https://github.com/storybookjs/storybook/issues/13277
-      '@emotion/core': toPath('node_modules/@emotion/react'),
-      '@emotion/styled': toPath('node_modules/@emotion/styled'),
-      'emotion-theming': toPath('node_modules/@emotion/react'),
+      '@emotion/react': require.resolve('@emotion/react'),
     };
 
     return config;

--- a/ws-nextjs-app/jest.config.ts
+++ b/ws-nextjs-app/jest.config.ts
@@ -35,6 +35,7 @@ const unitTests = {
     ...pathsToModuleNameMapper(compilerOptions.paths),
     '^uuid$': require.resolve('uuid'),
     '^react$': require.resolve('react'),
+    '^@emotion/react$': require.resolve('@emotion/react'),
   },
   setupFilesAfterEnv: ['./setupTests.ts'],
   snapshotSerializers: ['@emotion/jest/serializer'],

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -10,6 +10,7 @@ const assetPrefix =
   clientEnvVars.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN +
   clientEnvVars.SIMORGH_PUBLIC_STATIC_ASSETS_PATH;
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
   distDir: 'build',
@@ -41,6 +42,11 @@ module.exports = {
     config.resolve.fallback = {
       ...config.resolve.fallback,
       fs: false,
+    };
+
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@emotion/react': require.resolve('@emotion/react'),
     };
 
     config.plugins.push(

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
@@ -1,6 +1,7 @@
+/* * @jsxRuntime classic */
 /** @jsx jsx */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { jsx } from '@emotion/react';
 import Pagination from '#pages/TopicPage/Pagination';
 import Heading from '#app/components/Heading';
@@ -11,7 +12,7 @@ import LegacyText from '#app/legacy/containers/Text';
 import Blocks from '#app/legacy/containers/Blocks';
 import MetadataContainer from '../../../../../src/app/components/Metadata';
 import LinkedDataContainer from '../../../../../src/app/components/LinkedData';
-import PostsList from './Posts/index';
+import PostsList from './Posts';
 
 import styles from './styles';
 import { StreamResponse } from './Posts/types';
@@ -19,7 +20,6 @@ import { StreamResponse } from './Posts/types';
 const logger = nodeLogger(__filename);
 
 type ComponentProps = {
-  bbcOrigin?: string;
   pageData: {
     pageCount: number;
     activePage: number;
@@ -29,16 +29,11 @@ type ComponentProps = {
     liveTextStream: { content: StreamResponse | null };
   };
   pathname?: string;
-  showAdsBasedOnLocation?: boolean;
 };
 
-const LivePage = ({
-  bbcOrigin,
-  pageData,
-  pathname,
-  showAdsBasedOnLocation,
-}: ComponentProps) => {
+const LivePage = ({ pageData, pathname }: ComponentProps) => {
   const { lang } = useContext(ServiceContext);
+
   const {
     pageCount,
     activePage,
@@ -60,18 +55,18 @@ const LivePage = ({
     const componentsToRender = { text: LegacyText };
 
     return (
-      <>
+      <div css={styles.summary}>
         <Heading level={2}>Summary</Heading>
         <Blocks
           blocks={summaryBlocks}
           componentsToRender={componentsToRender}
         />
-      </>
+      </div>
     );
   };
 
   return (
-    <>
+    <div css={styles.background}>
       <MetadataContainer
         title="Test Live Page"
         lang={lang}
@@ -88,19 +83,6 @@ const LivePage = ({
         {liveTextStream.content && (
           <PostsList postData={liveTextStream.content} />
         )}
-        <pre css={styles.code}>
-          <Heading level={4}>Headers</Heading>
-          {bbcOrigin && (
-            <p>
-              bbc-origin: <span>{bbcOrigin}</span>
-            </p>
-          )}
-          <p>
-            bbc-adverts:{' '}
-            <span>{showAdsBasedOnLocation ? 'true' : 'false'}</span>
-          </p>
-        </pre>
-        <pre css={styles.code}>{JSON.stringify(pageData, null, 2)}</pre>
         <Pagination
           activePage={activePage}
           pageCount={pageCount}
@@ -110,7 +92,7 @@ const LivePage = ({
           page="Page"
         />
       </main>
-    </>
+    </div>
   );
 };
 

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
@@ -1,4 +1,3 @@
-/* * @jsxRuntime classic */
 /** @jsx jsx */
 
 import { useContext } from 'react';

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/Posts/index.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/Posts/index.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+/** @jsx jsx */
+
+import { jsx } from '@emotion/react';
 
 import pathOr from 'ramda/src/pathOr';
 import { OptimoBlock } from '#models/types/optimo';
@@ -7,6 +9,8 @@ import Blocks from '#app/legacy/containers/Blocks';
 import paragraph from '#app/legacy/containers/Paragraph';
 import Text from '#app/components/Text';
 import { Post, StreamResponse } from './types';
+
+import styles from './styles';
 
 // temporary solution to render LI/ OL blocks.
 const unorderedList = ({ blocks }: { blocks: OptimoBlock[] }) => {
@@ -73,10 +77,9 @@ const PostItem = ({ postItem }: { postItem: Post }) => {
   );
 
   return (
-    <div>
+    <div css={styles.postItem}>
       <PostHeadings headerBlocks={headerBlocks} />
       <PostContent contentBlocks={contentBlocks} />
-      <hr />
     </div>
   );
 };

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/Posts/styles.ts
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/Posts/styles.ts
@@ -1,0 +1,14 @@
+import { css, Theme } from '@emotion/react';
+import pixelsToRem from '../../../../../../src/app/utilities/pixelsToRem';
+
+export default {
+  postItem: ({ palette }: Theme) =>
+    css({
+      backgroundColor: palette.WHITE,
+      padding: `${pixelsToRem(16)}rem`,
+
+      '&:not(:last-child)': {
+        marginBottom: `${pixelsToRem(16)}rem`,
+      },
+    }),
+};

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
@@ -2,11 +2,16 @@
 
 exports[`Live Page creates snapshot of the live page 1`] = `
 .emotion-0 {
-  max-width: 63rem;
-  margin: 1.25rem auto;
+  background-color: #F6F6F6;
 }
 
 .emotion-1 {
+  max-width: 63rem;
+  margin: 0 auto;
+  padding: 1rem 0;
+}
+
+.emotion-2 {
   color: #141414;
   font-size: 1.75rem;
   line-height: 2rem;
@@ -17,20 +22,20 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-1 {
+  .emotion-2 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-1 {
+  .emotion-2 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
-.emotion-2 {
+.emotion-3 {
   color: #141414;
   font-size: 0.9375rem;
   line-height: 1.25rem;
@@ -40,20 +45,26 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-2 {
+  .emotion-3 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-2 {
+  .emotion-3 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
-.emotion-3 {
+.emotion-4 {
+  background-color: #FFFFFF;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.emotion-5 {
   color: #141414;
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -64,72 +75,72 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-3 {
+  .emotion-5 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-3 {
+  .emotion-5 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
-.emotion-4 {
+.emotion-6 {
   margin-bottom: 1.5rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-4 {
+  .emotion-6 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-4 {
+  .emotion-6 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-4 {
+  .emotion-6 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-4 {
+  .emotion-6 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-4 {
+  .emotion-6 {
     margin-left: 20%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-4 {
+  .emotion-6 {
     margin-left: 40%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-4 {
+  .emotion-6 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -138,7 +149,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -147,7 +158,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -156,7 +167,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       padding: 0 1rem;
@@ -165,7 +176,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -173,7 +184,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-4 {
+    .emotion-6 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -181,7 +192,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
-.emotion-5 {
+.emotion-7 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -192,24 +203,24 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-5 {
+  .emotion-7 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-5 {
+  .emotion-7 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
-.emotion-5>li {
+.emotion-7>li {
   position: relative;
 }
 
-.emotion-5>li::before {
+.emotion-7>li::before {
   top: 0.5rem;
   content: ' ';
   position: absolute;
@@ -220,59 +231,68 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   left: -1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
+  margin-bottom: 1rem;
+}
+
+.emotion-10 {
+  background-color: #FFFFFF;
+  padding: 1rem;
+}
+
+.emotion-10:not(:last-child) {
   margin-bottom: 1rem;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-8 {
+  .emotion-11 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-8 {
+  .emotion-11 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-8 {
+  .emotion-11 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-8 {
+  .emotion-11 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-8 {
+  .emotion-11 {
     margin-left: 16.666666666666668%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-8 {
+  .emotion-11 {
     margin-left: 33.333333333333336%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-8 {
+  .emotion-11 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -281,7 +301,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -290,7 +310,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -299,7 +319,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -308,7 +328,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       grid-column-start: 2;
@@ -316,7 +336,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-8 {
+    .emotion-11 {
       grid-template-columns: repeat(12, 1fr);
       grid-column-end: span 12;
       grid-column-start: 5;
@@ -324,7 +344,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
-.emotion-9 {
+.emotion-12 {
   font-size: 1.75rem;
   line-height: 2rem;
   font-family: ReithSerif,Helvetica,Arial,sans-serif;
@@ -338,78 +358,78 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-9 {
+  .emotion-12 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-9 {
+  .emotion-12 {
     font-size: 2.75rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-9 {
+  .emotion-12 {
     padding: 2.5rem 0;
   }
 }
 
-.emotion-9:focus {
+.emotion-12:focus {
   outline: none;
 }
 
 @media (max-width: 14.9375rem) {
-  .emotion-10 {
+  .emotion-13 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 15rem) and (max-width: 24.9375rem) {
-  .emotion-10 {
+  .emotion-13 {
     padding: 0 0.5rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 25rem) and (max-width: 37.4375rem) {
-  .emotion-10 {
+  .emotion-13 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-  .emotion-10 {
+  .emotion-13 {
     padding: 0 1rem;
     margin-left: 0%;
   }
 }
 
 @media (min-width: 63rem) and (max-width: 79.9375rem) {
-  .emotion-10 {
+  .emotion-13 {
     margin-left: 20%;
   }
 }
 
 @media (min-width: 80rem) {
-  .emotion-10 {
+  .emotion-13 {
     margin-left: 40%;
   }
 }
 
 @supports (display: grid) {
-  .emotion-10 {
+  .emotion-13 {
     display: block;
     width: initial;
     margin: 0;
   }
 
   @media (max-width: 14.9375rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -418,7 +438,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 15rem) and (max-width: 24.9375rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 0.5rem;
@@ -427,7 +447,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 25rem) and (max-width: 37.4375rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(6, 1fr);
       grid-column-end: span 6;
       padding: 0 1rem;
@@ -436,7 +456,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 37.5rem) and (max-width: 62.9375rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       padding: 0 1rem;
@@ -445,7 +465,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 63rem) and (max-width: 79.9375rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(5, 1fr);
       grid-column-end: span 5;
       grid-column-start: 2;
@@ -453,7 +473,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 
   @media (min-width: 80rem) {
-    .emotion-10 {
+    .emotion-13 {
       grid-template-columns: repeat(10, 1fr);
       grid-column-end: span 10;
       grid-column-start: 5;
@@ -461,7 +481,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
-.emotion-11 {
+.emotion-14 {
   font-size: 0.9375rem;
   line-height: 1.25rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -473,26 +493,26 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-11 {
+  .emotion-14 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-11 {
+  .emotion-14 {
     font-size: 1rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width: 63rem) {
-  .emotion-11 {
+  .emotion-14 {
     padding-right: 2.5rem;
   }
 }
 
-.emotion-19 {
+.emotion-24 {
   font-size: 1.25rem;
   line-height: 1.5rem;
   font-family: ReithSans,Helvetica,Arial,sans-serif;
@@ -504,26 +524,26 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-19 {
+  .emotion-24 {
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-24 {
     font-size: 2rem;
     line-height: 2.25rem;
   }
 }
 
 @media (min-width: 37.5rem) {
-  .emotion-19 {
+  .emotion-24 {
     padding-top: 2rem;
   }
 }
 
-.emotion-22 {
+.emotion-27 {
   font-family: ReithSans,Helvetica,Arial,sans-serif;
   font-weight: 400;
   font-style: italic;
@@ -531,1045 +551,288 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   font-weight: inherit;
 }
 
-.emotion-31 {
+.emotion-36 {
   color: #222222;
   border-bottom: 1px solid #B80000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-31:visited {
+.emotion-36:visited {
   color: #6E6E73;
   border-bottom: 1px solid #6E6E73;
 }
 
-.emotion-31:focus,
-.emotion-31:hover {
+.emotion-36:focus,
+.emotion-36:hover {
   border-bottom: 2px solid #B80000;
   color: #B80000;
 }
 
-.emotion-38 {
-  white-space: pre-wrap;
-  max-height: 50vh;
-  overflow: auto;
-  background-color: #f6f8fa;
-  padding: 1.25rem;
-  border-radius: 0.75rem;
-}
-
-.emotion-38>h4 {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  margin-bottom: 0.625rem;
-}
-
-.emotion-38>p {
-  margin: 0.25rem 0;
-}
-
-.emotion-39 {
-  color: #141414;
-  font-size: 1.125rem;
-  line-height: 1.375rem;
-  font-family: ReithSans,Helvetica,Arial,sans-serif;
-  font-style: normal;
-  font-weight: 700;
-  margin: 0;
-}
-
-@media (min-width: 20rem) and (max-width: 37.4375rem) {
-  .emotion-39 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
-  }
-}
-
-@media (min-width: 37.5rem) {
-  .emotion-39 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-  }
-}
-
 <div>
-  <main
+  <div
     class="emotion-0"
   >
-    <h1
+    <main
       class="emotion-1"
     >
-      Pidgin test 2
-    </h1>
-    <p
-      class="emotion-2"
-    >
-      Pidgin test 2 - the description
-    </p>
-    <h2
-      class="emotion-3"
-    >
-      Summary
-    </h2>
-    <div
-      class="emotion-4"
-      dir="ltr"
-    >
-      <ul
-        class="emotion-5"
-        dir="ltr"
-        role="list"
+      <h1
+        class="emotion-2"
       >
-        <li
-          class="emotion-6"
-          role="listitem"
+        Pidgin test 2
+      </h1>
+      <p
+        class="emotion-3"
+      >
+        Pidgin test 2 - the description
+      </p>
+      <div
+        class="emotion-4"
+      >
+        <h2
+          class="emotion-5"
         >
-          I am the summary box
-        </li>
-        <li
-          class="emotion-6"
-          role="listitem"
-        >
-          I need to include bulletpoints
-        </li>
-      </ul>
-    </div>
-    <div>
-      <div>
+          Summary
+        </h2>
         <div
-          class="emotion-8"
+          class="emotion-6"
           dir="ltr"
         >
-          <h1
-            class="emotion-9"
-            id="content"
-            tabindex="-1"
+          <ul
+            class="emotion-7"
+            dir="ltr"
+            role="list"
           >
-            Breaking news
-          </h1>
+            <li
+              class="emotion-8"
+              role="listitem"
+            >
+              I am the summary box
+            </li>
+            <li
+              class="emotion-8"
+              role="listitem"
+            >
+              I need to include bulletpoints
+            </li>
+          </ul>
         </div>
-        <div>
+      </div>
+      <div>
+        <div
+          class="emotion-10"
+        >
           <div
-            class="emotion-10"
+            class="emotion-11"
             dir="ltr"
           >
-            <p
-              class="emotion-11"
-              dir="ltr"
+            <h1
+              class="emotion-12"
+              id="content"
+              tabindex="-1"
             >
               Breaking news
-            </p>
+            </h1>
           </div>
-        </div>
-        <hr />
-      </div>
-      <div>
-        <div
-          class="emotion-8"
-          dir="ltr"
-        >
-          <h1
-            class="emotion-9"
-            id="content"
-            tabindex="-1"
-          >
-            Published 6.07pm Tues 9th
-          </h1>
-        </div>
-        <div>
-          <div
-            class="emotion-10"
-            dir="ltr"
-          >
-            <p
-              class="emotion-11"
+          <div>
+            <div
+              class="emotion-13"
               dir="ltr"
             >
-              Timestamp test
-            </p>
+              <p
+                class="emotion-14"
+                dir="ltr"
+              >
+                Breaking news
+              </p>
+            </div>
           </div>
-        </div>
-        <hr />
-      </div>
-      <div>
-        <div
-          class="emotion-8"
-          dir="ltr"
-        >
-          <h1
-            class="emotion-9"
-            id="content"
-            tabindex="-1"
-          >
-            Another post
-          </h1>
         </div>
         <div
           class="emotion-10"
-          dir="ltr"
         >
-          <h2
-            class="emotion-19"
-            id="Another-post-sub-headline"
-            tabindex="-1"
-          >
-            Another post sub headline
-          </h2>
-        </div>
-        <div>
           <div
-            class="emotion-10"
+            class="emotion-11"
             dir="ltr"
           >
-            <p
-              class="emotion-11"
+            <h1
+              class="emotion-12"
+              id="content"
+              tabindex="-1"
+            >
+              Published 6.07pm Tues 9th
+            </h1>
+          </div>
+          <div>
+            <div
+              class="emotion-13"
               dir="ltr"
             >
-              <b>
-                Another 
-              </b>
-              <i
-                class="emotion-22"
+              <p
+                class="emotion-14"
+                dir="ltr"
               >
-                short form text
-              </i>
-            </p>
+                Timestamp test
+              </p>
+            </div>
           </div>
-          <span
-            class="emotion-2"
-          >
-            <ul>
-              <li>
-                one
-              </li>
-              <li>
-                two
-              </li>
-              <li>
-                three
-              </li>
-            </ul>
-          </span>
-          <div
-            class="emotion-10"
-            dir="ltr"
-          >
-            <p
-              class="emotion-11"
-              dir="ltr"
-            />
-          </div>
-          <span
-            class="emotion-2"
-          >
-            <ul>
-              <li>
-                Bullet 1
-              </li>
-              <li>
-                Bullet 2
-              </li>
-              <li>
-                Bullet 3
-              </li>
-            </ul>
-          </span>
-          <div
-            class="emotion-10"
-            dir="ltr"
-          >
-            <p
-              class="emotion-11"
-              dir="ltr"
-            />
-          </div>
-          <div
-            class="emotion-10"
-            dir="ltr"
-          >
-            <p
-              class="emotion-11"
-              dir="ltr"
-            >
-              Here is a 
-              <a
-                class="focusIndicatorReducedWidth emotion-31"
-                href="/new/pidgin"
-              >
-                Link
-              </a>
-            </p>
-          </div>
-        </div>
-        <hr />
-      </div>
-      <div>
-        <div
-          class="emotion-8"
-          dir="ltr"
-        >
-          <h1
-            class="emotion-9"
-            id="content"
-            tabindex="-1"
-          >
-            Post headline
-          </h1>
         </div>
         <div
           class="emotion-10"
-          dir="ltr"
         >
-          <h2
-            class="emotion-19"
-            id="Post-sub-headline"
-            tabindex="-1"
-          >
-            Post sub headline
-          </h2>
-        </div>
-        <div>
           <div
-            class="emotion-10"
+            class="emotion-11"
             dir="ltr"
           >
-            <p
-              class="emotion-11"
+            <h1
+              class="emotion-12"
+              id="content"
+              tabindex="-1"
+            >
+              Another post
+            </h1>
+          </div>
+          <div
+            class="emotion-13"
+            dir="ltr"
+          >
+            <h2
+              class="emotion-24"
+              id="Another-post-sub-headline"
+              tabindex="-1"
+            >
+              Another post sub headline
+            </h2>
+          </div>
+          <div>
+            <div
+              class="emotion-13"
               dir="ltr"
             >
-              Some short form text
-            </p>
+              <p
+                class="emotion-14"
+                dir="ltr"
+              >
+                <b>
+                  Another 
+                </b>
+                <i
+                  class="emotion-27"
+                >
+                  short form text
+                </i>
+              </p>
+            </div>
+            <span
+              class="emotion-3"
+            >
+              <ul>
+                <li>
+                  one
+                </li>
+                <li>
+                  two
+                </li>
+                <li>
+                  three
+                </li>
+              </ul>
+            </span>
+            <div
+              class="emotion-13"
+              dir="ltr"
+            >
+              <p
+                class="emotion-14"
+                dir="ltr"
+              />
+            </div>
+            <span
+              class="emotion-3"
+            >
+              <ul>
+                <li>
+                  Bullet 1
+                </li>
+                <li>
+                  Bullet 2
+                </li>
+                <li>
+                  Bullet 3
+                </li>
+              </ul>
+            </span>
+            <div
+              class="emotion-13"
+              dir="ltr"
+            >
+              <p
+                class="emotion-14"
+                dir="ltr"
+              />
+            </div>
+            <div
+              class="emotion-13"
+              dir="ltr"
+            >
+              <p
+                class="emotion-14"
+                dir="ltr"
+              >
+                Here is a 
+                <a
+                  class="focusIndicatorReducedWidth emotion-36"
+                  href="/new/pidgin"
+                >
+                  Link
+                </a>
+              </p>
+            </div>
           </div>
         </div>
-        <hr />
+        <div
+          class="emotion-10"
+        >
+          <div
+            class="emotion-11"
+            dir="ltr"
+          >
+            <h1
+              class="emotion-12"
+              id="content"
+              tabindex="-1"
+            >
+              Post headline
+            </h1>
+          </div>
+          <div
+            class="emotion-13"
+            dir="ltr"
+          >
+            <h2
+              class="emotion-24"
+              id="Post-sub-headline"
+              tabindex="-1"
+            >
+              Post sub headline
+            </h2>
+          </div>
+          <div>
+            <div
+              class="emotion-13"
+              dir="ltr"
+            >
+              <p
+                class="emotion-14"
+                dir="ltr"
+              >
+                Some short form text
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <pre
-      class="emotion-38"
-    >
-      <h4
-        class="emotion-39"
-      >
-        Headers
-      </h4>
-      <p>
-        bbc-adverts:
-         
-        <span>
-          false
-        </span>
-      </p>
-    </pre>
-    <pre
-      class="emotion-38"
-    >
-      {
-  "title": "Pidgin test 2",
-  "description": "Pidgin test 2 - the description",
-  "language": "pcm",
-  "headerImage": null,
-  "promoImage": null,
-  "home": "pidgin",
-  "liveTextStream": {
-    "content": {
-      "data": {
-        "results": [
-          {
-            "typeCode": null,
-            "header": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "headline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Breaking news",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Breaking news",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "Breaking news",
-                      "blocks": [
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "Breaking news",
-                            "attributes": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "link": null,
-            "urn": "asset:2aa3edd0-abe6-4cf3-a2fe-a1a5e98aa71e",
-            "type": "POST",
-            "options": {
-              "isBreakingNews": true
-            },
-            "dates": {
-              "firstPublished": "2023-05-09T16:24:16+00:00",
-              "lastPublished": "2023-05-09T16:24:16+00:00",
-              "time": null,
-              "curated": "2023-05-09T16:24:18.631Z"
-            },
-            "titles": [
-              {
-                "title": null,
-                "source": "primary"
-              }
-            ],
-            "descriptions": [
-              {
-                "text": null,
-                "source": "summary"
-              }
-            ],
-            "images": [
-              {
-                "url": null,
-                "originalUrl": null,
-                "urlTemplate": null,
-                "altText": null,
-                "copyright": null
-              }
-            ]
-          },
-          {
-            "typeCode": null,
-            "header": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "headline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Published 6.07pm Tues 9th",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Published 6.07pm Tues 9th",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "Timestamp test",
-                      "blocks": [
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "Timestamp test",
-                            "attributes": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "link": null,
-            "urn": "asset:7cfd060e-d8e0-4364-b177-31d58ae0c062",
-            "type": "POST",
-            "options": {
-              "isBreakingNews": false
-            },
-            "dates": {
-              "firstPublished": "2023-05-09T15:07:38+00:00",
-              "lastPublished": "2023-05-09T15:07:38+00:00",
-              "time": null,
-              "curated": "2023-05-09T15:07:39.364Z"
-            },
-            "titles": [
-              {
-                "title": null,
-                "source": "primary"
-              }
-            ],
-            "descriptions": [
-              {
-                "text": null,
-                "source": "summary"
-              }
-            ],
-            "images": [
-              {
-                "url": null,
-                "originalUrl": null,
-                "urlTemplate": null,
-                "altText": null,
-                "copyright": null
-              }
-            ]
-          },
-          {
-            "typeCode": null,
-            "header": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "headline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Another post",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Another post",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "subheadline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Another post sub headline",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Another post sub headline",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "Another short form text",
-                      "blocks": [
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "Another ",
-                            "attributes": [
-                              "bold"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "short form text",
-                            "attributes": [
-                              "italic"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "orderedList",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "one",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "two",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "three",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "",
-                      "blocks": []
-                    }
-                  },
-                  {
-                    "type": "unorderedList",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "Bullet 1",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "Bullet 2",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "listItem",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "Bullet 3",
-                                  "attributes": [
-                                    "italic"
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "",
-                      "blocks": []
-                    }
-                  },
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "Here is a Link",
-                      "blocks": [
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "Here is a ",
-                            "attributes": []
-                          }
-                        },
-                        {
-                          "type": "urlLink",
-                          "model": {
-                            "text": "Link",
-                            "locator": "https://www.bbc.co.uk/new/pidgin",
-                            "blocks": [
-                              {
-                                "type": "fragment",
-                                "model": {
-                                  "text": "Link",
-                                  "attributes": []
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "link": null,
-            "urn": "asset:1009a4c7-ef57-4d77-a0f7-3ef886baee4c",
-            "type": "POST",
-            "options": {
-              "isBreakingNews": false
-            },
-            "dates": {
-              "firstPublished": "2023-03-21T13:22:05+00:00",
-              "lastPublished": "2023-03-21T13:22:05+00:00",
-              "time": null,
-              "curated": "2023-03-21T13:22:08.502Z"
-            },
-            "titles": [
-              {
-                "title": null,
-                "source": "primary"
-              }
-            ],
-            "descriptions": [
-              {
-                "text": null,
-                "source": "summary"
-              }
-            ],
-            "images": [
-              {
-                "url": null,
-                "originalUrl": null,
-                "urlTemplate": null,
-                "altText": null,
-                "copyright": null
-              }
-            ]
-          },
-          {
-            "typeCode": null,
-            "header": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "headline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Post headline",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Post headline",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "subheadline",
-                    "model": {
-                      "blocks": [
-                        {
-                          "type": "text",
-                          "model": {
-                            "blocks": [
-                              {
-                                "type": "paragraph",
-                                "model": {
-                                  "text": "Post sub headline",
-                                  "blocks": [
-                                    {
-                                      "type": "fragment",
-                                      "model": {
-                                        "text": "Post sub headline",
-                                        "attributes": []
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "content": {
-              "model": {
-                "blocks": [
-                  {
-                    "type": "paragraph",
-                    "model": {
-                      "text": "Some short form text",
-                      "blocks": [
-                        {
-                          "type": "fragment",
-                          "model": {
-                            "text": "Some short form text",
-                            "attributes": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            "link": null,
-            "urn": "asset:5a8d509c-fb87-4763-90ed-1e63a70c30a2",
-            "type": "POST",
-            "options": {
-              "isBreakingNews": false
-            },
-            "dates": {
-              "firstPublished": "2023-03-21T11:10:55+00:00",
-              "lastPublished": "2023-03-21T13:19:11+00:00",
-              "time": null,
-              "curated": "2023-03-21T11:10:56.704Z"
-            },
-            "titles": [
-              {
-                "title": null,
-                "source": "primary"
-              }
-            ],
-            "descriptions": [
-              {
-                "text": null,
-                "source": "summary"
-              }
-            ],
-            "images": [
-              {
-                "url": null,
-                "originalUrl": null,
-                "urlTemplate": null,
-                "altText": null,
-                "copyright": null
-              }
-            ]
-          }
-        ],
-        "page": {
-          "index": 1,
-          "total": 1
-        }
-      },
-      "contentType": "application/json; charset=utf-8"
-    }
-  },
-  "sportDataEvent": {
-    "id": null
-  },
-  "article": {
-    "id": null
-  },
-  "mediaCollections": [
-    {
-      "id": null
-    }
-  ],
-  "seo": {
-    "seoTitle": "Pidgin test 2",
-    "seoDescription": "Pidgin test 2 - the description"
-  },
-  "endDateTime": "2023-04-06T10:21:00.000Z",
-  "startDateTime": "2023-04-05T10:22:00.000Z",
-  "analytics": {
-    "page": {
-      "name": "live_coverage.c7p765ynk9qt.page",
-      "contentId": "urn:bbc:tipo:topic:c7p765ynk9qt"
-    }
-  },
-  "summaryPoints": {
-    "id": "urn:bbc:optimo:asset:c5x3899j84ro",
-    "content": {
-      "model": {
-        "blocks": [
-          {
-            "type": "text",
-            "model": {
-              "blocks": [
-                {
-                  "type": "unorderedList",
-                  "model": {
-                    "blocks": [
-                      {
-                        "type": "listItem",
-                        "model": {
-                          "blocks": [
-                            {
-                              "type": "paragraph",
-                              "model": {
-                                "text": "I am the summary box",
-                                "blocks": [
-                                  {
-                                    "type": "fragment",
-                                    "model": {
-                                      "text": "I am the summary box",
-                                      "attributes": []
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "type": "listItem",
-                        "model": {
-                          "blocks": [
-                            {
-                              "type": "paragraph",
-                              "model": {
-                                "text": "I need to include bulletpoints",
-                                "blocks": [
-                                  {
-                                    "type": "fragment",
-                                    "model": {
-                                      "text": "I need to include bulletpoints",
-                                      "attributes": []
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  },
-  "someResponse": {
-    "block": "Its a block"
-  }
-}
-    </pre>
-  </main>
+    </main>
+  </div>
 </div>
 `;

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/styles.ts
@@ -1,28 +1,21 @@
-import { css } from '@emotion/react';
+import { css, Theme } from '@emotion/react';
 import pixelsToRem from '../../../../../src/app/utilities/pixelsToRem';
 
 export default {
+  background: ({ palette }: Theme) =>
+    css({
+      backgroundColor: palette.GREY_2,
+    }),
   wrapper: () =>
     css({
       maxWidth: `${pixelsToRem(1008)}rem`,
-      margin: `${pixelsToRem(20)}rem auto`,
+      margin: '0 auto',
+      padding: `${pixelsToRem(16)}rem 0`,
     }),
-  code: () =>
+  summary: ({ palette }: Theme) =>
     css({
-      whiteSpace: 'pre-wrap',
-      maxHeight: '50vh',
-      overflow: 'auto',
-      backgroundColor: '#f6f8fa',
-      padding: `${pixelsToRem(20)}rem`,
-      borderRadius: `${pixelsToRem(12)}rem`,
-
-      '& > h4': {
-        textDecoration: 'underline',
-        marginBottom: `${pixelsToRem(10)}rem`,
-      },
-
-      '& > p': {
-        margin: '0.25rem 0',
-      },
+      backgroundColor: palette.WHITE,
+      padding: `${pixelsToRem(16)}rem`,
+      marginBottom: `${pixelsToRem(16)}rem`,
     }),
 };


### PR DESCRIPTION
Overall changes
======
Fixes an issue with working with multiple `node_modules` locally. The Next.JS app is importing Emotion components from the old app, so it appears to be getting confused about which copy of Emotion to use.

This fix adds in module resolution to the Next.JS apps Jest and `next.config.js` file to ensure that any references to `@emotion/react` should use the Next.JS compiled version, rather than the Express one. Not ideal but works.

Also adds basic styling to test theming and to check page weight increases with more CSS introduced.


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
