### PR TITLE
WSTEAMA-433: Add metadata block to local homepage fixtures

### DIFF
--- a/data/afaanoromoo/homePage/index.json
+++ b/data/afaanoromoo/homePage/index.json
@@ -493,7 +493,14 @@
         "title": "Viidiyoo",
         "visualProminence": "NORMAL"
       }
-    ]
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c93v2kkzl24t",
+        "contentType": "index-home",
+        "pageIdentifier": "afaanoromoo.page"
+      }
+    }
   },
   "contentType": "application/json; charset=utf-8",
   "dataSource": "Data is from Live Tipo"

--- a/data/afrique/homePage/index.json
+++ b/data/afrique/homePage/index.json
@@ -1009,7 +1009,14 @@
         "title": "Nos partenaires",
         "visualProminence": "NORMAL"
       }
-    ]
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cjln1ww62p1t",
+        "contentType": "index-home",
+        "pageIdentifier": "afrique.page"
+      }
+    }
   },
   "contentType": "application/json; charset=utf-8",
   "dataSource": "data is from TIPO live home page"

--- a/data/amharic/homePage/index.json
+++ b/data/amharic/homePage/index.json
@@ -1,237 +1,244 @@
 {
-    "data": {
-      "title": "BBC News Amharic",
-      "description": "",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "መነኩሴዋ ፒያኒስት፡ እማሆይ ጽጌ ማርያም ገብሩ አረፉ",
-              "firstPublished": "2022-03-15T04:07:52.000Z",
-              "link": "https://www.bbc.com/amharic/news-60741168",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9F90/production/_123684804_emahoy1.jpg",
-              "description": "በድንቅ የፒያኖ የሙዚቃ ሥራዎቻቸው የሚታወቁት እማሆይ ጽጌማርያም ገብሩ ማረፋቸውን በቅርብ የሚያውቋቸው ሰዎች ገለጹ። እማሆይ ጽጌማርያም በምንኩስና ወደ መንፈሳዊው ሕይወት ከመግባታቸው በፊት ቤተሰቦቻቸው የውብዳር የሚል ስም ነበር የሰጧቸው። በ1916 ዓ.ም. በአዲስ አበባ ውስጥ የተወለዱ እማሆይ ጽጌማርያም ገብሩ በኢትዮጵያ በቫዮሊን እና በፒያኖ ሙዚቃዎችን በማቀናበር በቀዳሚነት የሚጠቀሱ ናቸው። እማሆይ ጽጌማርያም በ99 ዓመታቸው ነው ከዚህ ዓለም በሞት የተለዩት።",
-              "imageAlt": "እማሆይ ጽጌ ማሪያም ገብሩ",
-              "id": "3e4fac31-4dc8-408f-af18-9f634d4fa4eb"
-            },
-            {
-              "type": "article",
-              "title": "ሕጻናት በቤት ሠራተኞች ማደጋቸው ችግሩ ምንድን ነው?",
-              "firstPublished": "2023-03-27T04:21:55.787Z",
-              "link": "https://www.bbc.com/amharic/articles/cglndmlkr2eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f789/live/eaca39e0-cb2a-11ed-be2e-754a65c11505.jpg",
-              "description": "ከቅርብ ጊዜ ወዲህ የሚሰሙት የጨቅላ ሕጻናት ደብዛ ከመጥፋት ጀምሮ እስከ ሚፈጸሙባቸው አሰቃቂ ወንጀሎች ድረስ ወላጆችን በተለይ እናቶችን እንቅልፍ የሚነሳ ጉዳይ ሆኗል። ከዚህ ባሻገር ግን ጨቅላ ልጆችን ቤት ውስጥ ትቶ መሄድ ብዙም ልብ ያልተባሉ ከአካላዊ ባሻገር ሥነ ልቦናዊ ፈተናዎችን እንዲጋፈጡ ያደርጋቸዋል። ታዲያ የኑሮ ግዴታን ለመወጣት ነፍስ ያላወቁ እና ለትምህርት ያልደረሱ ልጆችን ቤት ውስጥ ከሠራተኛ ጋር ትቶ ከመሄድ ውጪ ምን አማራጭ አለ?",
-              "imageAlt": "በእናቷ እቅፍ ውስጥ ሆና የምታለቅስ ሕጻን",
-              "id": "cglndmlkr2eo"
-            },
-            {
-              "type": "article",
-              "title": "በአርባ ምንጭ ጫሞ ሐይቅ ላይ ከሰጠሙት ሰዎች መካከል የሰባቱ አስከሬን ተገኘ",
-              "firstPublished": "2023-03-27T10:05:21.524Z",
-              "link": "https://www.bbc.com/amharic/articles/cpd80931m27o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1187/live/12357290-cc86-11ed-8826-bd7de7756a42.jpg",
-              "description": "ቅዳሜ መጋቢት 16/2015 ዓ.ም. በደቡብ ክልል ጋሞ ዞን በምትገኘው አርባ ምንጭ ውስጥ ጫሞ ሐይቅ ላይ በጀልባ ሲጓዙ ሰጥመው የደረሱበት ካልታወቀ ሰዎች መካከል የሰባቱ ሰዎች አስክሬን መገኘቱ ፖሊስ አስታውቋል።",
-              "imageAlt": "ቱሪስቶች በጫሞ ሐይቅ ላይ",
-              "id": "cpd80931m27o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:0879a9bf-9051-4e70-8932-d438ce39aa8a",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "BBC News Amharic Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ድብቁ የወሲብ ንግድ በሶማሊያ ",
-              "firstPublished": "2023-03-25T05:06:04.228Z",
-              "link": "https://www.bbc.com/amharic/articles/cl46gv53m6xo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/907f/live/d23af420-ca65-11ed-be2e-754a65c11505.jpg",
-              "description": "በሶማሊያ ዋና ከተማ ሞቃዲሾ ነዋሪ የሆኑ ሁለት ሴቶች እንዴት ምስጢራዊ ወደሆነው የወሲብ ንግድ እንደተሳቡ ለቢቢሲ ተናግረዋል። ለዓመታት በእርስ በርስ ጦርነት ስትናወጥ በነበረችው ሶማሊያ ውስጥ ጦርነቱ ጋብ ቢልም፣ አሁንም ሁከቶችን ማስተናገዷ አልቀረም።",
-              "imageAlt": "በጨለማ ውስጥ ከጀርባ የምትታይ ሴት ",
-              "id": "cl46gv53m6xo"
-            },
-            {
-              "type": "article",
-              "title": "የአሜሪካዋ ግዛት በልጆች የቲክቶክ እና ኢኒስታግራም አጠቃቀም ላይ ገደብ ጣለች",
-              "firstPublished": "2023-03-24T07:44:02.634Z",
-              "link": "https://www.bbc.com/amharic/articles/cpr5el75rl2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/210e/live/f9504f20-ca14-11ed-be2e-754a65c11505.jpg",
-              "description": "የአሜሪካዋ ዩታህ ግዛት አዳጊዎች ፌስቡክን፣ ቲክቶክ እና ኢነስታግራምን የመሰሉ ማኅበራዊ ሚዲያ አጠቃቀማቸው ላይ ገደብ በመጣል የመጀመሪያዋ ግዛት ሆነች።",
-              "imageAlt": "ለልጆች የአእምሮ ጤና ስጋት የሆነው ማኅበራዊ ሚዲያ ለወላጆችም አሳሳቢ ሆኗል",
-              "id": "cpr5el75rl2o"
-            },
-            {
-              "type": "article",
-              "title": "በረመዳን ወር ጤናችንን ለመጠበቅ የሚጠቅሙ አምስት ምክሮች",
-              "firstPublished": "2023-03-23T04:14:23.725Z",
-              "link": "https://www.bbc.com/amharic/articles/c19w4n30jdpo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8127/live/ab46bfa0-c89b-11ed-95f8-0154daa64c44.jpg",
-              "description": "በዓለም ላይ ወደ 2 ቢሊዮን የሚጠጉ ሙስሊሞች ዓመታዊውን የረምዳን ጾም ጀምረዋል። በጾም ወቅት አማኞች ከንጋት እስከ ምሽት ራሳቸውን ከምግብ እና ከመጠጥ ያርቃሉ። በዚህ ወቅት ስፖርት ማዘውተር ችግር አለው? የትኞቹን ምግቦች በይበልጥ መመገብ ይመከራል? የሰውነት እንቅስቃሴ ባለሙያው ቢላል ሐፊዝ፣ የሥነ ምግብ ባለሙያዋ ናዚማ ቁረሺ ለዚህ ጽሑፍ ተማክረዋል።",
-              "imageAlt": "ቴምር",
-              "id": "c19w4n30jdpo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a84415ed-8305-4d6d-875c-dda5c7d7a686",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "ከየፈርጁ",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT1M24S",
-              "title": "በ35 ሺህ የወዳደቁ ፕላስቲኮች የተሰራው ቅልብጭ ያለ ቤት",
-              "firstPublished": "2023-05-11T03:45:19.181Z",
-              "link": "https://www.bbc.com/amharic/articles/cekddm21533o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "በዓለም ላይ እጅግ የተበከለ ወንዝ ካላቸው አገራት መካከል ኢንዶኔዥያ አንዷ ናት። የአካባቢ ተቆርቋሪው ጋሪ ቤንችጊብ ይህንን ብክለት ለመከላከል ሥራ ጀምሯል። ወደ ወንዞች እና የባሕር ዳርቻዎች የተጣሉ ፕላስቲኮችን በማሰባሰብ ከ35 ሺህ በላይ በሚሆኑ ፕላስቲኮች የራሱን መኖሪያ ቤት ሰርቷል። ይህ ቤት ውስጡ ምን ይመስላል? በውስጡስ ምን ምን አካቷል?",
-              "imageAlt": "",
-              "id": "cekddm21533o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M39S",
-              "title": "በቱርክ ላይ ጉልህ ለውጥ ማምጣት የቻሉት ፕሬዝዳንት ኤርዶዋን እና ተጽእኗቸው",
-              "firstPublished": "2023-05-10T04:06:46.201Z",
-              "link": "https://www.bbc.com/amharic/articles/c1v00gwv6vro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ባለፉት ሁለት አስርት ዓመታት ቱርክን የመሩት ረሲፕ ታይፕ ኤርዶዋን በአገራቸው ውስጥ ታላቅ እመርታን ማስመዝገባቸው እና በዓለም ዙሪያም ተደማጭነቷን ማጉላታቸው ይነገርላቸዋል። በተለይ በምጣኔ ሃብት፣ በሴቶች መብት፣ በዓለም አቀፍ ግንኙነት እና በሐይማኖት ረገድ የሚጠቀሱ ለውጦችን ማስመዝገብ እንደቻሉ ይነገርላቸዋል። በቱርክ ላይ ጉልህ ለውጥ ማምጣት የቻሉት ፕሬዝዳንት ኤርዶዋን በሥልጣን ላይ ለመቆየት በምርጫ ይወዳደራሉ።",
-              "imageAlt": "",
-              "id": "c1v00gwv6vro"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M35S",
-              "title": "ለ35 ዓመታት ከወንዝ ውስጥ ብረታ ብረት በመሰብሰብ የኖሩት ‘ማግኔቱ’ አዛውንት",
-              "firstPublished": "2023-05-09T03:39:07.589Z",
-              "link": "https://www.bbc.com/amharic/articles/c037nxg3ylyo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "እኚህ ግለሰብ ጋንጉሊ ሳርካር ይባላል። ነዋሪነቱ በባንግላዲሽ መዲና ዳካ ነው። ላለፉት 35 ዓመታት ኑሯቸውን የመሩት ከሌሎች ሰዎች ለየት ባለ መልኩ ነው። ከተማዋቸውን የሚያልፍ ቡሪጋንጋ የሚባል ወንዝ አለ። ሰው ሁሉ ከእዚህ ወንዝ ዓሳ በማጥመድ ኑሮውን ይደጉማል። ጋንጉሊ ግን ላለፉት 35 ዓመታት ዓሳ አጥምደው አያውቁም። መተዳደሪያቸው ወንዙ ውስጥ የተጣሉ ብረታ ብረቶችን በማግኔት በመሰብሰብ ነው። በቀን ከ10 እስከ 15 ኪሎ ግራም ብረት እየሰበሰቡ በመሸጥ ዘመናትን አሳልፈዋል፤ አሁን ግን ችግር ገጥሟቸዋል።",
-              "imageAlt": "",
-              "id": "c037nxg3ylyo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M45S",
-              "title": "የንጉሥ ቻርለስ ሦስተኛ የንግሥና ሥነ ሥርዓት ገጽታዎች",
-              "firstPublished": "2023-05-08T08:30:44.529Z",
-              "link": "https://www.bbc.com/amharic/articles/czqn995y9n4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ንጉሥ ቻርለስ ሦስተኛ እና ንግሥት ካሚላ የንግሥና ሥነ ሥርዓት በደማቅ ሁኔታ ቅዳሜ ዕለት አከናውነዋል። በሥነ ሥርዓቱ ላይ ከ2 ሺህ በላይ ሰው ታድሟል። ሌሎች በ10 ሺህ የሚቆጠሩ ሰዎች ደግሞ ጥንዶቹን ለማየት በለንደን ጎዳናዎች ላይ ተሰልፈው ውለዋል። በአንጻሩ የዘውዳዊ ሥርዓቱን የሚቃወሙ ሰዎችም ድምጻቸውን ያሰሙበት ዕለት ነበር። የንግሥና ሥነ ሥርዓቱ በአመዛኙ ይህንን ይመስል ነበር።",
-              "imageAlt": "",
-              "id": "czqn995y9n4o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M46S",
-              "title": "የውሃ ሃብቷ ተሟጦ ያለውሃ ልትቀር ትችላለች የተባለችው አገር የገጠማት ፈተና",
-              "firstPublished": "2023-05-08T04:04:36.780Z",
-              "link": "https://www.bbc.com/amharic/articles/c2e91d4nv8zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "በ﻿አየር ንብረት ለውጥ ምክንያት በ2050 ከፊሉ የመካከለኛው ምሥራቅ አካባቢ ለመኖሪያነት አይሆንም ተብሎ ተሰግቷል። በከፍተኛ ሁኔታ በአየር ንብረት ለውጥ ምክንያት ለፈተና ይጋለጣሉ ከተባሉ የአካባቢው አገራት መካከል ዮርዳኖስ አንዷ ነች። በዚህም ሳቢያ የወደፊት ዕጣ ፈንታዋ የከፋ እንደሚሆን የተተነበየባት ዮርዳኖስ፣ ከወዲሁ ለውጦችን እና ምልክቶችን እየተጋፈጠች ነው። በአሁኑ ወቅት የሙት ባሕር መጠን እየቀነሰ ሲሆን ብዙ ቤቶችም ውሃ የሚያገኙት በሳምንት አንድ ቀን ብቻ ነው። ስለዚህ ዮርዳኖስ በአጭር ጊዜ ውስጥ ካለ ውሃ ልትቀር ይሆን?",
-              "imageAlt": "",
-              "id": "c2e91d4nv8zo"
-            },
-            {
-              "type": "video",
-              "duration": "PT7M8S",
-              "title": "ሽመልስ አራርሶ እና ታዋቂው የኬንያ ዘም መሽሩምስ ባንድ ሲታወሱ",
-              "firstPublished": "2023-05-07T04:57:09.476Z",
-              "link": "https://www.bbc.com/amharic/articles/c0wgdyddx53o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ታዋቂው ሙዚቀኛ ሽመልስ አራርሶ እና የኬንያው ዘም መሽሩምስ ባንድ በኢትዮጵያ አቆጣጠር ከ1980ዎቹ መጀመሪያ አንስቶ አስከ ሽመልስ ህልፈት ድረስ ኬንያን እና ኢትዮጵያን በሙዚቃ ያስተሳሰረ የጋራ ታሪኮች አሏቸው። ሽመልስ ከዘም መሽሩምስ ባንድ ጋር ሁለት አልበሞችን ሰርቷል። በሽመልስ ምክንያት ዘም መሽሩምስ ባንድ ወደ ኢትዮጵያ እየተመላለሰ ብዙ የሙዚቃ ድግሶችን አቅርቧል። አምስት አስርት ዓመታት ያስቆጠረ ዕድሜ ያለው ከዘም መሽሩምስ ባንድ አባላት ከሆኑት አምስት ወንድማማቾች መካከል ሁለቱ ከቢቢሲ ጋር ቆይታ አድርገዋል። በዚህ ቆይታቸው ስለሽመልስ አራርሶ እና ከሦስት አስርት ዓመታት በፊት ኢትዮጵያ ውስጥ ስላቀረቧቸው የሙዚቃዎች ድግሶች አውግተውናል።",
-              "imageAlt": "",
-              "id": "c0wgdyddx53o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M17S",
-              "title": "ሦስት ሳምንታትን ያስቆጠረው የሱዳን ግጭት ያስከተለው ቀውስ",
-              "firstPublished": "2023-05-06T05:08:11.761Z",
-              "link": "https://www.bbc.com/amharic/articles/cd1r8p01gp2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "በሱዳን ጦር እና በፈጥኖ ደራሽ ኃይሉ መካከል የተቀሰቀሰው ጦርነት ሦስት ሳምንታትን አስቆጥሯል። ሦስት ጊዜ የተኩስ አቁም ስምምነት ተደርጎ ነገር ግን በተደጋጋሚ ተጥሷል። ከ100 ሺህ በላይ ሰዎች አገራቸውን ለቀው ሲሰደዱ ሌሎች በመቶ ሺህ የሚቆጠሩ ደግሞ ከመኖሪያቸው ተፈናቅለዋል። በ10 ሚሊዮን የሚቆጠሩ ሱዳናውያን የአስቸኳይ ሰብዓዊ ድጋፍ ጠባቂ ሆነዋል። አሁንም ለሰባት ቀናት የሚቆይ ተኩስ አቁም ተደርጓል ቢባልም በካርቱም እና በሌሎች ከተሞች ከባድ ውጊያ እየተካሄደ ነው። ሁለቱም ኃይሎች ግጭቱን በቅርብ ጊዜ ያቆማሉ ተብሎ አይጠበቅም።\n",
-              "imageAlt": "",
-              "id": "cd1r8p01gp2o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M48S",
-              "title": "ለንጉሥ ቻርለስ የንግሥና ሥነ ሥርዓት የተዘጋጁት ወርቃማ ሰረገላዎች",
-              "firstPublished": "2023-05-05T03:58:05.569Z",
-              "link": "https://www.bbc.com/amharic/articles/cp6yjzdnpp4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "የንጉሥ ቻርለስ ሦሰተኛ የንግሥና ሥነ ሥርዓት ነገ ቅዳሜ ሚያዚያ 28/2015 ዓ.ም. በታላቅ ዝግጅት ለንደን ውስጥ ይከናወናራል። ንጉሡ እና ባለቤታቸው በዓለም ዕድሜ ጠገብ በሆኑ ወርቃማ ሰረገላዎች ላይ ሆነው ሥነ ሥርዓቱ ወደሚካሄድበት ቦታ ይሄዳሉ። በይፋ ንግሥናቸውን ከተቀበሉ በኋላም ወደ ባኪንግሃም ቤተ መንግሥት በልዩ ሥነ ሥርዓት ሲመለሱም ሰረገላዎቹ ተሳፍረው ይሆናል። እነዚህ ልዩ ሰረገላዎች ከአውሮፓውያኑ 1830ዎቹ ጀምሮ በተከናወኑ በእያንዳንዱ የንግሥና ሥነ ሥርዓቶች ላይ ያገለገሉ እጅግ የተዋቡ ሰረገላዎች ናቸው።",
-              "imageAlt": "",
-              "id": "cp6yjzdnpp4o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M37S",
-              "title": "እርጅናን ለማሸነፍ በየዓመቱ ሚሊዮን ዶላሮችን የሚያፈሰው ባለሃብት",
-              "firstPublished": "2023-05-03T05:10:59.867Z",
-              "link": "https://www.bbc.com/amharic/articles/ce7gn3rkxw7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ሚሊየነሩ ብሪያን ጆንሰን እርጅናውን ለመቀልበስ በየዓመቱ በሚሊዮኖች የሚቆጠር ዶላር በማውጣት ጥረት እያደረገ ነው። ብሪያን አሁን ዕድሜው 45 ነው። በስፖርት እና በሕክምና ግን ወደ 18 ዓመት መመለስ ይፈልጋል። ይህንንም ለማሳካት ሂደቱን የሚከታተሉ 30 አባላት ያሉት የሐኪሞች እና ሳይንቲስቶች ቡድን ቀጥሯል።",
-              "imageAlt": "",
-              "id": "ce7gn3rkxw7o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M23S",
-              "title": "‘እየሱስን ለማግኘት’ ጾም ላይ የቆዩ 100 የሚጠጉ ሰዎች አስከሬን የተገኘበት ስፍራ",
-              "firstPublished": "2023-04-29T05:13:46.030Z",
-              "link": "https://www.bbc.com/amharic/articles/cpvxwz7d1x5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "እየሱስን ለማግኘት እራሳቸውን በጾም አድክመው እንዲሞቱ በሚያበረታታ የእምነት ቡድን ስብከት የተነሳ የሞቱ ወደ 100 የሚደርሱ ሰዎች አስከሬን በምሥራቅ ኬንያ ተገኝቷል። አሁንም በዚሁ ስፍራ ከሃይማኖታዊው ትዕዛዝ አናፈነግጥም ብለው በርካታ ሰዎች በጾም ላይ እንደሚገኙ ፖሊስ አስታውቋል። በዚህም ሳቢያ የሟቾች ቁጥር ሊያሻቅብ ይችላል ተብሏል። የኬንያ መንግሥትም በእንዲህ አይነቱ ሃይማኖታዊ አስተምህሮ ዙሪያ እርምጃ እንዲወስድ ግፊት እየተደረገበት ነው።",
-              "imageAlt": "",
-              "id": "cpvxwz7d1x5o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M29S",
-              "title": "ሱዳንን እያመሰ ያለው ግጭት የተቀሰቀሰበት ምክንያት ምንድን ነው?",
-              "firstPublished": "2023-04-28T04:10:15.219Z",
-              "link": "https://www.bbc.com/amharic/articles/cxxypw3zwdzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ሁለት ሳምንት ሊሞላው የተቃረበው በሱዳን በተፈጠረው ወታደራዊ ግጭት በመቶዎች የሚቆጠሩ ሰዎች ተገድለዋል። ግጭቱ የሥልጣን ሽኩቻ ውስጥ በገቡት በአገሪቱ ሁለት ኃያላን የጦር ጄኔራሎች መካከል የሚደረግ ሲሆን የሌሎች አገራት እጅ እንዳለበትም ይነገራል። ለመሆኑ ይህ ግጭት መቀስቀስ ምክንያቱ ምንድን ነው?",
-              "imageAlt": "",
-              "id": "cxxypw3zwdzo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M27S",
-              "title": "የሱዳንን ግጭት በተመለከተ ከሚሰራጩ ቪዲዮዎች ምን ያህሎቹ እውነተኛ ናቸው?",
-              "firstPublished": "2023-04-26T04:13:57.766Z",
-              "link": "https://www.bbc.com/amharic/articles/c2lp0l7qvjzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "የሱዳንን ግጭት ተከትሎ እውነተኛ ያልሆኑ እና አሳሳች ቪዲዮዎች በማኅበራዊ ሚዲያ ላይ እየተሰራጩ ነው። ቢቢሲ አንዳንዶቹን ቪዲዮዎች በመመርመር ሐሰተኛነታቸውን እና ምንጫቸውን ለማወቅ ችሏል። ይህ ቪዲዮም ተጠቃሽ የሆኑትን ዳሷል። ",
-              "imageAlt": "",
-              "id": "c2lp0l7qvjzo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 7,
-          "link": "https://www.bbc.com/amharic/topics/c917ezk2pmvt",
-          "curationId": "urn:bbc:vivo:curation:a899f5cd-ad96-4585-8ed8-07b22070dc2d",
-          "curationType": "vivo-stream",
-          "position": 2,
-          "title": "ቪዲዮ",
-          "visualProminence": "NORMAL"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live home page"
-  }
+  "data": {
+    "title": "BBC News Amharic",
+    "description": "",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "መነኩሴዋ ፒያኒስት፡ እማሆይ ጽጌ ማርያም ገብሩ አረፉ",
+            "firstPublished": "2022-03-15T04:07:52.000Z",
+            "link": "https://www.bbc.com/amharic/news-60741168",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9F90/production/_123684804_emahoy1.jpg",
+            "description": "በድንቅ የፒያኖ የሙዚቃ ሥራዎቻቸው የሚታወቁት እማሆይ ጽጌማርያም ገብሩ ማረፋቸውን በቅርብ የሚያውቋቸው ሰዎች ገለጹ። እማሆይ ጽጌማርያም በምንኩስና ወደ መንፈሳዊው ሕይወት ከመግባታቸው በፊት ቤተሰቦቻቸው የውብዳር የሚል ስም ነበር የሰጧቸው። በ1916 ዓ.ም. በአዲስ አበባ ውስጥ የተወለዱ እማሆይ ጽጌማርያም ገብሩ በኢትዮጵያ በቫዮሊን እና በፒያኖ ሙዚቃዎችን በማቀናበር በቀዳሚነት የሚጠቀሱ ናቸው። እማሆይ ጽጌማርያም በ99 ዓመታቸው ነው ከዚህ ዓለም በሞት የተለዩት።",
+            "imageAlt": "እማሆይ ጽጌ ማሪያም ገብሩ",
+            "id": "3e4fac31-4dc8-408f-af18-9f634d4fa4eb"
+          },
+          {
+            "type": "article",
+            "title": "ሕጻናት በቤት ሠራተኞች ማደጋቸው ችግሩ ምንድን ነው?",
+            "firstPublished": "2023-03-27T04:21:55.787Z",
+            "link": "https://www.bbc.com/amharic/articles/cglndmlkr2eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f789/live/eaca39e0-cb2a-11ed-be2e-754a65c11505.jpg",
+            "description": "ከቅርብ ጊዜ ወዲህ የሚሰሙት የጨቅላ ሕጻናት ደብዛ ከመጥፋት ጀምሮ እስከ ሚፈጸሙባቸው አሰቃቂ ወንጀሎች ድረስ ወላጆችን በተለይ እናቶችን እንቅልፍ የሚነሳ ጉዳይ ሆኗል። ከዚህ ባሻገር ግን ጨቅላ ልጆችን ቤት ውስጥ ትቶ መሄድ ብዙም ልብ ያልተባሉ ከአካላዊ ባሻገር ሥነ ልቦናዊ ፈተናዎችን እንዲጋፈጡ ያደርጋቸዋል። ታዲያ የኑሮ ግዴታን ለመወጣት ነፍስ ያላወቁ እና ለትምህርት ያልደረሱ ልጆችን ቤት ውስጥ ከሠራተኛ ጋር ትቶ ከመሄድ ውጪ ምን አማራጭ አለ?",
+            "imageAlt": "በእናቷ እቅፍ ውስጥ ሆና የምታለቅስ ሕጻን",
+            "id": "cglndmlkr2eo"
+          },
+          {
+            "type": "article",
+            "title": "በአርባ ምንጭ ጫሞ ሐይቅ ላይ ከሰጠሙት ሰዎች መካከል የሰባቱ አስከሬን ተገኘ",
+            "firstPublished": "2023-03-27T10:05:21.524Z",
+            "link": "https://www.bbc.com/amharic/articles/cpd80931m27o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1187/live/12357290-cc86-11ed-8826-bd7de7756a42.jpg",
+            "description": "ቅዳሜ መጋቢት 16/2015 ዓ.ም. በደቡብ ክልል ጋሞ ዞን በምትገኘው አርባ ምንጭ ውስጥ ጫሞ ሐይቅ ላይ በጀልባ ሲጓዙ ሰጥመው የደረሱበት ካልታወቀ ሰዎች መካከል የሰባቱ ሰዎች አስክሬን መገኘቱ ፖሊስ አስታውቋል።",
+            "imageAlt": "ቱሪስቶች በጫሞ ሐይቅ ላይ",
+            "id": "cpd80931m27o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:0879a9bf-9051-4e70-8932-d438ce39aa8a",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "BBC News Amharic Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ድብቁ የወሲብ ንግድ በሶማሊያ ",
+            "firstPublished": "2023-03-25T05:06:04.228Z",
+            "link": "https://www.bbc.com/amharic/articles/cl46gv53m6xo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/907f/live/d23af420-ca65-11ed-be2e-754a65c11505.jpg",
+            "description": "በሶማሊያ ዋና ከተማ ሞቃዲሾ ነዋሪ የሆኑ ሁለት ሴቶች እንዴት ምስጢራዊ ወደሆነው የወሲብ ንግድ እንደተሳቡ ለቢቢሲ ተናግረዋል። ለዓመታት በእርስ በርስ ጦርነት ስትናወጥ በነበረችው ሶማሊያ ውስጥ ጦርነቱ ጋብ ቢልም፣ አሁንም ሁከቶችን ማስተናገዷ አልቀረም።",
+            "imageAlt": "በጨለማ ውስጥ ከጀርባ የምትታይ ሴት ",
+            "id": "cl46gv53m6xo"
+          },
+          {
+            "type": "article",
+            "title": "የአሜሪካዋ ግዛት በልጆች የቲክቶክ እና ኢኒስታግራም አጠቃቀም ላይ ገደብ ጣለች",
+            "firstPublished": "2023-03-24T07:44:02.634Z",
+            "link": "https://www.bbc.com/amharic/articles/cpr5el75rl2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/210e/live/f9504f20-ca14-11ed-be2e-754a65c11505.jpg",
+            "description": "የአሜሪካዋ ዩታህ ግዛት አዳጊዎች ፌስቡክን፣ ቲክቶክ እና ኢነስታግራምን የመሰሉ ማኅበራዊ ሚዲያ አጠቃቀማቸው ላይ ገደብ በመጣል የመጀመሪያዋ ግዛት ሆነች።",
+            "imageAlt": "ለልጆች የአእምሮ ጤና ስጋት የሆነው ማኅበራዊ ሚዲያ ለወላጆችም አሳሳቢ ሆኗል",
+            "id": "cpr5el75rl2o"
+          },
+          {
+            "type": "article",
+            "title": "በረመዳን ወር ጤናችንን ለመጠበቅ የሚጠቅሙ አምስት ምክሮች",
+            "firstPublished": "2023-03-23T04:14:23.725Z",
+            "link": "https://www.bbc.com/amharic/articles/c19w4n30jdpo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8127/live/ab46bfa0-c89b-11ed-95f8-0154daa64c44.jpg",
+            "description": "በዓለም ላይ ወደ 2 ቢሊዮን የሚጠጉ ሙስሊሞች ዓመታዊውን የረምዳን ጾም ጀምረዋል። በጾም ወቅት አማኞች ከንጋት እስከ ምሽት ራሳቸውን ከምግብ እና ከመጠጥ ያርቃሉ። በዚህ ወቅት ስፖርት ማዘውተር ችግር አለው? የትኞቹን ምግቦች በይበልጥ መመገብ ይመከራል? የሰውነት እንቅስቃሴ ባለሙያው ቢላል ሐፊዝ፣ የሥነ ምግብ ባለሙያዋ ናዚማ ቁረሺ ለዚህ ጽሑፍ ተማክረዋል።",
+            "imageAlt": "ቴምር",
+            "id": "c19w4n30jdpo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a84415ed-8305-4d6d-875c-dda5c7d7a686",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "ከየፈርጁ",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT1M24S",
+            "title": "በ35 ሺህ የወዳደቁ ፕላስቲኮች የተሰራው ቅልብጭ ያለ ቤት",
+            "firstPublished": "2023-05-11T03:45:19.181Z",
+            "link": "https://www.bbc.com/amharic/articles/cekddm21533o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "በዓለም ላይ እጅግ የተበከለ ወንዝ ካላቸው አገራት መካከል ኢንዶኔዥያ አንዷ ናት። የአካባቢ ተቆርቋሪው ጋሪ ቤንችጊብ ይህንን ብክለት ለመከላከል ሥራ ጀምሯል። ወደ ወንዞች እና የባሕር ዳርቻዎች የተጣሉ ፕላስቲኮችን በማሰባሰብ ከ35 ሺህ በላይ በሚሆኑ ፕላስቲኮች የራሱን መኖሪያ ቤት ሰርቷል። ይህ ቤት ውስጡ ምን ይመስላል? በውስጡስ ምን ምን አካቷል?",
+            "imageAlt": "",
+            "id": "cekddm21533o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M39S",
+            "title": "በቱርክ ላይ ጉልህ ለውጥ ማምጣት የቻሉት ፕሬዝዳንት ኤርዶዋን እና ተጽእኗቸው",
+            "firstPublished": "2023-05-10T04:06:46.201Z",
+            "link": "https://www.bbc.com/amharic/articles/c1v00gwv6vro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ባለፉት ሁለት አስርት ዓመታት ቱርክን የመሩት ረሲፕ ታይፕ ኤርዶዋን በአገራቸው ውስጥ ታላቅ እመርታን ማስመዝገባቸው እና በዓለም ዙሪያም ተደማጭነቷን ማጉላታቸው ይነገርላቸዋል። በተለይ በምጣኔ ሃብት፣ በሴቶች መብት፣ በዓለም አቀፍ ግንኙነት እና በሐይማኖት ረገድ የሚጠቀሱ ለውጦችን ማስመዝገብ እንደቻሉ ይነገርላቸዋል። በቱርክ ላይ ጉልህ ለውጥ ማምጣት የቻሉት ፕሬዝዳንት ኤርዶዋን በሥልጣን ላይ ለመቆየት በምርጫ ይወዳደራሉ።",
+            "imageAlt": "",
+            "id": "c1v00gwv6vro"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M35S",
+            "title": "ለ35 ዓመታት ከወንዝ ውስጥ ብረታ ብረት በመሰብሰብ የኖሩት ‘ማግኔቱ’ አዛውንት",
+            "firstPublished": "2023-05-09T03:39:07.589Z",
+            "link": "https://www.bbc.com/amharic/articles/c037nxg3ylyo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "እኚህ ግለሰብ ጋንጉሊ ሳርካር ይባላል። ነዋሪነቱ በባንግላዲሽ መዲና ዳካ ነው። ላለፉት 35 ዓመታት ኑሯቸውን የመሩት ከሌሎች ሰዎች ለየት ባለ መልኩ ነው። ከተማዋቸውን የሚያልፍ ቡሪጋንጋ የሚባል ወንዝ አለ። ሰው ሁሉ ከእዚህ ወንዝ ዓሳ በማጥመድ ኑሮውን ይደጉማል። ጋንጉሊ ግን ላለፉት 35 ዓመታት ዓሳ አጥምደው አያውቁም። መተዳደሪያቸው ወንዙ ውስጥ የተጣሉ ብረታ ብረቶችን በማግኔት በመሰብሰብ ነው። በቀን ከ10 እስከ 15 ኪሎ ግራም ብረት እየሰበሰቡ በመሸጥ ዘመናትን አሳልፈዋል፤ አሁን ግን ችግር ገጥሟቸዋል።",
+            "imageAlt": "",
+            "id": "c037nxg3ylyo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M45S",
+            "title": "የንጉሥ ቻርለስ ሦስተኛ የንግሥና ሥነ ሥርዓት ገጽታዎች",
+            "firstPublished": "2023-05-08T08:30:44.529Z",
+            "link": "https://www.bbc.com/amharic/articles/czqn995y9n4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ንጉሥ ቻርለስ ሦስተኛ እና ንግሥት ካሚላ የንግሥና ሥነ ሥርዓት በደማቅ ሁኔታ ቅዳሜ ዕለት አከናውነዋል። በሥነ ሥርዓቱ ላይ ከ2 ሺህ በላይ ሰው ታድሟል። ሌሎች በ10 ሺህ የሚቆጠሩ ሰዎች ደግሞ ጥንዶቹን ለማየት በለንደን ጎዳናዎች ላይ ተሰልፈው ውለዋል። በአንጻሩ የዘውዳዊ ሥርዓቱን የሚቃወሙ ሰዎችም ድምጻቸውን ያሰሙበት ዕለት ነበር። የንግሥና ሥነ ሥርዓቱ በአመዛኙ ይህንን ይመስል ነበር።",
+            "imageAlt": "",
+            "id": "czqn995y9n4o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M46S",
+            "title": "የውሃ ሃብቷ ተሟጦ ያለውሃ ልትቀር ትችላለች የተባለችው አገር የገጠማት ፈተና",
+            "firstPublished": "2023-05-08T04:04:36.780Z",
+            "link": "https://www.bbc.com/amharic/articles/c2e91d4nv8zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "በ﻿አየር ንብረት ለውጥ ምክንያት በ2050 ከፊሉ የመካከለኛው ምሥራቅ አካባቢ ለመኖሪያነት አይሆንም ተብሎ ተሰግቷል። በከፍተኛ ሁኔታ በአየር ንብረት ለውጥ ምክንያት ለፈተና ይጋለጣሉ ከተባሉ የአካባቢው አገራት መካከል ዮርዳኖስ አንዷ ነች። በዚህም ሳቢያ የወደፊት ዕጣ ፈንታዋ የከፋ እንደሚሆን የተተነበየባት ዮርዳኖስ፣ ከወዲሁ ለውጦችን እና ምልክቶችን እየተጋፈጠች ነው። በአሁኑ ወቅት የሙት ባሕር መጠን እየቀነሰ ሲሆን ብዙ ቤቶችም ውሃ የሚያገኙት በሳምንት አንድ ቀን ብቻ ነው። ስለዚህ ዮርዳኖስ በአጭር ጊዜ ውስጥ ካለ ውሃ ልትቀር ይሆን?",
+            "imageAlt": "",
+            "id": "c2e91d4nv8zo"
+          },
+          {
+            "type": "video",
+            "duration": "PT7M8S",
+            "title": "ሽመልስ አራርሶ እና ታዋቂው የኬንያ ዘም መሽሩምስ ባንድ ሲታወሱ",
+            "firstPublished": "2023-05-07T04:57:09.476Z",
+            "link": "https://www.bbc.com/amharic/articles/c0wgdyddx53o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ታዋቂው ሙዚቀኛ ሽመልስ አራርሶ እና የኬንያው ዘም መሽሩምስ ባንድ በኢትዮጵያ አቆጣጠር ከ1980ዎቹ መጀመሪያ አንስቶ አስከ ሽመልስ ህልፈት ድረስ ኬንያን እና ኢትዮጵያን በሙዚቃ ያስተሳሰረ የጋራ ታሪኮች አሏቸው። ሽመልስ ከዘም መሽሩምስ ባንድ ጋር ሁለት አልበሞችን ሰርቷል። በሽመልስ ምክንያት ዘም መሽሩምስ ባንድ ወደ ኢትዮጵያ እየተመላለሰ ብዙ የሙዚቃ ድግሶችን አቅርቧል። አምስት አስርት ዓመታት ያስቆጠረ ዕድሜ ያለው ከዘም መሽሩምስ ባንድ አባላት ከሆኑት አምስት ወንድማማቾች መካከል ሁለቱ ከቢቢሲ ጋር ቆይታ አድርገዋል። በዚህ ቆይታቸው ስለሽመልስ አራርሶ እና ከሦስት አስርት ዓመታት በፊት ኢትዮጵያ ውስጥ ስላቀረቧቸው የሙዚቃዎች ድግሶች አውግተውናል።",
+            "imageAlt": "",
+            "id": "c0wgdyddx53o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M17S",
+            "title": "ሦስት ሳምንታትን ያስቆጠረው የሱዳን ግጭት ያስከተለው ቀውስ",
+            "firstPublished": "2023-05-06T05:08:11.761Z",
+            "link": "https://www.bbc.com/amharic/articles/cd1r8p01gp2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "በሱዳን ጦር እና በፈጥኖ ደራሽ ኃይሉ መካከል የተቀሰቀሰው ጦርነት ሦስት ሳምንታትን አስቆጥሯል። ሦስት ጊዜ የተኩስ አቁም ስምምነት ተደርጎ ነገር ግን በተደጋጋሚ ተጥሷል። ከ100 ሺህ በላይ ሰዎች አገራቸውን ለቀው ሲሰደዱ ሌሎች በመቶ ሺህ የሚቆጠሩ ደግሞ ከመኖሪያቸው ተፈናቅለዋል። በ10 ሚሊዮን የሚቆጠሩ ሱዳናውያን የአስቸኳይ ሰብዓዊ ድጋፍ ጠባቂ ሆነዋል። አሁንም ለሰባት ቀናት የሚቆይ ተኩስ አቁም ተደርጓል ቢባልም በካርቱም እና በሌሎች ከተሞች ከባድ ውጊያ እየተካሄደ ነው። ሁለቱም ኃይሎች ግጭቱን በቅርብ ጊዜ ያቆማሉ ተብሎ አይጠበቅም።\n",
+            "imageAlt": "",
+            "id": "cd1r8p01gp2o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M48S",
+            "title": "ለንጉሥ ቻርለስ የንግሥና ሥነ ሥርዓት የተዘጋጁት ወርቃማ ሰረገላዎች",
+            "firstPublished": "2023-05-05T03:58:05.569Z",
+            "link": "https://www.bbc.com/amharic/articles/cp6yjzdnpp4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "የንጉሥ ቻርለስ ሦሰተኛ የንግሥና ሥነ ሥርዓት ነገ ቅዳሜ ሚያዚያ 28/2015 ዓ.ም. በታላቅ ዝግጅት ለንደን ውስጥ ይከናወናራል። ንጉሡ እና ባለቤታቸው በዓለም ዕድሜ ጠገብ በሆኑ ወርቃማ ሰረገላዎች ላይ ሆነው ሥነ ሥርዓቱ ወደሚካሄድበት ቦታ ይሄዳሉ። በይፋ ንግሥናቸውን ከተቀበሉ በኋላም ወደ ባኪንግሃም ቤተ መንግሥት በልዩ ሥነ ሥርዓት ሲመለሱም ሰረገላዎቹ ተሳፍረው ይሆናል። እነዚህ ልዩ ሰረገላዎች ከአውሮፓውያኑ 1830ዎቹ ጀምሮ በተከናወኑ በእያንዳንዱ የንግሥና ሥነ ሥርዓቶች ላይ ያገለገሉ እጅግ የተዋቡ ሰረገላዎች ናቸው።",
+            "imageAlt": "",
+            "id": "cp6yjzdnpp4o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M37S",
+            "title": "እርጅናን ለማሸነፍ በየዓመቱ ሚሊዮን ዶላሮችን የሚያፈሰው ባለሃብት",
+            "firstPublished": "2023-05-03T05:10:59.867Z",
+            "link": "https://www.bbc.com/amharic/articles/ce7gn3rkxw7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ሚሊየነሩ ብሪያን ጆንሰን እርጅናውን ለመቀልበስ በየዓመቱ በሚሊዮኖች የሚቆጠር ዶላር በማውጣት ጥረት እያደረገ ነው። ብሪያን አሁን ዕድሜው 45 ነው። በስፖርት እና በሕክምና ግን ወደ 18 ዓመት መመለስ ይፈልጋል። ይህንንም ለማሳካት ሂደቱን የሚከታተሉ 30 አባላት ያሉት የሐኪሞች እና ሳይንቲስቶች ቡድን ቀጥሯል።",
+            "imageAlt": "",
+            "id": "ce7gn3rkxw7o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M23S",
+            "title": "‘እየሱስን ለማግኘት’ ጾም ላይ የቆዩ 100 የሚጠጉ ሰዎች አስከሬን የተገኘበት ስፍራ",
+            "firstPublished": "2023-04-29T05:13:46.030Z",
+            "link": "https://www.bbc.com/amharic/articles/cpvxwz7d1x5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "እየሱስን ለማግኘት እራሳቸውን በጾም አድክመው እንዲሞቱ በሚያበረታታ የእምነት ቡድን ስብከት የተነሳ የሞቱ ወደ 100 የሚደርሱ ሰዎች አስከሬን በምሥራቅ ኬንያ ተገኝቷል። አሁንም በዚሁ ስፍራ ከሃይማኖታዊው ትዕዛዝ አናፈነግጥም ብለው በርካታ ሰዎች በጾም ላይ እንደሚገኙ ፖሊስ አስታውቋል። በዚህም ሳቢያ የሟቾች ቁጥር ሊያሻቅብ ይችላል ተብሏል። የኬንያ መንግሥትም በእንዲህ አይነቱ ሃይማኖታዊ አስተምህሮ ዙሪያ እርምጃ እንዲወስድ ግፊት እየተደረገበት ነው።",
+            "imageAlt": "",
+            "id": "cpvxwz7d1x5o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M29S",
+            "title": "ሱዳንን እያመሰ ያለው ግጭት የተቀሰቀሰበት ምክንያት ምንድን ነው?",
+            "firstPublished": "2023-04-28T04:10:15.219Z",
+            "link": "https://www.bbc.com/amharic/articles/cxxypw3zwdzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ሁለት ሳምንት ሊሞላው የተቃረበው በሱዳን በተፈጠረው ወታደራዊ ግጭት በመቶዎች የሚቆጠሩ ሰዎች ተገድለዋል። ግጭቱ የሥልጣን ሽኩቻ ውስጥ በገቡት በአገሪቱ ሁለት ኃያላን የጦር ጄኔራሎች መካከል የሚደረግ ሲሆን የሌሎች አገራት እጅ እንዳለበትም ይነገራል። ለመሆኑ ይህ ግጭት መቀስቀስ ምክንያቱ ምንድን ነው?",
+            "imageAlt": "",
+            "id": "cxxypw3zwdzo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M27S",
+            "title": "የሱዳንን ግጭት በተመለከተ ከሚሰራጩ ቪዲዮዎች ምን ያህሎቹ እውነተኛ ናቸው?",
+            "firstPublished": "2023-04-26T04:13:57.766Z",
+            "link": "https://www.bbc.com/amharic/articles/c2lp0l7qvjzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "የሱዳንን ግጭት ተከትሎ እውነተኛ ያልሆኑ እና አሳሳች ቪዲዮዎች በማኅበራዊ ሚዲያ ላይ እየተሰራጩ ነው። ቢቢሲ አንዳንዶቹን ቪዲዮዎች በመመርመር ሐሰተኛነታቸውን እና ምንጫቸውን ለማወቅ ችሏል። ይህ ቪዲዮም ተጠቃሽ የሆኑትን ዳሷል። ",
+            "imageAlt": "",
+            "id": "c2lp0l7qvjzo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 7,
+        "link": "https://www.bbc.com/amharic/topics/c917ezk2pmvt",
+        "curationId": "urn:bbc:vivo:curation:a899f5cd-ad96-4585-8ed8-07b22070dc2d",
+        "curationType": "vivo-stream",
+        "position": 2,
+        "title": "ቪዲዮ",
+        "visualProminence": "NORMAL"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cx35pee6zw8t",
+        "contentType": "index-home",
+        "pageIdentifier": "amharic.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live home page"
+}

--- a/data/arabic/homePage/index.json
+++ b/data/arabic/homePage/index.json
@@ -1,94 +1,101 @@
 {
-    "data": {
-      "title": "BBC News عربي",
-      "description": "بي بي سي العربية هي شبكة لنقل الأخبار والمعلومات ومقاطع الفيديو إلى العالم عبر عدة وسائط، تشمل الإنترنت ومواقع التواصل الاجتماعي والراديو والتلفزيون والهواتف المحمولة.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "الجيش السوداني: عمر البشير محتجز في مستشفى عسكري",
-              "firstPublished": "2023-04-26T08:31:21.000Z",
-              "link": "https://www.bbc.com/arabic/middleeast-65397516",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28B4/production/_129502401_sudan.jpg",
-              "description": "الأمم المتحدة تؤكد تواصلها مع قادة طرفي الصراع في السودان في مسعى لدعم وقف هش لإطلاق النار.",
-              "imageAlt": "طفل يقف أمام المباني المتضررة بعد القتال في السودان",
-              "id": "dee83173-08b3-4e53-9d1d-ac4f00d31102"
-            },
-            {
-              "type": "article",
-              "title": "ما مدى شعبية الملكية البريطانية في عهد الملك تشارلز؟",
-              "firstPublished": "2023-04-26T06:11:29.000Z",
-              "link": "https://www.bbc.com/arabic/world-65385456",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6288/production/_129442252_3super_promo_new_safe_zone-2.jpg",
-              "description": "قبل حفل التتويج للملك تشارلز، يسأل برنامج بي بي سي بانوراما عما إذا كان الرأي العام حول العائلة المالكة قد تغير.",
-              "imageAlt": "الملك تشارلز الثالث",
-              "id": "34510ad4-32ce-41b4-bdd7-7846d591a42b"
-            },
-            {
-              "type": "article",
-              "title": "تغريم شركة تبغ 635 مليون دولار لخرقها العقوبات على كوريا الشمالية",
-              "firstPublished": "2023-04-26T00:21:26.000Z",
-              "link": "https://www.bbc.com/arabic/business-65395278",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C288/production/_129500894_gettyimages-632796062.jpg",
-              "description": "رئيس شركة التبغ البريطانية الأمريكية قدم اعتذارا عن بيع السجائر إلى كوريا الشمالية ووصف ذلك بالسلوك السيء.",
-              "imageAlt": "كيم جونغ أون",
-              "id": "e0d4cb2d-fa85-43f7-9eba-ecadd3e92f18"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:eaa5c761-8d5f-4f56-b498-8644e5882424",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ما الذي نعرفه عن المتهمة بقتل المدون العسكري الروسي فلادلين تاتارسكي؟",
-              "firstPublished": "2023-04-03T17:45:51.000Z",
-              "link": "https://www.bbc.com/arabic/world-65057166",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/EC45/production/_129258406_e251d00a-830a-4067-bfdc-878144ffe485.jpg",
-              "description": "يبدو أن داريا تريبوفا معارضة للغزو الروسي لأوكرانيا، لكن الأصدقاء يقولون إنها لم تكن متطرفة.",
-              "imageAlt": "داريا",
-              "id": "be6ec409-247a-456e-a706-98687fa8f89b"
-            },
-            {
-              "type": "article",
-              "title": "ما ثمن معارضة بوتين؟",
-              "firstPublished": "2023-04-03T02:27:31.000Z",
-              "link": "https://www.bbc.com/arabic/world-65102769",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/CBBE/production/_129185125_gettyimages-464751308.jpg",
-              "description": "يحكم الرئيس بوتين روسيا فعليا بلا منازع، حيث اضطر المعارضون إلى مغادرة البلاد - أو تعرضوا لما هو أسوأ من ذلك.",
-              "imageAlt": "Mourners gather to place tributes at the site where Russian opposition leader and former Deputy Prime Minister Boris Nemtsov was killed on Bolshoi Moskvoretsky bridge, 28 February 2015",
-              "id": "82fcc39f-44e2-48a3-a4dc-3ab5619c2d8d"
-            },
-            {
-              "type": "article",
-              "title": "\"كانوا يرفضون إلحاقه بالمدرسة بمجرد معرفتهم أنه مصاب بالتوحد\"",
-              "firstPublished": "2023-04-02T04:00:15.000Z",
-              "link": "https://www.bbc.com/arabic/middleeast-63665548",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7068/production/_127667782_whatsappimage2022-10-26at16.44.16.jpg",
-              "description": "يعانى الأطفال المشخصون بالتوحد من عدم قبولهم في عدد من المدارس الحكومية في العالم العربي، وتعد تكلفة التعليم الخاص بهؤلاء الأطفال مرتفعة للغاية في المدارس الخاصة",
-              "imageAlt": "نوح",
-              "id": "0d086105-74de-4ef2-a91f-55d57bd866fc"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:7edde43a-22e2-4c51-bb2e-71bb6e4db46d",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "اخترنا لكم",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live home page"
-  }
+  "data": {
+    "title": "BBC News عربي",
+    "description": "بي بي سي العربية هي شبكة لنقل الأخبار والمعلومات ومقاطع الفيديو إلى العالم عبر عدة وسائط، تشمل الإنترنت ومواقع التواصل الاجتماعي والراديو والتلفزيون والهواتف المحمولة.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "الجيش السوداني: عمر البشير محتجز في مستشفى عسكري",
+            "firstPublished": "2023-04-26T08:31:21.000Z",
+            "link": "https://www.bbc.com/arabic/middleeast-65397516",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28B4/production/_129502401_sudan.jpg",
+            "description": "الأمم المتحدة تؤكد تواصلها مع قادة طرفي الصراع في السودان في مسعى لدعم وقف هش لإطلاق النار.",
+            "imageAlt": "طفل يقف أمام المباني المتضررة بعد القتال في السودان",
+            "id": "dee83173-08b3-4e53-9d1d-ac4f00d31102"
+          },
+          {
+            "type": "article",
+            "title": "ما مدى شعبية الملكية البريطانية في عهد الملك تشارلز؟",
+            "firstPublished": "2023-04-26T06:11:29.000Z",
+            "link": "https://www.bbc.com/arabic/world-65385456",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6288/production/_129442252_3super_promo_new_safe_zone-2.jpg",
+            "description": "قبل حفل التتويج للملك تشارلز، يسأل برنامج بي بي سي بانوراما عما إذا كان الرأي العام حول العائلة المالكة قد تغير.",
+            "imageAlt": "الملك تشارلز الثالث",
+            "id": "34510ad4-32ce-41b4-bdd7-7846d591a42b"
+          },
+          {
+            "type": "article",
+            "title": "تغريم شركة تبغ 635 مليون دولار لخرقها العقوبات على كوريا الشمالية",
+            "firstPublished": "2023-04-26T00:21:26.000Z",
+            "link": "https://www.bbc.com/arabic/business-65395278",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C288/production/_129500894_gettyimages-632796062.jpg",
+            "description": "رئيس شركة التبغ البريطانية الأمريكية قدم اعتذارا عن بيع السجائر إلى كوريا الشمالية ووصف ذلك بالسلوك السيء.",
+            "imageAlt": "كيم جونغ أون",
+            "id": "e0d4cb2d-fa85-43f7-9eba-ecadd3e92f18"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:eaa5c761-8d5f-4f56-b498-8644e5882424",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ما الذي نعرفه عن المتهمة بقتل المدون العسكري الروسي فلادلين تاتارسكي؟",
+            "firstPublished": "2023-04-03T17:45:51.000Z",
+            "link": "https://www.bbc.com/arabic/world-65057166",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/EC45/production/_129258406_e251d00a-830a-4067-bfdc-878144ffe485.jpg",
+            "description": "يبدو أن داريا تريبوفا معارضة للغزو الروسي لأوكرانيا، لكن الأصدقاء يقولون إنها لم تكن متطرفة.",
+            "imageAlt": "داريا",
+            "id": "be6ec409-247a-456e-a706-98687fa8f89b"
+          },
+          {
+            "type": "article",
+            "title": "ما ثمن معارضة بوتين؟",
+            "firstPublished": "2023-04-03T02:27:31.000Z",
+            "link": "https://www.bbc.com/arabic/world-65102769",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/CBBE/production/_129185125_gettyimages-464751308.jpg",
+            "description": "يحكم الرئيس بوتين روسيا فعليا بلا منازع، حيث اضطر المعارضون إلى مغادرة البلاد - أو تعرضوا لما هو أسوأ من ذلك.",
+            "imageAlt": "Mourners gather to place tributes at the site where Russian opposition leader and former Deputy Prime Minister Boris Nemtsov was killed on Bolshoi Moskvoretsky bridge, 28 February 2015",
+            "id": "82fcc39f-44e2-48a3-a4dc-3ab5619c2d8d"
+          },
+          {
+            "type": "article",
+            "title": "\"كانوا يرفضون إلحاقه بالمدرسة بمجرد معرفتهم أنه مصاب بالتوحد\"",
+            "firstPublished": "2023-04-02T04:00:15.000Z",
+            "link": "https://www.bbc.com/arabic/middleeast-63665548",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7068/production/_127667782_whatsappimage2022-10-26at16.44.16.jpg",
+            "description": "يعانى الأطفال المشخصون بالتوحد من عدم قبولهم في عدد من المدارس الحكومية في العالم العربي، وتعد تكلفة التعليم الخاص بهؤلاء الأطفال مرتفعة للغاية في المدارس الخاصة",
+            "imageAlt": "نوح",
+            "id": "0d086105-74de-4ef2-a91f-55d57bd866fc"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:7edde43a-22e2-4c51-bb2e-71bb6e4db46d",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "اخترنا لكم",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cx35pee6zvpt",
+        "contentType": "index-home",
+        "pageIdentifier": "arabic.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live home page"
+}

--- a/data/azeri/homePage/index.json
+++ b/data/azeri/homePage/index.json
@@ -1,307 +1,314 @@
 {
-    "data": {
-      "title": "BBC News Azərbaycanca",
-      "description": "BBC News Azərbaycanca öz səhifələrində Azərbaycan və dünyadan bu günün xəbərləri və şərhlərini təqdim edir. Visit BBC News Azerbaijan for the latest from Azerbaijan, Armenia, Georgia.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "“İran nüvə silahı əldə edərsə, ən böyük təhlükə Azərbaycana qarşı olacaq”, - Sülhəddin Əkbər",
-              "firstPublished": "2023-04-13T05:32:22.000Z",
-              "link": "https://www.bbc.com/azeri/azerbaijan-65260036",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6AEE/production/_129347372_sullll.jpg",
-              "description": "İsraillə əməkdaşlığa böyük önəm verən Azərbaycanın İranla münasibətlərində leksikonun getdikcə sərtləşdiyi görünür. İrana qarşı ittihamlar sadəcə, təzyiqdirmi yoxsa, daha ciddi planlar üçün ictimai fikrin hazırlanmasıdır? Siyasi təhlilçi Sülhəddin Əkbər şərh edir.",
-              "imageAlt": "Azərbaycan, İran, gərginlik, siyasət",
-              "id": "a46135b4-4758-457d-b26d-141ddb39ec8f"
-            },
-            {
-              "type": "article",
-              "title": "Azərbaycan-Ermənistan sərhədində atışma: tərəflər bir-birini \"sülh prosesini pozmaqda\" ittiham edirlər",
-              "firstPublished": "2023-04-11T14:00:46.000Z",
-              "link": "https://www.bbc.com/azeri/region-65243498",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15D13/production/_129336398_gettyimages-154788448.jpg",
-              "description": "Azərbaycan-Ermənistan sərhədində çərşənbə axşamı baş verən atışmada ümumilikdə 7 hərbçi həlak olub. Tərəflər bir-birini \"təxribatda\" və \"sülh prosesini pozmaqda\" günahlandırırlar.",
-              "imageAlt": "Azərbaycan, Ermənistan, Qarabağ, münaqişə, müharibə, sərhəd, Azərbaycan Müdafiə Nazirliyi",
-              "id": "ea52dbb7-2a8e-45d6-a8a7-d9727ea2d8be"
-            },
-            {
-              "type": "article",
-              "title": "İran hicabsız qadınları aşkarlamaq üçün “ağıllı\" kameralar yerləşdirir",
-              "firstPublished": "2023-04-11T06:00:08.000Z",
-              "link": "https://www.bbc.com/azeri/international-65237252",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FBC4/production/_129325446_86cabc4a9a53de7a6430f7c1ec59f5ee3eb752d40_0_3507_23011000x656.jpg",
-              "description": "İran hökuməti hicab geyinməkdən yayınan qadınları müəyyən etmək üçün \"ağıllı\" kameralardan istifadə edir. Hökumət bu üsulla hicab geyinmək istəməyən qadınları aşkarlayıb, onlara xəbərdarlıq mesajı göndərəcək.",
-              "imageAlt": "Иранские женщины, Тегеран, сентябрь 2022 г.",
-              "id": "a8549357-0e0f-4efb-bb5d-9124b917c818"
-            },
-            {
-              "type": "article",
-              "title": "Ukrayna müharibəsi: ABŞ-ın sızdırılan gizli sənədlərinə görə, Rusiyanın muzdlu əsgər qrupu \"Wagner\" Türkiyədən \"silah almaq istəyib\"; sənədləri kim və niyə sızdırıb?",
-              "firstPublished": "2023-04-10T16:42:57.346Z",
-              "link": "https://www.bbc.com/azeri/articles/cd1rjd93dg9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3bac/live/9f5482a0-d7bd-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "Ukraynadakı müharibə ilə bağlı internetdə sızdırılan ABŞ Müdafiə Nazirliyinə məxsus onlarla gizli sənəd arasında Rusiyanın muzdlu əsgər qrupu \"Vaqner\"in Türkiyədən silah və təchizat almağa cəhd etdiyinə dair iddialar da var.",
-              "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
-              "id": "cd1rjd93dg9o"
-            },
-            {
-              "type": "article",
-              "title": "Müqəddəs Qarabağ. Keçmişin müqədəsləşdirilməsi Azərbaycanla Ermənistan arasında sülh prosesinə necə mane olur",
-              "firstPublished": "2023-04-10T05:51:28.881Z",
-              "link": "https://www.bbc.com/azeri/articles/c0k0jngl8rlo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f531/live/f5ea7c40-d764-11ed-a519-2fbe7c84229a.png",
-              "description": "Birinci və ikinci Qarabağ müharibələri arxada qalıb. Ancaq otuz ildən bir qədər artıq müddətdə, tək hakimiyyətlərin deyil, həm də şair, yazısı və musiqiçilərin səyləri nəticəsində xalqlar arasında elə bir uçurum əmələ gəlib ki, onun hər iki tərəfində bunsuz daha öz ömürlərini belə təsəvvür etmirlər.",
-              "imageAlt": "Müqəddəsləşdirilən Qarabağ",
-              "id": "c0k0jngl8rlo"
-            },
-            {
-              "type": "article",
-              "title": "İraq ABŞ işğalından 20 il sonra: əksəriyyət Səddam Hüseynin dövründə daha yaxşı yaşadığını düşünür",
-              "firstPublished": "2023-04-09T07:38:16.294Z",
-              "link": "https://www.bbc.com/azeri/articles/crg5p9gxqljo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dcbb/live/b6cad650-d669-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "İraqda keçirilmiş sorğuya görə, əhalinin əksəriyyəti 2003-cü ildə ABŞ-ın işğalından sonra ölkədə həyat şəraitinin pisləşdiyini düşünür. Sorğu İraqın keçmiş prezidenti Səddam Hüseynin devrilməsinin 20-ci ildönümü ilə bağlı keçirilib.",
-              "imageAlt": "İraq, 2003",
-              "id": "crg5p9gxqljo"
-            },
-            {
-              "type": "article",
-              "title": "Türkiyə: Zəlzələ zonasında 300-dən çox binadan götürülmüş beton nümunələri davamlılıq testindən keçməyib ",
-              "firstPublished": "2023-04-09T15:30:02.904Z",
-              "link": "https://www.bbc.com/azeri/articles/cedyppjlqplo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b4bd/live/fbef8ad0-d6e8-11ed-a7c9-5303a236525c.png",
-              "description": "Türkiyədə Trabzon Karadeniz Texniki Universitetinin (KTU) İnşaat Mühəndisliyi fakültəsinin alimləri tərəfindən bu ilin 6 fevral zəlzələsi nəticəsində dağılmış 300-dən çox binadan götürülmüş nümunələr zəlzələyə davamlılıq testindən keçməyib.",
-              "imageAlt": "Türkiyə, 6 fevral zəlzələsinin dağıntıları",
-              "id": "cedyppjlqplo"
-            },
-            {
-              "type": "article",
-              "title": "İraqın işğalı dünyanın ən zəngin mədəniyyətlərdən birini necə məhv etdi?",
-              "firstPublished": "2023-04-08T15:52:05.063Z",
-              "link": "https://www.bbc.com/azeri/articles/c80rwl4xlzko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36fe/live/2021ae30-d5f7-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "İraqdakı nisbi sabitliyə baxmayaraq, ölkənin adı hələ də qətllər, partlayışlar, sünni və şiə silahlıları arasındakı qarşıdurma ilə əlaqələndirilir. Bunlardan bəzilərinin kökləri 2000-ci illərin əvvəllərindəki ABŞ-ın hərbi müdaxiləsi ilə bağlıdır.",
-              "imageAlt": "Divarda şir təsviri ",
-              "id": "c80rwl4xlzko"
-            },
-            {
-              "type": "article",
-              "title": "Vətənpərvərlik mahnıları, təhdidlər və kamera qarşısında üzr istəmə. Müharibə ilə razı olmayan rusiyalıların alçaldılması necə baş verir?",
-              "firstPublished": "2023-04-08T08:32:57.468Z",
-              "link": "https://www.bbc.com/azeri/articles/cerzkv919zvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/51ed/live/663df670-d5e4-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "\nMoskvadakı barda polis tərəfindən “Lyube” qrupunun mahnısını oxumağa məcbur edilən insanların videosu sosial şəbəkələrdə yayılandan sonra qızğın müzakirələrə səbəb olub. Ukrayna müharibəsi başlandıqdan sonra Rusiya güc xidmətlərinin bu kimi “qorxutma” hərəkətlərinin bir neçə halı qeydə alınıb. \n",
-              "imageAlt": "Polis və mahnı oxumağa məcbur edilənlər ",
-              "id": "cerzkv919zvo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:7e0fe940-b454-43cd-940b-a320035ee393",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Azərbaycanda 17 yaşlı yeniyetmə nə üçün Psixiatriyada saxlanılıb? ",
-              "firstPublished": "2023-04-05T18:07:07.945Z",
-              "link": "https://www.bbc.com/azeri/articles/cyjrw0grd7go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f8ca/live/b927bc70-d3d4-11ed-826b-7d79db1d67b1.jpg",
-              "description": "Bir neçə gündür ki, 1 saylı Psixiatriya Xəstəxanasında saxlanılan 17 yaşlı yeniyetmə bu gün xəstəxanadan buraxılıb, bu barədə Səhiyyə Nazirliyindən BBC-yə məlumat verilib.",
-              "imageAlt": "3 saylı uşaq internat evi Məhəmməd Hacıyev internatdan qaçan uşaq Ağahəsən Rəsulov Ailə, Qadın, Uşaq problemləri üzrə Dövlət Komitəsi  Elşad Hacıyev Daxili İşlər Nazirliyi Azərbaycan Bakı Xətai rayonu ",
-              "id": "cyjrw0grd7go"
-            },
-            {
-              "type": "article",
-              "title": "Erməni hərbçilər Azərbaycanda: terrorçu, girov, yoxsa alver materialıdırlar?",
-              "firstPublished": "2023-03-14T18:30:14.115Z",
-              "link": "https://www.bbc.com/azeri/articles/cn4rdgv22g6o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3b33/live/0c218310-c292-11ed-ad29-1d38fe2e3505.jpg",
-              "description": "İki ölkə arasında müharibənin və Dağlıq Qarabağda son toqquşmaların girovu olan onlarla erməni hərbi əsiri Bakıda dustaqlıqda qalmaqdadır. Bu hərbçiləri “terrorçu” adlandıran Azərbaycan onları Ermənistana verməyə tələsmir. Bu insanlar sülhə gətirəcəyi gözlənilən, lakin çıxmaza düşmüş danışıqlarda xırda karta çevrilib.",
-              "imageAlt": "Əsgərlər",
-              "id": "cn4rdgv22g6o"
-            },
-            {
-              "type": "article",
-              "title": "Türkiyə Finlandiyanın NATO-ya üzvlüyünü təsdiqləyib - Bu, niyə vacibdir?",
-              "firstPublished": "2023-03-31T06:27:52.570Z",
-              "link": "https://www.bbc.com/azeri/articles/c72dz858dnvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/606a/live/915a78f0-cf8c-11ed-b9a0-5749f01c568f.jpg",
-              "description": "Türkiyə parlamenti Finlandiyanın NATO-ya üzvlüyü ilə bağlı müraciətini təsdiqlədikdən sonra bu ölkə NATO-nun sayca 31-ci üzvü olacaq.",
-              "imageAlt": "Türkiyə, Nato, Finlandiya, Rusiya, ordu",
-              "id": "c72dz858dnvo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:00a85f79-e018-415e-8296-10525b110ed6",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Təhlil",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Küçə süpürgəçisi: \"Ölümümüzə qol çəkib işləyirik\"",
-              "firstPublished": "2023-04-01T07:14:52.940Z",
-              "link": "https://www.bbc.com/azeri/articles/c149ngev7rqo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4b6b/live/b11d35d0-cc8d-11ed-be2e-754a65c11505.jpg",
-              "description": "Ötən ilin noyabrında Bakının Sabunçu rayonunda 7 aylıq hamilə olan 36 yaşlı küçə süpürgəçisi Pərvanə Məmmədova iş başında - avto-qəzada həyatını itirib.  Bu hadisə təmizlik işçilərinin təhlükəsizliyi məsələsini aktuallaşdırdı.  ",
-              "imageAlt": "Süpürgəçilər",
-              "id": "c149ngev7rqo"
-            },
-            {
-              "type": "article",
-              "title": "Bakıda son silahlı atışmalardan narahatsınız? Sakinlər cavab verirlər",
-              "firstPublished": "2023-04-04T16:51:51.000Z",
-              "link": "https://www.bbc.com/azeri/azerbaijan-65182374",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/174FF/production/_129278459_qadnmsahib.png",
-              "description": "Son vaxtlar Bakıda baş vermiş silahlı hücumlar sakinləri narahat edirmi? Bakı sakinlərinin bu suala cavabları.",
-              "imageAlt": "Bakı sakinləri son günlər paytaxtda olan atışmalardan keçirdikləri hisslər barədə danışırlar",
-              "id": "eb2cc68f-980b-40ba-85dd-b67d7ec4a2f0"
-            },
-            {
-              "type": "article",
-              "title": "“Azərbaycanın Təl-Əvivdə səfirlik açması İran üçün çox ciddi mesaj idi”, - Keyvan Hüseyni",
-              "firstPublished": "2023-04-01T08:22:55.000Z",
-              "link": "https://www.bbc.com/azeri/azerbaijan-65147142",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1017A/production/_129241956_kayvan.jpg",
-              "description": "İran və Azərbaycan arasında pisləşən münasibətlər və söz savaşı hansı nəticələrə gətirib çıxara bilər? BBC Farscadan Yaxın Şərq üzrə siyasi təhlilçi Keyvan Hüseyni cavab verir. Həftə bu gün proqramını Aygül Mehman təqdim edir.",
-              "imageAlt": "Kayvan Hosseini Keyvan Hüseyni BBC Farsca xidmeti yaxın şərq üzrə siyasi təhlilçi siyasət siyasi təhlillər siyasi ekspert İran-Azərbaycan İran-Azərbaycan münasibətləri İran-Azerbaycan əlaqələri O taylı bu taylı Azərbaycan Güney Azərbaycan İran azərbaycanlıları",
-              "id": "217aeb8e-2ddd-47b7-8308-241ddd279de2"
-            },
-            {
-              "type": "article",
-              "title": "\"Məmurların övladları cibində dollar gəzdirəndə, mən dərman gəzdirirəm\", - müharibə iştirakçısı",
-              "firstPublished": "2023-03-29T13:26:58.000Z",
-              "link": "https://www.bbc.com/azeri/azerbaijan-65106907",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4E13/production/_129178991_qazilrinaksiyasphoto1.jpg",
-              "description": "Çərşənbə axşamı günü bir neçə İkinci Qarabağ müharibəsinin iştirakçısı Əmək və Əhalinin Sosial Müdafiəsi Nazirliyinin qarşısında etiraz aksiyası keçiriblər.",
-              "imageAlt": "Martın 28-də bir qrup qazi Əmək və Əhalinin Sosial Müdafiəsi Nazirliyinn qarşısında etiraz aksiyası keçirib",
-              "id": "300f57cf-3272-4225-a8ce-416b597fbb8a"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:6d723f36-5c35-4b57-8fe9-7375b4dd2b61",
-          "curationType": "tipo-curation",
-          "position": 2,
-          "title": "Video və audio",
-          "visualProminence": "NORMAL",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": " \"Pojarnı olmayan\" reproduktiv sağlamlıq və ailə planlaşdırılması haqqında qanun Azərbaycanda niyə qəbul olunmur? ",
-              "firstPublished": "2023-03-27T14:16:06.168Z",
-              "link": "https://www.bbc.com/azeri/articles/cw0914kxwdeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e311/live/946faf00-cca9-11ed-81b1-bb32d8fa8ed0.jpg",
-              "description": "Azərbaycanda 2000-ci illərin sonlarından başlayaraq, reproduktiv sağlamlıq və ailə planlaşdırılması haqqında qanun layihəsinin qəbulu ilə bağlı müzakirələr gedir.",
-              "imageAlt": "hamilə, qadınlar, ",
-              "id": "cw0914kxwdeo"
-            },
-            {
-              "type": "article",
-              "title": "Əfqanıstanda qızların təhsili: \"Oğlanların məktəbə getdiyini görəndə ürəyim ağrıyır\"",
-              "firstPublished": "2023-03-28T06:43:21.000Z",
-              "link": "https://www.bbc.com/azeri/international-65096653",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/AD13/production/_129170344_95fdb310-7066-41c0-8533-696b44f39c29.jpg",
-              "description": "Əfqanıstanlı yeniyetmə qızlar Talibanın məktəbə getmək qadağasından sonra çarəsiz hiss etdiklərini deyirlər. Qızlar hər gün ağrı ilə yaşadıqlarını və başlarına gələnlərə görə qlobal qəzəbin səngiməsindən qorxduqlarını deyirlər - bu həftə onlarsız başqa bir məktəb dövrü başlayandan sonra bu hiss daha da güclənib.",
-              "imageAlt": "Əfqanıstan qadın qadın azadlıqları",
-              "id": "61ce2f65-121e-4ae0-8c02-ab00c1ba9dad"
-            },
-            {
-              "type": "article",
-              "title": "Ukrayna müharibəsi: Rusiyanın enerji müharibəsi strategiyası niyə işləmir?",
-              "firstPublished": "2023-03-16T06:18:24.234Z",
-              "link": "https://www.bbc.com/azeri/articles/c72849w02kzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2185/live/9622a230-c3c1-11ed-95f8-0154daa64c44.jpg",
-              "description": "Rusiyanın son bir ayda Ukraynanın enerji infrastrukturunu hədəf alması Kremlin ilk böyük və koordinasiya edilmiş hücum dalğasıdır. Lakin bundan əvvəl Ukraynanın işğalının bir ilini qeyd etmək məqsədi ilə başladılan hücum strategiyası da qoyulan hədəflərə çatmaqda uğursuz oldu. ",
-              "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
-              "id": "c72849w02kzo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:bebcfc8c-1dff-4366-b658-cb49873726cf",
-          "curationType": "tipo-curation",
-          "position": 3,
-          "title": "Dərgi",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "İlham Əliyevin yenilənən komandası: Paşayevlərin və Cabbarovun  \"adamları\", texnokratlar və hakimiyyətə loyal kadrlar",
-              "firstPublished": "2023-04-04T18:33:41.708Z",
-              "link": "https://www.bbc.com/azeri/articles/cyjrgwwkk1ro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/42d4/live/df7b06c0-d311-11ed-a594-39471b35c943.jpg",
-              "description": "Parlamentdə kənd təsərrüfatı naziri İnam Kərimovun Ramiz Rzayevin təqaüdə göndərilməsi ilə boşalan Ali Məhkəmənin sədrliyi postuna təyin olunması  bu səbəbdən müzakirə olunur: nazir olmazdan əvvəl hökumətin uğurlu layihələrindən biri sayılan, əhali arasında rəğbətlə qarşılanan ASAN xidmətin ilk rəhbəri olmuş İnam Kərimov hüquqşünas olsa da, onun bioqrafiyasında hakimlik təcrübəsi yoxdur.  ",
-              "imageAlt": "İlham Əliyev, İnam Kərimov",
-              "id": "cyjrgwwkk1ro"
-            },
-            {
-              "type": "article",
-              "title": "Bu gündən Rusiya Ermənistandan süd məhsullarının idxalını dayandırır",
-              "firstPublished": "2023-03-31T15:43:06.100Z",
-              "link": "https://www.bbc.com/azeri/articles/c0d49vrm8nvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ac78/live/c65ad050-d378-11ed-be2e-754a65c11505.jpg",
-              "description": "Rusiya bu qərarını qida təhlükəsizliyi ilə əlaqələndirir, amma Ermənistan bunu təkzib edir. Digər tərəfdən Rusiya Ukrayna müharibəsi başlayandan bəri Ermənistana üz tutan rus miqrantlar bu ölkənin iqtisadiyyatında müsbət dönüş yarada bilirlər. BBC-ə danışan bəzi təhlilçilər rusiyalı miqrantların Ermənistan iqtisadiyyatda rolunun mənfi təsirləri də olduğunu deyirlər.",
-              "imageAlt": "Rusiya Ermənistandan süd almağı dayandırıb",
-              "id": "c0d49vrm8nvo"
-            },
-            {
-              "type": "article",
-              "title": "Ukrayna müharibəsi: Rusiyanın müharibə bloqçuları kimlərdir və onlar niyə məşhurdur?",
-              "firstPublished": "2023-04-06T06:31:49.769Z",
-              "link": "https://www.bbc.com/azeri/articles/c3g69yqjgq9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c284/live/160367e0-d444-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "Bazar günü Sankt Peterburqdakı partlayışda ölən Vladlen Tatarski Rusiyanın “müharibə müxbirlərindən” biri olub. Bəs bu bloqçular kimlərdir və onlar niyə məşhurdurlar?",
-              "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
-              "id": "c3g69yqjgq9o"
-            },
-            {
-              "type": "article",
-              "title": "“Biz Müdafiə Nazirliyi ilə çox yaxınıq”. Baş komandan Salyukovun ailəsi vətənpərvərliyi necə biznesə çevirib",
-              "firstPublished": "2023-04-02T10:02:21.129Z",
-              "link": "https://www.bbc.com/azeri/articles/cv2q1nxe54go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5bd5/live/f6209900-d125-11ed-be2e-754a65c11505.png",
-              "description": "Rusiya ordusu Ukraynada müharibə apardığı bir vaxtda ölkənin hərbi hissələrində ilin adət halını almış ən mühüm hadisəsi – 9 may Qələbə paradına hazırlıq da gedir. Moskva Qırmızı meydanında keçirilən əsas hərbi parada isə artıq onuncu dəfə Quru Qoşunların komandanı, ordu generalı Oleq Salyukov komandanlıq edəcək. Çoxsaylı vətənpərvərlik və hərbi bayram tədbirlərinin təşkilindən isə, onun ailəsi qazanır. Bütün bunların necə olmasını – BBC Rusca xidməti araşdırıb.",
-              "imageAlt": "General Salyukov Qırmızı meydanda",
-              "id": "cv2q1nxe54go"
-            },
-            {
-              "type": "article",
-              "title": "Fazil Mustafa kimdir? ",
-              "firstPublished": "2023-03-30T15:44:27.711Z",
-              "link": "https://www.bbc.com/azeri/articles/cp3jj0278x8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ff59/live/9e3dd1e0-cefe-11ed-be2e-754a65c11505.jpg",
-              "description": "Çərşənbə axşamı günü Milli Məclisin deputatı Fazil Mustafa öz evinin qarşısında güllələndi. Dövlət Təhlükəsizlik Xidməti bu hadisəni \"terror aktı\" kimi araşdırdığını açıqladı. ",
-              "imageAlt": "Fazil Mustafa",
-              "id": "cp3jj0278x8o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:34570907-4f35-4c41-b7a3-fd023a938fbb",
-          "curationType": "tipo-curation",
-          "position": 4,
-          "title": "Bunları da oxuyun",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO home page"
-  }
+  "data": {
+    "title": "BBC News Azərbaycanca",
+    "description": "BBC News Azərbaycanca öz səhifələrində Azərbaycan və dünyadan bu günün xəbərləri və şərhlərini təqdim edir. Visit BBC News Azerbaijan for the latest from Azerbaijan, Armenia, Georgia.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "“İran nüvə silahı əldə edərsə, ən böyük təhlükə Azərbaycana qarşı olacaq”, - Sülhəddin Əkbər",
+            "firstPublished": "2023-04-13T05:32:22.000Z",
+            "link": "https://www.bbc.com/azeri/azerbaijan-65260036",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6AEE/production/_129347372_sullll.jpg",
+            "description": "İsraillə əməkdaşlığa böyük önəm verən Azərbaycanın İranla münasibətlərində leksikonun getdikcə sərtləşdiyi görünür. İrana qarşı ittihamlar sadəcə, təzyiqdirmi yoxsa, daha ciddi planlar üçün ictimai fikrin hazırlanmasıdır? Siyasi təhlilçi Sülhəddin Əkbər şərh edir.",
+            "imageAlt": "Azərbaycan, İran, gərginlik, siyasət",
+            "id": "a46135b4-4758-457d-b26d-141ddb39ec8f"
+          },
+          {
+            "type": "article",
+            "title": "Azərbaycan-Ermənistan sərhədində atışma: tərəflər bir-birini \"sülh prosesini pozmaqda\" ittiham edirlər",
+            "firstPublished": "2023-04-11T14:00:46.000Z",
+            "link": "https://www.bbc.com/azeri/region-65243498",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15D13/production/_129336398_gettyimages-154788448.jpg",
+            "description": "Azərbaycan-Ermənistan sərhədində çərşənbə axşamı baş verən atışmada ümumilikdə 7 hərbçi həlak olub. Tərəflər bir-birini \"təxribatda\" və \"sülh prosesini pozmaqda\" günahlandırırlar.",
+            "imageAlt": "Azərbaycan, Ermənistan, Qarabağ, münaqişə, müharibə, sərhəd, Azərbaycan Müdafiə Nazirliyi",
+            "id": "ea52dbb7-2a8e-45d6-a8a7-d9727ea2d8be"
+          },
+          {
+            "type": "article",
+            "title": "İran hicabsız qadınları aşkarlamaq üçün “ağıllı\" kameralar yerləşdirir",
+            "firstPublished": "2023-04-11T06:00:08.000Z",
+            "link": "https://www.bbc.com/azeri/international-65237252",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FBC4/production/_129325446_86cabc4a9a53de7a6430f7c1ec59f5ee3eb752d40_0_3507_23011000x656.jpg",
+            "description": "İran hökuməti hicab geyinməkdən yayınan qadınları müəyyən etmək üçün \"ağıllı\" kameralardan istifadə edir. Hökumət bu üsulla hicab geyinmək istəməyən qadınları aşkarlayıb, onlara xəbərdarlıq mesajı göndərəcək.",
+            "imageAlt": "Иранские женщины, Тегеран, сентябрь 2022 г.",
+            "id": "a8549357-0e0f-4efb-bb5d-9124b917c818"
+          },
+          {
+            "type": "article",
+            "title": "Ukrayna müharibəsi: ABŞ-ın sızdırılan gizli sənədlərinə görə, Rusiyanın muzdlu əsgər qrupu \"Wagner\" Türkiyədən \"silah almaq istəyib\"; sənədləri kim və niyə sızdırıb?",
+            "firstPublished": "2023-04-10T16:42:57.346Z",
+            "link": "https://www.bbc.com/azeri/articles/cd1rjd93dg9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3bac/live/9f5482a0-d7bd-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "Ukraynadakı müharibə ilə bağlı internetdə sızdırılan ABŞ Müdafiə Nazirliyinə məxsus onlarla gizli sənəd arasında Rusiyanın muzdlu əsgər qrupu \"Vaqner\"in Türkiyədən silah və təchizat almağa cəhd etdiyinə dair iddialar da var.",
+            "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
+            "id": "cd1rjd93dg9o"
+          },
+          {
+            "type": "article",
+            "title": "Müqəddəs Qarabağ. Keçmişin müqədəsləşdirilməsi Azərbaycanla Ermənistan arasında sülh prosesinə necə mane olur",
+            "firstPublished": "2023-04-10T05:51:28.881Z",
+            "link": "https://www.bbc.com/azeri/articles/c0k0jngl8rlo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f531/live/f5ea7c40-d764-11ed-a519-2fbe7c84229a.png",
+            "description": "Birinci və ikinci Qarabağ müharibələri arxada qalıb. Ancaq otuz ildən bir qədər artıq müddətdə, tək hakimiyyətlərin deyil, həm də şair, yazısı və musiqiçilərin səyləri nəticəsində xalqlar arasında elə bir uçurum əmələ gəlib ki, onun hər iki tərəfində bunsuz daha öz ömürlərini belə təsəvvür etmirlər.",
+            "imageAlt": "Müqəddəsləşdirilən Qarabağ",
+            "id": "c0k0jngl8rlo"
+          },
+          {
+            "type": "article",
+            "title": "İraq ABŞ işğalından 20 il sonra: əksəriyyət Səddam Hüseynin dövründə daha yaxşı yaşadığını düşünür",
+            "firstPublished": "2023-04-09T07:38:16.294Z",
+            "link": "https://www.bbc.com/azeri/articles/crg5p9gxqljo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dcbb/live/b6cad650-d669-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "İraqda keçirilmiş sorğuya görə, əhalinin əksəriyyəti 2003-cü ildə ABŞ-ın işğalından sonra ölkədə həyat şəraitinin pisləşdiyini düşünür. Sorğu İraqın keçmiş prezidenti Səddam Hüseynin devrilməsinin 20-ci ildönümü ilə bağlı keçirilib.",
+            "imageAlt": "İraq, 2003",
+            "id": "crg5p9gxqljo"
+          },
+          {
+            "type": "article",
+            "title": "Türkiyə: Zəlzələ zonasında 300-dən çox binadan götürülmüş beton nümunələri davamlılıq testindən keçməyib ",
+            "firstPublished": "2023-04-09T15:30:02.904Z",
+            "link": "https://www.bbc.com/azeri/articles/cedyppjlqplo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b4bd/live/fbef8ad0-d6e8-11ed-a7c9-5303a236525c.png",
+            "description": "Türkiyədə Trabzon Karadeniz Texniki Universitetinin (KTU) İnşaat Mühəndisliyi fakültəsinin alimləri tərəfindən bu ilin 6 fevral zəlzələsi nəticəsində dağılmış 300-dən çox binadan götürülmüş nümunələr zəlzələyə davamlılıq testindən keçməyib.",
+            "imageAlt": "Türkiyə, 6 fevral zəlzələsinin dağıntıları",
+            "id": "cedyppjlqplo"
+          },
+          {
+            "type": "article",
+            "title": "İraqın işğalı dünyanın ən zəngin mədəniyyətlərdən birini necə məhv etdi?",
+            "firstPublished": "2023-04-08T15:52:05.063Z",
+            "link": "https://www.bbc.com/azeri/articles/c80rwl4xlzko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36fe/live/2021ae30-d5f7-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "İraqdakı nisbi sabitliyə baxmayaraq, ölkənin adı hələ də qətllər, partlayışlar, sünni və şiə silahlıları arasındakı qarşıdurma ilə əlaqələndirilir. Bunlardan bəzilərinin kökləri 2000-ci illərin əvvəllərindəki ABŞ-ın hərbi müdaxiləsi ilə bağlıdır.",
+            "imageAlt": "Divarda şir təsviri ",
+            "id": "c80rwl4xlzko"
+          },
+          {
+            "type": "article",
+            "title": "Vətənpərvərlik mahnıları, təhdidlər və kamera qarşısında üzr istəmə. Müharibə ilə razı olmayan rusiyalıların alçaldılması necə baş verir?",
+            "firstPublished": "2023-04-08T08:32:57.468Z",
+            "link": "https://www.bbc.com/azeri/articles/cerzkv919zvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/51ed/live/663df670-d5e4-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "\nMoskvadakı barda polis tərəfindən “Lyube” qrupunun mahnısını oxumağa məcbur edilən insanların videosu sosial şəbəkələrdə yayılandan sonra qızğın müzakirələrə səbəb olub. Ukrayna müharibəsi başlandıqdan sonra Rusiya güc xidmətlərinin bu kimi “qorxutma” hərəkətlərinin bir neçə halı qeydə alınıb. \n",
+            "imageAlt": "Polis və mahnı oxumağa məcbur edilənlər ",
+            "id": "cerzkv919zvo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:7e0fe940-b454-43cd-940b-a320035ee393",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Azərbaycanda 17 yaşlı yeniyetmə nə üçün Psixiatriyada saxlanılıb? ",
+            "firstPublished": "2023-04-05T18:07:07.945Z",
+            "link": "https://www.bbc.com/azeri/articles/cyjrw0grd7go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f8ca/live/b927bc70-d3d4-11ed-826b-7d79db1d67b1.jpg",
+            "description": "Bir neçə gündür ki, 1 saylı Psixiatriya Xəstəxanasında saxlanılan 17 yaşlı yeniyetmə bu gün xəstəxanadan buraxılıb, bu barədə Səhiyyə Nazirliyindən BBC-yə məlumat verilib.",
+            "imageAlt": "3 saylı uşaq internat evi Məhəmməd Hacıyev internatdan qaçan uşaq Ağahəsən Rəsulov Ailə, Qadın, Uşaq problemləri üzrə Dövlət Komitəsi  Elşad Hacıyev Daxili İşlər Nazirliyi Azərbaycan Bakı Xətai rayonu ",
+            "id": "cyjrw0grd7go"
+          },
+          {
+            "type": "article",
+            "title": "Erməni hərbçilər Azərbaycanda: terrorçu, girov, yoxsa alver materialıdırlar?",
+            "firstPublished": "2023-03-14T18:30:14.115Z",
+            "link": "https://www.bbc.com/azeri/articles/cn4rdgv22g6o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3b33/live/0c218310-c292-11ed-ad29-1d38fe2e3505.jpg",
+            "description": "İki ölkə arasında müharibənin və Dağlıq Qarabağda son toqquşmaların girovu olan onlarla erməni hərbi əsiri Bakıda dustaqlıqda qalmaqdadır. Bu hərbçiləri “terrorçu” adlandıran Azərbaycan onları Ermənistana verməyə tələsmir. Bu insanlar sülhə gətirəcəyi gözlənilən, lakin çıxmaza düşmüş danışıqlarda xırda karta çevrilib.",
+            "imageAlt": "Əsgərlər",
+            "id": "cn4rdgv22g6o"
+          },
+          {
+            "type": "article",
+            "title": "Türkiyə Finlandiyanın NATO-ya üzvlüyünü təsdiqləyib - Bu, niyə vacibdir?",
+            "firstPublished": "2023-03-31T06:27:52.570Z",
+            "link": "https://www.bbc.com/azeri/articles/c72dz858dnvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/606a/live/915a78f0-cf8c-11ed-b9a0-5749f01c568f.jpg",
+            "description": "Türkiyə parlamenti Finlandiyanın NATO-ya üzvlüyü ilə bağlı müraciətini təsdiqlədikdən sonra bu ölkə NATO-nun sayca 31-ci üzvü olacaq.",
+            "imageAlt": "Türkiyə, Nato, Finlandiya, Rusiya, ordu",
+            "id": "c72dz858dnvo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:00a85f79-e018-415e-8296-10525b110ed6",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Təhlil",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Küçə süpürgəçisi: \"Ölümümüzə qol çəkib işləyirik\"",
+            "firstPublished": "2023-04-01T07:14:52.940Z",
+            "link": "https://www.bbc.com/azeri/articles/c149ngev7rqo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4b6b/live/b11d35d0-cc8d-11ed-be2e-754a65c11505.jpg",
+            "description": "Ötən ilin noyabrında Bakının Sabunçu rayonunda 7 aylıq hamilə olan 36 yaşlı küçə süpürgəçisi Pərvanə Məmmədova iş başında - avto-qəzada həyatını itirib.  Bu hadisə təmizlik işçilərinin təhlükəsizliyi məsələsini aktuallaşdırdı.  ",
+            "imageAlt": "Süpürgəçilər",
+            "id": "c149ngev7rqo"
+          },
+          {
+            "type": "article",
+            "title": "Bakıda son silahlı atışmalardan narahatsınız? Sakinlər cavab verirlər",
+            "firstPublished": "2023-04-04T16:51:51.000Z",
+            "link": "https://www.bbc.com/azeri/azerbaijan-65182374",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/174FF/production/_129278459_qadnmsahib.png",
+            "description": "Son vaxtlar Bakıda baş vermiş silahlı hücumlar sakinləri narahat edirmi? Bakı sakinlərinin bu suala cavabları.",
+            "imageAlt": "Bakı sakinləri son günlər paytaxtda olan atışmalardan keçirdikləri hisslər barədə danışırlar",
+            "id": "eb2cc68f-980b-40ba-85dd-b67d7ec4a2f0"
+          },
+          {
+            "type": "article",
+            "title": "“Azərbaycanın Təl-Əvivdə səfirlik açması İran üçün çox ciddi mesaj idi”, - Keyvan Hüseyni",
+            "firstPublished": "2023-04-01T08:22:55.000Z",
+            "link": "https://www.bbc.com/azeri/azerbaijan-65147142",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1017A/production/_129241956_kayvan.jpg",
+            "description": "İran və Azərbaycan arasında pisləşən münasibətlər və söz savaşı hansı nəticələrə gətirib çıxara bilər? BBC Farscadan Yaxın Şərq üzrə siyasi təhlilçi Keyvan Hüseyni cavab verir. Həftə bu gün proqramını Aygül Mehman təqdim edir.",
+            "imageAlt": "Kayvan Hosseini Keyvan Hüseyni BBC Farsca xidmeti yaxın şərq üzrə siyasi təhlilçi siyasət siyasi təhlillər siyasi ekspert İran-Azərbaycan İran-Azərbaycan münasibətləri İran-Azerbaycan əlaqələri O taylı bu taylı Azərbaycan Güney Azərbaycan İran azərbaycanlıları",
+            "id": "217aeb8e-2ddd-47b7-8308-241ddd279de2"
+          },
+          {
+            "type": "article",
+            "title": "\"Məmurların övladları cibində dollar gəzdirəndə, mən dərman gəzdirirəm\", - müharibə iştirakçısı",
+            "firstPublished": "2023-03-29T13:26:58.000Z",
+            "link": "https://www.bbc.com/azeri/azerbaijan-65106907",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4E13/production/_129178991_qazilrinaksiyasphoto1.jpg",
+            "description": "Çərşənbə axşamı günü bir neçə İkinci Qarabağ müharibəsinin iştirakçısı Əmək və Əhalinin Sosial Müdafiəsi Nazirliyinin qarşısında etiraz aksiyası keçiriblər.",
+            "imageAlt": "Martın 28-də bir qrup qazi Əmək və Əhalinin Sosial Müdafiəsi Nazirliyinn qarşısında etiraz aksiyası keçirib",
+            "id": "300f57cf-3272-4225-a8ce-416b597fbb8a"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:6d723f36-5c35-4b57-8fe9-7375b4dd2b61",
+        "curationType": "tipo-curation",
+        "position": 2,
+        "title": "Video və audio",
+        "visualProminence": "NORMAL",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": " \"Pojarnı olmayan\" reproduktiv sağlamlıq və ailə planlaşdırılması haqqında qanun Azərbaycanda niyə qəbul olunmur? ",
+            "firstPublished": "2023-03-27T14:16:06.168Z",
+            "link": "https://www.bbc.com/azeri/articles/cw0914kxwdeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e311/live/946faf00-cca9-11ed-81b1-bb32d8fa8ed0.jpg",
+            "description": "Azərbaycanda 2000-ci illərin sonlarından başlayaraq, reproduktiv sağlamlıq və ailə planlaşdırılması haqqında qanun layihəsinin qəbulu ilə bağlı müzakirələr gedir.",
+            "imageAlt": "hamilə, qadınlar, ",
+            "id": "cw0914kxwdeo"
+          },
+          {
+            "type": "article",
+            "title": "Əfqanıstanda qızların təhsili: \"Oğlanların məktəbə getdiyini görəndə ürəyim ağrıyır\"",
+            "firstPublished": "2023-03-28T06:43:21.000Z",
+            "link": "https://www.bbc.com/azeri/international-65096653",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/AD13/production/_129170344_95fdb310-7066-41c0-8533-696b44f39c29.jpg",
+            "description": "Əfqanıstanlı yeniyetmə qızlar Talibanın məktəbə getmək qadağasından sonra çarəsiz hiss etdiklərini deyirlər. Qızlar hər gün ağrı ilə yaşadıqlarını və başlarına gələnlərə görə qlobal qəzəbin səngiməsindən qorxduqlarını deyirlər - bu həftə onlarsız başqa bir məktəb dövrü başlayandan sonra bu hiss daha da güclənib.",
+            "imageAlt": "Əfqanıstan qadın qadın azadlıqları",
+            "id": "61ce2f65-121e-4ae0-8c02-ab00c1ba9dad"
+          },
+          {
+            "type": "article",
+            "title": "Ukrayna müharibəsi: Rusiyanın enerji müharibəsi strategiyası niyə işləmir?",
+            "firstPublished": "2023-03-16T06:18:24.234Z",
+            "link": "https://www.bbc.com/azeri/articles/c72849w02kzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2185/live/9622a230-c3c1-11ed-95f8-0154daa64c44.jpg",
+            "description": "Rusiyanın son bir ayda Ukraynanın enerji infrastrukturunu hədəf alması Kremlin ilk böyük və koordinasiya edilmiş hücum dalğasıdır. Lakin bundan əvvəl Ukraynanın işğalının bir ilini qeyd etmək məqsədi ilə başladılan hücum strategiyası da qoyulan hədəflərə çatmaqda uğursuz oldu. ",
+            "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
+            "id": "c72849w02kzo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:bebcfc8c-1dff-4366-b658-cb49873726cf",
+        "curationType": "tipo-curation",
+        "position": 3,
+        "title": "Dərgi",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "İlham Əliyevin yenilənən komandası: Paşayevlərin və Cabbarovun  \"adamları\", texnokratlar və hakimiyyətə loyal kadrlar",
+            "firstPublished": "2023-04-04T18:33:41.708Z",
+            "link": "https://www.bbc.com/azeri/articles/cyjrgwwkk1ro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/42d4/live/df7b06c0-d311-11ed-a594-39471b35c943.jpg",
+            "description": "Parlamentdə kənd təsərrüfatı naziri İnam Kərimovun Ramiz Rzayevin təqaüdə göndərilməsi ilə boşalan Ali Məhkəmənin sədrliyi postuna təyin olunması  bu səbəbdən müzakirə olunur: nazir olmazdan əvvəl hökumətin uğurlu layihələrindən biri sayılan, əhali arasında rəğbətlə qarşılanan ASAN xidmətin ilk rəhbəri olmuş İnam Kərimov hüquqşünas olsa da, onun bioqrafiyasında hakimlik təcrübəsi yoxdur.  ",
+            "imageAlt": "İlham Əliyev, İnam Kərimov",
+            "id": "cyjrgwwkk1ro"
+          },
+          {
+            "type": "article",
+            "title": "Bu gündən Rusiya Ermənistandan süd məhsullarının idxalını dayandırır",
+            "firstPublished": "2023-03-31T15:43:06.100Z",
+            "link": "https://www.bbc.com/azeri/articles/c0d49vrm8nvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ac78/live/c65ad050-d378-11ed-be2e-754a65c11505.jpg",
+            "description": "Rusiya bu qərarını qida təhlükəsizliyi ilə əlaqələndirir, amma Ermənistan bunu təkzib edir. Digər tərəfdən Rusiya Ukrayna müharibəsi başlayandan bəri Ermənistana üz tutan rus miqrantlar bu ölkənin iqtisadiyyatında müsbət dönüş yarada bilirlər. BBC-ə danışan bəzi təhlilçilər rusiyalı miqrantların Ermənistan iqtisadiyyatda rolunun mənfi təsirləri də olduğunu deyirlər.",
+            "imageAlt": "Rusiya Ermənistandan süd almağı dayandırıb",
+            "id": "c0d49vrm8nvo"
+          },
+          {
+            "type": "article",
+            "title": "Ukrayna müharibəsi: Rusiyanın müharibə bloqçuları kimlərdir və onlar niyə məşhurdur?",
+            "firstPublished": "2023-04-06T06:31:49.769Z",
+            "link": "https://www.bbc.com/azeri/articles/c3g69yqjgq9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c284/live/160367e0-d444-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "Bazar günü Sankt Peterburqdakı partlayışda ölən Vladlen Tatarski Rusiyanın “müharibə müxbirlərindən” biri olub. Bəs bu bloqçular kimlərdir və onlar niyə məşhurdurlar?",
+            "imageAlt": "Rusiya, Ukrayna, müharibə, münaqişə",
+            "id": "c3g69yqjgq9o"
+          },
+          {
+            "type": "article",
+            "title": "“Biz Müdafiə Nazirliyi ilə çox yaxınıq”. Baş komandan Salyukovun ailəsi vətənpərvərliyi necə biznesə çevirib",
+            "firstPublished": "2023-04-02T10:02:21.129Z",
+            "link": "https://www.bbc.com/azeri/articles/cv2q1nxe54go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5bd5/live/f6209900-d125-11ed-be2e-754a65c11505.png",
+            "description": "Rusiya ordusu Ukraynada müharibə apardığı bir vaxtda ölkənin hərbi hissələrində ilin adət halını almış ən mühüm hadisəsi – 9 may Qələbə paradına hazırlıq da gedir. Moskva Qırmızı meydanında keçirilən əsas hərbi parada isə artıq onuncu dəfə Quru Qoşunların komandanı, ordu generalı Oleq Salyukov komandanlıq edəcək. Çoxsaylı vətənpərvərlik və hərbi bayram tədbirlərinin təşkilindən isə, onun ailəsi qazanır. Bütün bunların necə olmasını – BBC Rusca xidməti araşdırıb.",
+            "imageAlt": "General Salyukov Qırmızı meydanda",
+            "id": "cv2q1nxe54go"
+          },
+          {
+            "type": "article",
+            "title": "Fazil Mustafa kimdir? ",
+            "firstPublished": "2023-03-30T15:44:27.711Z",
+            "link": "https://www.bbc.com/azeri/articles/cp3jj0278x8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ff59/live/9e3dd1e0-cefe-11ed-be2e-754a65c11505.jpg",
+            "description": "Çərşənbə axşamı günü Milli Məclisin deputatı Fazil Mustafa öz evinin qarşısında güllələndi. Dövlət Təhlükəsizlik Xidməti bu hadisəni \"terror aktı\" kimi araşdırdığını açıqladı. ",
+            "imageAlt": "Fazil Mustafa",
+            "id": "cp3jj0278x8o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:34570907-4f35-4c41-b7a3-fd023a938fbb",
+        "curationType": "tipo-curation",
+        "position": 4,
+        "title": "Bunları da oxuyun",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cx35pee66wwt",
+        "contentType": "index-home",
+        "pageIdentifier": "azeri.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO home page"
+}

--- a/data/bengali/homePage/index.json
+++ b/data/bengali/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "খবর, সর্বশেষ খবর, ব্রেকিং নিউজ | News, latest news, breaking news - BBC News বাংলা",
-      "description": "বাংলাদেশ এবং বিশ্বের সর্বশেষ খবর, প্রতিবেদন, বিশ্লেষণ, সাক্ষাৎকার, ভিডিও, অডিও এবং ফিচারের জন্য বিবিসি বাংলার ওয়েবসাইটে আসুন। খেলাধুলা, বিনোদন, ব্যবসা-বাণিজ্য, বিজ্ঞান, প্রযুক্তি এবং স্বাস্থ্য সহ নানা বিষয়ে ফিচার ও বিশ্লেষণও থাকে আমাদের পাতায়।",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "কাবুল বিমানবন্দর হামলায় পরিকল্পনাকারী আইএস নেতাকে হত্যা করেছে তালেবান",
-              "firstPublished": "2023-04-26T03:17:28.528Z",
-              "link": "https://www.bbc.com/bengali/articles/cp4v27e84dko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd96/live/076a06a0-e3dd-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "তালেবান আফগানিস্তানের নিয়ন্ত্রণে নেয়ার সময় যখন অসংখ্য মানুষ দেশ ছেড়ে পালিয়ে যাওয়ার চেষ্টা করছিলেন, ২০২১ সালের অগাস্টে কাবুল বিমানবন্দরে ওই বোমা হামলায় ১৭০ জন বেসামরিক মানুষ ও ১৩জন মার্কিন সেনা নিহত হন।",
-              "imageAlt": "আফগানিস্তান বিমানবন্দরে পলায়নরত মানুষের ভিড়",
-              "id": "cp4v27e84dko"
-            },
-            {
-              "type": "article",
-              "title": "ঈদ এবং অন্য উৎসবে বাংলাদেশের যেসব আঞ্চলিক খাবার জনপ্রিয় ",
-              "firstPublished": "2023-04-26T09:00:10.728Z",
-              "link": "https://www.bbc.com/bengali/articles/c6p94j936pvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d1b3/live/20711640-df85-11ed-ae89-7731c94fd3c1.jpg",
-              "description": "বাংলাদেশের একেক জেলায় একেক রকমের খাবারের প্রচলন আর জনপ্রিয়তা রয়েছে।  \nইতিহাসবিদেরা বলছেন, প্রত্যেক জেলাতেই রয়েছে তাদের নিজস্ব খাবার যা ভোজনরসিকদের মনে জায়গা করে নিয়েছে।",
-              "imageAlt": "টেবিলে নানা ধরনের খাবারের আয়োজন",
-              "id": "c6p94j936pvo"
-            },
-            {
-              "type": "article",
-              "title": "গ্যাসের গন্ধে আতঙ্ক, সরবরাহ লাইনের লিকেজ দুর্যোগ ডেকে আনতে পারে",
-              "firstPublished": "2023-04-25T18:07:57.831Z",
-              "link": "https://www.bbc.com/bengali/articles/cd1r5xprlp3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/27bb/live/4f3476e0-e384-11ed-91f0-71eb7dc39d29.jpg",
-              "description": "সোমবার ঢাকার বিভিন্ন এলাকায় গ্যাসের ঝাঁঝাল গন্ধ পেলে নগরবাসীর মধ্যে আতঙ্ক ছড়িয়ে পড়ে। আপাতত পরিস্থিতি নিয়ন্ত্রণে এলেও একসাথে এতোগুলো এলাকায় গ্যাস লিক হওয়ার ঘটনায় বড় ধরণের দুর্ঘটনার আশঙ্কা করছেন বিশেষজ্ঞরা। ",
-              "imageAlt": "২০১৯ সালের ২০শে ফেব্রুয়ারির ছবি",
-              "id": "cd1r5xprlp3o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:705fa609-e889-42f3-b3b5-c324305a4772",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "সাড়ে ছয় ঘণ্টা পর বঙ্গবাজারে আগুন নিয়ন্ত্রণে, ফায়ার সার্ভিস অফিসে হামলা",
-              "firstPublished": "2023-04-04T02:37:59.163Z",
-              "link": "https://www.bbc.com/bengali/articles/cx0nw4pq22eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2e33/live/14dd0f40-d2a2-11ed-9247-dd9d83ee1ef6.jpg",
-              "description": "মার্কেট ও আশেপাশের এলাকায় আগুন জ্বলছে। আগুন নিয়ন্ত্রণে আনতে হিমশিম খাচ্ছে ফায়ার সার্ভিস কর্মীরা।",
-              "imageAlt": "বঙ্গবাজারে আগুনে পুড়ে গেছে বহু দোকান",
-              "id": "cx0nw4pq22eo"
-            },
-            {
-              "type": "article",
-              "title": "আগামীতে বিশ্ববিদ্যালয় ভর্তি পরীক্ষা হবে একটি, এটি কিভাবে কাজ করবে",
-              "firstPublished": "2023-04-04T02:16:49.466Z",
-              "link": "https://www.bbc.com/bengali/articles/cg62e116z56o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5cfc/live/6f90b960-d247-11ed-be2e-754a65c11505.jpg",
-              "description": "নতুন এই পদ্ধতি চালু হলে শিক্ষার্থী ও অভিভাবকদের ভোগান্তি কমবে, অর্থ সাশ্রয় হবে বলে জানিয়েছে ইউজিসি। তারা বলছে, উন্নত বিশ্বের বিশ্ববিদ্যালয়ে ভর্তি এই নিয়মে চলে। শুধু বাংলাদেশে আলাদা পরীক্ষা হয়।",
-              "imageAlt": "ঢাকা বিশ্ববিদ্যালয় সমাবর্তন।",
-              "id": "cg62e116z56o"
-            },
-            {
-              "type": "article",
-              "title": "প্রাণহীন এফডিসিতে নায়ক-নায়িকা নেই, সিনেমার শুটিংও নেই ",
-              "firstPublished": "2023-04-04T01:52:01.342Z",
-              "link": "https://www.bbc.com/bengali/articles/cv2q59drvgro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/81bf/live/b1b77af0-d228-11ed-be2e-754a65c11505.jpg",
-              "description": "যে এফডিসি একসময় বাংলাদেশের চলচ্চিত্রের প্রধান কেন্দ্র ছিল, অভিনয়-শুটিং, এডিটিং মিলে সরগরম পরিবেশ ছিল, এখন কেন সেটা জৌলুসহীন?  কেন নির্মাতারা আর এফডিসিতে যাননা?  ",
-              "imageAlt": "এফডিসিতে আগের মতো সেই জৌলুসপূর্ণ পরিবেশ এখন আর দেখা যায় না",
-              "id": "cv2q59drvgro"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a43a3556-dc42-4bcc-81d2-ff08bafcbe58",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Editor's choice",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO page"
-  }
+  "data": {
+    "title": "খবর, সর্বশেষ খবর, ব্রেকিং নিউজ | News, latest news, breaking news - BBC News বাংলা",
+    "description": "বাংলাদেশ এবং বিশ্বের সর্বশেষ খবর, প্রতিবেদন, বিশ্লেষণ, সাক্ষাৎকার, ভিডিও, অডিও এবং ফিচারের জন্য বিবিসি বাংলার ওয়েবসাইটে আসুন। খেলাধুলা, বিনোদন, ব্যবসা-বাণিজ্য, বিজ্ঞান, প্রযুক্তি এবং স্বাস্থ্য সহ নানা বিষয়ে ফিচার ও বিশ্লেষণও থাকে আমাদের পাতায়।",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "কাবুল বিমানবন্দর হামলায় পরিকল্পনাকারী আইএস নেতাকে হত্যা করেছে তালেবান",
+            "firstPublished": "2023-04-26T03:17:28.528Z",
+            "link": "https://www.bbc.com/bengali/articles/cp4v27e84dko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd96/live/076a06a0-e3dd-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "তালেবান আফগানিস্তানের নিয়ন্ত্রণে নেয়ার সময় যখন অসংখ্য মানুষ দেশ ছেড়ে পালিয়ে যাওয়ার চেষ্টা করছিলেন, ২০২১ সালের অগাস্টে কাবুল বিমানবন্দরে ওই বোমা হামলায় ১৭০ জন বেসামরিক মানুষ ও ১৩জন মার্কিন সেনা নিহত হন।",
+            "imageAlt": "আফগানিস্তান বিমানবন্দরে পলায়নরত মানুষের ভিড়",
+            "id": "cp4v27e84dko"
+          },
+          {
+            "type": "article",
+            "title": "ঈদ এবং অন্য উৎসবে বাংলাদেশের যেসব আঞ্চলিক খাবার জনপ্রিয় ",
+            "firstPublished": "2023-04-26T09:00:10.728Z",
+            "link": "https://www.bbc.com/bengali/articles/c6p94j936pvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d1b3/live/20711640-df85-11ed-ae89-7731c94fd3c1.jpg",
+            "description": "বাংলাদেশের একেক জেলায় একেক রকমের খাবারের প্রচলন আর জনপ্রিয়তা রয়েছে।  \nইতিহাসবিদেরা বলছেন, প্রত্যেক জেলাতেই রয়েছে তাদের নিজস্ব খাবার যা ভোজনরসিকদের মনে জায়গা করে নিয়েছে।",
+            "imageAlt": "টেবিলে নানা ধরনের খাবারের আয়োজন",
+            "id": "c6p94j936pvo"
+          },
+          {
+            "type": "article",
+            "title": "গ্যাসের গন্ধে আতঙ্ক, সরবরাহ লাইনের লিকেজ দুর্যোগ ডেকে আনতে পারে",
+            "firstPublished": "2023-04-25T18:07:57.831Z",
+            "link": "https://www.bbc.com/bengali/articles/cd1r5xprlp3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/27bb/live/4f3476e0-e384-11ed-91f0-71eb7dc39d29.jpg",
+            "description": "সোমবার ঢাকার বিভিন্ন এলাকায় গ্যাসের ঝাঁঝাল গন্ধ পেলে নগরবাসীর মধ্যে আতঙ্ক ছড়িয়ে পড়ে। আপাতত পরিস্থিতি নিয়ন্ত্রণে এলেও একসাথে এতোগুলো এলাকায় গ্যাস লিক হওয়ার ঘটনায় বড় ধরণের দুর্ঘটনার আশঙ্কা করছেন বিশেষজ্ঞরা। ",
+            "imageAlt": "২০১৯ সালের ২০শে ফেব্রুয়ারির ছবি",
+            "id": "cd1r5xprlp3o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:705fa609-e889-42f3-b3b5-c324305a4772",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "সাড়ে ছয় ঘণ্টা পর বঙ্গবাজারে আগুন নিয়ন্ত্রণে, ফায়ার সার্ভিস অফিসে হামলা",
+            "firstPublished": "2023-04-04T02:37:59.163Z",
+            "link": "https://www.bbc.com/bengali/articles/cx0nw4pq22eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2e33/live/14dd0f40-d2a2-11ed-9247-dd9d83ee1ef6.jpg",
+            "description": "মার্কেট ও আশেপাশের এলাকায় আগুন জ্বলছে। আগুন নিয়ন্ত্রণে আনতে হিমশিম খাচ্ছে ফায়ার সার্ভিস কর্মীরা।",
+            "imageAlt": "বঙ্গবাজারে আগুনে পুড়ে গেছে বহু দোকান",
+            "id": "cx0nw4pq22eo"
+          },
+          {
+            "type": "article",
+            "title": "আগামীতে বিশ্ববিদ্যালয় ভর্তি পরীক্ষা হবে একটি, এটি কিভাবে কাজ করবে",
+            "firstPublished": "2023-04-04T02:16:49.466Z",
+            "link": "https://www.bbc.com/bengali/articles/cg62e116z56o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5cfc/live/6f90b960-d247-11ed-be2e-754a65c11505.jpg",
+            "description": "নতুন এই পদ্ধতি চালু হলে শিক্ষার্থী ও অভিভাবকদের ভোগান্তি কমবে, অর্থ সাশ্রয় হবে বলে জানিয়েছে ইউজিসি। তারা বলছে, উন্নত বিশ্বের বিশ্ববিদ্যালয়ে ভর্তি এই নিয়মে চলে। শুধু বাংলাদেশে আলাদা পরীক্ষা হয়।",
+            "imageAlt": "ঢাকা বিশ্ববিদ্যালয় সমাবর্তন।",
+            "id": "cg62e116z56o"
+          },
+          {
+            "type": "article",
+            "title": "প্রাণহীন এফডিসিতে নায়ক-নায়িকা নেই, সিনেমার শুটিংও নেই ",
+            "firstPublished": "2023-04-04T01:52:01.342Z",
+            "link": "https://www.bbc.com/bengali/articles/cv2q59drvgro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/81bf/live/b1b77af0-d228-11ed-be2e-754a65c11505.jpg",
+            "description": "যে এফডিসি একসময় বাংলাদেশের চলচ্চিত্রের প্রধান কেন্দ্র ছিল, অভিনয়-শুটিং, এডিটিং মিলে সরগরম পরিবেশ ছিল, এখন কেন সেটা জৌলুসহীন?  কেন নির্মাতারা আর এফডিসিতে যাননা?  ",
+            "imageAlt": "এফডিসিতে আগের মতো সেই জৌলুসপূর্ণ পরিবেশ এখন আর দেখা যায় না",
+            "id": "cv2q59drvgro"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a43a3556-dc42-4bcc-81d2-ff08bafcbe58",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Editor's choice",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c2eq2ggzz8kt",
+        "contentType": "index-home",
+        "pageIdentifier": "bengali.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO page"
+}

--- a/data/burmese/homePage/index.json
+++ b/data/burmese/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "ဘီဘီစီ မြန်မာ | အထူးသတင်း | နောက်ဆုံးရ သတင်း | နောက်ဆုံးရခေါင်းစဉ် သတင်း |မြန်မာသတင်း - BBC News မြန်မာ",
-      "description": "နောက်ဆုံးရ သတင်း၊ အထူးသတင်း၊ ကမ္ဘာနဲ့ မြန်မာ့ရေးရာ သတင်းတွေ၊ ဗီဒီယိုနဲ့ ရုပ်သံ သတင်းတွေ၊ ဆောင်းပါးတွေကို ဘီဘီစီမြန်မာပိုင်း စာမျက်နှာမှာ အချိန်နဲ့ တပြေးညီ တင်ဆက်ပေးနေပါတယ်။ အနုပညာ၊ ဘောလုံး၊ အားကစား၊ သိပ္ပံ နည်းပညာနဲ့ စီးပွားရေး စတဲ့ အကြောင်းအရာမျိုးစုံကိုလည်း ဖတ်ရှု ကြည့်ရှုနိုင်ပါတယ်။",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ဧပြီလ ၂၆ ရက်ထိပ်တန်းသတင်းများ- ကရင်အမျိုးသားအစည်းအရုံးရဲ့ ၁၇ ကြိမ်မြောက် ညီလာခံ ကျင်းပနေ",
-              "firstPublished": "2023-04-26T02:51:16.402Z",
-              "link": "https://www.bbc.com/burmese/articles/czkxrd2mvrzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1b12/live/65220c80-e445-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "သင်္ကြန်ကာလမှာ ခရမ်းမြို့နယ်ရဲစခန်းတိုက်ခိုက်ခံခဲ့ရပြီးတဲ့နောက် စစ်ကောင်စီတပ်ဘက်က ခရမ်း PDF တပ်ဖွဲ့ဝင်တွေကို ဖမ်းဆီးခဲ့တာဖြစ်ပါတယ်။ ",
-              "imageAlt": "၂၀၁၇ ခုနှစ်တုန်းက ကျင်းပခဲ့တဲ့ ၁၆ ကြိမ်မြောက် KNU ညီလာခံ ",
-              "id": "czkxrd2mvrzo"
-            },
-            {
-              "type": "article",
-              "title": "အမေရိကန် သမ္မတ ဘိုင်ဒန် ရွေးကောက်ပွဲ ပြန်ဝင်မယ်-ဧပြီ ၂၅ ရက် ညနေခင်း နိုင်ငံတကာ သတင်းများ",
-              "firstPublished": "2023-04-25T11:51:10.532Z",
-              "link": "https://www.bbc.com/burmese/articles/cy0v709vgp3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6719/live/7365c0c0-e35f-11ed-9110-f53e4ac17370.jpg",
-              "description": "",
-              "imageAlt": "No Tag",
-              "id": "cy0v709vgp3o"
-            },
-            {
-              "type": "article",
-              "title": "ဧပြီ ၂၅ ရက်၊ ထိပ်တန်းသတင်းများ- ဖယ်ခုံ၊ ဆောင်းဖွေးဆေးပေးခန်း လေကြောင်းတိုက်ခိုက်ခံရ ",
-              "firstPublished": "2023-04-25T03:03:06.251Z",
-              "link": "https://www.bbc.com/burmese/articles/ceq694g2w0vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bbf6/live/f2657a30-e357-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "ထောင်ချခံထားရတဲ့ နိုင်ငံရေးအကျဉ်းသားတွေကို မိသားစုက တွေ့ဆုံခွင့်မရကြတာကြောင့် ‌ထိန်းသိမ်းခံထားရသူတွေအနေနဲ့ အကျဉ်းထောင်ထဲမှာ ဘယ်လိုအခက်အခဲတွေနဲ့ ရင်ဆိုင်နေကြရတယ်ဆိုတာကို မသိရတဲ့အခြေအနေထိကို ဖြစ်လာနေတယ်လို့ ဆိုကြပါတယ်။",
-              "imageAlt": "ဖယ်ခုံ၊ ဆောင်းဖွေးဆေးပေးခန်း လေကြောင်းတိုက်ခိုက်ခံရ ",
-              "id": "ceq694g2w0vo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:5e6b5e68-6ae7-4510-9737-8aa4ce31401d",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ဓာတ်ခွဲခန်းတွေက ဗိုင်းရပ်စ်တွေ ပျံ့နိုင်သလား",
-              "firstPublished": "2023-03-26T08:52:31.000Z",
-              "link": "https://www.bbc.com/burmese/world-64904261",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/12AF/production/_128838740_61a94379-371d-4317-9afa-2deb3c9a198c.jpg",
-              "description": "အမေရိကန် FBI ကယူဆသလိုပဲ အရင် အမေရိကန် ရောဂါကာကွယ်ရေးနဲ့ ထိန်းချုပ်ရေး ဌာန အကြီးအကဲကလည်း ဒီ ကိုဗစ် ၁၉ ဟာ တရုတ်ပြည်က ဓာတ်ခွဲခန်းတခုဆီကနေ မတော်တဆ ယိုစိမ့် ထွက်လာခဲ့တာ ဖြစ်တယ်လို့ ကွန်ဂရက်လွှတ်တော်မှာ အစီရင်ခံခဲ့ပါတယ်။ ဗိုင်းရပ်စ်ပိုးတွေ ဓာတ်ခွဲခန်းက ယိုစိမ့်လာဖို့ လွယ်ကူသလား။ အရင်ရော ကြုံခဲ့ဖူးသလား",
-              "imageAlt": "Policemen stand in front of the Wuhan Institute of Virology",
-              "id": "68b8766b-bd7e-47e1-9af6-8ee21f8b91eb"
-            },
-            {
-              "type": "article",
-              "title": "ကမ္ဘာ့အကြာဆုံး ပြည်တွင်းစစ်နဲ့ မအောင်မြင်တဲ့ နိုင်ငံပြုဖြစ်စဉ်",
-              "firstPublished": "2023-03-25T11:54:01.141Z",
-              "link": "https://www.bbc.com/burmese/articles/ce92zwvnd97o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/73e6/live/ca68ca90-c279-11ed-95f8-0154daa64c44.jpg",
-              "description": "လောလောဆယ် နှစ်ပိုင်းအတွင်းမှာလည်း နိုင်ငံအနှံ့ ပီဒီအက်ဖ် ပြောက်ကျားတပ်တွေ ပေါ်လာပြီး ပြည်တွင်းစစ်ကို အသက်ဆက်ခဲ့ပြန်ပါတယ်။ ",
-              "imageAlt": "burma",
-              "id": "ce92zwvnd97o"
-            },
-            {
-              "type": "article",
-              "title": "တရုတ်နည်းပညာကုမ္ပဏီတွေဟာ လုံခြုံရေးအရ အန္တရာယ်ရှိလား",
-              "firstPublished": "2023-03-25T16:28:18.000Z",
-              "link": "https://www.bbc.com/burmese/world-65063474",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/10607/production/_129097076_chinatechindex1.png",
-              "description": "တစ်တော့နဲ့ တခြား တရုတ်နည်းပညာ ကုမ္ပဏီတွေကို ပိတ်ပင်လာတဲ့ နိုင်ငံတွေ တိုးပွားလာ",
-              "imageAlt": "Window of a tech store in Beijing",
-              "id": "d45d7a84-183e-41ad-96d5-54a1ca482e45"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:f2a68804-a696-4ecc-91bb-93ab6af0a2a6",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "ဆောင်းပါး",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from Live TIPO page"
-  }
+  "data": {
+    "title": "ဘီဘီစီ မြန်မာ | အထူးသတင်း | နောက်ဆုံးရ သတင်း | နောက်ဆုံးရခေါင်းစဉ် သတင်း |မြန်မာသတင်း - BBC News မြန်မာ",
+    "description": "နောက်ဆုံးရ သတင်း၊ အထူးသတင်း၊ ကမ္ဘာနဲ့ မြန်မာ့ရေးရာ သတင်းတွေ၊ ဗီဒီယိုနဲ့ ရုပ်သံ သတင်းတွေ၊ ဆောင်းပါးတွေကို ဘီဘီစီမြန်မာပိုင်း စာမျက်နှာမှာ အချိန်နဲ့ တပြေးညီ တင်ဆက်ပေးနေပါတယ်။ အနုပညာ၊ ဘောလုံး၊ အားကစား၊ သိပ္ပံ နည်းပညာနဲ့ စီးပွားရေး စတဲ့ အကြောင်းအရာမျိုးစုံကိုလည်း ဖတ်ရှု ကြည့်ရှုနိုင်ပါတယ်။",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ဧပြီလ ၂၆ ရက်ထိပ်တန်းသတင်းများ- ကရင်အမျိုးသားအစည်းအရုံးရဲ့ ၁၇ ကြိမ်မြောက် ညီလာခံ ကျင်းပနေ",
+            "firstPublished": "2023-04-26T02:51:16.402Z",
+            "link": "https://www.bbc.com/burmese/articles/czkxrd2mvrzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1b12/live/65220c80-e445-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "သင်္ကြန်ကာလမှာ ခရမ်းမြို့နယ်ရဲစခန်းတိုက်ခိုက်ခံခဲ့ရပြီးတဲ့နောက် စစ်ကောင်စီတပ်ဘက်က ခရမ်း PDF တပ်ဖွဲ့ဝင်တွေကို ဖမ်းဆီးခဲ့တာဖြစ်ပါတယ်။ ",
+            "imageAlt": "၂၀၁၇ ခုနှစ်တုန်းက ကျင်းပခဲ့တဲ့ ၁၆ ကြိမ်မြောက် KNU ညီလာခံ ",
+            "id": "czkxrd2mvrzo"
+          },
+          {
+            "type": "article",
+            "title": "အမေရိကန် သမ္မတ ဘိုင်ဒန် ရွေးကောက်ပွဲ ပြန်ဝင်မယ်-ဧပြီ ၂၅ ရက် ညနေခင်း နိုင်ငံတကာ သတင်းများ",
+            "firstPublished": "2023-04-25T11:51:10.532Z",
+            "link": "https://www.bbc.com/burmese/articles/cy0v709vgp3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6719/live/7365c0c0-e35f-11ed-9110-f53e4ac17370.jpg",
+            "description": "",
+            "imageAlt": "No Tag",
+            "id": "cy0v709vgp3o"
+          },
+          {
+            "type": "article",
+            "title": "ဧပြီ ၂၅ ရက်၊ ထိပ်တန်းသတင်းများ- ဖယ်ခုံ၊ ဆောင်းဖွေးဆေးပေးခန်း လေကြောင်းတိုက်ခိုက်ခံရ ",
+            "firstPublished": "2023-04-25T03:03:06.251Z",
+            "link": "https://www.bbc.com/burmese/articles/ceq694g2w0vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bbf6/live/f2657a30-e357-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "ထောင်ချခံထားရတဲ့ နိုင်ငံရေးအကျဉ်းသားတွေကို မိသားစုက တွေ့ဆုံခွင့်မရကြတာကြောင့် ‌ထိန်းသိမ်းခံထားရသူတွေအနေနဲ့ အကျဉ်းထောင်ထဲမှာ ဘယ်လိုအခက်အခဲတွေနဲ့ ရင်ဆိုင်နေကြရတယ်ဆိုတာကို မသိရတဲ့အခြေအနေထိကို ဖြစ်လာနေတယ်လို့ ဆိုကြပါတယ်။",
+            "imageAlt": "ဖယ်ခုံ၊ ဆောင်းဖွေးဆေးပေးခန်း လေကြောင်းတိုက်ခိုက်ခံရ ",
+            "id": "ceq694g2w0vo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:5e6b5e68-6ae7-4510-9737-8aa4ce31401d",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ဓာတ်ခွဲခန်းတွေက ဗိုင်းရပ်စ်တွေ ပျံ့နိုင်သလား",
+            "firstPublished": "2023-03-26T08:52:31.000Z",
+            "link": "https://www.bbc.com/burmese/world-64904261",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/12AF/production/_128838740_61a94379-371d-4317-9afa-2deb3c9a198c.jpg",
+            "description": "အမေရိကန် FBI ကယူဆသလိုပဲ အရင် အမေရိကန် ရောဂါကာကွယ်ရေးနဲ့ ထိန်းချုပ်ရေး ဌာန အကြီးအကဲကလည်း ဒီ ကိုဗစ် ၁၉ ဟာ တရုတ်ပြည်က ဓာတ်ခွဲခန်းတခုဆီကနေ မတော်တဆ ယိုစိမ့် ထွက်လာခဲ့တာ ဖြစ်တယ်လို့ ကွန်ဂရက်လွှတ်တော်မှာ အစီရင်ခံခဲ့ပါတယ်။ ဗိုင်းရပ်စ်ပိုးတွေ ဓာတ်ခွဲခန်းက ယိုစိမ့်လာဖို့ လွယ်ကူသလား။ အရင်ရော ကြုံခဲ့ဖူးသလား",
+            "imageAlt": "Policemen stand in front of the Wuhan Institute of Virology",
+            "id": "68b8766b-bd7e-47e1-9af6-8ee21f8b91eb"
+          },
+          {
+            "type": "article",
+            "title": "ကမ္ဘာ့အကြာဆုံး ပြည်တွင်းစစ်နဲ့ မအောင်မြင်တဲ့ နိုင်ငံပြုဖြစ်စဉ်",
+            "firstPublished": "2023-03-25T11:54:01.141Z",
+            "link": "https://www.bbc.com/burmese/articles/ce92zwvnd97o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/73e6/live/ca68ca90-c279-11ed-95f8-0154daa64c44.jpg",
+            "description": "လောလောဆယ် နှစ်ပိုင်းအတွင်းမှာလည်း နိုင်ငံအနှံ့ ပီဒီအက်ဖ် ပြောက်ကျားတပ်တွေ ပေါ်လာပြီး ပြည်တွင်းစစ်ကို အသက်ဆက်ခဲ့ပြန်ပါတယ်။ ",
+            "imageAlt": "burma",
+            "id": "ce92zwvnd97o"
+          },
+          {
+            "type": "article",
+            "title": "တရုတ်နည်းပညာကုမ္ပဏီတွေဟာ လုံခြုံရေးအရ အန္တရာယ်ရှိလား",
+            "firstPublished": "2023-03-25T16:28:18.000Z",
+            "link": "https://www.bbc.com/burmese/world-65063474",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/10607/production/_129097076_chinatechindex1.png",
+            "description": "တစ်တော့နဲ့ တခြား တရုတ်နည်းပညာ ကုမ္ပဏီတွေကို ပိတ်ပင်လာတဲ့ နိုင်ငံတွေ တိုးပွားလာ",
+            "imageAlt": "Window of a tech store in Beijing",
+            "id": "d45d7a84-183e-41ad-96d5-54a1ca482e45"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:f2a68804-a696-4ecc-91bb-93ab6af0a2a6",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "ဆောင်းပါး",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c897lqqzk1zt",
+        "contentType": "index-home",
+        "pageIdentifier": "burmese.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from Live TIPO page"
+}

--- a/data/gahuza/homePage/index.json
+++ b/data/gahuza/homePage/index.json
@@ -1,365 +1,372 @@
 {
-    "data": {
-      "title": "BBC News Gahuza",
-      "description": "",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Rusesabagina: Uko Qatar iza mu irekurwa rye",
-              "firstPublished": "2023-03-27T08:16:58.910Z",
-              "link": "https://www.bbc.com/gahuza/articles/c72vq9w7701o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a80b/live/ed086130-cc76-11ed-a249-7bbdfc224c64.jpg",
-              "description": "Byitezwe ko igihe icyo aricyo cyose Rusesabagina ashobora kuva mu Rwanda, ariko ntabwo ahita ajya mu rugo rwe muri Amerika, arabanza muri Qatar.",
-              "imageAlt": "Kuwa kabiri Perezida Kagame yari i Doha aho yaganiriye n'umutegetsi w'ikirenga w'iki gihugu Tamim bin Hamad Al-Thani.",
-              "id": "c72vq9w7701o"
-            },
-            {
-              "type": "article",
-              "title": "Uganda: Umuhungu wa Museveni avuga ko azasezera mu gisirikare 'uyu mwaka' ",
-              "firstPublished": "2023-03-27T13:29:15.533Z",
-              "link": "https://www.bbc.com/gahuza/articles/clw1r3x75elo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d7d8/live/7dfc5a70-cc9f-11ed-a0f2-f391991bf052.jpg",
-              "description": "Abitangaje hashize iminsi asibye ubutumwa bwo kuri Twitter, yavugagamo ko aziyamamaza mu matora ya perezida yo mu mwaka wa 2026. ",
-              "imageAlt": "Muhoozi Kainerugaba",
-              "id": "clw1r3x75elo"
-            },
-            {
-              "type": "article",
-              "title": "Jack Ma washinze Alibaba yabonetse nyuma y'igihe kinini atagaragara ",
-              "firstPublished": "2023-03-27T11:04:51.948Z",
-              "link": "https://www.bbc.com/gahuza/articles/cp6wzn054xdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a7b5/live/e337a310-cc8e-11ed-be2e-754a65c11505.jpg",
-              "description": "Jack Ma w'imyaka 58 yabonetse gacye kuva yanenga abashinzwe kugenzura ubukungu bw'Ubushinwa mu 2020.  ",
-              "imageAlt": "Kuva mu mpera za 2020 Jack Ma yabonetse gacye cyane mu bantu",
-              "id": "cp6wzn054xdo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:cf1b146e-c9de-4b47-b345-f85f32d2a80b",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "BBC News Gahuza Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Rusesabagina na ‘Sankara’ bararekurwa, 'si ku gitutu cya Amerika' - Umuvugizi",
-              "firstPublished": "2023-03-24T16:58:52.049Z",
-              "link": "https://www.bbc.com/gahuza/articles/ce92v5gvv1vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7c9b/live/6f5b05d0-ca64-11ed-be2e-754a65c11505.jpg",
-              "description": "Paul Rusesabagina mu ibaruwa isaba imbabazi yatangajwe na leta, avuga ko “ibibazo bijyanye na politiki y’u Rwanda nzabisiga inyuma yanjye”.",
-              "imageAlt": "Rusesabagina yerekanywe afungiye mu Rwanda muri Kanama(8) 2020 mu buryo bwavuzweho cyane",
-              "id": "ce92v5gvv1vo"
-            },
-            {
-              "type": "article",
-              "title": "Uyu munsi mu rubanza rwa Kabuga: Inzobere yavuze ko atashobora gusubiza ku byo aregwa",
-              "firstPublished": "2023-03-23T14:09:25.844Z",
-              "link": "https://www.bbc.com/gahuza/articles/crg5qp7nx32o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a56c/live/969dc160-c96e-11ed-bb75-4187a06ea88d.jpg",
-              "description": "Inzobere mu buzima bwo mu mutwe Profeseri Gillian Mezey, umwe muri eshatu zigenga zakoze raporo ku buzima bwa Kabuga, ni we wumviswe uyu munsi. ",
-              "imageAlt": "Félicien Kabuga ubwo yari akurikiye iburanisha kuri uyu wa kane",
-              "id": "crg5qp7nx32o"
-            },
-            {
-              "type": "article",
-              "title": "Impinduka muri leta DR Congo - Vital Kamerhe na Jean Pierre Bemba binjiye muri guverinoma",
-              "firstPublished": "2023-03-24T06:11:51.208Z",
-              "link": "https://www.bbc.com/gahuza/articles/c4n7ez33qpqo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/356d/live/602c67c0-ca0a-11ed-ba93-a55a7032c318.jpg",
-              "description": "Vital Kamerhe na Jean Pierre Bemba ni bamwe mu bigugu muri politiki ya DR Congo bashobora gukomeza uruhande rwa Tshisekedi mbere y’amatora. ",
-              "imageAlt": "Vital Kamerhe (ibumoso) na Jean Pierre Bemba",
-              "id": "c4n7ez33qpqo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:de476937-7ca0-4a72-8ab7-5c2c3817271f",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Ivyo BBC Gahuza ibahitiramwo",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT4M46S",
-              "title": "DR Congo – Rwanda: Abahitanywe n'imyuzure bari gushobora gukingirwa?",
-              "firstPublished": "2023-05-10T20:42:53.549Z",
-              "link": "https://www.bbc.com/gahuza/articles/c28mm84jznwo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/84c6/live/c802d2f0-ef6f-11ed-a142-ab0e42bfd9c3.png",
-              "description": "Abantu amajana bapfiriye nka rimwe, mu burengero bushira uburaruko mu Rwanda, na Kalehe muri DR Congo, ibihumbi baracaronderwa. Umuhinga Ir. Anne-Marie Bihirabake agabisha ibi bihugu ko ata kwijajara.",
-              "imageAlt": "Abishwe n'imyuzure baharurwa mu majana, ibihumbi baracaronderwa",
-              "id": "c28mm84jznwo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M39S",
-              "title": "Turkey: igihe co gusuzuma intwaro ya Erdogan kirageze",
-              "firstPublished": "2023-05-10T15:01:38.735Z",
-              "link": "https://www.bbc.com/gahuza/articles/cw5kk4p6wzpo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f84a/live/778d1c90-ef42-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "",
-              "imageAlt": "Erdogan yiyamamaza inyuma y'imyaka 20 ari k'ubutegeetsi",
-              "id": "cw5kk4p6wzpo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M45S",
-              "title": "Umwami Charles III: ibimenyetso bikomeye vy’ubwami, mw’iyimikwa ",
-              "firstPublished": "2023-05-08T13:27:20.272Z",
-              "link": "https://www.bbc.com/gahuza/articles/cn0x32pjv8po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3b09/live/5420c7c0-eda3-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "",
-              "imageAlt": "Umwami Charles III n'umwamikazi Camilla",
-              "id": "cn0x32pjv8po"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M43S",
-              "title": "Charles III: Iyimikwa nk’Umwami rivuze iki kuri bamwe, muri Africa?",
-              "firstPublished": "2023-05-03T22:16:29.284Z",
-              "link": "https://www.bbc.com/gahuza/articles/cy90kx7l5ywo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1abe/live/17aa6a50-e9ff-11ed-a142-ab0e42bfd9c3.png",
-              "description": "",
-              "imageAlt": "Uko bamwe muri Africa babona iyimikwa rya Charles III",
-              "id": "cy90kx7l5ywo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M25S",
-              "title": "Uko ibihugu biri mu ngorane z’ubutunzi bitabarwa",
-              "firstPublished": "2023-04-29T03:27:01.567Z",
-              "link": "https://www.bbc.com/gahuza/articles/c2q1464739vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d59d/live/4c346890-e63d-11ed-a142-ab0e42bfd9c3.png",
-              "description": "",
-              "imageAlt": "Ku cicaro c'ikigega c'isi muri USA",
-              "id": "c2q1464739vo"
-            },
-            {
-              "type": "article",
-              "title": "Kenya: ahabereye ivyaha burimwo impfu zifatiye kw’idini",
-              "firstPublished": "2023-04-27T15:05:22.524Z",
-              "link": "https://www.bbc.com/gahuza/articles/c4np33gx0pdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b7e7/live/8eb57ba0-e50c-11ed-8df1-d74cbf1089d7.png",
-              "description": "",
-              "imageAlt": "Abapfuye bisonzesha bashoboye gutorwa barahambwe n'iteka",
-              "id": "c4np33gx0pdo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M38S",
-              "title": "Isi yibuka ko umubu ari kamwe m’udukoko twica: gute?",
-              "firstPublished": "2023-04-26T20:31:50.175Z",
-              "link": "https://www.bbc.com/gahuza/articles/c3gvny19ldmo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6aac/live/25156570-e471-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Uko hamwe muri Afrika batuza imibu itera malaria",
-              "id": "c3gvny19ldmo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M37S",
-              "title": "“Ninasubira kuba muto nshaka kuzomera nk’umuhungu wanje”",
-              "firstPublished": "2023-04-26T19:28:50.972Z",
-              "link": "https://www.bbc.com/gahuza/articles/cv276m5l755o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/08c5/live/52751550-e468-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Bryan Johnson w’imyaka 45, avuga ko afise imyaka 18. ",
-              "id": "cv276m5l755o"
-            },
-            {
-              "type": "article",
-              "title": "Sudan: Tahura imvo y’izi ntambara",
-              "firstPublished": "2023-04-25T16:29:34.350Z",
-              "link": "https://www.bbc.com/gahuza/articles/cd1r5xqq517o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e2d2/live/d824a870-e385-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Intambara zasize igisagara Khartoum ari umusaka",
-              "id": "cd1r5xqq517o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M45S",
-              "title": "Video: Emery Ngarambe aravuga ingaruka zo gufata 'booster' n'uko yayihevye",
-              "firstPublished": "2023-04-25T16:12:21.773Z",
-              "link": "https://www.bbc.com/gahuza/articles/c3gvnlyd6r7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Kubera kunywa ibiyayuramutwe, Emery Ngarambe yama mu gasho no mu bitaro. Yariba ico abonye cose muhira, akavuga ko yagiye kubiheba amaze kwiba mu muryango nk'ibintu vyoba biciye nk'imodoka.",
-              "imageAlt": "",
-              "id": "c3gvnlyd6r7o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M1S",
-              "title": "Afghanistan: uko abigisha babaye mu mirimo yabo",
-              "firstPublished": "2023-04-24T14:48:06.282Z",
-              "link": "https://www.bbc.com/gahuza/articles/c4npvwezj9eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f801/live/f88133f0-e2ad-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Afghanistan, ubuzima bwa bamwe mu bigisha",
-              "id": "c4npvwezj9eo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M27S",
-              "title": "Sudan: uko amasanamu y’ibinyoma ku ntambara akwiragizwa",
-              "firstPublished": "2023-04-22T21:30:40.799Z",
-              "link": "https://www.bbc.com/gahuza/articles/c72zxd64ydno",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f47d/live/a6c3b6a0-e154-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Sudan: Itohoza ku masanamu y’ibinyoma mu ntambara",
-              "id": "c72zxd64ydno"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 5,
-          "curationId": "urn:bbc:vivo:curation:187eb2c6-a4f0-4a31-adf1-5941beaf849d",
-          "curationType": "vivo-stream",
-          "position": 2,
-          "title": "Videos",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Barcelona: Kizigenza Sergio Busquets agiye gusezera inyuma y’imyaka 18",
-              "firstPublished": "2023-05-10T11:31:27.519Z",
-              "link": "https://www.bbc.com/gahuza/articles/c72119q6p4zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1688/live/43073e50-ef25-11ed-a188-1b6d50771321.jpg",
-              "description": "Kizigenza Sergio Busquets yemeje ko azova muri Barcelona mu mpera z’uno mwaka w’inkino inyuma y’imyaka 18 akinira uno murwi. ",
-              "imageAlt": "Sergio Busquets yinjiye muri Barcelona mu 2005 akaba yatanguye gukina mu murwi mukuru mu 2008",
-              "id": "c72119q6p4zo"
-            },
-            {
-              "type": "article",
-              "title": "West Ham 1 - 0 Man U: David de Gea arabaye uruvugo inyuma y’ikosa ryaraye rihumiye umurwi wiwe ",
-              "firstPublished": "2023-05-08T11:23:48.846Z",
-              "link": "https://www.bbc.com/gahuza/articles/cyd86g7nv66o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8351/live/42429410-ed8b-11ed-bb92-65f9d49396ea.jpg",
-              "description": "Ikosa ryakozwe n’umunyegori David de Gea ryatumye Saïd Benrahma wa West Ham  yinjiza igitsindo kimwe rudende c’urwo rukino ku munota wa 27.",
-              "imageAlt": "De Gea",
-              "id": "cyd86g7nv66o"
-            },
-            {
-              "type": "article",
-              "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Neymar, Messi, Fati, Amrabat, Rashford, Kane",
-              "firstPublished": "2023-05-05T10:23:38.248Z",
-              "link": "https://www.bbc.com/gahuza/articles/c72jryjn8jeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b6ea/live/89364630-eb2b-11ed-b4d7-a9cb08bb71d4.jpg",
-              "description": "Newcastle United irarondera Neymar, nayo Wolves ikaba irondera guha Barcelona imiriyoni 30 z’ama-euro yongere ishireko n’umukinyi wayo wo hagati Ruben Neves, kugira ngo irabe ko aba ba-Catalans boyiha  Ansu Fati w’imyaka 20.",
-              "imageAlt": "Neymar",
-              "id": "c72jryjn8jeo"
-            },
-            {
-              "type": "article",
-              "title": "'Haaland akwiye icyubahiro yahawe' – Guardiola",
-              "firstPublished": "2023-05-04T04:21:02.506Z",
-              "link": "https://www.bbc.com/gahuza/articles/c720zj0pvpgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b386/live/ce18f250-ea2e-11ed-a40f-310b757365da.jpg",
-              "description": "Umutoza wa Manchester City Pep Guardiola avuga ko Erling Haaland yari akwiye icyubahiro yahawe na bagenzi be bamuhagurukira, nyuma yo guca umuhigo wo gutsinda ibitego byinshi muri Premier League mu mwaka w'imikino. ",
-              "imageAlt": "Haaland yishimira intsinzi",
-              "id": "c720zj0pvpgo"
-            },
-            {
-              "type": "article",
-              "title": "Lionel Messi: Uyu musatirizi wa Argentine azova muri PSG uyu mwaka w'inkino uheze",
-              "firstPublished": "2023-05-03T17:00:17.485Z",
-              "link": "https://www.bbc.com/gahuza/articles/cldknr7ylx5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7f1f/live/ea7646d0-e9d1-11ed-9ff0-1714980264ca.jpg",
-              "description": "Lionel Messi azova muri Paris St-Germain mu ci umwaka w’inkino uheze igihe amasezerano yasinye azoba arangiye",
-              "imageAlt": "Lionel Messi",
-              "id": "cldknr7ylx5o"
-            },
-            {
-              "type": "article",
-              "title": "Lionel Messi: PSG yamuhagaritse indwi zibiri kubera urugendo yakoze muri Saudi Arabia ",
-              "firstPublished": "2023-05-03T05:47:16.972Z",
-              "link": "https://www.bbc.com/gahuza/articles/c80y6y746x8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6e/live/e27d8b30-e974-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "Kizigenza w’umurwi nserukiragihugu wa Argentina Lionel Messi yahagaritswe na Paris St-Germain mu kiringo c’indwi zibiri inyuma y’urugendo yagize muri Arabie Saoudite muri ino ndwi ata ruhusha yahawe n’umurwi wiwe. ",
-              "imageAlt": "Lionel Messi yatsindiye igikombe c'isi yose mu murwi nserukiragihugu wa Argentina muri Kigarama (12) ",
-              "id": "c80y6y746x8o"
-            },
-            {
-              "type": "article",
-              "title": "Uko umutoza Florent Ibenge wa Al-Hilal SC yahunze Sudan ",
-              "firstPublished": "2023-05-01T08:12:59.847Z",
-              "link": "https://www.bbc.com/gahuza/articles/cev4gdz9ndlo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1622/live/585e7380-e7e7-11ed-9dec-01bddd554611.jpg",
-              "description": "Florent Ibenge, umutoza w'Umunye-Congo w'ikipe iri ku mwanya wa mbere muri Sudan, avuga ko yizeye kongera guhura n'abakinnyi be mu gihe cya vuba. ",
-              "imageAlt": "Umutoza Florent Ibenge wa Al-Hilal mu mukino wa CAF Champions League hagati ya Al Ahly yo mu Misiri na Al-Hilal Omdurman yo muri Sudan",
-              "id": "cev4gdz9ndlo"
-            },
-            {
-              "type": "article",
-              "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Haaland, Zaha, Mount, Maddison, Abraham, Dybala, Mané ",
-              "firstPublished": "2023-05-01T07:43:57.849Z",
-              "link": "https://www.bbc.com/gahuza/articles/cgln252jy2go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1882/live/1e183170-e7f1-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "Manchester City iriko iritegurira ibiganiro na Erling Haaland kugira imuhe amasezerano mashasha, naho Wilfried Zaha  akaba ariko atera amero Arsenal, Juventus, Chelsea na Barcelona, aya n'ayandi ni mu yavugwa kuri uno wa mbere.",
-              "imageAlt": "Erling Haaland",
-              "id": "cgln252jy2go"
-            },
-            {
-              "type": "article",
-              "title": "Rurangiranwa mu mupira w'amaguru Pelé yashizwe  muri kazinduzi nk'icitiranwa ca 'mbonekarimwe'",
-              "firstPublished": "2023-04-27T15:54:09.786Z",
-              "link": "https://www.bbc.com/gahuza/articles/cp352vxzx32o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/06be/live/028cb020-e512-11ed-95b5-3fc903c2600a.jpg",
-              "description": "Pelé, iritazirano rya rurangiranwa mu mupira w'amaguru aherutse gupfa, ryabaye icitiranwa ca \"kidasanzwe, ntagereranywa, mbonekarimwe\". ",
-              "imageAlt": "Pelé",
-              "id": "cp352vxzx32o"
-            },
-            {
-              "type": "article",
-              "title": "Igikombe kiri mu biganza byacu kandi tugomba kubibyaza umusaruro – Guardiola",
-              "firstPublished": "2023-04-27T03:53:52.727Z",
-              "link": "https://www.bbc.com/gahuza/articles/c51pd159rk2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c014/live/2bbcba50-e4ac-11ed-82f6-5be9c54f2d36.jpg",
-              "description": "Umutoza Pep Guardiola avuga ko ikipe ye ya Manchester City yerekanye ko ishoboye iyo \"nta yandi mahitamo ahari uretse gutsinda\", nyuma yuko inyagiye Arsenal bigatuma iba mu mwanya mwiza mu nkundura yo guhatanira igikombe. ",
-              "imageAlt": "Bumwe mu buryo Pep Guardiola yifashemo mu mukino Man City yatsinzemo Arsenal",
-              "id": "c51pd159rk2o"
-            },
-            {
-              "type": "article",
-              "title": "Ayavugwa mu mupira w’amaguru: Kane, Rashford, Zaha, Neymar, Firmino, Mac Allister, Gavi, Laporte",
-              "firstPublished": "2023-04-25T10:40:14.712Z",
-              "link": "https://www.bbc.com/gahuza/articles/czkxmknxggxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6a/live/097eb410-e354-11ed-8d37-35f29b0896ac.jpg",
-              "description": "Manchester United iriko irarondera hasi hejuru umusatirizi wa Tottenham Harry Kane, yongera ikurikiranira hagufi Neymar, nayo Arsenal, Chelsea na Paris St-Germain ikanuriye amaso umusatirizi wa Crystal Palace Wilfried Zaha ...aya n'ayandi ni mu yavugwa kuri uno wa kabiri.",
-              "imageAlt": "Neymar",
-              "id": "czkxmknxggxo"
-            },
-            {
-              "type": "article",
-              "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Messi, Raphinha, Osimhen, Mac Allister, Watkins",
-              "firstPublished": "2023-04-23T06:36:38.068Z",
-              "link": "https://www.bbc.com/gahuza/articles/c5145x47l20o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a8d2/live/9b563040-e19f-11ed-8df1-d74cbf1089d7.png",
-              "description": "Paris St-Germain izorekura Lionel Messi amasezerano ifitaniye nawe arangiye mu ci riza, Barcelona iramaze kuneka abakinyi bashika 13 mu gikorwa co kurondera umukinyi w’inyuma ku ruhande rw’i buryo mu ci riza, aya n'ayandi ni mu yavugwa kuri uno wa Mungu.",
-              "imageAlt": "Lionel Messi yakoze ibidasanzwe mu myaka itari mike yamaze akinira umurwi Barcelona wamureze kuva mu bwana, muri kino gihe akaba akinira PSG wo mu Bufaransa",
-              "id": "c5145x47l20o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 14,
-          "curationId": "urn:bbc:vivo:curation:622a5a2a-9b1b-44d8-b37c-13771d75897b",
-          "curationType": "vivo-stream",
-          "position": 3,
-          "title": "Imikino",
-          "visualProminence": "NORMAL"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO page"
-  }
+  "data": {
+    "title": "BBC News Gahuza",
+    "description": "",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Rusesabagina: Uko Qatar iza mu irekurwa rye",
+            "firstPublished": "2023-03-27T08:16:58.910Z",
+            "link": "https://www.bbc.com/gahuza/articles/c72vq9w7701o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a80b/live/ed086130-cc76-11ed-a249-7bbdfc224c64.jpg",
+            "description": "Byitezwe ko igihe icyo aricyo cyose Rusesabagina ashobora kuva mu Rwanda, ariko ntabwo ahita ajya mu rugo rwe muri Amerika, arabanza muri Qatar.",
+            "imageAlt": "Kuwa kabiri Perezida Kagame yari i Doha aho yaganiriye n'umutegetsi w'ikirenga w'iki gihugu Tamim bin Hamad Al-Thani.",
+            "id": "c72vq9w7701o"
+          },
+          {
+            "type": "article",
+            "title": "Uganda: Umuhungu wa Museveni avuga ko azasezera mu gisirikare 'uyu mwaka' ",
+            "firstPublished": "2023-03-27T13:29:15.533Z",
+            "link": "https://www.bbc.com/gahuza/articles/clw1r3x75elo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d7d8/live/7dfc5a70-cc9f-11ed-a0f2-f391991bf052.jpg",
+            "description": "Abitangaje hashize iminsi asibye ubutumwa bwo kuri Twitter, yavugagamo ko aziyamamaza mu matora ya perezida yo mu mwaka wa 2026. ",
+            "imageAlt": "Muhoozi Kainerugaba",
+            "id": "clw1r3x75elo"
+          },
+          {
+            "type": "article",
+            "title": "Jack Ma washinze Alibaba yabonetse nyuma y'igihe kinini atagaragara ",
+            "firstPublished": "2023-03-27T11:04:51.948Z",
+            "link": "https://www.bbc.com/gahuza/articles/cp6wzn054xdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a7b5/live/e337a310-cc8e-11ed-be2e-754a65c11505.jpg",
+            "description": "Jack Ma w'imyaka 58 yabonetse gacye kuva yanenga abashinzwe kugenzura ubukungu bw'Ubushinwa mu 2020.  ",
+            "imageAlt": "Kuva mu mpera za 2020 Jack Ma yabonetse gacye cyane mu bantu",
+            "id": "cp6wzn054xdo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:cf1b146e-c9de-4b47-b345-f85f32d2a80b",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "BBC News Gahuza Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Rusesabagina na ‘Sankara’ bararekurwa, 'si ku gitutu cya Amerika' - Umuvugizi",
+            "firstPublished": "2023-03-24T16:58:52.049Z",
+            "link": "https://www.bbc.com/gahuza/articles/ce92v5gvv1vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7c9b/live/6f5b05d0-ca64-11ed-be2e-754a65c11505.jpg",
+            "description": "Paul Rusesabagina mu ibaruwa isaba imbabazi yatangajwe na leta, avuga ko “ibibazo bijyanye na politiki y’u Rwanda nzabisiga inyuma yanjye”.",
+            "imageAlt": "Rusesabagina yerekanywe afungiye mu Rwanda muri Kanama(8) 2020 mu buryo bwavuzweho cyane",
+            "id": "ce92v5gvv1vo"
+          },
+          {
+            "type": "article",
+            "title": "Uyu munsi mu rubanza rwa Kabuga: Inzobere yavuze ko atashobora gusubiza ku byo aregwa",
+            "firstPublished": "2023-03-23T14:09:25.844Z",
+            "link": "https://www.bbc.com/gahuza/articles/crg5qp7nx32o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a56c/live/969dc160-c96e-11ed-bb75-4187a06ea88d.jpg",
+            "description": "Inzobere mu buzima bwo mu mutwe Profeseri Gillian Mezey, umwe muri eshatu zigenga zakoze raporo ku buzima bwa Kabuga, ni we wumviswe uyu munsi. ",
+            "imageAlt": "Félicien Kabuga ubwo yari akurikiye iburanisha kuri uyu wa kane",
+            "id": "crg5qp7nx32o"
+          },
+          {
+            "type": "article",
+            "title": "Impinduka muri leta DR Congo - Vital Kamerhe na Jean Pierre Bemba binjiye muri guverinoma",
+            "firstPublished": "2023-03-24T06:11:51.208Z",
+            "link": "https://www.bbc.com/gahuza/articles/c4n7ez33qpqo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/356d/live/602c67c0-ca0a-11ed-ba93-a55a7032c318.jpg",
+            "description": "Vital Kamerhe na Jean Pierre Bemba ni bamwe mu bigugu muri politiki ya DR Congo bashobora gukomeza uruhande rwa Tshisekedi mbere y’amatora. ",
+            "imageAlt": "Vital Kamerhe (ibumoso) na Jean Pierre Bemba",
+            "id": "c4n7ez33qpqo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:de476937-7ca0-4a72-8ab7-5c2c3817271f",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Ivyo BBC Gahuza ibahitiramwo",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT4M46S",
+            "title": "DR Congo – Rwanda: Abahitanywe n'imyuzure bari gushobora gukingirwa?",
+            "firstPublished": "2023-05-10T20:42:53.549Z",
+            "link": "https://www.bbc.com/gahuza/articles/c28mm84jznwo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/84c6/live/c802d2f0-ef6f-11ed-a142-ab0e42bfd9c3.png",
+            "description": "Abantu amajana bapfiriye nka rimwe, mu burengero bushira uburaruko mu Rwanda, na Kalehe muri DR Congo, ibihumbi baracaronderwa. Umuhinga Ir. Anne-Marie Bihirabake agabisha ibi bihugu ko ata kwijajara.",
+            "imageAlt": "Abishwe n'imyuzure baharurwa mu majana, ibihumbi baracaronderwa",
+            "id": "c28mm84jznwo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M39S",
+            "title": "Turkey: igihe co gusuzuma intwaro ya Erdogan kirageze",
+            "firstPublished": "2023-05-10T15:01:38.735Z",
+            "link": "https://www.bbc.com/gahuza/articles/cw5kk4p6wzpo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f84a/live/778d1c90-ef42-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "",
+            "imageAlt": "Erdogan yiyamamaza inyuma y'imyaka 20 ari k'ubutegeetsi",
+            "id": "cw5kk4p6wzpo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M45S",
+            "title": "Umwami Charles III: ibimenyetso bikomeye vy’ubwami, mw’iyimikwa ",
+            "firstPublished": "2023-05-08T13:27:20.272Z",
+            "link": "https://www.bbc.com/gahuza/articles/cn0x32pjv8po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3b09/live/5420c7c0-eda3-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "",
+            "imageAlt": "Umwami Charles III n'umwamikazi Camilla",
+            "id": "cn0x32pjv8po"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M43S",
+            "title": "Charles III: Iyimikwa nk’Umwami rivuze iki kuri bamwe, muri Africa?",
+            "firstPublished": "2023-05-03T22:16:29.284Z",
+            "link": "https://www.bbc.com/gahuza/articles/cy90kx7l5ywo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1abe/live/17aa6a50-e9ff-11ed-a142-ab0e42bfd9c3.png",
+            "description": "",
+            "imageAlt": "Uko bamwe muri Africa babona iyimikwa rya Charles III",
+            "id": "cy90kx7l5ywo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M25S",
+            "title": "Uko ibihugu biri mu ngorane z’ubutunzi bitabarwa",
+            "firstPublished": "2023-04-29T03:27:01.567Z",
+            "link": "https://www.bbc.com/gahuza/articles/c2q1464739vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d59d/live/4c346890-e63d-11ed-a142-ab0e42bfd9c3.png",
+            "description": "",
+            "imageAlt": "Ku cicaro c'ikigega c'isi muri USA",
+            "id": "c2q1464739vo"
+          },
+          {
+            "type": "article",
+            "title": "Kenya: ahabereye ivyaha burimwo impfu zifatiye kw’idini",
+            "firstPublished": "2023-04-27T15:05:22.524Z",
+            "link": "https://www.bbc.com/gahuza/articles/c4np33gx0pdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b7e7/live/8eb57ba0-e50c-11ed-8df1-d74cbf1089d7.png",
+            "description": "",
+            "imageAlt": "Abapfuye bisonzesha bashoboye gutorwa barahambwe n'iteka",
+            "id": "c4np33gx0pdo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M38S",
+            "title": "Isi yibuka ko umubu ari kamwe m’udukoko twica: gute?",
+            "firstPublished": "2023-04-26T20:31:50.175Z",
+            "link": "https://www.bbc.com/gahuza/articles/c3gvny19ldmo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6aac/live/25156570-e471-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Uko hamwe muri Afrika batuza imibu itera malaria",
+            "id": "c3gvny19ldmo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M37S",
+            "title": "“Ninasubira kuba muto nshaka kuzomera nk’umuhungu wanje”",
+            "firstPublished": "2023-04-26T19:28:50.972Z",
+            "link": "https://www.bbc.com/gahuza/articles/cv276m5l755o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/08c5/live/52751550-e468-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Bryan Johnson w’imyaka 45, avuga ko afise imyaka 18. ",
+            "id": "cv276m5l755o"
+          },
+          {
+            "type": "article",
+            "title": "Sudan: Tahura imvo y’izi ntambara",
+            "firstPublished": "2023-04-25T16:29:34.350Z",
+            "link": "https://www.bbc.com/gahuza/articles/cd1r5xqq517o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e2d2/live/d824a870-e385-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Intambara zasize igisagara Khartoum ari umusaka",
+            "id": "cd1r5xqq517o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M45S",
+            "title": "Video: Emery Ngarambe aravuga ingaruka zo gufata 'booster' n'uko yayihevye",
+            "firstPublished": "2023-04-25T16:12:21.773Z",
+            "link": "https://www.bbc.com/gahuza/articles/c3gvnlyd6r7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Kubera kunywa ibiyayuramutwe, Emery Ngarambe yama mu gasho no mu bitaro. Yariba ico abonye cose muhira, akavuga ko yagiye kubiheba amaze kwiba mu muryango nk'ibintu vyoba biciye nk'imodoka.",
+            "imageAlt": "",
+            "id": "c3gvnlyd6r7o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M1S",
+            "title": "Afghanistan: uko abigisha babaye mu mirimo yabo",
+            "firstPublished": "2023-04-24T14:48:06.282Z",
+            "link": "https://www.bbc.com/gahuza/articles/c4npvwezj9eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f801/live/f88133f0-e2ad-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Afghanistan, ubuzima bwa bamwe mu bigisha",
+            "id": "c4npvwezj9eo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M27S",
+            "title": "Sudan: uko amasanamu y’ibinyoma ku ntambara akwiragizwa",
+            "firstPublished": "2023-04-22T21:30:40.799Z",
+            "link": "https://www.bbc.com/gahuza/articles/c72zxd64ydno",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f47d/live/a6c3b6a0-e154-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Sudan: Itohoza ku masanamu y’ibinyoma mu ntambara",
+            "id": "c72zxd64ydno"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 5,
+        "curationId": "urn:bbc:vivo:curation:187eb2c6-a4f0-4a31-adf1-5941beaf849d",
+        "curationType": "vivo-stream",
+        "position": 2,
+        "title": "Videos",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Barcelona: Kizigenza Sergio Busquets agiye gusezera inyuma y’imyaka 18",
+            "firstPublished": "2023-05-10T11:31:27.519Z",
+            "link": "https://www.bbc.com/gahuza/articles/c72119q6p4zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1688/live/43073e50-ef25-11ed-a188-1b6d50771321.jpg",
+            "description": "Kizigenza Sergio Busquets yemeje ko azova muri Barcelona mu mpera z’uno mwaka w’inkino inyuma y’imyaka 18 akinira uno murwi. ",
+            "imageAlt": "Sergio Busquets yinjiye muri Barcelona mu 2005 akaba yatanguye gukina mu murwi mukuru mu 2008",
+            "id": "c72119q6p4zo"
+          },
+          {
+            "type": "article",
+            "title": "West Ham 1 - 0 Man U: David de Gea arabaye uruvugo inyuma y’ikosa ryaraye rihumiye umurwi wiwe ",
+            "firstPublished": "2023-05-08T11:23:48.846Z",
+            "link": "https://www.bbc.com/gahuza/articles/cyd86g7nv66o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8351/live/42429410-ed8b-11ed-bb92-65f9d49396ea.jpg",
+            "description": "Ikosa ryakozwe n’umunyegori David de Gea ryatumye Saïd Benrahma wa West Ham  yinjiza igitsindo kimwe rudende c’urwo rukino ku munota wa 27.",
+            "imageAlt": "De Gea",
+            "id": "cyd86g7nv66o"
+          },
+          {
+            "type": "article",
+            "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Neymar, Messi, Fati, Amrabat, Rashford, Kane",
+            "firstPublished": "2023-05-05T10:23:38.248Z",
+            "link": "https://www.bbc.com/gahuza/articles/c72jryjn8jeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b6ea/live/89364630-eb2b-11ed-b4d7-a9cb08bb71d4.jpg",
+            "description": "Newcastle United irarondera Neymar, nayo Wolves ikaba irondera guha Barcelona imiriyoni 30 z’ama-euro yongere ishireko n’umukinyi wayo wo hagati Ruben Neves, kugira ngo irabe ko aba ba-Catalans boyiha  Ansu Fati w’imyaka 20.",
+            "imageAlt": "Neymar",
+            "id": "c72jryjn8jeo"
+          },
+          {
+            "type": "article",
+            "title": "'Haaland akwiye icyubahiro yahawe' – Guardiola",
+            "firstPublished": "2023-05-04T04:21:02.506Z",
+            "link": "https://www.bbc.com/gahuza/articles/c720zj0pvpgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b386/live/ce18f250-ea2e-11ed-a40f-310b757365da.jpg",
+            "description": "Umutoza wa Manchester City Pep Guardiola avuga ko Erling Haaland yari akwiye icyubahiro yahawe na bagenzi be bamuhagurukira, nyuma yo guca umuhigo wo gutsinda ibitego byinshi muri Premier League mu mwaka w'imikino. ",
+            "imageAlt": "Haaland yishimira intsinzi",
+            "id": "c720zj0pvpgo"
+          },
+          {
+            "type": "article",
+            "title": "Lionel Messi: Uyu musatirizi wa Argentine azova muri PSG uyu mwaka w'inkino uheze",
+            "firstPublished": "2023-05-03T17:00:17.485Z",
+            "link": "https://www.bbc.com/gahuza/articles/cldknr7ylx5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7f1f/live/ea7646d0-e9d1-11ed-9ff0-1714980264ca.jpg",
+            "description": "Lionel Messi azova muri Paris St-Germain mu ci umwaka w’inkino uheze igihe amasezerano yasinye azoba arangiye",
+            "imageAlt": "Lionel Messi",
+            "id": "cldknr7ylx5o"
+          },
+          {
+            "type": "article",
+            "title": "Lionel Messi: PSG yamuhagaritse indwi zibiri kubera urugendo yakoze muri Saudi Arabia ",
+            "firstPublished": "2023-05-03T05:47:16.972Z",
+            "link": "https://www.bbc.com/gahuza/articles/c80y6y746x8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6e/live/e27d8b30-e974-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "Kizigenza w’umurwi nserukiragihugu wa Argentina Lionel Messi yahagaritswe na Paris St-Germain mu kiringo c’indwi zibiri inyuma y’urugendo yagize muri Arabie Saoudite muri ino ndwi ata ruhusha yahawe n’umurwi wiwe. ",
+            "imageAlt": "Lionel Messi yatsindiye igikombe c'isi yose mu murwi nserukiragihugu wa Argentina muri Kigarama (12) ",
+            "id": "c80y6y746x8o"
+          },
+          {
+            "type": "article",
+            "title": "Uko umutoza Florent Ibenge wa Al-Hilal SC yahunze Sudan ",
+            "firstPublished": "2023-05-01T08:12:59.847Z",
+            "link": "https://www.bbc.com/gahuza/articles/cev4gdz9ndlo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1622/live/585e7380-e7e7-11ed-9dec-01bddd554611.jpg",
+            "description": "Florent Ibenge, umutoza w'Umunye-Congo w'ikipe iri ku mwanya wa mbere muri Sudan, avuga ko yizeye kongera guhura n'abakinnyi be mu gihe cya vuba. ",
+            "imageAlt": "Umutoza Florent Ibenge wa Al-Hilal mu mukino wa CAF Champions League hagati ya Al Ahly yo mu Misiri na Al-Hilal Omdurman yo muri Sudan",
+            "id": "cev4gdz9ndlo"
+          },
+          {
+            "type": "article",
+            "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Haaland, Zaha, Mount, Maddison, Abraham, Dybala, Mané ",
+            "firstPublished": "2023-05-01T07:43:57.849Z",
+            "link": "https://www.bbc.com/gahuza/articles/cgln252jy2go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1882/live/1e183170-e7f1-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "Manchester City iriko iritegurira ibiganiro na Erling Haaland kugira imuhe amasezerano mashasha, naho Wilfried Zaha  akaba ariko atera amero Arsenal, Juventus, Chelsea na Barcelona, aya n'ayandi ni mu yavugwa kuri uno wa mbere.",
+            "imageAlt": "Erling Haaland",
+            "id": "cgln252jy2go"
+          },
+          {
+            "type": "article",
+            "title": "Rurangiranwa mu mupira w'amaguru Pelé yashizwe  muri kazinduzi nk'icitiranwa ca 'mbonekarimwe'",
+            "firstPublished": "2023-04-27T15:54:09.786Z",
+            "link": "https://www.bbc.com/gahuza/articles/cp352vxzx32o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/06be/live/028cb020-e512-11ed-95b5-3fc903c2600a.jpg",
+            "description": "Pelé, iritazirano rya rurangiranwa mu mupira w'amaguru aherutse gupfa, ryabaye icitiranwa ca \"kidasanzwe, ntagereranywa, mbonekarimwe\". ",
+            "imageAlt": "Pelé",
+            "id": "cp352vxzx32o"
+          },
+          {
+            "type": "article",
+            "title": "Igikombe kiri mu biganza byacu kandi tugomba kubibyaza umusaruro – Guardiola",
+            "firstPublished": "2023-04-27T03:53:52.727Z",
+            "link": "https://www.bbc.com/gahuza/articles/c51pd159rk2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c014/live/2bbcba50-e4ac-11ed-82f6-5be9c54f2d36.jpg",
+            "description": "Umutoza Pep Guardiola avuga ko ikipe ye ya Manchester City yerekanye ko ishoboye iyo \"nta yandi mahitamo ahari uretse gutsinda\", nyuma yuko inyagiye Arsenal bigatuma iba mu mwanya mwiza mu nkundura yo guhatanira igikombe. ",
+            "imageAlt": "Bumwe mu buryo Pep Guardiola yifashemo mu mukino Man City yatsinzemo Arsenal",
+            "id": "c51pd159rk2o"
+          },
+          {
+            "type": "article",
+            "title": "Ayavugwa mu mupira w’amaguru: Kane, Rashford, Zaha, Neymar, Firmino, Mac Allister, Gavi, Laporte",
+            "firstPublished": "2023-04-25T10:40:14.712Z",
+            "link": "https://www.bbc.com/gahuza/articles/czkxmknxggxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6a/live/097eb410-e354-11ed-8d37-35f29b0896ac.jpg",
+            "description": "Manchester United iriko irarondera hasi hejuru umusatirizi wa Tottenham Harry Kane, yongera ikurikiranira hagufi Neymar, nayo Arsenal, Chelsea na Paris St-Germain ikanuriye amaso umusatirizi wa Crystal Palace Wilfried Zaha ...aya n'ayandi ni mu yavugwa kuri uno wa kabiri.",
+            "imageAlt": "Neymar",
+            "id": "czkxmknxggxo"
+          },
+          {
+            "type": "article",
+            "title": "Ayavugwa mw’igura n’igurishwa ry’abakinyi: Messi, Raphinha, Osimhen, Mac Allister, Watkins",
+            "firstPublished": "2023-04-23T06:36:38.068Z",
+            "link": "https://www.bbc.com/gahuza/articles/c5145x47l20o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a8d2/live/9b563040-e19f-11ed-8df1-d74cbf1089d7.png",
+            "description": "Paris St-Germain izorekura Lionel Messi amasezerano ifitaniye nawe arangiye mu ci riza, Barcelona iramaze kuneka abakinyi bashika 13 mu gikorwa co kurondera umukinyi w’inyuma ku ruhande rw’i buryo mu ci riza, aya n'ayandi ni mu yavugwa kuri uno wa Mungu.",
+            "imageAlt": "Lionel Messi yakoze ibidasanzwe mu myaka itari mike yamaze akinira umurwi Barcelona wamureze kuva mu bwana, muri kino gihe akaba akinira PSG wo mu Bufaransa",
+            "id": "c5145x47l20o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 14,
+        "curationId": "urn:bbc:vivo:curation:622a5a2a-9b1b-44d8-b37c-13771d75897b",
+        "curationType": "vivo-stream",
+        "position": 3,
+        "title": "Imikino",
+        "visualProminence": "NORMAL"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c897lqqzkgkt",
+        "contentType": "index-home",
+        "pageIdentifier": "gahuza.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO page"
+}

--- a/data/gujarati/homePage/index.json
+++ b/data/gujarati/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "સમાચાર - BBC News ગુજરાતી",
-      "description": "બ્રેકિંગ ન્યુઝ, હવામાન, વેપાર, મનોરંજન, ગુજરાત, ભારત અને વિશ્વના સમાચાર, વિશ્લેષણ, BBCના ખાસ અહેવાલો, ટીવી બુલેટિન, વિડિઓ અને ફોટો ગેલેરી.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ભારતમાં વિદેશથી લવાયેલા ચિત્તાનાં ‘રહસ્યમય’ મૃત્યુ પાછળ શું છે કારણ?",
-              "firstPublished": "2023-04-26T08:28:52.629Z",
-              "link": "https://www.bbc.com/gujarati/articles/cqv025vj45yo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e8ee/live/48ee90f0-e40f-11ed-8df1-d74cbf1089d7.png",
-              "description": "ગત વર્ષે વડા પ્રધાન મોદીના જન્મદિવસે 17 સપ્ટેમ્બરના રોજ નામીબિયાથી આઠ ચિત્તા લાવવામાં આવ્યા.",
-              "imageAlt": "વર્ષ 2022માં નરેન્દ્ર મોદીના જન્મદિવસે નામીબિયાથી ચિત્તા ભારત લાવવામાં આવ્યા હતા",
-              "id": "cqv025vj45yo"
-            },
-            {
-              "type": "article",
-              "title": "સુદાનમાં એક ગુજરાતી વેપારીએ 150 વર્ષ પહેલાં ખોલ્યો હતો ધંધાનો રસ્તો, હવે ત્યાં શું કરે છે ભારતીયો?",
-              "firstPublished": "2023-04-26T03:10:58.624Z",
-              "link": "https://www.bbc.com/gujarati/articles/c0wg7pelze7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/87e4/live/6ca1e5c0-e37d-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "સુદાનમાં ચાલી રહેલા સંઘર્ષ વચ્ચે ભારતીયોને બહાર કાઢવા માટે મોદી સરકારે ઑપરેશન કાવેરી શરૂ કર્યું છે. ચાલો જાણીએ સુદાન અને ભારતની ઐતિહાસિક સંબંધોની કહાણી.",
-              "imageAlt": "પ્રભુ એસ કે",
-              "id": "c0wg7pelze7o"
-            },
-            {
-              "type": "article",
-              "title": "18 વર્ષના સ્પિનર નૂર અહમદ કોણ છે જેમણે મુંબઈ ઇન્ડિયન્સને હંફાવીને ગુજરાત ટાઇટન્સને વિજેતા બનાવ્યું?",
-              "firstPublished": "2023-04-26T04:49:34.167Z",
-              "link": "https://www.bbc.com/gujarati/articles/cl52n1x84l5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ece0/live/3a098f20-e3ee-11ed-8df1-d74cbf1089d7.png",
-              "description": "છેલ્લી ઓવરનો પહેલો બૉલ વાઈડ હતો. આ અંગે મુંબઈ ઈન્ડિયન્સનો રિવ્યુ લેવામાં આવ્યો હતો. પરિણામ ગુજરાતની તરફેણમાં રહ્યું હતું.",
-              "imageAlt": "નૂર મોહમ્મદ",
-              "id": "cl52n1x84l5o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a3085ae7-27b9-4ec7-95ea-f7e7935a6b08",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "વિરાટ કોહલીની એ સિક્સરે ચાહકોને 12 વર્ષ પહેલાં ધોનીએ મારેલી સિક્સરની યાદ અપાવી દીધી",
-              "firstPublished": "2023-04-03T06:11:15.502Z",
-              "link": "https://www.bbc.com/gujarati/articles/cqvjq5e27ewo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4933/live/768cfa60-d1e5-11ed-be2e-754a65c11505.png",
-              "description": "આઈપીએલ-16માં દમદાર શરૂઆત પછી તમામ લોકો અનુમાન લગાવી રહ્યા હતા કે કોહલી આઈપીએલમાં ટ્રૉફી જીતવાનું મિશન લઈને જ મેદાને ઊતર્યા છે.",
-              "imageAlt": "વિરાટ કોહલી",
-              "id": "cqvjq5e27ewo"
-            },
-            {
-              "type": "article",
-              "title": "રાહુલ ગાંધીને માનહાનિ કેસમાં 13 એપ્રિલ સુધી જામીન, 3મેએ આગામી સુનાવણી",
-              "firstPublished": "2023-04-02T15:23:25.000Z",
-              "link": "https://www.bbc.com/gujarati/india-65156517",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/17C0E/production/_129249279_5b0b310a-ca89-4908-ab79-55f22b52418e.jpg",
-              "description": "સુરતની સેશન કોર્ટે સોમવારે કૉંગ્રેસના પૂર્વ અધ્યક્ષ રાહુલ ગાંધીના જામીન 13 એપ્રીલ સુધી વધારી દીધા છે. રાહુલ ગાંધીએ વર્ષ 2019માં એક માનહાનિ કેસમાં દોષિત ગણવા અને બે વર્ષની સજાના વિરુદ્ધમાં અરજી દાખલ કરી હતી.",
-              "imageAlt": "રાહુલ ગાંધી",
-              "id": "e36c4828-67e1-4b76-84e5-c03ca985c09e"
-            },
-            {
-              "type": "article",
-              "title": "અમેરિકા બૉર્ડર પાસેથી મળેલા મૃતદેહો ગુજરાતીઓના? મહેસાણાનો પરિવાર કઈ રીતે પહોંચ્યો હતો કૅનેડા?",
-              "firstPublished": "2023-04-02T09:26:30.299Z",
-              "link": "https://www.bbc.com/gujarati/articles/cw9rwr4l9yqo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/91be/live/70ccca40-d133-11ed-be2e-754a65c11505.jpg",
-              "description": "મહેસાણાનો ચાર સભ્યોનો પરિવાર એક મહિના પહેલાં ફરવા માટે કૅનેડા ગયો હતો. છેલ્લા 15 દિવસથી આ પરિવાર સંપર્કવિહોણો છે.",
-              "imageAlt": "કૅનેડામાં ભારતીયોનાં મૃત્યુ",
-              "id": "cw9rwr4l9yqo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:f936e873-0700-42bf-8c6a-18196bc60720",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "બીબીસી વિશેષ",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO page"
-  }
+  "data": {
+    "title": "સમાચાર - BBC News ગુજરાતી",
+    "description": "બ્રેકિંગ ન્યુઝ, હવામાન, વેપાર, મનોરંજન, ગુજરાત, ભારત અને વિશ્વના સમાચાર, વિશ્લેષણ, BBCના ખાસ અહેવાલો, ટીવી બુલેટિન, વિડિઓ અને ફોટો ગેલેરી.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ભારતમાં વિદેશથી લવાયેલા ચિત્તાનાં ‘રહસ્યમય’ મૃત્યુ પાછળ શું છે કારણ?",
+            "firstPublished": "2023-04-26T08:28:52.629Z",
+            "link": "https://www.bbc.com/gujarati/articles/cqv025vj45yo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e8ee/live/48ee90f0-e40f-11ed-8df1-d74cbf1089d7.png",
+            "description": "ગત વર્ષે વડા પ્રધાન મોદીના જન્મદિવસે 17 સપ્ટેમ્બરના રોજ નામીબિયાથી આઠ ચિત્તા લાવવામાં આવ્યા.",
+            "imageAlt": "વર્ષ 2022માં નરેન્દ્ર મોદીના જન્મદિવસે નામીબિયાથી ચિત્તા ભારત લાવવામાં આવ્યા હતા",
+            "id": "cqv025vj45yo"
+          },
+          {
+            "type": "article",
+            "title": "સુદાનમાં એક ગુજરાતી વેપારીએ 150 વર્ષ પહેલાં ખોલ્યો હતો ધંધાનો રસ્તો, હવે ત્યાં શું કરે છે ભારતીયો?",
+            "firstPublished": "2023-04-26T03:10:58.624Z",
+            "link": "https://www.bbc.com/gujarati/articles/c0wg7pelze7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/87e4/live/6ca1e5c0-e37d-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "સુદાનમાં ચાલી રહેલા સંઘર્ષ વચ્ચે ભારતીયોને બહાર કાઢવા માટે મોદી સરકારે ઑપરેશન કાવેરી શરૂ કર્યું છે. ચાલો જાણીએ સુદાન અને ભારતની ઐતિહાસિક સંબંધોની કહાણી.",
+            "imageAlt": "પ્રભુ એસ કે",
+            "id": "c0wg7pelze7o"
+          },
+          {
+            "type": "article",
+            "title": "18 વર્ષના સ્પિનર નૂર અહમદ કોણ છે જેમણે મુંબઈ ઇન્ડિયન્સને હંફાવીને ગુજરાત ટાઇટન્સને વિજેતા બનાવ્યું?",
+            "firstPublished": "2023-04-26T04:49:34.167Z",
+            "link": "https://www.bbc.com/gujarati/articles/cl52n1x84l5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ece0/live/3a098f20-e3ee-11ed-8df1-d74cbf1089d7.png",
+            "description": "છેલ્લી ઓવરનો પહેલો બૉલ વાઈડ હતો. આ અંગે મુંબઈ ઈન્ડિયન્સનો રિવ્યુ લેવામાં આવ્યો હતો. પરિણામ ગુજરાતની તરફેણમાં રહ્યું હતું.",
+            "imageAlt": "નૂર મોહમ્મદ",
+            "id": "cl52n1x84l5o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a3085ae7-27b9-4ec7-95ea-f7e7935a6b08",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "વિરાટ કોહલીની એ સિક્સરે ચાહકોને 12 વર્ષ પહેલાં ધોનીએ મારેલી સિક્સરની યાદ અપાવી દીધી",
+            "firstPublished": "2023-04-03T06:11:15.502Z",
+            "link": "https://www.bbc.com/gujarati/articles/cqvjq5e27ewo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4933/live/768cfa60-d1e5-11ed-be2e-754a65c11505.png",
+            "description": "આઈપીએલ-16માં દમદાર શરૂઆત પછી તમામ લોકો અનુમાન લગાવી રહ્યા હતા કે કોહલી આઈપીએલમાં ટ્રૉફી જીતવાનું મિશન લઈને જ મેદાને ઊતર્યા છે.",
+            "imageAlt": "વિરાટ કોહલી",
+            "id": "cqvjq5e27ewo"
+          },
+          {
+            "type": "article",
+            "title": "રાહુલ ગાંધીને માનહાનિ કેસમાં 13 એપ્રિલ સુધી જામીન, 3મેએ આગામી સુનાવણી",
+            "firstPublished": "2023-04-02T15:23:25.000Z",
+            "link": "https://www.bbc.com/gujarati/india-65156517",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/17C0E/production/_129249279_5b0b310a-ca89-4908-ab79-55f22b52418e.jpg",
+            "description": "સુરતની સેશન કોર્ટે સોમવારે કૉંગ્રેસના પૂર્વ અધ્યક્ષ રાહુલ ગાંધીના જામીન 13 એપ્રીલ સુધી વધારી દીધા છે. રાહુલ ગાંધીએ વર્ષ 2019માં એક માનહાનિ કેસમાં દોષિત ગણવા અને બે વર્ષની સજાના વિરુદ્ધમાં અરજી દાખલ કરી હતી.",
+            "imageAlt": "રાહુલ ગાંધી",
+            "id": "e36c4828-67e1-4b76-84e5-c03ca985c09e"
+          },
+          {
+            "type": "article",
+            "title": "અમેરિકા બૉર્ડર પાસેથી મળેલા મૃતદેહો ગુજરાતીઓના? મહેસાણાનો પરિવાર કઈ રીતે પહોંચ્યો હતો કૅનેડા?",
+            "firstPublished": "2023-04-02T09:26:30.299Z",
+            "link": "https://www.bbc.com/gujarati/articles/cw9rwr4l9yqo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/91be/live/70ccca40-d133-11ed-be2e-754a65c11505.jpg",
+            "description": "મહેસાણાનો ચાર સભ્યોનો પરિવાર એક મહિના પહેલાં ફરવા માટે કૅનેડા ગયો હતો. છેલ્લા 15 દિવસથી આ પરિવાર સંપર્કવિહોણો છે.",
+            "imageAlt": "કૅનેડામાં ભારતીયોનાં મૃત્યુ",
+            "id": "cw9rwr4l9yqo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:f936e873-0700-42bf-8c6a-18196bc60720",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "બીબીસી વિશેષ",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cnnmzrr14w9t",
+        "contentType": "index-home",
+        "pageIdentifier": "gujarati.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO page"
+}

--- a/data/hausa/homePage/index.json
+++ b/data/hausa/homePage/index.json
@@ -1,500 +1,507 @@
 {
-    "data": {
-      "title": "BBC News Hausa",
-      "description": "",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Zaɓuka kusan 100 INEC za ta ƙarasa a watan gobe",
-              "firstPublished": "2023-03-27T14:51:06.555Z",
-              "link": "https://www.bbc.com/hausa/articles/cevny200752o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ca4e/live/a3a13b40-ccab-11ed-9b0a-6f4a90e45a6a.jpg",
-              "description": "A wani saƙo da ta wallafa a shafinta na Twitter ranar Litinin, INEC  ta ce ta yanke wannan shawara ce bayan wata ganawa tsakanin manyan jami'anta.",
-              "imageAlt": "INEC Chair",
-              "id": "cevny200752o"
-            },
-            {
-              "type": "article",
-              "title": "Ƴan Najeriya za su yi kewar Buhari idan ya gama mulki – Garba Shehu",
-              "firstPublished": "2023-03-27T07:26:37.000Z",
-              "link": "https://www.bbc.com/hausa/live/labarai-65086040",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4FA2/production/_129168302__114295251_40161767_2152852741595472_3271934952567996416_n.jpg",
-              "description": "Wannan shafi ne da yake kawo muku abubuwan da ke faruwa a Najeriya da sauran sassan duniya.",
-              "imageAlt": "Garba Shehu",
-              "id": "f0db6ef0-3a0d-41a8-8868-a8c40c0ff2e0"
-            },
-            {
-              "type": "article",
-              "title": "Abin da ya sa muka dakatar da Iyorchia Ayu - PDP",
-              "firstPublished": "2023-03-27T09:53:54.835Z",
-              "link": "https://www.bbc.com/hausa/articles/cqvj351npexo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3962/live/eb1881a0-cc82-11ed-be2e-754a65c11505.png",
-              "description": "Jam'iyyar PDP ta ce ta dakatar da shugabanta na ƙasa, Iyorchia Ayu bisa zargin sa da wasu ayyuka na cin amanar jam'iyyar.",
-              "imageAlt": "...",
-              "id": "cqvj351npexo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:94c73456-7ae0-4033-8e88-8e4240a65f2e",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "'Yadda surukata ta ɓata cikin laka bayan mahaukaciyar guguwa'",
-              "firstPublished": "2023-03-26T11:26:10.076Z",
-              "link": "https://www.bbc.com/hausa/articles/c51e5wwge9yo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1bbd/live/0f60c450-c88c-11ed-8985-09a61927b152.png",
-              "description": "Jikokin Violet Frank guda biyu suna tuna mata surukarta da ta ɓata, bayan afkuwar mummunar guguwar da ta yi sanadin rugujewar ɗaruruwan gidaje. ",
-              "imageAlt": "Violet Frank",
-              "id": "c51e5wwge9yo"
-            },
-            {
-              "type": "commentary",
-              "title": "Rundunar sojin Najeriya ta ƙaryata zargin kisan ƙananan yara",
-              "firstPublished": "2023-03-26T07:38:59.000Z",
-              "link": "https://www.bbc.com/hausa/live/labarai-65079802",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13AC8/production/_129148508_mediaitem129148507.jpg",
-              "description": "Wannan shafi ne da yake kawo muku abubuwan da ke faruwa a Najeriya da sauran sassan duniya.",
-              "imageAlt": "ds",
-              "id": "c1e7fd59-8aa6-4e94-91fa-899b8a02324d"
-            },
-            {
-              "type": "article",
-              "title": "Yadda matan Indiya suke amfani da allura domin kariya daga cin zarafi",
-              "firstPublished": "2023-03-26T16:52:16.036Z",
-              "link": "https://www.bbc.com/hausa/articles/crg5jzrljk8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f04a/live/56e132e0-ca5a-11ed-be2e-754a65c11505.jpg",
-              "description": "Kusan kowace mace a Indiya tana da labarin da za ta bayar na cin zarafin da ya faru a wajen taron mutane-Ko dai wani ya taba mata mama ko taba mata duwawunta, ko ya zunguri mamanta ko ya mata goge.",
-              "imageAlt": "...",
-              "id": "crg5jzrljk8o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:9f144cb4-ac4a-4072-b3ad-4681b4846261",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Labarai da Rahotanni Na Musamman",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT6M46S",
-              "title": "Daga Bakin Mai Ita tare da Bintu ta Dadin Kowa",
-              "firstPublished": "2023-05-11T03:59:29.221Z",
-              "link": "https://www.bbc.com/hausa/articles/c04mm49evveo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "A wannan mako, mun tattauna da Fatima Sa'id Abdullahi wadda aka fi sani da Bintu a shirin fim mai dogon zango, Dadin Kowa.",
-              "imageAlt": "",
-              "id": "c04mm49evveo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M28S",
-              "title": "'Abin da ya sa muke so a zaɓi Akpabio shugaban Majalisar Dattijai'",
-              "firstPublished": "2023-05-10T10:32:25.834Z",
-              "link": "https://www.bbc.com/hausa/articles/cm5llk53355o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Dalilan da suka sanya tsofaffin sanatoci ke son Sanata Godswill Akpabio ya zama shugaban Majalisar Dattijan Najeriya.",
-              "imageAlt": "",
-              "id": "cm5llk53355o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M39S",
-              "title": "Yadda Turkiyya ta canza a ƙarƙashin mulkin Erdogan",
-              "firstPublished": "2023-05-09T20:48:36.722Z",
-              "link": "https://www.bbc.com/hausa/articles/cyree52dg6jo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Zaɓen jin ra'ayin jama'a ya nuna cewa shugaban na fuskantar gagarumar adawa daga wajen babban abokin karawarsa, Kemal Kilicdaroglu.",
-              "imageAlt": "",
-              "id": "cyree52dg6jo"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M31S",
-              "title": "Sana'ar gargajiyar da har yanzu ke fid da matasan zamani kunya ",
-              "firstPublished": "2023-05-09T03:52:02.750Z",
-              "link": "https://www.bbc.com/hausa/articles/ckdy20v2241o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "A bidiyon, matashi Mukhtar Muhammad ya yi bayani game da sana'ar ta bugu da yadda ake yin ta. Ya ce sana'ar ta bugu ta yi masa rana don kuwa, da ita ya samu ya kammala karatunsa, ya gina gida sannan ya yi aure, kuma yake riƙe iyalinsa.",
-              "imageAlt": "",
-              "id": "ckdy20v2241o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M58S",
-              "title": "Matashin da ke burin ƙera wa sojojin Najeriya jiragen yaƙi",
-              "firstPublished": "2023-05-08T04:08:16.456Z",
-              "link": "https://www.bbc.com/hausa/articles/cyjpr734gkzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Wani matashi mai fasahar ƙere-ƙere a Najeriya ya ce ya fara tunanin ƙera wa sojojin Najeriya jirgin yaƙi na sama maras matuƙi ne a lokacin da aka sace ɗaliban sakandiren Kankara su fiye da 300.",
-              "imageAlt": "",
-              "id": "cyjpr734gkzo"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M50S",
-              "title": "Abin da ya sa nake bin ra’ayi ƴaƴana game da rayuwarsu – Ali Nuhu",
-              "firstPublished": "2023-05-07T03:44:14.803Z",
-              "link": "https://www.bbc.com/hausa/articles/cev40vvqxw2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Fitaccen jarumin fina-finan Hausa na Kannywood Ali Nuhu ya ce inda don ta shi ne ya fi so ɗansa ya gaje shi a harkar fim.",
-              "imageAlt": "",
-              "id": "cev40vvqxw2o"
-            },
-            {
-              "type": "video",
-              "duration": "PT4M1S",
-              "title": "Muna fata sarki Charles lll ya yi koyi  da mahaifiyarsa wajen riƙe ƙasashen Afirka - Bazoum",
-              "firstPublished": "2023-05-06T15:50:40.711Z",
-              "link": "https://www.bbc.com/hausa/articles/c06pzp87x1xo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Shugaban ƙasar Nijar Mohamed Bazoum ya ce ƙasarsa da Birtaniya na da babbar alaƙa, kasancewa a shekarun baya-bayan na Birtaniya ta buɗe ofishin jakadanci a ƙasar domin ƙarfafa zumunci tsakanin ƙasashen biyu.",
-              "imageAlt": "",
-              "id": "c06pzp87x1xo"
-            },
-            {
-              "type": "video",
-              "duration": "PT8M50S",
-              "title": "Na sha suka ne kawai saboda a cusguna wa mijina - Turai 'Yar'adua",
-              "firstPublished": "2023-05-05T20:15:37.072Z",
-              "link": "https://www.bbc.com/hausa/articles/c6p9n47q583o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Uwargidan tsohon shugaban Najeriya, ta ce a kullum tana tuna rayuwarsu da Umaru 'Yar'adua, \"kawai dai bambancin yau (ranar cikarsa shekara 13 da rasuwa) ina jin daɗi saboda mutane suna taruwa ana karatu(n Alƙur'ani), ana yi masa addu'a\".  ",
-              "imageAlt": "",
-              "id": "c6p9n47q583o"
-            },
-            {
-              "type": "video",
-              "duration": "PT8M3S",
-              "title": "Ku San Malamanku  tare da Sheik Imam Mansur",
-              "firstPublished": "2023-05-05T04:40:33.903Z",
-              "link": "https://www.bbc.com/hausa/articles/c4n7dj99r83o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Sheik Mansur ɗaya ne daga cikin fitattun malaman Ɗariƙar Tijjaniya a jihar Kano",
-              "imageAlt": "",
-              "id": "c4n7dj99r83o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M38S",
-              "title": "Lokacin da ƴan Najeriya daga Sudan suka haɗu da ƴan’uwansu a Abuja",
-              "firstPublished": "2023-05-04T15:11:44.115Z",
-              "link": "https://www.bbc.com/hausa/articles/c8vr6gd22evo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Rukuni na farko na daliban na Najeriya daga Sudan waɗanda ke guje wa yaki sun isa gida ne da talatainin dare, ranar Laraba.",
-              "imageAlt": "",
-              "id": "c8vr6gd22evo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M24S",
-              "title": "Wane ne Charles, sabon sarkin Birtaniya?",
-              "firstPublished": "2023-05-04T11:16:43.751Z",
-              "link": "https://www.bbc.com/hausa/articles/cekdv5r84pgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "A ranar Asabar 6 ga watan Mayu ne za a rantsar da Sarki Charles a matsayin sarkin Birtaniya.",
-              "imageAlt": "",
-              "id": "cekdv5r84pgo"
-            },
-            {
-              "type": "video",
-              "duration": "PT4M55S",
-              "title": "Daga Bakin Mai Ita tare da Saude ta Daɗin Kowa",
-              "firstPublished": "2023-05-04T04:12:52.504Z",
-              "link": "https://www.bbc.com/hausa/articles/cv2kdy8ldk0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "",
-              "imageAlt": "",
-              "id": "cv2kdy8ldk0o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 14,
-          "curationId": "urn:bbc:vivo:curation:7bf2e91a-9585-49ad-b1f7-ec52eade566b",
-          "curationType": "vivo-stream",
-          "position": 2,
-          "title": "Labaran Bidiyo",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Sergio Busquets zai bar Barcelona a karshen kakar bana",
-              "firstPublished": "2023-05-10T15:05:28.795Z",
-              "link": "https://www.bbc.com/hausa/articles/cpedd071gq4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4d8a/live/c8185030-ef42-11ed-876b-9b5ed953ac30.jpg",
-              "description": "Kyaftin Sergio Busquets ya tabbatar da zai bar Barcelona a karshen kakar nan, bayan shekara 18 yana Camp Nou.",
-              "imageAlt": "Sergio Busquets",
-              "id": "cpedd071gq4o"
-            },
-            {
-              "type": "article",
-              "title": "Inter ta ci Milan a Champions League a wasan hamayya ",
-              "firstPublished": "2023-05-10T14:52:19.947Z",
-              "link": "https://www.bbc.com/hausa/articles/c51ll2d46pxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/41d1/live/b23d2f40-ef80-11ed-a835-b7ada014e694.jpg",
-              "description": "Inter Milan ta doke AC Milan da cin 2-0 a wasan farko a daf da karshe a Champions League ranar Laraba a Sansiro.",
-              "imageAlt": "Champions League",
-              "id": "c51ll2d46pxo"
-            },
-            {
-              "type": "article",
-              "title": "Man Utd za ta sayi Ramos, Chelsea na son riƙe Felix",
-              "firstPublished": "2023-05-10T03:44:22.869Z",
-              "link": "https://www.bbc.com/hausa/articles/c2ellrlj98eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a299/live/37553c80-eece-11ed-8656-6fd4be3d6b36.jpg",
-              "description": "Man Utd ta tattauna da Benfica domin sayen Goncalo Ramos, yayin da Chelsea za ta bayar da 'yan wasa biyu da kuɗi don riƙe Felix.",
-              "imageAlt": "Goncalo Ramos",
-              "id": "c2ellrlj98eo"
-            },
-            {
-              "type": "article",
-              "title": "Saka na daf da saka hannu kan ci gaba da taka leda a Arsenal",
-              "firstPublished": "2023-05-09T21:50:35.978Z",
-              "link": "https://www.bbc.com/hausa/articles/cqv0j7pwgexo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d62e/live/4feeaa60-eea1-11ed-afbc-135d5f64367b.jpg",
-              "description": "Arsenal na sa ran sanar da kulla yarjejeniya kafin karshen Premier League ta bana da cewar Bukayo Saka ya amince zai ci gaba da wasa a Gunners.",
-              "imageAlt": "Bukayo Saka",
-              "id": "cqv0j7pwgexo"
-            },
-            {
-              "type": "article",
-              "title": "Inaki Pena zai ci gaba da golan Barca zuwa 2026",
-              "firstPublished": "2023-05-09T15:46:58.029Z",
-              "link": "https://www.bbc.com/hausa/articles/c1900j721pko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/536c/live/e7313d80-ee7d-11ed-95f4-432d69491e22.jpg",
-              "description": "Barcelona ta cimma yarjejeniya da Inaki Pena, domin ya ci gaba da wasa a kungiyar zuwa karshen kakar Yunin 2026.",
-              "imageAlt": "Inaki Pena",
-              "id": "c1900j721pko"
-            },
-            {
-              "type": "article",
-              "title": "Real Madrid da Man City sun tashi 1-1 a Champions League",
-              "firstPublished": "2023-05-09T14:04:39.138Z",
-              "link": "https://www.bbc.com/hausa/articles/c2q1zl2drklo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/aae1/live/ea8715b0-ee71-11ed-b77c-232898381cd2.jpg",
-              "description": "Real Madrid da Manchester City sun tashi 1-1 a wasan farko a daf da karshe a Champions League ranar Talata a Santiago Bernabeu.",
-              "imageAlt": "Chamiopns League",
-              "id": "c2q1zl2drklo"
-            },
-            {
-              "type": "article",
-              "title": "PSG na zawarcin Mourinho, Messi da Al Hilal sun kasa cimma matsaya",
-              "firstPublished": "2023-05-09T03:50:37.664Z",
-              "link": "https://www.bbc.com/hausa/articles/c3g95jxw31qo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5fac/live/3f314e40-ee00-11ed-b387-ebf7ae18b0fb.jpg",
-              "description": "Mai bayar da shawara kan harkokin ƙwallon ƙafa na PSG, Luis Campos ya yi magana da wakilin Jose Mourinho a kan zama kociyan ƙungiyar.",
-              "imageAlt": "Jose Mourinho",
-              "id": "c3g95jxw31qo"
-            },
-            {
-              "type": "article",
-              "title": "Messi da Argentina sun lashe bikin kyautukan Laureus na wasanni ",
-              "firstPublished": "2023-05-08T19:06:22.792Z",
-              "link": "https://www.bbc.com/hausa/articles/cz51p2xn78do",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b5f5/live/87f0e560-edd2-11ed-997e-fb58a0712bf1.jpg",
-              "description": "Lionel Messi ya lashe kyautar fitatcen dan wasa, yayin da Argentina ta zama gwarzuwar tawaga ta shekara a bikin Laureus World Sports Awards.",
-              "imageAlt": "Lionel Messi",
-              "id": "cz51p2xn78do"
-            },
-            {
-              "type": "article",
-              "title": "Fulham ta kara yin kasa da Leicester a teburin Premier",
-              "firstPublished": "2023-05-08T17:15:21.406Z",
-              "link": "https://www.bbc.com/hausa/articles/c894ywwx9p9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/da12/live/7240e500-edc1-11ed-9b87-5dd5b5540288.jpg",
-              "description": "Fulham ta kara sa Leicester City cikin matsi, bayan cin 5-3 ranar Litinin a wasan mako na 35 a Premier League a Craven Cottage.",
-              "imageAlt": "Premier League",
-              "id": "c894ywwx9p9o"
-            },
-            {
-              "type": "article",
-              "title": "Artur Dias ne zai busa wasan Real da City a Champions League",
-              "firstPublished": "2023-05-08T15:08:55.671Z",
-              "link": "https://www.bbc.com/hausa/articles/c6p5zgw77rzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2a95/live/ebd84680-edb0-11ed-9720-4d91333e4ae1.jpg",
-              "description": " Artur Dias ne zai busa wasan Real Madrid da Manchester City a Champions League ranar Talata.",
-              "imageAlt": "Artur Dias",
-              "id": "c6p5zgw77rzo"
-            },
-            {
-              "type": "article",
-              "title": "Za mu kare cikin 'yan hudun farko a Premier League - Ten Hag",
-              "firstPublished": "2023-05-08T14:26:26.826Z",
-              "link": "https://www.bbc.com/hausa/articles/cz9rj8pg8jeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/12bb/live/6eac6080-eda9-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "Erik ten Hag ya ce har yanzu Manchester United tana da damar kammala gasar Premier League ta bana a cikin 'yan hudun farko.",
-              "imageAlt": "Erik ten Hag",
-              "id": "cz9rj8pg8jeo"
-            },
-            {
-              "type": "article",
-              "title": "Barcelona na son Gundogan, Napoli za ta rike Osimhen",
-              "firstPublished": "2023-05-08T04:07:48.524Z",
-              "link": "https://www.bbc.com/hausa/articles/cx8p5wnr42eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28d1/live/8a99bb80-ed54-11ed-b4db-359123bad414.jpg",
-              "description": "Barcelona na da kwarin gwiwar kammala cinikin dan wasan tsakiya na Manchester City da Jamus Ilkay Gundogan.",
-              "imageAlt": "Ilkay Gundogan",
-              "id": "cx8p5wnr42eo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 40,
-          "curationId": "urn:bbc:vivo:curation:8bec007e-f0cd-4a73-8768-cd7a5548ab81",
-          "curationType": "vivo-stream",
-          "position": 3,
-          "title": "Wasanni",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Da wuya a samu maganin cutar kansa a nan kusa – Bincike",
-              "firstPublished": "2023-04-13T11:42:39.389Z",
-              "link": "https://www.bbc.com/hausa/articles/clkl8kegyxpo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/52a7/live/06714830-d9ec-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Sakamakon nazarin da aka gudanar ta hanyar bibiyar cutukan kansa na tsawon shekara tara, ya bai wa masu bincike mamaki da tsoro kan irin jan aikin da ke gabansu.",
-              "imageAlt": "...",
-              "id": "clkl8kegyxpo"
-            },
-            {
-              "type": "article",
-              "title": "An yi gwajin ƙwayar hana haihuwa ga maza",
-              "firstPublished": "2023-02-18T04:12:03.727Z",
-              "link": "https://www.bbc.com/hausa/articles/c3g3391gp75o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e294/live/ebfdf9c0-adf0-11ed-8f65-71bfa0525ce3.png",
-              "description": "Masana kimiyya sun ce akwai yiwuwar a ci nasara wajen tabbatar da wata ƙwayar hana haihuwa, bayan gano wani sanadari da ke iya hana maniyyi tafiya zuwa wurin da ƙwayaye suke.",
-              "imageAlt": "Maniyyi lokacin da yake shiga cikin ƙwai",
-              "id": "c3g3391gp75o"
-            },
-            {
-              "type": "article",
-              "title": "Saudiyya za ta tura mace ta farko zuwa sararin samaniya a 2023",
-              "firstPublished": "2023-02-14T04:25:34.302Z",
-              "link": "https://www.bbc.com/hausa/articles/c89ejr5l1j8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c6a0/live/49467190-abbf-11ed-8f65-71bfa0525ce3.jpg",
-              "description": "Ƙasar Saudiyya ta bayyana cewa za ta aika mace ta farko cikin 'yan sama jannatin da za ta tura zuwa sararin samaniya a cikin wannan shekarar.",
-              "imageAlt": "Tashar sararin samaniya ta ƙasa da ƙasa",
-              "id": "c89ejr5l1j8o"
-            },
-            {
-              "type": "article",
-              "title": "Ƙasashen da za su yi rige-rigen zuwa duniyar wata a 2023",
-              "firstPublished": "2023-01-02T03:48:09.547Z",
-              "link": "https://www.bbc.com/hausa/articles/c88gwwev6p7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/74bb/live/eaaf6b70-86b9-11ed-90a7-556e529f9f89.png",
-              "description": "A shekarar 2023, Rasha da Indiya da Hukumar Kula da Sararin Samaniyar Tarayyar Turai za su ƙdaamar da shirin zuwa duniyar wata da kuma kutsawa can cikin sararin samaniya.will be launching missions to the Moon, and further into deep space.",
-              "imageAlt": "Picture of nose cone of Artemis-i SLS rocket and Orion capsule on launch gantry with moon above ",
-              "id": "c88gwwev6p7o"
-            },
-            {
-              "type": "article",
-              "title": "Masana kimiyya sun gano sirrin kwaɗi masu jikin tangaran da kamewar jini ",
-              "firstPublished": "2022-12-24T04:01:24.973Z",
-              "link": "https://www.bbc.com/hausa/articles/c2jgl1n25xjo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3353/live/4abe5cf0-832d-11ed-90a7-556e529f9f89.jpg",
-              "description": "Tun da daɗewa masana kimiyya suna da masaniya game da kwaɗo mai jikin tangaran amma ba su iya fahimtar yadda yake rikiɗa har ake iya ganin cikin cikinsa ba.",
-              "imageAlt": "glass frog",
-              "id": "c2jgl1n25xjo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M25S",
-              "title": "Za a fara duba yawan ruwan da ke doron duniya daga sararin samaniya",
-              "firstPublished": "2022-12-21T16:13:51.492Z",
-              "link": "https://www.bbc.com/hausa/articles/c3gpg73370do",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Hukumar sararin samaniya ta Amurka ta ƙaddamar da wani tauraron ɗan adam za ta yi bincike na farko kan yawan ruwan da ke kwarara a doron duniya.",
-              "imageAlt": "",
-              "id": "c3gpg73370do"
-            },
-            {
-              "type": "article",
-              "title": "Abin da ya kamata ku sani kan ƙirƙirar kazar da za ta dinga haifar kaza zalla ",
-              "firstPublished": "2022-12-17T03:51:00.999Z",
-              "link": "https://www.bbc.com/hausa/articles/c99g0njk5rgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a642/live/629af250-7c90-11ed-90a7-556e529f9f89.png",
-              "description": "Masu bincike a Isra'ila sun ce sun ƙirƙiri kazar da aka yi wa ƙwayoyin halittarta kwaskwarima don su dinga haifar kaji mata zalla. ",
-              "imageAlt": "'Yan tsakin da aka jirkita wa ƙwayoyin halitta za su dinga haihuwar kaji ne kawai ban da zakaru ",
-              "id": "c99g0njk5rgo"
-            },
-            {
-              "type": "article",
-              "title": "Jirgin da Nasa ta aika duniyar wata ya komo duniyarmu ta Earth lafiya",
-              "firstPublished": "2022-12-12T16:59:15.832Z",
-              "link": "https://www.bbc.com/hausa/articles/cp47plv18dko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a9d9/live/6071fc30-7a3d-11ed-90a7-556e529f9f89.jpg",
-              "description": "Kan rokar mai suna Orion capsule, ya fado kasa cikin Tekun Pacific, bayan ya yi wa duniyar wata shigar burtu, tare da dawowa doron kasa.",
-              "imageAlt": "apollo ",
-              "id": "cp47plv18dko"
-            },
-            {
-              "type": "video",
-              "duration": "PT50S",
-              "title": "Yadda ƴan sama jannatin Nasa suka fita tattaki a sararin samaniya ",
-              "firstPublished": "2022-12-05T18:10:45.547Z",
-              "link": "https://www.bbc.com/hausa/articles/c16594r5epzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "A﻿ wannan bidiyon za ku ga yadda ƴan sama jannatin Nasa suka fita tattaki daga cikin tashar ƙasa da ƙasa da ke shawagi a sararin samaniya don kafa faifan solar a kan tashar ta ISS.",
-              "imageAlt": "",
-              "id": "c16594r5epzo"
-            },
-            {
-              "type": "article",
-              "title": "M﻿e ke faruwa a cikin dutse mafi girma mai aman wuta?",
-              "firstPublished": "2022-12-01T03:51:22.286Z",
-              "link": "https://www.bbc.com/hausa/articles/crg72v2p4rdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/88f6/live/e9ad6f50-70c1-11ed-94b2-efbc7109d3dd.png",
-              "description": "T﻿algen wutan yana ta kwarara ta gefen dutsen a zafin da ya kai digiri 1,000 a ma'aunin celcius, sai dai masana na cewa wannan ba zai kasance wata barazana ba ga mazauna wurin.",
-              "imageAlt": "..",
-              "id": "crg72v2p4rdo"
-            },
-            {
-              "type": "article",
-              "title": "An haife tagwayen da aka daskarar da 'yan tayinsu shekara 30 da suka wuce",
-              "firstPublished": "2022-11-23T10:40:44.908Z",
-              "link": "https://www.bbc.com/hausa/articles/cv271ke60yeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/98dd/live/af074a20-6b11-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "\"﻿Shekarata biyar a lokacin da Ubangiji ya wanzar da rayuwar Lydia da Timothy, ya kuma ta adana rayuwar tasu sun lokacin har sai yanzu da suka zama mutane,\" kamar yadda Philip Ridgeway ya shaida wa CNN.",
-              "imageAlt": "Yan biyu",
-              "id": "cv271ke60yeo"
-            },
-            {
-              "type": "article",
-              "title": "Yadda k﻿umbon Artemis ya isa duniyar wata lami lafiya",
-              "firstPublished": "2022-11-23T09:22:20.398Z",
-              "link": "https://www.bbc.com/hausa/articles/c25kjg4w9g0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3685/live/580f2300-6b0c-11ed-94b2-efbc7109d3dd.png",
-              "description": "Nasa ta ce zuwa yanzu dai shirin \"ya wuce yadda aka tsammace shi\" tun bayan ƙaddamar da shi a makon da ya gabata.",
-              "imageAlt": "Orion da Wata",
-              "id": "c25kjg4w9g0o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 5,
-          "curationId": "urn:bbc:vivo:curation:3517b320-d238-4d82-9556-9d01ca43de1d",
-          "curationType": "vivo-stream",
-          "position": 4,
-          "title": "Kimiyya da Fasaha",
-          "visualProminence": "NORMAL"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from Live TIPO page"
-  }
+  "data": {
+    "title": "BBC News Hausa",
+    "description": "",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Zaɓuka kusan 100 INEC za ta ƙarasa a watan gobe",
+            "firstPublished": "2023-03-27T14:51:06.555Z",
+            "link": "https://www.bbc.com/hausa/articles/cevny200752o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ca4e/live/a3a13b40-ccab-11ed-9b0a-6f4a90e45a6a.jpg",
+            "description": "A wani saƙo da ta wallafa a shafinta na Twitter ranar Litinin, INEC  ta ce ta yanke wannan shawara ce bayan wata ganawa tsakanin manyan jami'anta.",
+            "imageAlt": "INEC Chair",
+            "id": "cevny200752o"
+          },
+          {
+            "type": "article",
+            "title": "Ƴan Najeriya za su yi kewar Buhari idan ya gama mulki – Garba Shehu",
+            "firstPublished": "2023-03-27T07:26:37.000Z",
+            "link": "https://www.bbc.com/hausa/live/labarai-65086040",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4FA2/production/_129168302__114295251_40161767_2152852741595472_3271934952567996416_n.jpg",
+            "description": "Wannan shafi ne da yake kawo muku abubuwan da ke faruwa a Najeriya da sauran sassan duniya.",
+            "imageAlt": "Garba Shehu",
+            "id": "f0db6ef0-3a0d-41a8-8868-a8c40c0ff2e0"
+          },
+          {
+            "type": "article",
+            "title": "Abin da ya sa muka dakatar da Iyorchia Ayu - PDP",
+            "firstPublished": "2023-03-27T09:53:54.835Z",
+            "link": "https://www.bbc.com/hausa/articles/cqvj351npexo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3962/live/eb1881a0-cc82-11ed-be2e-754a65c11505.png",
+            "description": "Jam'iyyar PDP ta ce ta dakatar da shugabanta na ƙasa, Iyorchia Ayu bisa zargin sa da wasu ayyuka na cin amanar jam'iyyar.",
+            "imageAlt": "...",
+            "id": "cqvj351npexo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:94c73456-7ae0-4033-8e88-8e4240a65f2e",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "'Yadda surukata ta ɓata cikin laka bayan mahaukaciyar guguwa'",
+            "firstPublished": "2023-03-26T11:26:10.076Z",
+            "link": "https://www.bbc.com/hausa/articles/c51e5wwge9yo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1bbd/live/0f60c450-c88c-11ed-8985-09a61927b152.png",
+            "description": "Jikokin Violet Frank guda biyu suna tuna mata surukarta da ta ɓata, bayan afkuwar mummunar guguwar da ta yi sanadin rugujewar ɗaruruwan gidaje. ",
+            "imageAlt": "Violet Frank",
+            "id": "c51e5wwge9yo"
+          },
+          {
+            "type": "commentary",
+            "title": "Rundunar sojin Najeriya ta ƙaryata zargin kisan ƙananan yara",
+            "firstPublished": "2023-03-26T07:38:59.000Z",
+            "link": "https://www.bbc.com/hausa/live/labarai-65079802",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13AC8/production/_129148508_mediaitem129148507.jpg",
+            "description": "Wannan shafi ne da yake kawo muku abubuwan da ke faruwa a Najeriya da sauran sassan duniya.",
+            "imageAlt": "ds",
+            "id": "c1e7fd59-8aa6-4e94-91fa-899b8a02324d"
+          },
+          {
+            "type": "article",
+            "title": "Yadda matan Indiya suke amfani da allura domin kariya daga cin zarafi",
+            "firstPublished": "2023-03-26T16:52:16.036Z",
+            "link": "https://www.bbc.com/hausa/articles/crg5jzrljk8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f04a/live/56e132e0-ca5a-11ed-be2e-754a65c11505.jpg",
+            "description": "Kusan kowace mace a Indiya tana da labarin da za ta bayar na cin zarafin da ya faru a wajen taron mutane-Ko dai wani ya taba mata mama ko taba mata duwawunta, ko ya zunguri mamanta ko ya mata goge.",
+            "imageAlt": "...",
+            "id": "crg5jzrljk8o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:9f144cb4-ac4a-4072-b3ad-4681b4846261",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Labarai da Rahotanni Na Musamman",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT6M46S",
+            "title": "Daga Bakin Mai Ita tare da Bintu ta Dadin Kowa",
+            "firstPublished": "2023-05-11T03:59:29.221Z",
+            "link": "https://www.bbc.com/hausa/articles/c04mm49evveo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "A wannan mako, mun tattauna da Fatima Sa'id Abdullahi wadda aka fi sani da Bintu a shirin fim mai dogon zango, Dadin Kowa.",
+            "imageAlt": "",
+            "id": "c04mm49evveo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M28S",
+            "title": "'Abin da ya sa muke so a zaɓi Akpabio shugaban Majalisar Dattijai'",
+            "firstPublished": "2023-05-10T10:32:25.834Z",
+            "link": "https://www.bbc.com/hausa/articles/cm5llk53355o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Dalilan da suka sanya tsofaffin sanatoci ke son Sanata Godswill Akpabio ya zama shugaban Majalisar Dattijan Najeriya.",
+            "imageAlt": "",
+            "id": "cm5llk53355o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M39S",
+            "title": "Yadda Turkiyya ta canza a ƙarƙashin mulkin Erdogan",
+            "firstPublished": "2023-05-09T20:48:36.722Z",
+            "link": "https://www.bbc.com/hausa/articles/cyree52dg6jo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Zaɓen jin ra'ayin jama'a ya nuna cewa shugaban na fuskantar gagarumar adawa daga wajen babban abokin karawarsa, Kemal Kilicdaroglu.",
+            "imageAlt": "",
+            "id": "cyree52dg6jo"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M31S",
+            "title": "Sana'ar gargajiyar da har yanzu ke fid da matasan zamani kunya ",
+            "firstPublished": "2023-05-09T03:52:02.750Z",
+            "link": "https://www.bbc.com/hausa/articles/ckdy20v2241o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "A bidiyon, matashi Mukhtar Muhammad ya yi bayani game da sana'ar ta bugu da yadda ake yin ta. Ya ce sana'ar ta bugu ta yi masa rana don kuwa, da ita ya samu ya kammala karatunsa, ya gina gida sannan ya yi aure, kuma yake riƙe iyalinsa.",
+            "imageAlt": "",
+            "id": "ckdy20v2241o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M58S",
+            "title": "Matashin da ke burin ƙera wa sojojin Najeriya jiragen yaƙi",
+            "firstPublished": "2023-05-08T04:08:16.456Z",
+            "link": "https://www.bbc.com/hausa/articles/cyjpr734gkzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Wani matashi mai fasahar ƙere-ƙere a Najeriya ya ce ya fara tunanin ƙera wa sojojin Najeriya jirgin yaƙi na sama maras matuƙi ne a lokacin da aka sace ɗaliban sakandiren Kankara su fiye da 300.",
+            "imageAlt": "",
+            "id": "cyjpr734gkzo"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M50S",
+            "title": "Abin da ya sa nake bin ra’ayi ƴaƴana game da rayuwarsu – Ali Nuhu",
+            "firstPublished": "2023-05-07T03:44:14.803Z",
+            "link": "https://www.bbc.com/hausa/articles/cev40vvqxw2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Fitaccen jarumin fina-finan Hausa na Kannywood Ali Nuhu ya ce inda don ta shi ne ya fi so ɗansa ya gaje shi a harkar fim.",
+            "imageAlt": "",
+            "id": "cev40vvqxw2o"
+          },
+          {
+            "type": "video",
+            "duration": "PT4M1S",
+            "title": "Muna fata sarki Charles lll ya yi koyi  da mahaifiyarsa wajen riƙe ƙasashen Afirka - Bazoum",
+            "firstPublished": "2023-05-06T15:50:40.711Z",
+            "link": "https://www.bbc.com/hausa/articles/c06pzp87x1xo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Shugaban ƙasar Nijar Mohamed Bazoum ya ce ƙasarsa da Birtaniya na da babbar alaƙa, kasancewa a shekarun baya-bayan na Birtaniya ta buɗe ofishin jakadanci a ƙasar domin ƙarfafa zumunci tsakanin ƙasashen biyu.",
+            "imageAlt": "",
+            "id": "c06pzp87x1xo"
+          },
+          {
+            "type": "video",
+            "duration": "PT8M50S",
+            "title": "Na sha suka ne kawai saboda a cusguna wa mijina - Turai 'Yar'adua",
+            "firstPublished": "2023-05-05T20:15:37.072Z",
+            "link": "https://www.bbc.com/hausa/articles/c6p9n47q583o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Uwargidan tsohon shugaban Najeriya, ta ce a kullum tana tuna rayuwarsu da Umaru 'Yar'adua, \"kawai dai bambancin yau (ranar cikarsa shekara 13 da rasuwa) ina jin daɗi saboda mutane suna taruwa ana karatu(n Alƙur'ani), ana yi masa addu'a\".  ",
+            "imageAlt": "",
+            "id": "c6p9n47q583o"
+          },
+          {
+            "type": "video",
+            "duration": "PT8M3S",
+            "title": "Ku San Malamanku  tare da Sheik Imam Mansur",
+            "firstPublished": "2023-05-05T04:40:33.903Z",
+            "link": "https://www.bbc.com/hausa/articles/c4n7dj99r83o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Sheik Mansur ɗaya ne daga cikin fitattun malaman Ɗariƙar Tijjaniya a jihar Kano",
+            "imageAlt": "",
+            "id": "c4n7dj99r83o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M38S",
+            "title": "Lokacin da ƴan Najeriya daga Sudan suka haɗu da ƴan’uwansu a Abuja",
+            "firstPublished": "2023-05-04T15:11:44.115Z",
+            "link": "https://www.bbc.com/hausa/articles/c8vr6gd22evo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Rukuni na farko na daliban na Najeriya daga Sudan waɗanda ke guje wa yaki sun isa gida ne da talatainin dare, ranar Laraba.",
+            "imageAlt": "",
+            "id": "c8vr6gd22evo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M24S",
+            "title": "Wane ne Charles, sabon sarkin Birtaniya?",
+            "firstPublished": "2023-05-04T11:16:43.751Z",
+            "link": "https://www.bbc.com/hausa/articles/cekdv5r84pgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "A ranar Asabar 6 ga watan Mayu ne za a rantsar da Sarki Charles a matsayin sarkin Birtaniya.",
+            "imageAlt": "",
+            "id": "cekdv5r84pgo"
+          },
+          {
+            "type": "video",
+            "duration": "PT4M55S",
+            "title": "Daga Bakin Mai Ita tare da Saude ta Daɗin Kowa",
+            "firstPublished": "2023-05-04T04:12:52.504Z",
+            "link": "https://www.bbc.com/hausa/articles/cv2kdy8ldk0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "",
+            "imageAlt": "",
+            "id": "cv2kdy8ldk0o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 14,
+        "curationId": "urn:bbc:vivo:curation:7bf2e91a-9585-49ad-b1f7-ec52eade566b",
+        "curationType": "vivo-stream",
+        "position": 2,
+        "title": "Labaran Bidiyo",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Sergio Busquets zai bar Barcelona a karshen kakar bana",
+            "firstPublished": "2023-05-10T15:05:28.795Z",
+            "link": "https://www.bbc.com/hausa/articles/cpedd071gq4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4d8a/live/c8185030-ef42-11ed-876b-9b5ed953ac30.jpg",
+            "description": "Kyaftin Sergio Busquets ya tabbatar da zai bar Barcelona a karshen kakar nan, bayan shekara 18 yana Camp Nou.",
+            "imageAlt": "Sergio Busquets",
+            "id": "cpedd071gq4o"
+          },
+          {
+            "type": "article",
+            "title": "Inter ta ci Milan a Champions League a wasan hamayya ",
+            "firstPublished": "2023-05-10T14:52:19.947Z",
+            "link": "https://www.bbc.com/hausa/articles/c51ll2d46pxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/41d1/live/b23d2f40-ef80-11ed-a835-b7ada014e694.jpg",
+            "description": "Inter Milan ta doke AC Milan da cin 2-0 a wasan farko a daf da karshe a Champions League ranar Laraba a Sansiro.",
+            "imageAlt": "Champions League",
+            "id": "c51ll2d46pxo"
+          },
+          {
+            "type": "article",
+            "title": "Man Utd za ta sayi Ramos, Chelsea na son riƙe Felix",
+            "firstPublished": "2023-05-10T03:44:22.869Z",
+            "link": "https://www.bbc.com/hausa/articles/c2ellrlj98eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a299/live/37553c80-eece-11ed-8656-6fd4be3d6b36.jpg",
+            "description": "Man Utd ta tattauna da Benfica domin sayen Goncalo Ramos, yayin da Chelsea za ta bayar da 'yan wasa biyu da kuɗi don riƙe Felix.",
+            "imageAlt": "Goncalo Ramos",
+            "id": "c2ellrlj98eo"
+          },
+          {
+            "type": "article",
+            "title": "Saka na daf da saka hannu kan ci gaba da taka leda a Arsenal",
+            "firstPublished": "2023-05-09T21:50:35.978Z",
+            "link": "https://www.bbc.com/hausa/articles/cqv0j7pwgexo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d62e/live/4feeaa60-eea1-11ed-afbc-135d5f64367b.jpg",
+            "description": "Arsenal na sa ran sanar da kulla yarjejeniya kafin karshen Premier League ta bana da cewar Bukayo Saka ya amince zai ci gaba da wasa a Gunners.",
+            "imageAlt": "Bukayo Saka",
+            "id": "cqv0j7pwgexo"
+          },
+          {
+            "type": "article",
+            "title": "Inaki Pena zai ci gaba da golan Barca zuwa 2026",
+            "firstPublished": "2023-05-09T15:46:58.029Z",
+            "link": "https://www.bbc.com/hausa/articles/c1900j721pko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/536c/live/e7313d80-ee7d-11ed-95f4-432d69491e22.jpg",
+            "description": "Barcelona ta cimma yarjejeniya da Inaki Pena, domin ya ci gaba da wasa a kungiyar zuwa karshen kakar Yunin 2026.",
+            "imageAlt": "Inaki Pena",
+            "id": "c1900j721pko"
+          },
+          {
+            "type": "article",
+            "title": "Real Madrid da Man City sun tashi 1-1 a Champions League",
+            "firstPublished": "2023-05-09T14:04:39.138Z",
+            "link": "https://www.bbc.com/hausa/articles/c2q1zl2drklo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/aae1/live/ea8715b0-ee71-11ed-b77c-232898381cd2.jpg",
+            "description": "Real Madrid da Manchester City sun tashi 1-1 a wasan farko a daf da karshe a Champions League ranar Talata a Santiago Bernabeu.",
+            "imageAlt": "Chamiopns League",
+            "id": "c2q1zl2drklo"
+          },
+          {
+            "type": "article",
+            "title": "PSG na zawarcin Mourinho, Messi da Al Hilal sun kasa cimma matsaya",
+            "firstPublished": "2023-05-09T03:50:37.664Z",
+            "link": "https://www.bbc.com/hausa/articles/c3g95jxw31qo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5fac/live/3f314e40-ee00-11ed-b387-ebf7ae18b0fb.jpg",
+            "description": "Mai bayar da shawara kan harkokin ƙwallon ƙafa na PSG, Luis Campos ya yi magana da wakilin Jose Mourinho a kan zama kociyan ƙungiyar.",
+            "imageAlt": "Jose Mourinho",
+            "id": "c3g95jxw31qo"
+          },
+          {
+            "type": "article",
+            "title": "Messi da Argentina sun lashe bikin kyautukan Laureus na wasanni ",
+            "firstPublished": "2023-05-08T19:06:22.792Z",
+            "link": "https://www.bbc.com/hausa/articles/cz51p2xn78do",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b5f5/live/87f0e560-edd2-11ed-997e-fb58a0712bf1.jpg",
+            "description": "Lionel Messi ya lashe kyautar fitatcen dan wasa, yayin da Argentina ta zama gwarzuwar tawaga ta shekara a bikin Laureus World Sports Awards.",
+            "imageAlt": "Lionel Messi",
+            "id": "cz51p2xn78do"
+          },
+          {
+            "type": "article",
+            "title": "Fulham ta kara yin kasa da Leicester a teburin Premier",
+            "firstPublished": "2023-05-08T17:15:21.406Z",
+            "link": "https://www.bbc.com/hausa/articles/c894ywwx9p9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/da12/live/7240e500-edc1-11ed-9b87-5dd5b5540288.jpg",
+            "description": "Fulham ta kara sa Leicester City cikin matsi, bayan cin 5-3 ranar Litinin a wasan mako na 35 a Premier League a Craven Cottage.",
+            "imageAlt": "Premier League",
+            "id": "c894ywwx9p9o"
+          },
+          {
+            "type": "article",
+            "title": "Artur Dias ne zai busa wasan Real da City a Champions League",
+            "firstPublished": "2023-05-08T15:08:55.671Z",
+            "link": "https://www.bbc.com/hausa/articles/c6p5zgw77rzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2a95/live/ebd84680-edb0-11ed-9720-4d91333e4ae1.jpg",
+            "description": " Artur Dias ne zai busa wasan Real Madrid da Manchester City a Champions League ranar Talata.",
+            "imageAlt": "Artur Dias",
+            "id": "c6p5zgw77rzo"
+          },
+          {
+            "type": "article",
+            "title": "Za mu kare cikin 'yan hudun farko a Premier League - Ten Hag",
+            "firstPublished": "2023-05-08T14:26:26.826Z",
+            "link": "https://www.bbc.com/hausa/articles/cz9rj8pg8jeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/12bb/live/6eac6080-eda9-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "Erik ten Hag ya ce har yanzu Manchester United tana da damar kammala gasar Premier League ta bana a cikin 'yan hudun farko.",
+            "imageAlt": "Erik ten Hag",
+            "id": "cz9rj8pg8jeo"
+          },
+          {
+            "type": "article",
+            "title": "Barcelona na son Gundogan, Napoli za ta rike Osimhen",
+            "firstPublished": "2023-05-08T04:07:48.524Z",
+            "link": "https://www.bbc.com/hausa/articles/cx8p5wnr42eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28d1/live/8a99bb80-ed54-11ed-b4db-359123bad414.jpg",
+            "description": "Barcelona na da kwarin gwiwar kammala cinikin dan wasan tsakiya na Manchester City da Jamus Ilkay Gundogan.",
+            "imageAlt": "Ilkay Gundogan",
+            "id": "cx8p5wnr42eo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 40,
+        "curationId": "urn:bbc:vivo:curation:8bec007e-f0cd-4a73-8768-cd7a5548ab81",
+        "curationType": "vivo-stream",
+        "position": 3,
+        "title": "Wasanni",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Da wuya a samu maganin cutar kansa a nan kusa – Bincike",
+            "firstPublished": "2023-04-13T11:42:39.389Z",
+            "link": "https://www.bbc.com/hausa/articles/clkl8kegyxpo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/52a7/live/06714830-d9ec-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Sakamakon nazarin da aka gudanar ta hanyar bibiyar cutukan kansa na tsawon shekara tara, ya bai wa masu bincike mamaki da tsoro kan irin jan aikin da ke gabansu.",
+            "imageAlt": "...",
+            "id": "clkl8kegyxpo"
+          },
+          {
+            "type": "article",
+            "title": "An yi gwajin ƙwayar hana haihuwa ga maza",
+            "firstPublished": "2023-02-18T04:12:03.727Z",
+            "link": "https://www.bbc.com/hausa/articles/c3g3391gp75o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e294/live/ebfdf9c0-adf0-11ed-8f65-71bfa0525ce3.png",
+            "description": "Masana kimiyya sun ce akwai yiwuwar a ci nasara wajen tabbatar da wata ƙwayar hana haihuwa, bayan gano wani sanadari da ke iya hana maniyyi tafiya zuwa wurin da ƙwayaye suke.",
+            "imageAlt": "Maniyyi lokacin da yake shiga cikin ƙwai",
+            "id": "c3g3391gp75o"
+          },
+          {
+            "type": "article",
+            "title": "Saudiyya za ta tura mace ta farko zuwa sararin samaniya a 2023",
+            "firstPublished": "2023-02-14T04:25:34.302Z",
+            "link": "https://www.bbc.com/hausa/articles/c89ejr5l1j8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c6a0/live/49467190-abbf-11ed-8f65-71bfa0525ce3.jpg",
+            "description": "Ƙasar Saudiyya ta bayyana cewa za ta aika mace ta farko cikin 'yan sama jannatin da za ta tura zuwa sararin samaniya a cikin wannan shekarar.",
+            "imageAlt": "Tashar sararin samaniya ta ƙasa da ƙasa",
+            "id": "c89ejr5l1j8o"
+          },
+          {
+            "type": "article",
+            "title": "Ƙasashen da za su yi rige-rigen zuwa duniyar wata a 2023",
+            "firstPublished": "2023-01-02T03:48:09.547Z",
+            "link": "https://www.bbc.com/hausa/articles/c88gwwev6p7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/74bb/live/eaaf6b70-86b9-11ed-90a7-556e529f9f89.png",
+            "description": "A shekarar 2023, Rasha da Indiya da Hukumar Kula da Sararin Samaniyar Tarayyar Turai za su ƙdaamar da shirin zuwa duniyar wata da kuma kutsawa can cikin sararin samaniya.will be launching missions to the Moon, and further into deep space.",
+            "imageAlt": "Picture of nose cone of Artemis-i SLS rocket and Orion capsule on launch gantry with moon above ",
+            "id": "c88gwwev6p7o"
+          },
+          {
+            "type": "article",
+            "title": "Masana kimiyya sun gano sirrin kwaɗi masu jikin tangaran da kamewar jini ",
+            "firstPublished": "2022-12-24T04:01:24.973Z",
+            "link": "https://www.bbc.com/hausa/articles/c2jgl1n25xjo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3353/live/4abe5cf0-832d-11ed-90a7-556e529f9f89.jpg",
+            "description": "Tun da daɗewa masana kimiyya suna da masaniya game da kwaɗo mai jikin tangaran amma ba su iya fahimtar yadda yake rikiɗa har ake iya ganin cikin cikinsa ba.",
+            "imageAlt": "glass frog",
+            "id": "c2jgl1n25xjo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M25S",
+            "title": "Za a fara duba yawan ruwan da ke doron duniya daga sararin samaniya",
+            "firstPublished": "2022-12-21T16:13:51.492Z",
+            "link": "https://www.bbc.com/hausa/articles/c3gpg73370do",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Hukumar sararin samaniya ta Amurka ta ƙaddamar da wani tauraron ɗan adam za ta yi bincike na farko kan yawan ruwan da ke kwarara a doron duniya.",
+            "imageAlt": "",
+            "id": "c3gpg73370do"
+          },
+          {
+            "type": "article",
+            "title": "Abin da ya kamata ku sani kan ƙirƙirar kazar da za ta dinga haifar kaza zalla ",
+            "firstPublished": "2022-12-17T03:51:00.999Z",
+            "link": "https://www.bbc.com/hausa/articles/c99g0njk5rgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a642/live/629af250-7c90-11ed-90a7-556e529f9f89.png",
+            "description": "Masu bincike a Isra'ila sun ce sun ƙirƙiri kazar da aka yi wa ƙwayoyin halittarta kwaskwarima don su dinga haifar kaji mata zalla. ",
+            "imageAlt": "'Yan tsakin da aka jirkita wa ƙwayoyin halitta za su dinga haihuwar kaji ne kawai ban da zakaru ",
+            "id": "c99g0njk5rgo"
+          },
+          {
+            "type": "article",
+            "title": "Jirgin da Nasa ta aika duniyar wata ya komo duniyarmu ta Earth lafiya",
+            "firstPublished": "2022-12-12T16:59:15.832Z",
+            "link": "https://www.bbc.com/hausa/articles/cp47plv18dko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a9d9/live/6071fc30-7a3d-11ed-90a7-556e529f9f89.jpg",
+            "description": "Kan rokar mai suna Orion capsule, ya fado kasa cikin Tekun Pacific, bayan ya yi wa duniyar wata shigar burtu, tare da dawowa doron kasa.",
+            "imageAlt": "apollo ",
+            "id": "cp47plv18dko"
+          },
+          {
+            "type": "video",
+            "duration": "PT50S",
+            "title": "Yadda ƴan sama jannatin Nasa suka fita tattaki a sararin samaniya ",
+            "firstPublished": "2022-12-05T18:10:45.547Z",
+            "link": "https://www.bbc.com/hausa/articles/c16594r5epzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "A﻿ wannan bidiyon za ku ga yadda ƴan sama jannatin Nasa suka fita tattaki daga cikin tashar ƙasa da ƙasa da ke shawagi a sararin samaniya don kafa faifan solar a kan tashar ta ISS.",
+            "imageAlt": "",
+            "id": "c16594r5epzo"
+          },
+          {
+            "type": "article",
+            "title": "M﻿e ke faruwa a cikin dutse mafi girma mai aman wuta?",
+            "firstPublished": "2022-12-01T03:51:22.286Z",
+            "link": "https://www.bbc.com/hausa/articles/crg72v2p4rdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/88f6/live/e9ad6f50-70c1-11ed-94b2-efbc7109d3dd.png",
+            "description": "T﻿algen wutan yana ta kwarara ta gefen dutsen a zafin da ya kai digiri 1,000 a ma'aunin celcius, sai dai masana na cewa wannan ba zai kasance wata barazana ba ga mazauna wurin.",
+            "imageAlt": "..",
+            "id": "crg72v2p4rdo"
+          },
+          {
+            "type": "article",
+            "title": "An haife tagwayen da aka daskarar da 'yan tayinsu shekara 30 da suka wuce",
+            "firstPublished": "2022-11-23T10:40:44.908Z",
+            "link": "https://www.bbc.com/hausa/articles/cv271ke60yeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/98dd/live/af074a20-6b11-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "\"﻿Shekarata biyar a lokacin da Ubangiji ya wanzar da rayuwar Lydia da Timothy, ya kuma ta adana rayuwar tasu sun lokacin har sai yanzu da suka zama mutane,\" kamar yadda Philip Ridgeway ya shaida wa CNN.",
+            "imageAlt": "Yan biyu",
+            "id": "cv271ke60yeo"
+          },
+          {
+            "type": "article",
+            "title": "Yadda k﻿umbon Artemis ya isa duniyar wata lami lafiya",
+            "firstPublished": "2022-11-23T09:22:20.398Z",
+            "link": "https://www.bbc.com/hausa/articles/c25kjg4w9g0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3685/live/580f2300-6b0c-11ed-94b2-efbc7109d3dd.png",
+            "description": "Nasa ta ce zuwa yanzu dai shirin \"ya wuce yadda aka tsammace shi\" tun bayan ƙaddamar da shi a makon da ya gabata.",
+            "imageAlt": "Orion da Wata",
+            "id": "c25kjg4w9g0o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 5,
+        "curationId": "urn:bbc:vivo:curation:3517b320-d238-4d82-9556-9d01ca43de1d",
+        "curationType": "vivo-stream",
+        "position": 4,
+        "title": "Kimiyya da Fasaha",
+        "visualProminence": "NORMAL"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cvp5j11g223t",
+        "contentType": "index-home",
+        "pageIdentifier": "hausa.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from Live TIPO page"
+}

--- a/data/hindi/homePage/index.json
+++ b/data/hindi/homePage/index.json
@@ -1,94 +1,101 @@
 {
-    "data": {
-      "title": "BBC News हिंदी",
-      "description": "हिंदी में ताज़ा समाचार, ब्रेकिंग न्यूज़, वीडियो, ऑडियो और फ़ीचर. बीबीसी हिंदी डॉटकॉम पर भारत, पाकिस्तान और चीन सहित दुनिया भर की ताज़ा ख़बरें. BBC HINDI for up-to-the-minute news, breaking news, video, audio and feature stories.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "आनंद मोहन के 'अपराध' और बिहार की राजनीति में उनके उतार-चढ़ाव की कहानी",
-              "firstPublished": "2023-04-26T10:37:20.000Z",
-              "link": "https://www.bbc.com/hindi/india-65398572",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D908/production/_129506555_11.jpg",
-              "description": "कभी पूर्व प्रधानमंत्री चंद्रशेखर के करीब रहे आनंद मोहन 1990 के दशक में बिहार की राजनीति में प्रमुखता से उभरे. एक डीएम की हत्या ने उनके चढ़ते ग्राफ़ को थाम दिया. अब वो फिर चर्चा में हैं.",
-              "imageAlt": "आनंद मोहन",
-              "id": "f1a17d16-866e-433e-9f30-4de334eadd76"
-            },
-            {
-              "type": "article",
-              "title": "राजस्थानः दलित लड़कियों का घोड़ी पर बैठना दलितों को ही गवारा नहीं",
-              "firstPublished": "2023-04-26T03:37:25.000Z",
-              "link": "https://www.bbc.com/hindi/india-65388279",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/17E1C/production/_129502879_img-20230422-wa0062.jpg",
-              "description": "बाड़मेर के मेली गांव में शादी से पहले लड़कियों को पहली बार घोड़ी पर बिठाया गया. इसके लिए उनके परिवार पर जुर्माना लगाया गया और न देने पर उन्हें समाज से निकाल दिया गया.",
-              "imageAlt": "राजस्थान",
-              "id": "12971e03-e015-4198-97de-c1547d49c2cd"
-            },
-            {
-              "type": "article",
-              "title": "छत्तीसगढ़ में माओवादी हमला, 10 जवानों समेत 11 की मौत",
-              "firstPublished": "2023-04-26T10:42:08.000Z",
-              "link": "https://www.bbc.com/hindi/india-65398579",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15162/production/_129507368_e16697cc-47c8-49a5-91f9-e56d6b416ba4.jpg",
-              "description": "पुलिस के मुताबिक दंतेवाड़ा के अरनपुर इलाके में संदिग्ध माओवादियों ने आईईडी से हमला किया. गृह मंत्री अमित शाह ने मुख्यमंत्री भूपेश बघेल से घटना की जानकारी ली है.",
-              "imageAlt": "घटनास्थल की तस्वीर",
-              "id": "cd8aa17a-c7fa-479a-832b-869803de3074"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:c5c30d41-8bb5-4681-8cd3-0d9231d9034a",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "पॉडकास्ट",
-              "firstPublished": "2022-06-16T09:10:08.000Z",
-              "link": "https://www.bbc.com/hindi/institutional-61824775",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1652D/production/_125873419_bsp_hindi.png",
-              "description": "बीबीसी हिंदी के पॉडकास्ट",
-              "imageAlt": "बात सरहद पार",
-              "id": "e7859d46-3530-483f-80b3-9c4b9ec329f2"
-            },
-            {
-              "type": "article",
-              "title": "करौली दंगे का ख़ौफ़ आज भी लोगों के ज़ेहन में ज़िंदा है: ग्राउंड रिपोर्ट",
-              "firstPublished": "2023-04-01T09:22:09.000Z",
-              "link": "https://www.bbc.com/hindi/india-65144626",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/149C8/production/_129242448_kotia.png",
-              "description": "बीते साल करौली में हुए दंगे ने राजस्थान जैसे शांत माने जाने वाले प्रदेश को देशभर में चर्चाओं में ला दिया था. एक साल बाद भी यहां दंगे के दाग़ मिटाने के प्रयास किए जा रहे हैं.",
-              "imageAlt": "सुशीला नेमिचंद कोटिया",
-              "id": "f8d70bf5-be51-47d2-bf4e-b1e5844e11ba"
-            },
-            {
-              "type": "article",
-              "title": "आईपीएल 2023 के पहले मैच में गुजरात टाइटंस की चेन्नई सुपर किंग्स पर जीत",
-              "firstPublished": "2023-03-31T16:08:00.000Z",
-              "link": "https://www.bbc.com/hindi/sport-65142107",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2259/production/_129239780_shubman_gill_ipl2023_ani.jpg",
-              "description": "ऋतुराज गायकवाड़ के 92 रनों की बदौलत चेन्नई सुपर किंग्स ने गुजरात टाइटंस के सामने जीत के लिए 179 रनों का लक्ष्य रखा था.",
-              "imageAlt": "शुभमन गिल",
-              "id": "de320fb1-2d32-470e-9c22-ac0b588b16f9"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:907e1c33-e9dc-4b9f-b6f2-6615e886bf74",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "ज़रूर पढ़ें",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from Live TIPO page"
-  }
+  "data": {
+    "title": "BBC News हिंदी",
+    "description": "हिंदी में ताज़ा समाचार, ब्रेकिंग न्यूज़, वीडियो, ऑडियो और फ़ीचर. बीबीसी हिंदी डॉटकॉम पर भारत, पाकिस्तान और चीन सहित दुनिया भर की ताज़ा ख़बरें. BBC HINDI for up-to-the-minute news, breaking news, video, audio and feature stories.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "आनंद मोहन के 'अपराध' और बिहार की राजनीति में उनके उतार-चढ़ाव की कहानी",
+            "firstPublished": "2023-04-26T10:37:20.000Z",
+            "link": "https://www.bbc.com/hindi/india-65398572",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D908/production/_129506555_11.jpg",
+            "description": "कभी पूर्व प्रधानमंत्री चंद्रशेखर के करीब रहे आनंद मोहन 1990 के दशक में बिहार की राजनीति में प्रमुखता से उभरे. एक डीएम की हत्या ने उनके चढ़ते ग्राफ़ को थाम दिया. अब वो फिर चर्चा में हैं.",
+            "imageAlt": "आनंद मोहन",
+            "id": "f1a17d16-866e-433e-9f30-4de334eadd76"
+          },
+          {
+            "type": "article",
+            "title": "राजस्थानः दलित लड़कियों का घोड़ी पर बैठना दलितों को ही गवारा नहीं",
+            "firstPublished": "2023-04-26T03:37:25.000Z",
+            "link": "https://www.bbc.com/hindi/india-65388279",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/17E1C/production/_129502879_img-20230422-wa0062.jpg",
+            "description": "बाड़मेर के मेली गांव में शादी से पहले लड़कियों को पहली बार घोड़ी पर बिठाया गया. इसके लिए उनके परिवार पर जुर्माना लगाया गया और न देने पर उन्हें समाज से निकाल दिया गया.",
+            "imageAlt": "राजस्थान",
+            "id": "12971e03-e015-4198-97de-c1547d49c2cd"
+          },
+          {
+            "type": "article",
+            "title": "छत्तीसगढ़ में माओवादी हमला, 10 जवानों समेत 11 की मौत",
+            "firstPublished": "2023-04-26T10:42:08.000Z",
+            "link": "https://www.bbc.com/hindi/india-65398579",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15162/production/_129507368_e16697cc-47c8-49a5-91f9-e56d6b416ba4.jpg",
+            "description": "पुलिस के मुताबिक दंतेवाड़ा के अरनपुर इलाके में संदिग्ध माओवादियों ने आईईडी से हमला किया. गृह मंत्री अमित शाह ने मुख्यमंत्री भूपेश बघेल से घटना की जानकारी ली है.",
+            "imageAlt": "घटनास्थल की तस्वीर",
+            "id": "cd8aa17a-c7fa-479a-832b-869803de3074"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:c5c30d41-8bb5-4681-8cd3-0d9231d9034a",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "पॉडकास्ट",
+            "firstPublished": "2022-06-16T09:10:08.000Z",
+            "link": "https://www.bbc.com/hindi/institutional-61824775",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1652D/production/_125873419_bsp_hindi.png",
+            "description": "बीबीसी हिंदी के पॉडकास्ट",
+            "imageAlt": "बात सरहद पार",
+            "id": "e7859d46-3530-483f-80b3-9c4b9ec329f2"
+          },
+          {
+            "type": "article",
+            "title": "करौली दंगे का ख़ौफ़ आज भी लोगों के ज़ेहन में ज़िंदा है: ग्राउंड रिपोर्ट",
+            "firstPublished": "2023-04-01T09:22:09.000Z",
+            "link": "https://www.bbc.com/hindi/india-65144626",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/149C8/production/_129242448_kotia.png",
+            "description": "बीते साल करौली में हुए दंगे ने राजस्थान जैसे शांत माने जाने वाले प्रदेश को देशभर में चर्चाओं में ला दिया था. एक साल बाद भी यहां दंगे के दाग़ मिटाने के प्रयास किए जा रहे हैं.",
+            "imageAlt": "सुशीला नेमिचंद कोटिया",
+            "id": "f8d70bf5-be51-47d2-bf4e-b1e5844e11ba"
+          },
+          {
+            "type": "article",
+            "title": "आईपीएल 2023 के पहले मैच में गुजरात टाइटंस की चेन्नई सुपर किंग्स पर जीत",
+            "firstPublished": "2023-03-31T16:08:00.000Z",
+            "link": "https://www.bbc.com/hindi/sport-65142107",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2259/production/_129239780_shubman_gill_ipl2023_ani.jpg",
+            "description": "ऋतुराज गायकवाड़ के 92 रनों की बदौलत चेन्नई सुपर किंग्स ने गुजरात टाइटंस के सामने जीत के लिए 179 रनों का लक्ष्य रखा था.",
+            "imageAlt": "शुभमन गिल",
+            "id": "de320fb1-2d32-470e-9c22-ac0b588b16f9"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:907e1c33-e9dc-4b9f-b6f2-6615e886bf74",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "ज़रूर पढ़ें",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cg8nwjjm7vet",
+        "contentType": "index-home",
+        "pageIdentifier": "hindi.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from Live TIPO page"
+}

--- a/data/igbo/homePage/index.json
+++ b/data/igbo/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "BBC News Ìgbò",
-      "description": "BBC News Igbo na-agbasa akụkọ sị Naịjirịa, Afịrịka na mba ụwa niile... Ihe na-eme ugbua gbasara akụkọ, egwuregwu, ihe nkiri na ihe na-ewu ewu... BBC Nkeji.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "DSS: Wepụ aka enwe n'ofe na Benue",
-              "firstPublished": "2018-01-22T07:23:31.000Z",
-              "link": "https://www.bbc.com/igbo/23182501",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/C23D/test/_63652794_hi043976049.jpg",
-              "description": "DSS achọpụtala n'aka ndị ISS dị na mkpamkpa nke na-akpa na Naijirịa ugbua nke gosiri na ọbughị nanị ndị Fulani na-achụ ehị na-kpa arụa",
-              "imageAlt": "DSS na Benue Steeti",
-              "id": "4a559b9f-5165-414a-aff5-df7c7e00ea71"
-            },
-            {
-              "type": "article",
-              "title": "Dịka osi ga n'ime asọmpi Premier League",
-              "firstPublished": "2018-01-20T20:13:11.000Z",
-              "link": "https://www.bbc.com/igbo/23182766",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/7AC1/test/_63652413_arsenalwin.jpg",
-              "description": "Asọmpi Premier league ndị ụbọchị taa akwakọrọla ọnụ, a na wetara gi osi ga. ebe otu egwuregwu ndị ama ama nwetachara mmeri n'asọmpi ha.",
-              "imageAlt": "Iwobi, Nacho,koscielny na Lacazette bụ ndị nyere Arsenal goolu",
-              "id": "8d557026-688f-174a-a1fc-0f6cfc79a7cd"
-            },
-            {
-              "type": "audio",
-              "title": "Akụkọ BBC Igbo na Nkeji",
-              "firstPublished": "2018-01-22T17:25:03.000Z",
-              "link": "https://www.bbc.com/igbo/23183171",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/AB95/test/_63652934_p01g1v11.jpg",
-              "description": "Akụkọ ihe na-eme n'ụwa niile",
-              "imageAlt": "Akụkọ ihe na-eme n'ụwa niile",
-              "id": "371a4efb-be07-944b-9073-4255a59e20aa"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:97c7bccd-d175-4359-9eb3-8663b92d787f",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Lee ihe Barcelona mere Real Betis",
-              "firstPublished": "2018-01-22T10:13:55.000Z",
-              "link": "https://www.bbc.com/igbo/23182930",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/0721/test/_63652810_hi016761180.jpg",
-              "description": "Barcelona emerigo Real Betis na asọmpị La Liga",
-              "imageAlt": "Lionel Messi",
-              "id": "acc14be3-0e2d-ad44-b452-475726998e1a"
-            },
-            {
-              "type": "article",
-              "title": "Aubameyang nwere ike ifu ndị Arsenal ọnụ ego karịrị nderi pounds iri ise",
-              "firstPublished": "2018-01-21T14:51:44.000Z",
-              "link": "https://www.bbc.com/igbo/23182890",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/9EB1/test/_63652604_aubameyang.jpg",
-              "description": "Agbu a ndị otu bọọlụ Arsenal na Dortmund ebidola mkparịta ụka maka azụma ahịa Aubameyang dịka ọ ga-abụ onye kacha oke ọnụ ahịa ndị Arsenal ga-azụ.",
-              "imageAlt": "Aubameyang enyela ọkpụ goolu iri na atọ n'ime asọmpi iri na ise na oge a",
-              "id": "140306d0-dd86-ca48-93ac-6b54bc8b35be"
-            },
-            {
-              "type": "article",
-              "title": "\"Alexis Sanchez ga-abanye Manchester united ma ọ buru na.....\" Wenger",
-              "firstPublished": "2018-01-21T08:29:37.000Z",
-              "link": "https://www.bbc.com/igbo/23182810",
-              "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/FF91/test/_63652456_henrykandsanchez.jpg",
-              "description": "Onye nchikwa Arsenal ,Arsene wenger ekwuola na Alexis Sanchez ga-abanye Manchester United ma ọ buru na Henrikh Mkhitaryan bata otu Arsenal",
-              "imageAlt": "Alexis Sanchez gawa Manchester United,Henrikh Mkhitaryan a bata Arsenal Fc",
-              "id": "b31b1d97-e133-fa45-924f-43ac66f1edeb"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:bfc90fa6-512b-4b7f-accd-29a4c4530679",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Editor's choice",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from test TIPO page"
-  }
+  "data": {
+    "title": "BBC News Ìgbò",
+    "description": "BBC News Igbo na-agbasa akụkọ sị Naịjirịa, Afịrịka na mba ụwa niile... Ihe na-eme ugbua gbasara akụkọ, egwuregwu, ihe nkiri na ihe na-ewu ewu... BBC Nkeji.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "DSS: Wepụ aka enwe n'ofe na Benue",
+            "firstPublished": "2018-01-22T07:23:31.000Z",
+            "link": "https://www.bbc.com/igbo/23182501",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/C23D/test/_63652794_hi043976049.jpg",
+            "description": "DSS achọpụtala n'aka ndị ISS dị na mkpamkpa nke na-akpa na Naijirịa ugbua nke gosiri na ọbughị nanị ndị Fulani na-achụ ehị na-kpa arụa",
+            "imageAlt": "DSS na Benue Steeti",
+            "id": "4a559b9f-5165-414a-aff5-df7c7e00ea71"
+          },
+          {
+            "type": "article",
+            "title": "Dịka osi ga n'ime asọmpi Premier League",
+            "firstPublished": "2018-01-20T20:13:11.000Z",
+            "link": "https://www.bbc.com/igbo/23182766",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/7AC1/test/_63652413_arsenalwin.jpg",
+            "description": "Asọmpi Premier league ndị ụbọchị taa akwakọrọla ọnụ, a na wetara gi osi ga. ebe otu egwuregwu ndị ama ama nwetachara mmeri n'asọmpi ha.",
+            "imageAlt": "Iwobi, Nacho,koscielny na Lacazette bụ ndị nyere Arsenal goolu",
+            "id": "8d557026-688f-174a-a1fc-0f6cfc79a7cd"
+          },
+          {
+            "type": "audio",
+            "title": "Akụkọ BBC Igbo na Nkeji",
+            "firstPublished": "2018-01-22T17:25:03.000Z",
+            "link": "https://www.bbc.com/igbo/23183171",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/AB95/test/_63652934_p01g1v11.jpg",
+            "description": "Akụkọ ihe na-eme n'ụwa niile",
+            "imageAlt": "Akụkọ ihe na-eme n'ụwa niile",
+            "id": "371a4efb-be07-944b-9073-4255a59e20aa"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:97c7bccd-d175-4359-9eb3-8663b92d787f",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Lee ihe Barcelona mere Real Betis",
+            "firstPublished": "2018-01-22T10:13:55.000Z",
+            "link": "https://www.bbc.com/igbo/23182930",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/0721/test/_63652810_hi016761180.jpg",
+            "description": "Barcelona emerigo Real Betis na asọmpị La Liga",
+            "imageAlt": "Lionel Messi",
+            "id": "acc14be3-0e2d-ad44-b452-475726998e1a"
+          },
+          {
+            "type": "article",
+            "title": "Aubameyang nwere ike ifu ndị Arsenal ọnụ ego karịrị nderi pounds iri ise",
+            "firstPublished": "2018-01-21T14:51:44.000Z",
+            "link": "https://www.bbc.com/igbo/23182890",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/9EB1/test/_63652604_aubameyang.jpg",
+            "description": "Agbu a ndị otu bọọlụ Arsenal na Dortmund ebidola mkparịta ụka maka azụma ahịa Aubameyang dịka ọ ga-abụ onye kacha oke ọnụ ahịa ndị Arsenal ga-azụ.",
+            "imageAlt": "Aubameyang enyela ọkpụ goolu iri na atọ n'ime asọmpi iri na ise na oge a",
+            "id": "140306d0-dd86-ca48-93ac-6b54bc8b35be"
+          },
+          {
+            "type": "article",
+            "title": "\"Alexis Sanchez ga-abanye Manchester united ma ọ buru na.....\" Wenger",
+            "firstPublished": "2018-01-21T08:29:37.000Z",
+            "link": "https://www.bbc.com/igbo/23182810",
+            "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/FF91/test/_63652456_henrykandsanchez.jpg",
+            "description": "Onye nchikwa Arsenal ,Arsene wenger ekwuola na Alexis Sanchez ga-abanye Manchester United ma ọ buru na Henrikh Mkhitaryan bata otu Arsenal",
+            "imageAlt": "Alexis Sanchez gawa Manchester United,Henrikh Mkhitaryan a bata Arsenal Fc",
+            "id": "b31b1d97-e133-fa45-924f-43ac66f1edeb"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:bfc90fa6-512b-4b7f-accd-29a4c4530679",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Editor's choice",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c44evppzkj4t",
+        "contentType": "index-home",
+        "pageIdentifier": "igbo.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from test TIPO page"
+}

--- a/data/indonesia/homePage/index.json
+++ b/data/indonesia/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "Berita - BBC News Indonesia",
-      "description": "Berbagai laporan mendalam yang membahas teknologi dan ilmu pengetahuan dalam tahap riset, penerapan, maupun konsep.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "WHO kembali temukan obat batuk sirup beracun buatan India",
-              "firstPublished": "2023-04-26T08:31:30.519Z",
-              "link": "https://www.bbc.com/indonesia/articles/c510wq291ywo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c6ed/live/0b7cb6a0-e407-11ed-9232-39fabe427fdc.jpg",
-              "description": "Organisasi Kesehatan Dunia (WHO) mengatakan bahwa sejumlah sirup obat batuk yang diproduksi di India yang terkontaminasi telah ditemukan di Kepulauan Marshall dan Mikronesia. Obat tersebut mengandung senyawa yang beracun dan 'bisa berakibat fatal' jika dikonsumsi manusia.",
-              "imageAlt": "Guaifenesin digunakan sebagai obat untuk meredakan dada yang tersumbat dan gejala batuk",
-              "id": "c510wq291ywo"
-            },
-            {
-              "type": "article",
-              "title": "PPP dan PDIP pilih Ganjar Pranowo sebagai capres ",
-              "firstPublished": "2023-04-21T06:59:39.827Z",
-              "link": "https://www.bbc.com/indonesia/articles/ckrk2ynv9npo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b81/live/53f2ce40-e08f-11ed-a76d-f53e6a30358f.jpg",
-              "description": "Ketua Umum DPP PDIP, Megawati Soekarnoputri, resmi mengumumkan Ganjar Pranowo sebagai calon presiden pilihan Partai Demokrasi Indonesia Perjuangan (PDIP) menjelang Pemilu 2024.",
-              "imageAlt": "Ketua Umum PDI Perjuangan Megawati Soekarnoputri (tengah) menyematkan peci kepada calon Presiden 2024 yang diajukan PDI Perjuangan Ganjar Pranowo (kanan) di Istana Batu Tulis, Bogor, Jawa Barat, Jumat (21/04). ",
-              "id": "ckrk2ynv9npo"
-            },
-            {
-              "type": "article",
-              "title": "Petani sebut 'panas luar biasa', apakah Indonesia terkena gelombang panas?",
-              "firstPublished": "2023-04-26T01:18:38.091Z",
-              "link": "https://www.bbc.com/indonesia/articles/cnk0xyz0495o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9dc9/live/21d2a8b0-e3d0-11ed-b5e3-a77137eaf5ea.jpg",
-              "description": "Badan Meteorologi, Klimatologi, dan Geofisika (BMKG) mengatakan bahwa gelombang panas Asia yang tengah melanda Asia Selatan tidak terjadi pada Indonesia. Namun, para petani dan warganet mulai khawatir cuaca di Indonesia akan semakin panas mendekati musim kemarau. ",
-              "imageAlt": "Petani di Banda Aceh terdampak kekeringan.",
-              "id": "cnk0xyz0495o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:cc23f79c-5394-4402-9339-e33176d13e78",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Rusia pimpin Dewan Keamanan PBB, Ukraina: ‘Lelucon April Mop terburuk’",
-              "firstPublished": "2023-04-01T23:54:37.000Z",
-              "link": "https://www.bbc.com/indonesia/dunia-65152584",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C2FA/production/_129241994_3c97db3984891d5791181fba703f3d2473bf143b0_0_5184_35791000x690.jpg",
-              "description": "Menteri Luar Negeri Ukraina, Dmytro Kuleba, menyebut kepemimpinan Rusia dalam DK PBB merupakan \"lelucon terburuk yang pernah ada untuk Hari April Mop\".",
-              "imageAlt": "Tank Rusia bergerak di Kota Mariupol, Ukraina, pada Maret 2022.",
-              "id": "a856ef6a-49c3-4c45-ab84-b050c34a3ca6"
-            },
-            {
-              "type": "article",
-              "title": "Menyandingkan penolakan Israel di Piala Dunia U-20 dengan sikap Sukarno di Asian Games 1962, relevankah? ",
-              "firstPublished": "2023-04-01T02:39:32.722Z",
-              "link": "https://www.bbc.com/indonesia/articles/c25vev1re52o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7303/live/4b53ddf0-cfd3-11ed-b15c-a1f77745679f.jpg",
-              "description": "",
-              "imageAlt": "Anggota komunitas CentennialZ memegang poster saat melakukan \"Aksi Duka 1 Juta Pita Hitam\" di kawasan Senayan, Jakarta, Jumat (31/03)",
-              "id": "c25vev1re52o"
-            },
-            {
-              "type": "article",
-              "title": "'Saya kasihan pada putri saya' - Warga Thailand keluhkan kabut polusi kuning yang semakin tebal",
-              "firstPublished": "2023-04-02T04:43:44.755Z",
-              "link": "https://www.bbc.com/indonesia/articles/crgjl25711go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/da12/live/a97667e0-cfab-11ed-ba41-8f6fba0dffcb.jpg",
-              "description": "Thommamoon Khowasat telah berusaha menjelaskan pada putrinya yang berumur empat tahun bahwa awan kuning di luar jendela mereka – yang telah menangkap imajinasinya – sebenarnya berbahaya bagi kesehatannya.",
-              "imageAlt": "Thommamoon Khowasat khawatir akan kualitas udara buruk yang semakin parah di Chiang Rai",
-              "id": "crgjl25711go"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:02c6143c-e86a-47f4-bb44-953623d15f7a",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Majalah",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "Berita - BBC News Indonesia",
+    "description": "Berbagai laporan mendalam yang membahas teknologi dan ilmu pengetahuan dalam tahap riset, penerapan, maupun konsep.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "WHO kembali temukan obat batuk sirup beracun buatan India",
+            "firstPublished": "2023-04-26T08:31:30.519Z",
+            "link": "https://www.bbc.com/indonesia/articles/c510wq291ywo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c6ed/live/0b7cb6a0-e407-11ed-9232-39fabe427fdc.jpg",
+            "description": "Organisasi Kesehatan Dunia (WHO) mengatakan bahwa sejumlah sirup obat batuk yang diproduksi di India yang terkontaminasi telah ditemukan di Kepulauan Marshall dan Mikronesia. Obat tersebut mengandung senyawa yang beracun dan 'bisa berakibat fatal' jika dikonsumsi manusia.",
+            "imageAlt": "Guaifenesin digunakan sebagai obat untuk meredakan dada yang tersumbat dan gejala batuk",
+            "id": "c510wq291ywo"
+          },
+          {
+            "type": "article",
+            "title": "PPP dan PDIP pilih Ganjar Pranowo sebagai capres ",
+            "firstPublished": "2023-04-21T06:59:39.827Z",
+            "link": "https://www.bbc.com/indonesia/articles/ckrk2ynv9npo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b81/live/53f2ce40-e08f-11ed-a76d-f53e6a30358f.jpg",
+            "description": "Ketua Umum DPP PDIP, Megawati Soekarnoputri, resmi mengumumkan Ganjar Pranowo sebagai calon presiden pilihan Partai Demokrasi Indonesia Perjuangan (PDIP) menjelang Pemilu 2024.",
+            "imageAlt": "Ketua Umum PDI Perjuangan Megawati Soekarnoputri (tengah) menyematkan peci kepada calon Presiden 2024 yang diajukan PDI Perjuangan Ganjar Pranowo (kanan) di Istana Batu Tulis, Bogor, Jawa Barat, Jumat (21/04). ",
+            "id": "ckrk2ynv9npo"
+          },
+          {
+            "type": "article",
+            "title": "Petani sebut 'panas luar biasa', apakah Indonesia terkena gelombang panas?",
+            "firstPublished": "2023-04-26T01:18:38.091Z",
+            "link": "https://www.bbc.com/indonesia/articles/cnk0xyz0495o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9dc9/live/21d2a8b0-e3d0-11ed-b5e3-a77137eaf5ea.jpg",
+            "description": "Badan Meteorologi, Klimatologi, dan Geofisika (BMKG) mengatakan bahwa gelombang panas Asia yang tengah melanda Asia Selatan tidak terjadi pada Indonesia. Namun, para petani dan warganet mulai khawatir cuaca di Indonesia akan semakin panas mendekati musim kemarau. ",
+            "imageAlt": "Petani di Banda Aceh terdampak kekeringan.",
+            "id": "cnk0xyz0495o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:cc23f79c-5394-4402-9339-e33176d13e78",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Rusia pimpin Dewan Keamanan PBB, Ukraina: ‘Lelucon April Mop terburuk’",
+            "firstPublished": "2023-04-01T23:54:37.000Z",
+            "link": "https://www.bbc.com/indonesia/dunia-65152584",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C2FA/production/_129241994_3c97db3984891d5791181fba703f3d2473bf143b0_0_5184_35791000x690.jpg",
+            "description": "Menteri Luar Negeri Ukraina, Dmytro Kuleba, menyebut kepemimpinan Rusia dalam DK PBB merupakan \"lelucon terburuk yang pernah ada untuk Hari April Mop\".",
+            "imageAlt": "Tank Rusia bergerak di Kota Mariupol, Ukraina, pada Maret 2022.",
+            "id": "a856ef6a-49c3-4c45-ab84-b050c34a3ca6"
+          },
+          {
+            "type": "article",
+            "title": "Menyandingkan penolakan Israel di Piala Dunia U-20 dengan sikap Sukarno di Asian Games 1962, relevankah? ",
+            "firstPublished": "2023-04-01T02:39:32.722Z",
+            "link": "https://www.bbc.com/indonesia/articles/c25vev1re52o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7303/live/4b53ddf0-cfd3-11ed-b15c-a1f77745679f.jpg",
+            "description": "",
+            "imageAlt": "Anggota komunitas CentennialZ memegang poster saat melakukan \"Aksi Duka 1 Juta Pita Hitam\" di kawasan Senayan, Jakarta, Jumat (31/03)",
+            "id": "c25vev1re52o"
+          },
+          {
+            "type": "article",
+            "title": "'Saya kasihan pada putri saya' - Warga Thailand keluhkan kabut polusi kuning yang semakin tebal",
+            "firstPublished": "2023-04-02T04:43:44.755Z",
+            "link": "https://www.bbc.com/indonesia/articles/crgjl25711go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/da12/live/a97667e0-cfab-11ed-ba41-8f6fba0dffcb.jpg",
+            "description": "Thommamoon Khowasat telah berusaha menjelaskan pada putrinya yang berumur empat tahun bahwa awan kuning di luar jendela mereka – yang telah menangkap imajinasinya – sebenarnya berbahaya bagi kesehatannya.",
+            "imageAlt": "Thommamoon Khowasat khawatir akan kualitas udara buruk yang semakin parah di Chiang Rai",
+            "id": "crgjl25711go"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:02c6143c-e86a-47f4-bb44-953623d15f7a",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Majalah",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:ck2nelljke2t",
+        "contentType": "index-home",
+        "pageIdentifier": "indonesia.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/japanese/homePage/index.json
+++ b/data/japanese/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "最新ニュース - BBCニュース",
-      "description": "BBCニュースが伝える世界の動き、BBCニュースならではの視点を日本語でお届けします。世界各地で取材する日々の出来事、世界の人が注目している話題の紹介や解説を、日本語の記事、ビデオ、写真ギャラリーなどで",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "過去最深の海中で泳ぐ魚を確認　伊豆・小笠原海溝＝国際研究グループ",
-              "firstPublished": "2023-04-03T08:50:19.000Z",
-              "link": "https://www.bbc.com/japanese/features-and-analysis-65161437",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/EED8/production/_129244116_index.jpg",
-              "description": "日本やオーストラリアなどの科学者が参加する国際研究チームがこのほど、これまでに最も深い海中で泳ぐ魚を確認した。「スネイルフィッシュ」として知られるクサウオの一種で、伊豆・小笠原海溝の水深8336メートルで撮影された。",
-              "imageAlt": "Deepest fish",
-              "id": "21b5533a-7624-42b8-84df-0893de57db4d"
-            },
-            {
-              "type": "article",
-              "title": "【解説】 トランプ氏起訴はみんな分かっていた、それでも大きな衝撃",
-              "firstPublished": "2023-03-31T08:36:38.000Z",
-              "link": "https://www.bbc.com/japanese/features-and-analysis-65136156",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/139AF/production/_129230308_trumpintexas.jpg",
-              "description": "トランプ前米大統領が起訴された。大きな衝撃が米政界に広がっている。",
-              "imageAlt": "Donald Trump dances during a rally at the Waco Regional Airport on March 25, 2023",
-              "id": "a083dc05-69aa-4644-8087-09863c3e21be"
-            },
-            {
-              "type": "article",
-              "title": "トランプ前米大統領を訴追するマンハッタンの検事とは",
-              "firstPublished": "2023-04-02T02:51:23.000Z",
-              "link": "https://www.bbc.com/japanese/features-and-analysis-65152671",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8420/production/_129042833_gettyimages-1447235029.jpg",
-              "description": "アルヴィン・ブラッグ氏（49）は2021年、黒人男性として史上初めて、ニューヨーク地区検事に公選された。そのブラッグ検事が浴びる歴史のスポットライトは、ますますまぶしさを増している。",
-              "imageAlt": "Manhattan District Attorney Alvin Bragg at the New York Supreme Court in December 2022",
-              "id": "b294dcfa-5e33-4efe-88c9-a3ab5a04fa44"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:eb3bbee0-b44a-43bb-8a6d-d29a9127ce2d",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "読み物・解説",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "最新ニュース - BBCニュース",
+    "description": "BBCニュースが伝える世界の動き、BBCニュースならではの視点を日本語でお届けします。世界各地で取材する日々の出来事、世界の人が注目している話題の紹介や解説を、日本語の記事、ビデオ、写真ギャラリーなどで",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "過去最深の海中で泳ぐ魚を確認　伊豆・小笠原海溝＝国際研究グループ",
+            "firstPublished": "2023-04-03T08:50:19.000Z",
+            "link": "https://www.bbc.com/japanese/features-and-analysis-65161437",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/EED8/production/_129244116_index.jpg",
+            "description": "日本やオーストラリアなどの科学者が参加する国際研究チームがこのほど、これまでに最も深い海中で泳ぐ魚を確認した。「スネイルフィッシュ」として知られるクサウオの一種で、伊豆・小笠原海溝の水深8336メートルで撮影された。",
+            "imageAlt": "Deepest fish",
+            "id": "21b5533a-7624-42b8-84df-0893de57db4d"
+          },
+          {
+            "type": "article",
+            "title": "【解説】 トランプ氏起訴はみんな分かっていた、それでも大きな衝撃",
+            "firstPublished": "2023-03-31T08:36:38.000Z",
+            "link": "https://www.bbc.com/japanese/features-and-analysis-65136156",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/139AF/production/_129230308_trumpintexas.jpg",
+            "description": "トランプ前米大統領が起訴された。大きな衝撃が米政界に広がっている。",
+            "imageAlt": "Donald Trump dances during a rally at the Waco Regional Airport on March 25, 2023",
+            "id": "a083dc05-69aa-4644-8087-09863c3e21be"
+          },
+          {
+            "type": "article",
+            "title": "トランプ前米大統領を訴追するマンハッタンの検事とは",
+            "firstPublished": "2023-04-02T02:51:23.000Z",
+            "link": "https://www.bbc.com/japanese/features-and-analysis-65152671",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8420/production/_129042833_gettyimages-1447235029.jpg",
+            "description": "アルヴィン・ブラッグ氏（49）は2021年、黒人男性として史上初めて、ニューヨーク地区検事に公選された。そのブラッグ検事が浴びる歴史のスポットライトは、ますますまぶしさを増している。",
+            "imageAlt": "Manhattan District Attorney Alvin Bragg at the New York Supreme Court in December 2022",
+            "id": "b294dcfa-5e33-4efe-88c9-a3ab5a04fa44"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:eb3bbee0-b44a-43bb-8a6d-d29a9127ce2d",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "読み物・解説",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c44evppzl99t",
+        "contentType": "index-home",
+        "pageIdentifier": "japanese.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/korean/homePage/index.json
+++ b/data/korean/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News 코리아",
-      "description": "BBC 코리아&#x27;는 한반도는 물론 전 세계 독자 및 청취자에게 뉴스를 전달합니다. 우리의 목표는 공정하고 공평한 뉴스를 보도하는 것입니다.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "스토미 대니얼스와 도널드 트럼프 사이에 무슨 일이 있었나?",
-              "firstPublished": "2023-03-31T06:22:24.000Z",
-              "link": "https://www.bbc.com/korean/international-65096697",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/140F/production/_128953150_befunkycollage.jpg",
-              "description": "트럼프는 2018년 의혹이 제기된 이후 대니얼스와의 성적 관계를 부인해왔다.",
-              "imageAlt": "Collage photograph of Mr Trump and his wife, Melania and adult film star Stormy Daniels",
-              "id": "2a8c416a-ccee-43f2-a595-93397e9b8923"
-            },
-            {
-              "type": "article",
-              "title": "골드만삭스, ‘AI가 일자리 3억 개 대체할 수 있어’",
-              "firstPublished": "2023-03-30T09:22:26.517Z",
-              "link": "https://www.bbc.com/korean/articles/cld11p4vkr2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/82b1/live/18f62e60-cedb-11ed-be2e-754a65c11505.jpg",
-              "description": "세계적인 투자 은행 ‘골드만삭스’가 인공지능(AI)이 앞으로 정규직 일자리 3억 개를 대체할 수도 있다는 내용의 보고서를 발표했다. 다만 AI의 장기적인 영향은 매우 불확실하다며 확고하게 들리는 예측이라도 걸러 들어야 한다는 의견도 제기됐다.",
-              "imageAlt": "직장에서 컴퓨터를 보고 있는 두 여성",
-              "id": "cld11p4vkr2o"
-            },
-            {
-              "type": "article",
-              "title": "럼블: 사용자가 주류 플랫폼에서 ‘취소당하는’ 것을 막겠다는 SNS 기업",
-              "firstPublished": "2023-03-27T05:18:29.777Z",
-              "link": "https://www.bbc.com/korean/articles/cz9jvzjpe8zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/05ea/live/0ba3e0e0-cc51-11ed-be2e-754a65c11505.jpg",
-              "description": "지난 2013년 영상 스트리밍 웹사이트로 시작한 ‘럼블’은 “다양한 견해를 환영하는 중립적인 플랫폼”을 표방하며 기존 빅테크 기업의 SNS 컨텐츠 관리 기조에 맞서고 있다.",
-              "imageAlt": "럼블 로고와 여러 사람의 얼굴",
-              "id": "cz9jvzjpe8zo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:18119a7d-3da0-4c12-b380-1f176c4769ca",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "이 시간 이슈",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News 코리아",
+    "description": "BBC 코리아&#x27;는 한반도는 물론 전 세계 독자 및 청취자에게 뉴스를 전달합니다. 우리의 목표는 공정하고 공평한 뉴스를 보도하는 것입니다.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "스토미 대니얼스와 도널드 트럼프 사이에 무슨 일이 있었나?",
+            "firstPublished": "2023-03-31T06:22:24.000Z",
+            "link": "https://www.bbc.com/korean/international-65096697",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/140F/production/_128953150_befunkycollage.jpg",
+            "description": "트럼프는 2018년 의혹이 제기된 이후 대니얼스와의 성적 관계를 부인해왔다.",
+            "imageAlt": "Collage photograph of Mr Trump and his wife, Melania and adult film star Stormy Daniels",
+            "id": "2a8c416a-ccee-43f2-a595-93397e9b8923"
+          },
+          {
+            "type": "article",
+            "title": "골드만삭스, ‘AI가 일자리 3억 개 대체할 수 있어’",
+            "firstPublished": "2023-03-30T09:22:26.517Z",
+            "link": "https://www.bbc.com/korean/articles/cld11p4vkr2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/82b1/live/18f62e60-cedb-11ed-be2e-754a65c11505.jpg",
+            "description": "세계적인 투자 은행 ‘골드만삭스’가 인공지능(AI)이 앞으로 정규직 일자리 3억 개를 대체할 수도 있다는 내용의 보고서를 발표했다. 다만 AI의 장기적인 영향은 매우 불확실하다며 확고하게 들리는 예측이라도 걸러 들어야 한다는 의견도 제기됐다.",
+            "imageAlt": "직장에서 컴퓨터를 보고 있는 두 여성",
+            "id": "cld11p4vkr2o"
+          },
+          {
+            "type": "article",
+            "title": "럼블: 사용자가 주류 플랫폼에서 ‘취소당하는’ 것을 막겠다는 SNS 기업",
+            "firstPublished": "2023-03-27T05:18:29.777Z",
+            "link": "https://www.bbc.com/korean/articles/cz9jvzjpe8zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/05ea/live/0ba3e0e0-cc51-11ed-be2e-754a65c11505.jpg",
+            "description": "지난 2013년 영상 스트리밍 웹사이트로 시작한 ‘럼블’은 “다양한 견해를 환영하는 중립적인 플랫폼”을 표방하며 기존 빅테크 기업의 SNS 컨텐츠 관리 기조에 맞서고 있다.",
+            "imageAlt": "럼블 로고와 여러 사람의 얼굴",
+            "id": "cz9jvzjpe8zo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:18119a7d-3da0-4c12-b380-1f176c4769ca",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "이 시간 이슈",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c44evppzrvjt",
+        "contentType": "index-home",
+        "pageIdentifier": "korean.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/marathi/homePage/index.json
+++ b/data/marathi/homePage/index.json
@@ -1,608 +1,615 @@
 {
-    "data": {
-      "title": "बातम्या - BBC News मराठी",
-      "description": "महाराष्ट्र, देश आणि जगभरातल्या ताज्या बातम्या, लेख आणि व्हीडिओ. Get the latest BBC News stories from India and the world in Marathi.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "'कोण संजय राऊत' ते 'अजित पवार गोड माणूस'... पवार-राऊत वादाचा अर्थ काय?",
-              "firstPublished": "2023-04-21T12:05:47.129Z",
-              "link": "https://www.bbc.com/marathi/articles/crgxwdldgzwo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ff1b/live/88110e10-e0cd-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "महाविकास आघाडीतील दोन प्रमुख नेते – अजित पवार आणि संजय राऊत हे गेल्या काही दिवसांपासून आमनेसामने उभे ठाकले आहेत.",
-              "imageAlt": "अजित पवार",
-              "id": "crgxwdldgzwo"
-            },
-            {
-              "type": "article",
-              "title": "गोध्रा रेल्वे हिंसाचार प्रकरणातील आठ दोषींना जामीन मंजूर",
-              "firstPublished": "2019-12-11T08:56:11.000Z",
-              "link": "https://www.bbc.com/marathi/india-50739241",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F80A/production/_110089436_85a42487-7ccb-4437-aa15-d26707a06966.jpg",
-              "description": "या प्रकरणातील इतर 4 दोषींची संबंधित गुन्ह्यातील भूमिका पाहून त्यांना जामीन नाकारण्यात आल्याचं कोर्टाने सांगितलं.",
-              "imageAlt": "नानावटी अहवाल",
-              "id": "85e39c68-5bd3-1148-9440-a2b5464750f6"
-            },
-            {
-              "type": "article",
-              "title": "'माझा जन्म बलात्कारातून झाला; पण ती ओळख मला नकोय'",
-              "firstPublished": "2023-04-21T10:23:24.713Z",
-              "link": "https://www.bbc.com/marathi/articles/cjr1xl9wpjvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/02b6/live/bc1aa8c0-e02c-11ed-97eb-f9fe665d2627.jpg",
-              "description": "बलात्कारातून जन्माला येणाऱ्या मुलांना इंग्लंड आणि वेल्समध्ये आता गुन्हातले पीडित (victims of crime)अशी ओळख मिळणार, असं तिथल्या सरकारने जाहीर केलं आहे. ",
-              "imageAlt": "तसनिम",
-              "id": "cjr1xl9wpjvo"
-            },
-            {
-              "type": "article",
-              "title": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
-              "firstPublished": "2020-07-14T14:43:45.000Z",
-              "link": "https://www.bbc.com/marathi/india-53408193",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/494B/production/_129436781_gettyimages-1152519784.jpg",
-              "description": "मराठा आरक्षण सुप्रीम कोर्टाने फेटाळलं आहे. इंद्रा साहनी प्रकरणात सुप्रीम कोर्टाने जी 50 टक्के आरक्षण मर्यादा आखली होती ती ओलंडण्यास नकार दिला आहे.",
-              "imageAlt": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
-              "id": "77ef59b4-edc2-4062-af82-5b4c85580176"
-            },
-            {
-              "type": "article",
-              "title": "मटण विक्रेता ते युट्यूबर बनलेल्या 'राजा'ला  'बिझनेस मॉडेल' असं सापडलं..",
-              "firstPublished": "2023-04-21T09:21:35.238Z",
-              "link": "https://www.bbc.com/marathi/articles/czvkl8lxvywo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1349/live/6bbf9160-e022-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "पहिल्या सहा महिन्यात राजाला युट्यूबमधून केवळ 8 हजार रुपयांचं उत्पन्न मिळालं. पण त्या एका व्हीडिओने त्याचं बिझनेस मॉडेल सापडलं..",
-              "imageAlt": "बुहारी जंक्शन",
-              "id": "czvkl8lxvywo"
-            },
-            {
-              "type": "article",
-              "title": "सोन्याच्या खाणी असलेल्या सुदानसाठी हे सोनंच शाप बनलंय, कारण...",
-              "firstPublished": "2023-04-21T05:45:45.111Z",
-              "link": "https://www.bbc.com/marathi/articles/cev4lxln094o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cc14/live/cec6d2b0-dfb3-11ed-8527-1de9829b7a0e.jpg",
-              "description": "",
-              "imageAlt": "सुदान, सोनं, अर्थकारण",
-              "id": "cev4lxln094o"
-            },
-            {
-              "type": "article",
-              "title": "बीबीसी मराठी : या आठवड्यातील महत्त्वाच्या बातम्या आणि लेख..",
-              "firstPublished": "2023-04-21T12:53:33.205Z",
-              "link": "https://www.bbc.com/marathi/articles/cd1kdv8lzg4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e77d/live/0695f3a0-e041-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "राजकारण, मनोरंजन, प्रेरणादायी, ट्रेंडिंग आणि ज्ञानवर्धक असे पाच लेख जे तुम्ही नक्की वाचले पाहिजेत.. ",
-              "imageAlt": "ऐश्वर्या राय बच्चन आणि आराध्या बच्चन",
-              "id": "cd1kdv8lzg4o"
-            },
-            {
-              "type": "article",
-              "title": "'शेतीपेक्षा नोकरी मोठी नाही' असं म्हणत फेसबुकवरून शेती शिकवणारी सविता ताई",
-              "firstPublished": "2023-04-21T07:19:44.234Z",
-              "link": "https://www.bbc.com/marathi/articles/c4npqp7d50vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0310/live/6b077c10-e00e-11ed-846f-77d452f521b4.jpg",
-              "description": "“शेतकरी राजा आहे. कोरोनाने दाखवून दिलं की नोकरी कधीही जाऊ शकते. पण शेतात आपण कधीही पिकवून पोट भरू शकतो. दुसऱ्यांना खाऊ घालू शकतो.”",
-              "imageAlt": "शेतकरी सविता डकले",
-              "id": "c4npqp7d50vo"
-            },
-            {
-              "type": "link",
-              "title": "बाळाच्या जन्मापूर्वीच त्यात आवडीनुसार गुण आणणं शक्य आहे का? ऐका ही गोष्ट दुनियेची",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/marathi/podcasts/p0b1s4nm",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a581/live/2b46d450-e049-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "BBC Marathi podcast",
-              "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp0b1s4nm"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:9e770afa-9fff-4e31-b078-08d270c75723",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT4M29S",
-              "title": "चाकोरी मोडून हवेत उडणाऱ्या 'या' मुलींना भेटलात?",
-              "firstPublished": "2023-04-19T15:36:04.963Z",
-              "link": "https://www.bbc.com/marathi/articles/cd121xww570o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5440/live/4a02f430-e04b-11ed-8df1-d74cbf1089d7.jpg",
-              "description": " बीर बिलिंगला अ‍ॅक्युरसी पॅराग्लायडिंग चॅम्पियनशिप पार पडली.",
-              "imageAlt": "BBC Marathi",
-              "id": "cd121xww570o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M58S",
-              "title": "रमझानदरम्यान या बायका आपली पाळी का लपवतात?",
-              "firstPublished": "2023-04-17T15:55:13.670Z",
-              "link": "https://www.bbc.com/marathi/articles/c6plpd484l5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3fb8/live/22e05e30-dd38-11ed-bebb-19e897771a2d.jpg",
-              "description": " रमझानच्या महिन्यात महिलांना पाळी आली तर त्यांना जेवणाची सूट असते\n",
-              "imageAlt": "महिला ",
-              "id": "c6plpd484l5o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M32S",
-              "title": "सानपाड्याच्या उड्डाणपुलाखाली असं उभारलं क्रीडा संकुल",
-              "firstPublished": "2023-04-17T05:58:36.810Z",
-              "link": "https://www.bbc.com/marathi/articles/cleqe4dpn91o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e0a0/live/7d474b10-dce1-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "\nनवी मुंबईतील सानपाडा येथील उड्डाणपुलाखाली महानगरपालिकेतर्फे क्रीडा संकुल सुरू बनवण्यात आलं आहे.",
-              "imageAlt": "सानपाडा ",
-              "id": "cleqe4dpn91o"
-            },
-            {
-              "type": "video",
-              "duration": "PT5M14S",
-              "title": "डान्स करुन हे आजी-आजोबा पार्किन्सन कसे विसरले?",
-              "firstPublished": "2023-04-12T16:24:46.676Z",
-              "link": "https://www.bbc.com/marathi/articles/c2j7y5zr1z3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3109/live/6589f590-d94e-11ed-8f78-bbb0e517b829.png",
-              "description": "पार्किन्सन हा आजार मेंदूमधल्या बदलांमुळे होतो.",
-              "imageAlt": "parkinson",
-              "id": "c2j7y5zr1z3o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M24S",
-              "title": "पतीच्या मृतदेहासाठी ती 84 दिवस लढली आणि...",
-              "firstPublished": "2023-04-21T11:19:02.366Z",
-              "link": "https://www.bbc.com/marathi/articles/ce96dejv6mvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7f65/live/08bac3e0-e04b-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "पतीचा मृत्यू झाल्यानंतर त्याच्या मृतदेहासाठी त्यांना इतकं का झगडावं लागलं?",
-              "imageAlt": "BBC Marathi",
-              "id": "ce96dejv6mvo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M56S",
-              "title": "अंधश्रद्धेपोटी या पती–पत्नीने होम करून स्वतःला असं संपवलं...",
-              "firstPublished": "2023-04-21T09:13:27.847Z",
-              "link": "https://www.bbc.com/marathi/articles/c97653er2elo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6637/live/dda78b20-e04a-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "अतिशय धार्मिक वृत्तीच्या जोडप्याने मुक्ती मिळवण्याच्या उद्देशाने कमळ पूजा केली. बळी म्हणून त्यांनी स्वत:लाच अर्पण केलं. ",
-              "imageAlt": "BBC Marathi",
-              "id": "c97653er2elo"
-            },
-            {
-              "type": "video",
-              "duration": "PT8M",
-              "title": "मासिक पाळी : शारीरिक वाढ योग्य, पण वयात येऊनही पाळी सुरू न होण्यामागची कारणं काय?",
-              "firstPublished": "2023-04-17T06:00:58.606Z",
-              "link": "https://www.bbc.com/marathi/articles/cp4142vwy4xo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b1de/live/cc24b230-dce2-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "period",
-              "id": "cp4142vwy4xo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M29S",
-              "title": "पुण्यात हापूस आंबाही आता EMIवर मिळतोय, पाहा कसा...",
-              "firstPublished": "2023-04-14T10:26:44.005Z",
-              "link": "https://www.bbc.com/marathi/articles/cxepzp6prmjo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b683/live/07879080-e04a-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "पुण्यात हापूस आंबा EMI वर मिळू लागलाय. पुण्यातल्या एका आंबे व्यापाऱ्याने ही शक्कल लढवलीय.",
-              "imageAlt": "BBC Marathi",
-              "id": "cxepzp6prmjo"
-            },
-            {
-              "type": "video",
-              "duration": "PT5M28S",
-              "title": "वेताळ टेकडी की रस्ता - पुणेकरांना नेमकं काय हवंय?",
-              "firstPublished": "2023-04-13T15:34:32.098Z",
-              "link": "https://www.bbc.com/marathi/articles/c19wx74vxkgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5dc8/live/7baf2080-da10-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "प्रस्तावित बालभारती ते पौड फाटा रस्ता वादाचं कारण ठरले आहेत.",
-              "imageAlt": "वेताळ टेकडी",
-              "id": "c19wx74vxkgo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "link": "https://www.bbc.com/marathi/topics/cl29j0epz13t",
-          "curationId": "urn:bbc:tipo:list:895e4320-6bd5-4bba-8c1f-cb5f041501c4",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "व्हीडिओ",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
-              "firstPublished": "2020-07-14T14:43:45.000Z",
-              "link": "https://www.bbc.com/marathi/india-53408193",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/494B/production/_129436781_gettyimages-1152519784.jpg",
-              "description": "मराठा आरक्षण सुप्रीम कोर्टाने फेटाळलं आहे. इंद्रा साहनी प्रकरणात सुप्रीम कोर्टाने जी 50 टक्के आरक्षण मर्यादा आखली होती ती ओलंडण्यास नकार दिला आहे.",
-              "imageAlt": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
-              "id": "77ef59b4-edc2-4062-af82-5b4c85580176"
-            },
-            {
-              "type": "article",
-              "title": "बीबीसी मराठी : या आठवड्यातील महत्त्वाच्या बातम्या आणि लेख..",
-              "firstPublished": "2023-04-21T12:53:33.205Z",
-              "link": "https://www.bbc.com/marathi/articles/cd1kdv8lzg4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e77d/live/0695f3a0-e041-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "राजकारण, मनोरंजन, प्रेरणादायी, ट्रेंडिंग आणि ज्ञानवर्धक असे पाच लेख जे तुम्ही नक्की वाचले पाहिजेत.. ",
-              "imageAlt": "ऐश्वर्या राय बच्चन आणि आराध्या बच्चन",
-              "id": "cd1kdv8lzg4o"
-            },
-            {
-              "type": "article",
-              "title": "शिवाजी महाराजांचे हिंदुत्व आणि आताचे हिंदुत्व वेगळे आहे, असं शाहू महाराज छत्रपती यांनी का म्हटलं? ",
-              "firstPublished": "2023-04-20T06:19:33.007Z",
-              "link": "https://www.bbc.com/marathi/articles/c04v75d4y8jo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd8a/live/e3d7b1b0-df68-11ed-b18c-c7bc9fbbf441.jpg",
-              "description": "“हमे समझाने का मौका भी नहीं मिला. कोई साथ नही दे रहा था. मेरे चाचा का गोडाऊन भी जलाया. गाव मे सब बोल रहे थे की हमे निकालनेवाले है.”",
-              "imageAlt": "शाहू महाराज छत्रपती ",
-              "id": "c04v75d4y8jo"
-            },
-            {
-              "type": "article",
-              "title": "'महाराष्ट्र भूषण' कार्यक्रमातील दुर्घटनेच्या चौकशीसाठी एक सदस्यीय समिती",
-              "firstPublished": "2023-04-21T03:33:03.656Z",
-              "link": "https://www.bbc.com/marathi/articles/cd1gy3y9ed3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5213/live/ddfad9b0-dfe6-11ed-8ca4-a1ea302e69ef.jpg",
-              "description": "नवी मुंबईतील खारघरमध्ये पार पडलेल्या महाराष्ट्र भूषण पुरस्कार सोहळ्यात चेंगराचेंगरी आणि उष्माघातामुळे 14 श्रीसेवकांचा मृत्यू झाला.",
-              "imageAlt": "अप्पासाहेब धर्माधिकारी",
-              "id": "cd1gy3y9ed3o"
-            },
-            {
-              "type": "article",
-              "title": "गौतम अदानी-शरद पवार यांची भेट, अदानींबद्दल शरद पवार यांनी काय लिहून ठेवलंय?",
-              "firstPublished": "2023-04-08T07:35:09.250Z",
-              "link": "https://www.bbc.com/marathi/articles/cndr86d4z3lo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2a45/live/74aba960-d5d9-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "हिंडनबर्ग अहवाल प्रकरणात गौतम अदानी यांना लक्ष्य करण्यात आलं. विरोधी पक्षांनीही हा मुद्दा समजून न घेता त्यावरून राजकारण करण्यावर भर दिला, असं स्पष्ट वक्तव्य राष्ट्रवादी काँग्रेस अध्यक्ष शरद पवार यांनी केलं आहे.",
-              "imageAlt": "शऱद पवार, गौतम अदानी",
-              "id": "cndr86d4z3lo"
-            },
-            {
-              "type": "article",
-              "title": "शेतकऱ्याचा अपघाती मृत्यू झाल्यास 2 लाख रुपये मदत मिळवण्यासाठी 'या' गोष्टी करा",
-              "firstPublished": "2023-04-20T07:50:54.485Z",
-              "link": "https://www.bbc.com/marathi/articles/c98nq87pn1go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/61ca/live/cfb58270-df45-11ed-9edd-65d06cd4e0d6.jpg",
-              "description": "या योजनेत विमा कंपनीकडून दावे वेळेत निकाली न काढणं, अनावश्यक त्रुटी काढून विमा नाकारणं या बाबी समोर आल्या होत्या. पण आता या योजनेत सुधारणा करण्यात आल्या आहेत. ",
-              "imageAlt": "प्रातिनिधिक फोटो",
-              "id": "c98nq87pn1go"
-            },
-            {
-              "type": "link",
-              "title": "तीन गोष्टी पॉडकास्ट: एन्काउंटर का होतात? कायदा यावर काय सांगतो?",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/marathi/podcasts/p09431p4",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d557/live/3ad4cbe0-e060-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "BBC Marathi",
-              "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp09431p4"
-            },
-            {
-              "type": "link",
-              "title": "सोपी गोष्ट पॉडकास्ट: महाराष्ट्र भूषण कार्यक्रमासारखा उष्माघात कसा टाळावा?",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/marathi/podcasts/p09437hm",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cbd2/live/a4063aa0-e05f-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "BBC Marathi",
-              "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp09437hm"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "link": "https://www.bbc.com/marathi/topics/c5qvpxvv7y3t",
-          "curationId": "urn:bbc:tipo:list:ed72965c-ba76-4af8-b923-303848b6cb4a",
-          "curationType": "tipo-curation",
-          "position": 2,
-          "title": "महाराष्ट्र",
-          "visualProminence": "NORMAL",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "आराध्या बच्चनशी संबंधित व्हीडिओवरून यूट्यूबला कोर्टाने म्हटलं...",
-              "firstPublished": "2023-04-21T04:26:07.013Z",
-              "link": "https://www.bbc.com/marathi/articles/clm9ndle4peo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/71b5/live/cb6663a0-dff5-11ed-8484-ef64a8a974f5.jpg",
-              "description": "यूट्यूबर आराध्या बच्चन हिच्याशी संबंधित काही व्हीडिओ आहेत. या व्हिडिओबद्दल यूट्यूबविरोधात दाखल केलेल्या याचिकेत आराध्याने म्हटलेलं...",
-              "imageAlt": "आराध्या बच्चन, ऐश्वर्या राय बच्चन",
-              "id": "clm9ndle4peo"
-            },
-            {
-              "type": "article",
-              "title": "दहशतवाद्यांनी लष्कराचा ट्रक पेटवला, 5 भारतीय सैनिकांचा मृत्यू ",
-              "firstPublished": "2023-04-20T16:22:57.916Z",
-              "link": "https://www.bbc.com/marathi/articles/cd1gykpk0z0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1959/live/05070cf0-df96-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "लष्कर ",
-              "id": "cd1gykpk0z0o"
-            },
-            {
-              "type": "article",
-              "title": "जातनिहाय जनगणनेच्या मुद्द्यावर 2024 मध्ये विरोधी पक्ष एकत्र येतील का?",
-              "firstPublished": "2023-04-21T01:34:48.770Z",
-              "link": "https://www.bbc.com/marathi/articles/c72j34dr4nko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1300/live/b9dbe3f0-df8a-11ed-a158-1d8a463a971f.jpg",
-              "description": "भारतात जातनिहाय जनगणनेच्या मुद्द्यावर 1951 मध्ये तत्कालीन पंतप्रधान जवाहरलाल नेहरू यांच्या कार्यकाळात चर्चा झाली होती. पण त्यावेळी जातनिहाय जनगणना मात्र झाली नाही. ",
-              "imageAlt": "राहुल गांधी",
-              "id": "c72j34dr4nko"
-            },
-            {
-              "type": "article",
-              "title": "सलमान खान त्याचे चित्रपट ईदलाच का रिलीज करतो?",
-              "firstPublished": "2021-05-13T12:34:17.000Z",
-              "link": "https://www.bbc.com/marathi/india-57099674",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/158D6/production/_118487288_53b25bd5-e585-46e5-9546-1e60fa6821dc.jpg",
-              "description": "सलमानचा चित्रपट आणि ईद हे समीकरण इतकं घट्ट झालं आहे की, इतर कोणताही बिग बजेट चित्रपट यावेळी प्रदर्शित होत नाही.",
-              "imageAlt": "सलमान ख़ान",
-              "id": "db1d044b-4e3a-4dcf-939a-f0a9c65fb8b3"
-            },
-            {
-              "type": "article",
-              "title": "काविळ कशामुळे होते? काविळीचे प्रकार कोणते आणि त्याची लक्षणं कशी ओळखायची?",
-              "firstPublished": "2023-04-19T04:27:58.253Z",
-              "link": "https://www.bbc.com/marathi/articles/cv2r2743203o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0fe8/live/b840e6a0-dddf-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "काविळीची अशी वेगवेगळी कारणं असल्यामुळे त्यावरील उपचारही ती कशामुळे झाली यावर अवलंबून असतात. ",
-              "imageAlt": "काविळ",
-              "id": "cv2r2743203o"
-            },
-            {
-              "type": "article",
-              "title": "नरोडा गाव हत्याकांड प्रकरणातून माया कोडनानी आणि बाबू बजरंगी यांची निर्दोष सुटका",
-              "firstPublished": "2023-04-20T13:09:06.597Z",
-              "link": "https://www.bbc.com/marathi/articles/c6pe356j9ygo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/09fa/live/39dc6fc0-df7c-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "माया कोडनानी आणि बाबू बजरंगी ",
-              "id": "c6pe356j9ygo"
-            },
-            {
-              "type": "article",
-              "title": "समलिंगी विवाह सुनावणीशी संबंधित 5 मुलभूत प्रश्नं आणि 5 उत्तरं",
-              "firstPublished": "2023-04-20T12:01:34.107Z",
-              "link": "https://www.bbc.com/marathi/articles/cgx4qx9vnv8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13bf/live/ed748960-df62-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "समलिंगी विवाह ही संकल्पना ‘शहरी किंवा तत्सम’ असल्याचे दर्शवणारी कोणतीही माहिती सरकारकडे नाही, असे सरन्यायाधीश धनंजय चंद्रचूड यांनी नमूद केले आहे.",
-              "imageAlt": "महिला",
-              "id": "cgx4qx9vnv8o"
-            },
-            {
-              "type": "article",
-              "title": "रमजान ईद : ईद-उल-फित्र म्हणजे काय? ईदची तारीख कशी ठरते?",
-              "firstPublished": "2023-04-20T04:21:57.000Z",
-              "link": "https://www.bbc.com/marathi/international-65332910",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F155/production/_129418716_gettyimages-1317419494.jpg",
-              "description": "मुस्लीम धर्मीयांमध्ये ईद हा सण अत्यंत पवित्र मानला जातो. रमजान ईद मुस्लीम धर्मींयांचा सर्वात मोठा सण म्हणूनही ओळखला जातो.",
-              "imageAlt": "नमाज पढणारी मुलगी",
-              "id": "90cdb2b2-8d64-49c4-a455-9b1323c2df2c"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "link": "https://www.bbc.com/marathi/topics/cxnyk3y49x6t",
-          "curationId": "urn:bbc:tipo:list:2e5faf80-82ce-4980-9910-19f4d5abe5c2",
-          "curationType": "tipo-curation",
-          "position": 3,
-          "title": "भारत",
-          "visualProminence": "NORMAL",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "दीड लाख लोकांवर भूतविद्येचा प्रयोग करणारा धर्मोपदेशक, त्याने भूतांबद्दल काय म्हटलं? ",
-              "firstPublished": "2023-04-21T08:10:57.713Z",
-              "link": "https://www.bbc.com/marathi/articles/c9rxpx3g2ndo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0ac0/live/49d21aa0-e013-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "“भूतं पळवून लावण्याच्या विनंत्या सोमवारी संध्याकाळी 6.30 ते 7.30 या वेळेतच स्वीकारल्या जातील. रोमच्या बिशपच्या अख्त्यारित नसलेल्यांनी आपल्या भागातील बिशपकडे जावं.”",
-              "imageAlt": "गॅब्रिएल अमार्थ",
-              "id": "c9rxpx3g2ndo"
-            },
-            {
-              "type": "article",
-              "title": "ट्विटर : पैसे न भरणाऱ्या अकाऊंट्सची ब्ल्यू टिक गायब",
-              "firstPublished": "2022-11-02T05:06:18.000Z",
-              "link": "https://www.bbc.com/marathi/international-63481458",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9815/production/_129433983_gettyimages-1247307955.jpg",
-              "description": "भारतासह जगभरातील अनेक नेते, अभिनेते, पत्रकार, गायक आणि सेलिब्रिटीजचे ब्ल्यू टिक काढण्यास सुरुवात झालीय.",
-              "imageAlt": "इलॉन मस्क",
-              "id": "9a604d82-ce47-42e7-ba9e-6a9ccccde072"
-            },
-            {
-              "type": "article",
-              "title": "कोरडा ब्रेड आणि पिण्यासाठी टॉयलेटमधील नळाचे पाणी; सुदानमध्ये अडकलेल्या भारतीयांचे हाल",
-              "firstPublished": "2023-04-20T15:25:52.906Z",
-              "link": "https://www.bbc.com/marathi/articles/cn3vlgpgmemo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e681/live/5658cd40-df88-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "भारतीय ",
-              "id": "cn3vlgpgmemo"
-            },
-            {
-              "type": "article",
-              "title": "100 ठार, एका भारतीयाचाही मृत्यू: सुदान का पेटलंय? 5 प्रश्न, 5 उत्तरं",
-              "firstPublished": "2023-04-20T02:02:26.524Z",
-              "link": "https://www.bbc.com/marathi/articles/cjqdez8dl4ko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8200/live/7f1e9a00-decc-11ed-8df1-d74cbf1089d7.png",
-              "description": "सुदानमध्ये सध्या देशाचं लष्कर आणि निमलष्करी दल एकमेकांसमोर उभं ठाकलेत.",
-              "imageAlt": "सुदानमध्ये शनिवारपासून हिंसाचार उफाळला आहे",
-              "id": "cjqdez8dl4ko"
-            },
-            {
-              "type": "article",
-              "title": "येमेन : रमजानच्या कार्यक्रमावेळी चेंगराचेंगरी, 78 जण ठार ",
-              "firstPublished": "2023-04-20T02:32:54.723Z",
-              "link": "https://www.bbc.com/marathi/articles/ce42qe8xyl7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7fa2/live/27fb0330-df21-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "रॉयटर्सने दिलेल्या बातमीनुसार एका शाळेत प्रत्येक व्यक्तीला 700 रुपये दान म्हणून मिळणार होते. त्यावेळी अनेक लोक एकत्र आले आणि ही घटना घडली.",
-              "imageAlt": "येमन ",
-              "id": "ce42qe8xyl7o"
-            },
-            {
-              "type": "article",
-              "title": "सुदानमध्ये काय घडतंय, कशावरून निर्माण झाला वाद?",
-              "firstPublished": "2023-04-17T12:24:00.152Z",
-              "link": "https://www.bbc.com/marathi/articles/cll94eln84zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e4a1/live/5d166f80-dc71-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "सुदानची राजधानी खार्तूममध्ये शनिवारी लष्कर आणि निमलष्करी दलांमध्ये झालेल्या गोळीबार आणि स्फोटानंतर परिस्थिती कठीण झाली आहे.",
-              "imageAlt": "सुदान",
-              "id": "cll94eln84zo"
-            },
-            {
-              "type": "article",
-              "title": "अल्पवयीन मुलींवर बलात्कार, गरोदरपणाच्या प्रकरणांचं वाढतं प्रमाण पण आरोपी मोकाट ",
-              "firstPublished": "2023-04-18T15:10:58.380Z",
-              "link": "https://www.bbc.com/marathi/articles/cv2v28r3yk2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/99be/live/34fbd910-dd3c-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "तरुण मुलींच्या लैंगिक शोषणात वाढ झाल्यामुळे हे प्रमाण देखील वाढलंय. पण यातले गुन्हेगार मात्र मोकाट फिरत आहेत. बीबीसी आफ्रिका आयचा रिपोर्ट. ",
-              "imageAlt": "महिला, अत्याचार, सुरक्षा",
-              "id": "cv2v28r3yk2o"
-            },
-            {
-              "type": "article",
-              "title": "आर्टिफिशियल इंटेलिजन्समुळे नोकरी जाईल अशी भीती तुम्हाला वाटते का?",
-              "firstPublished": "2023-04-19T13:59:12.567Z",
-              "link": "https://www.bbc.com/marathi/articles/cn328vnyk1go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/33b0/live/23b0b850-debe-11ed-a633-85787213893a.jpg",
-              "description": "काही कर्मचाऱ्यांच्या मनात अशी चिंता आहे की त्यांच्या नोकरीचं काय होणार. त्यांनी अशा प्रकारची चिंता व्यक्त केल्याची देखील अनेक उदाहरणं आहेत. आपली कौशल्यं ही काळानुसार प्रासंगिक राहतील की नाही, येत्या काही वर्षांत नोकरीच्या बाजारात आपल्या कौशल्यांना काही किंमत राहील की नाही याची चिंता त्यांना भेडसावत आहे.",
-              "imageAlt": "कर्मचारी ",
-              "id": "cn328vnyk1go"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "link": "https://www.bbc.com/marathi/topics/c719d2enyn3t",
-          "curationId": "urn:bbc:tipo:list:907b0119-a1c7-4f03-a6c0-f35018b6e28c",
-          "curationType": "tipo-curation",
-          "position": 4,
-          "title": "जगभरात",
-          "visualProminence": "NORMAL",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "उस्ताद झाकिर हुसैन यांचा तबला बनवणाऱ्या मराठी मुलाला राष्ट्रीय पुरस्कार ",
-              "firstPublished": "2023-04-11T12:03:39.398Z",
-              "link": "https://www.bbc.com/marathi/articles/c0k0jev0rd2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b75/live/898af6f0-d463-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "",
-              "imageAlt": "किशोर व्हटकर पुरस्कारासमवेत ",
-              "id": "c0k0jev0rd2o"
-            },
-            {
-              "type": "article",
-              "title": "मुंबईच्या सफाई कामगाराने मिळवली परदेशी विद्यापीठात Ph.D साठी स्कॉलरशिप",
-              "firstPublished": "2023-04-02T11:20:38.261Z",
-              "link": "https://www.bbc.com/marathi/articles/c51vq78ln17o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0748/live/7c815d30-d113-11ed-8cbd-114449e5a4bd.jpg",
-              "description": "कुटुंबाचा उदरनिर्वाह चालवण्यासाठी मयूरला शिक्षण सोडून सफाई कर्मचाऱ्याची नोकरी करण्याचा निर्णय घ्यावा लागला होता.",
-              "imageAlt": "मयूर हेलिया",
-              "id": "c51vq78ln17o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M59S",
-              "title": "रेशीम शेतीसाठी तुतीच्या रोपांची नर्सरी उभारली आणि केली लाखोंची कमाई ",
-              "firstPublished": "2023-03-21T15:21:14.006Z",
-              "link": "https://www.bbc.com/marathi/articles/c8v745e23ezo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e637/live/ec5d91e0-c7fa-11ed-95f8-0154daa64c44.jpg",
-              "description": "वशिष्ट वासुदेव पिसाळ यांनी बीड जिल्ह्यातल्या कांबी गावात तुतीची नर्सरी सुरू केली आहे.",
-              "imageAlt": "रेशीम शेती",
-              "id": "c8v745e23ezo"
-            },
-            {
-              "type": "article",
-              "title": "क्रिकेटमुळे बळकट होत असलेल्या दिव्यांग महिलांची कहाणी",
-              "firstPublished": "2023-03-17T01:13:30.875Z",
-              "link": "https://www.bbc.com/marathi/articles/c2j789jxy4mo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8754/live/9df49690-c40b-11ed-95f8-0154daa64c44.jpg",
-              "description": "\"घरी बसा, मुलांची काळजी घ्या, घराबाहेर जाण्यात वेळ वाया घालवू नका अशा कित्येक गोष्टी कानावर पडत असतात.\"",
-              "imageAlt": "क्रिकेट",
-              "id": "c2j789jxy4mo"
-            },
-            {
-              "type": "article",
-              "title": "तृतीयपंथी सेक्सवर्कर अलिशा जेव्हा आरोग्यदूत बनते...",
-              "firstPublished": "2023-03-20T01:19:03.330Z",
-              "link": "https://www.bbc.com/marathi/articles/czk8lypr1v9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e3c5/live/8a6923e0-c66b-11ed-95f8-0154daa64c44.jpg",
-              "description": "नटून थटून रात्रीच्या अंधारात रस्त्यावर उभी राहिलेली, गाड्यांच्या आत डोकावणारी अलिशा एक सेक्स वर्कर आहे. ",
-              "imageAlt": "आलिशा",
-              "id": "czk8lypr1v9o"
-            },
-            {
-              "type": "article",
-              "title": "एका खुर्चीपासून ब्युटी पार्लरची सुरुवात, आता मात्र 4 लाखांचा सेटअप",
-              "firstPublished": "2023-02-20T04:33:16.000Z",
-              "link": "https://www.bbc.com/marathi/india-64696093",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/25CD/production/_128677690_p3.jpg",
-              "description": "प्रीती जाधव औरंगाबाद जिल्ह्यामध्ये एका छोटाश्या रांजनगाव गावात राहतात. तिथंच घरातच त्यांनी पार्लर सुरू केलं आहे.",
-              "imageAlt": "प्रीती जाधव",
-              "id": "cb839033-455b-42b0-838d-c871a548a6a9"
-            },
-            {
-              "type": "article",
-              "title": "'शेळीपालनामुळे 10-12 लाखांचं घर झालं, आज माझा संसारगाडा शेळ्यांवरच सुरू आहे'",
-              "firstPublished": "2023-02-11T13:11:54.000Z",
-              "link": "https://www.bbc.com/marathi/india-64610340",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/821E/production/_128601333_36feaf70-6ba1-4fc3-99a2-cee33da008f6.jpg",
-              "description": "\"शेळींनी मला जगण्याचा मार्ग दाखवला. शेळीपालनामुळे 10 ते 12 लाखाचं घर झालं, गाडी झाली. जो काही संसारगाडा चालू आहे, हा फक्त शेळीपालनावरच चालू आहे.\"",
-              "imageAlt": "रवी राजपूत",
-              "id": "8eec5fb2-362d-4baf-9c66-4a3d176aabcf"
-            },
-            {
-              "type": "article",
-              "title": "हुरडा विक्रीतून 'ही' 2 गावं 4 महिन्यात कोट्यवधी रुपये कशी कमावताहेत?",
-              "firstPublished": "2023-01-24T04:47:32.911Z",
-              "link": "https://www.bbc.com/marathi/articles/crgv96n6yd4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b8ad/live/d33a7cc0-9ae4-11ed-af00-ed950259f6d8.jpg",
-              "description": "“ज्वारी 3 ते 4 हजार रुपये क्विंटल जाते. हुरड्याचा दर आम्हाला 200, 120 रुपये प्रती किलो मिळतो. त्याच्यामुळे आम्ही हुरड्यातच विकून टाकतो.”",
-              "imageAlt": "शेतकरी संतोष गावंडे",
-              "id": "crgv96n6yd4o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M36S",
-              "title": "सांगलीमध्ये रिक्षा रिव्हर्स चालवण्याची स्पर्धा पाहिलीत? ",
-              "firstPublished": "2023-01-29T05:07:48.406Z",
-              "link": "https://www.bbc.com/marathi/articles/c1dz47py99ko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d43c/live/a65ce1e0-9f92-11ed-937f-9f0b0599f176.png",
-              "description": "सांगलीमध्ये हरिपूर गावात ‘ऑटो रिक्षा  रिव्हर्स ड्रायव्हिंग स्पर्धा’ पार पडली.",
-              "imageAlt": "रिक्षा ",
-              "id": "c1dz47py99ko"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a62d55b7-5673-4f27-a840-31f482c1b749",
-          "curationType": "tipo-curation",
-          "position": 5,
-          "title": "आशेचे किरण",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "बातम्या - BBC News मराठी",
+    "description": "महाराष्ट्र, देश आणि जगभरातल्या ताज्या बातम्या, लेख आणि व्हीडिओ. Get the latest BBC News stories from India and the world in Marathi.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "'कोण संजय राऊत' ते 'अजित पवार गोड माणूस'... पवार-राऊत वादाचा अर्थ काय?",
+            "firstPublished": "2023-04-21T12:05:47.129Z",
+            "link": "https://www.bbc.com/marathi/articles/crgxwdldgzwo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ff1b/live/88110e10-e0cd-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "महाविकास आघाडीतील दोन प्रमुख नेते – अजित पवार आणि संजय राऊत हे गेल्या काही दिवसांपासून आमनेसामने उभे ठाकले आहेत.",
+            "imageAlt": "अजित पवार",
+            "id": "crgxwdldgzwo"
+          },
+          {
+            "type": "article",
+            "title": "गोध्रा रेल्वे हिंसाचार प्रकरणातील आठ दोषींना जामीन मंजूर",
+            "firstPublished": "2019-12-11T08:56:11.000Z",
+            "link": "https://www.bbc.com/marathi/india-50739241",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F80A/production/_110089436_85a42487-7ccb-4437-aa15-d26707a06966.jpg",
+            "description": "या प्रकरणातील इतर 4 दोषींची संबंधित गुन्ह्यातील भूमिका पाहून त्यांना जामीन नाकारण्यात आल्याचं कोर्टाने सांगितलं.",
+            "imageAlt": "नानावटी अहवाल",
+            "id": "85e39c68-5bd3-1148-9440-a2b5464750f6"
+          },
+          {
+            "type": "article",
+            "title": "'माझा जन्म बलात्कारातून झाला; पण ती ओळख मला नकोय'",
+            "firstPublished": "2023-04-21T10:23:24.713Z",
+            "link": "https://www.bbc.com/marathi/articles/cjr1xl9wpjvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/02b6/live/bc1aa8c0-e02c-11ed-97eb-f9fe665d2627.jpg",
+            "description": "बलात्कारातून जन्माला येणाऱ्या मुलांना इंग्लंड आणि वेल्समध्ये आता गुन्हातले पीडित (victims of crime)अशी ओळख मिळणार, असं तिथल्या सरकारने जाहीर केलं आहे. ",
+            "imageAlt": "तसनिम",
+            "id": "cjr1xl9wpjvo"
+          },
+          {
+            "type": "article",
+            "title": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
+            "firstPublished": "2020-07-14T14:43:45.000Z",
+            "link": "https://www.bbc.com/marathi/india-53408193",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/494B/production/_129436781_gettyimages-1152519784.jpg",
+            "description": "मराठा आरक्षण सुप्रीम कोर्टाने फेटाळलं आहे. इंद्रा साहनी प्रकरणात सुप्रीम कोर्टाने जी 50 टक्के आरक्षण मर्यादा आखली होती ती ओलंडण्यास नकार दिला आहे.",
+            "imageAlt": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
+            "id": "77ef59b4-edc2-4062-af82-5b4c85580176"
+          },
+          {
+            "type": "article",
+            "title": "मटण विक्रेता ते युट्यूबर बनलेल्या 'राजा'ला  'बिझनेस मॉडेल' असं सापडलं..",
+            "firstPublished": "2023-04-21T09:21:35.238Z",
+            "link": "https://www.bbc.com/marathi/articles/czvkl8lxvywo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1349/live/6bbf9160-e022-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "पहिल्या सहा महिन्यात राजाला युट्यूबमधून केवळ 8 हजार रुपयांचं उत्पन्न मिळालं. पण त्या एका व्हीडिओने त्याचं बिझनेस मॉडेल सापडलं..",
+            "imageAlt": "बुहारी जंक्शन",
+            "id": "czvkl8lxvywo"
+          },
+          {
+            "type": "article",
+            "title": "सोन्याच्या खाणी असलेल्या सुदानसाठी हे सोनंच शाप बनलंय, कारण...",
+            "firstPublished": "2023-04-21T05:45:45.111Z",
+            "link": "https://www.bbc.com/marathi/articles/cev4lxln094o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cc14/live/cec6d2b0-dfb3-11ed-8527-1de9829b7a0e.jpg",
+            "description": "",
+            "imageAlt": "सुदान, सोनं, अर्थकारण",
+            "id": "cev4lxln094o"
+          },
+          {
+            "type": "article",
+            "title": "बीबीसी मराठी : या आठवड्यातील महत्त्वाच्या बातम्या आणि लेख..",
+            "firstPublished": "2023-04-21T12:53:33.205Z",
+            "link": "https://www.bbc.com/marathi/articles/cd1kdv8lzg4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e77d/live/0695f3a0-e041-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "राजकारण, मनोरंजन, प्रेरणादायी, ट्रेंडिंग आणि ज्ञानवर्धक असे पाच लेख जे तुम्ही नक्की वाचले पाहिजेत.. ",
+            "imageAlt": "ऐश्वर्या राय बच्चन आणि आराध्या बच्चन",
+            "id": "cd1kdv8lzg4o"
+          },
+          {
+            "type": "article",
+            "title": "'शेतीपेक्षा नोकरी मोठी नाही' असं म्हणत फेसबुकवरून शेती शिकवणारी सविता ताई",
+            "firstPublished": "2023-04-21T07:19:44.234Z",
+            "link": "https://www.bbc.com/marathi/articles/c4npqp7d50vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0310/live/6b077c10-e00e-11ed-846f-77d452f521b4.jpg",
+            "description": "“शेतकरी राजा आहे. कोरोनाने दाखवून दिलं की नोकरी कधीही जाऊ शकते. पण शेतात आपण कधीही पिकवून पोट भरू शकतो. दुसऱ्यांना खाऊ घालू शकतो.”",
+            "imageAlt": "शेतकरी सविता डकले",
+            "id": "c4npqp7d50vo"
+          },
+          {
+            "type": "link",
+            "title": "बाळाच्या जन्मापूर्वीच त्यात आवडीनुसार गुण आणणं शक्य आहे का? ऐका ही गोष्ट दुनियेची",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/marathi/podcasts/p0b1s4nm",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a581/live/2b46d450-e049-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "BBC Marathi podcast",
+            "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp0b1s4nm"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:9e770afa-9fff-4e31-b078-08d270c75723",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT4M29S",
+            "title": "चाकोरी मोडून हवेत उडणाऱ्या 'या' मुलींना भेटलात?",
+            "firstPublished": "2023-04-19T15:36:04.963Z",
+            "link": "https://www.bbc.com/marathi/articles/cd121xww570o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5440/live/4a02f430-e04b-11ed-8df1-d74cbf1089d7.jpg",
+            "description": " बीर बिलिंगला अ‍ॅक्युरसी पॅराग्लायडिंग चॅम्पियनशिप पार पडली.",
+            "imageAlt": "BBC Marathi",
+            "id": "cd121xww570o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M58S",
+            "title": "रमझानदरम्यान या बायका आपली पाळी का लपवतात?",
+            "firstPublished": "2023-04-17T15:55:13.670Z",
+            "link": "https://www.bbc.com/marathi/articles/c6plpd484l5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3fb8/live/22e05e30-dd38-11ed-bebb-19e897771a2d.jpg",
+            "description": " रमझानच्या महिन्यात महिलांना पाळी आली तर त्यांना जेवणाची सूट असते\n",
+            "imageAlt": "महिला ",
+            "id": "c6plpd484l5o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M32S",
+            "title": "सानपाड्याच्या उड्डाणपुलाखाली असं उभारलं क्रीडा संकुल",
+            "firstPublished": "2023-04-17T05:58:36.810Z",
+            "link": "https://www.bbc.com/marathi/articles/cleqe4dpn91o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e0a0/live/7d474b10-dce1-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "\nनवी मुंबईतील सानपाडा येथील उड्डाणपुलाखाली महानगरपालिकेतर्फे क्रीडा संकुल सुरू बनवण्यात आलं आहे.",
+            "imageAlt": "सानपाडा ",
+            "id": "cleqe4dpn91o"
+          },
+          {
+            "type": "video",
+            "duration": "PT5M14S",
+            "title": "डान्स करुन हे आजी-आजोबा पार्किन्सन कसे विसरले?",
+            "firstPublished": "2023-04-12T16:24:46.676Z",
+            "link": "https://www.bbc.com/marathi/articles/c2j7y5zr1z3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3109/live/6589f590-d94e-11ed-8f78-bbb0e517b829.png",
+            "description": "पार्किन्सन हा आजार मेंदूमधल्या बदलांमुळे होतो.",
+            "imageAlt": "parkinson",
+            "id": "c2j7y5zr1z3o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M24S",
+            "title": "पतीच्या मृतदेहासाठी ती 84 दिवस लढली आणि...",
+            "firstPublished": "2023-04-21T11:19:02.366Z",
+            "link": "https://www.bbc.com/marathi/articles/ce96dejv6mvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7f65/live/08bac3e0-e04b-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "पतीचा मृत्यू झाल्यानंतर त्याच्या मृतदेहासाठी त्यांना इतकं का झगडावं लागलं?",
+            "imageAlt": "BBC Marathi",
+            "id": "ce96dejv6mvo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M56S",
+            "title": "अंधश्रद्धेपोटी या पती–पत्नीने होम करून स्वतःला असं संपवलं...",
+            "firstPublished": "2023-04-21T09:13:27.847Z",
+            "link": "https://www.bbc.com/marathi/articles/c97653er2elo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6637/live/dda78b20-e04a-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "अतिशय धार्मिक वृत्तीच्या जोडप्याने मुक्ती मिळवण्याच्या उद्देशाने कमळ पूजा केली. बळी म्हणून त्यांनी स्वत:लाच अर्पण केलं. ",
+            "imageAlt": "BBC Marathi",
+            "id": "c97653er2elo"
+          },
+          {
+            "type": "video",
+            "duration": "PT8M",
+            "title": "मासिक पाळी : शारीरिक वाढ योग्य, पण वयात येऊनही पाळी सुरू न होण्यामागची कारणं काय?",
+            "firstPublished": "2023-04-17T06:00:58.606Z",
+            "link": "https://www.bbc.com/marathi/articles/cp4142vwy4xo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b1de/live/cc24b230-dce2-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "period",
+            "id": "cp4142vwy4xo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M29S",
+            "title": "पुण्यात हापूस आंबाही आता EMIवर मिळतोय, पाहा कसा...",
+            "firstPublished": "2023-04-14T10:26:44.005Z",
+            "link": "https://www.bbc.com/marathi/articles/cxepzp6prmjo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b683/live/07879080-e04a-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "पुण्यात हापूस आंबा EMI वर मिळू लागलाय. पुण्यातल्या एका आंबे व्यापाऱ्याने ही शक्कल लढवलीय.",
+            "imageAlt": "BBC Marathi",
+            "id": "cxepzp6prmjo"
+          },
+          {
+            "type": "video",
+            "duration": "PT5M28S",
+            "title": "वेताळ टेकडी की रस्ता - पुणेकरांना नेमकं काय हवंय?",
+            "firstPublished": "2023-04-13T15:34:32.098Z",
+            "link": "https://www.bbc.com/marathi/articles/c19wx74vxkgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5dc8/live/7baf2080-da10-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "प्रस्तावित बालभारती ते पौड फाटा रस्ता वादाचं कारण ठरले आहेत.",
+            "imageAlt": "वेताळ टेकडी",
+            "id": "c19wx74vxkgo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "link": "https://www.bbc.com/marathi/topics/cl29j0epz13t",
+        "curationId": "urn:bbc:tipo:list:895e4320-6bd5-4bba-8c1f-cb5f041501c4",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "व्हीडिओ",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
+            "firstPublished": "2020-07-14T14:43:45.000Z",
+            "link": "https://www.bbc.com/marathi/india-53408193",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/494B/production/_129436781_gettyimages-1152519784.jpg",
+            "description": "मराठा आरक्षण सुप्रीम कोर्टाने फेटाळलं आहे. इंद्रा साहनी प्रकरणात सुप्रीम कोर्टाने जी 50 टक्के आरक्षण मर्यादा आखली होती ती ओलंडण्यास नकार दिला आहे.",
+            "imageAlt": "मराठा आरक्षणाच्या मागणीचा 40 वर्षांचा प्रवास, काय काय घडलं होतं आतापर्यंत?",
+            "id": "77ef59b4-edc2-4062-af82-5b4c85580176"
+          },
+          {
+            "type": "article",
+            "title": "बीबीसी मराठी : या आठवड्यातील महत्त्वाच्या बातम्या आणि लेख..",
+            "firstPublished": "2023-04-21T12:53:33.205Z",
+            "link": "https://www.bbc.com/marathi/articles/cd1kdv8lzg4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e77d/live/0695f3a0-e041-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "राजकारण, मनोरंजन, प्रेरणादायी, ट्रेंडिंग आणि ज्ञानवर्धक असे पाच लेख जे तुम्ही नक्की वाचले पाहिजेत.. ",
+            "imageAlt": "ऐश्वर्या राय बच्चन आणि आराध्या बच्चन",
+            "id": "cd1kdv8lzg4o"
+          },
+          {
+            "type": "article",
+            "title": "शिवाजी महाराजांचे हिंदुत्व आणि आताचे हिंदुत्व वेगळे आहे, असं शाहू महाराज छत्रपती यांनी का म्हटलं? ",
+            "firstPublished": "2023-04-20T06:19:33.007Z",
+            "link": "https://www.bbc.com/marathi/articles/c04v75d4y8jo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd8a/live/e3d7b1b0-df68-11ed-b18c-c7bc9fbbf441.jpg",
+            "description": "“हमे समझाने का मौका भी नहीं मिला. कोई साथ नही दे रहा था. मेरे चाचा का गोडाऊन भी जलाया. गाव मे सब बोल रहे थे की हमे निकालनेवाले है.”",
+            "imageAlt": "शाहू महाराज छत्रपती ",
+            "id": "c04v75d4y8jo"
+          },
+          {
+            "type": "article",
+            "title": "'महाराष्ट्र भूषण' कार्यक्रमातील दुर्घटनेच्या चौकशीसाठी एक सदस्यीय समिती",
+            "firstPublished": "2023-04-21T03:33:03.656Z",
+            "link": "https://www.bbc.com/marathi/articles/cd1gy3y9ed3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5213/live/ddfad9b0-dfe6-11ed-8ca4-a1ea302e69ef.jpg",
+            "description": "नवी मुंबईतील खारघरमध्ये पार पडलेल्या महाराष्ट्र भूषण पुरस्कार सोहळ्यात चेंगराचेंगरी आणि उष्माघातामुळे 14 श्रीसेवकांचा मृत्यू झाला.",
+            "imageAlt": "अप्पासाहेब धर्माधिकारी",
+            "id": "cd1gy3y9ed3o"
+          },
+          {
+            "type": "article",
+            "title": "गौतम अदानी-शरद पवार यांची भेट, अदानींबद्दल शरद पवार यांनी काय लिहून ठेवलंय?",
+            "firstPublished": "2023-04-08T07:35:09.250Z",
+            "link": "https://www.bbc.com/marathi/articles/cndr86d4z3lo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2a45/live/74aba960-d5d9-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "हिंडनबर्ग अहवाल प्रकरणात गौतम अदानी यांना लक्ष्य करण्यात आलं. विरोधी पक्षांनीही हा मुद्दा समजून न घेता त्यावरून राजकारण करण्यावर भर दिला, असं स्पष्ट वक्तव्य राष्ट्रवादी काँग्रेस अध्यक्ष शरद पवार यांनी केलं आहे.",
+            "imageAlt": "शऱद पवार, गौतम अदानी",
+            "id": "cndr86d4z3lo"
+          },
+          {
+            "type": "article",
+            "title": "शेतकऱ्याचा अपघाती मृत्यू झाल्यास 2 लाख रुपये मदत मिळवण्यासाठी 'या' गोष्टी करा",
+            "firstPublished": "2023-04-20T07:50:54.485Z",
+            "link": "https://www.bbc.com/marathi/articles/c98nq87pn1go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/61ca/live/cfb58270-df45-11ed-9edd-65d06cd4e0d6.jpg",
+            "description": "या योजनेत विमा कंपनीकडून दावे वेळेत निकाली न काढणं, अनावश्यक त्रुटी काढून विमा नाकारणं या बाबी समोर आल्या होत्या. पण आता या योजनेत सुधारणा करण्यात आल्या आहेत. ",
+            "imageAlt": "प्रातिनिधिक फोटो",
+            "id": "c98nq87pn1go"
+          },
+          {
+            "type": "link",
+            "title": "तीन गोष्टी पॉडकास्ट: एन्काउंटर का होतात? कायदा यावर काय सांगतो?",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/marathi/podcasts/p09431p4",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d557/live/3ad4cbe0-e060-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "BBC Marathi",
+            "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp09431p4"
+          },
+          {
+            "type": "link",
+            "title": "सोपी गोष्ट पॉडकास्ट: महाराष्ट्र भूषण कार्यक्रमासारखा उष्माघात कसा टाळावा?",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/marathi/podcasts/p09437hm",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cbd2/live/a4063aa0-e05f-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "BBC Marathi",
+            "id": "https%3A%2F%2Fwww.bbc.com%2Fmarathi%2Fpodcasts%2Fp09437hm"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "link": "https://www.bbc.com/marathi/topics/c5qvpxvv7y3t",
+        "curationId": "urn:bbc:tipo:list:ed72965c-ba76-4af8-b923-303848b6cb4a",
+        "curationType": "tipo-curation",
+        "position": 2,
+        "title": "महाराष्ट्र",
+        "visualProminence": "NORMAL",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "आराध्या बच्चनशी संबंधित व्हीडिओवरून यूट्यूबला कोर्टाने म्हटलं...",
+            "firstPublished": "2023-04-21T04:26:07.013Z",
+            "link": "https://www.bbc.com/marathi/articles/clm9ndle4peo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/71b5/live/cb6663a0-dff5-11ed-8484-ef64a8a974f5.jpg",
+            "description": "यूट्यूबर आराध्या बच्चन हिच्याशी संबंधित काही व्हीडिओ आहेत. या व्हिडिओबद्दल यूट्यूबविरोधात दाखल केलेल्या याचिकेत आराध्याने म्हटलेलं...",
+            "imageAlt": "आराध्या बच्चन, ऐश्वर्या राय बच्चन",
+            "id": "clm9ndle4peo"
+          },
+          {
+            "type": "article",
+            "title": "दहशतवाद्यांनी लष्कराचा ट्रक पेटवला, 5 भारतीय सैनिकांचा मृत्यू ",
+            "firstPublished": "2023-04-20T16:22:57.916Z",
+            "link": "https://www.bbc.com/marathi/articles/cd1gykpk0z0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1959/live/05070cf0-df96-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "लष्कर ",
+            "id": "cd1gykpk0z0o"
+          },
+          {
+            "type": "article",
+            "title": "जातनिहाय जनगणनेच्या मुद्द्यावर 2024 मध्ये विरोधी पक्ष एकत्र येतील का?",
+            "firstPublished": "2023-04-21T01:34:48.770Z",
+            "link": "https://www.bbc.com/marathi/articles/c72j34dr4nko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1300/live/b9dbe3f0-df8a-11ed-a158-1d8a463a971f.jpg",
+            "description": "भारतात जातनिहाय जनगणनेच्या मुद्द्यावर 1951 मध्ये तत्कालीन पंतप्रधान जवाहरलाल नेहरू यांच्या कार्यकाळात चर्चा झाली होती. पण त्यावेळी जातनिहाय जनगणना मात्र झाली नाही. ",
+            "imageAlt": "राहुल गांधी",
+            "id": "c72j34dr4nko"
+          },
+          {
+            "type": "article",
+            "title": "सलमान खान त्याचे चित्रपट ईदलाच का रिलीज करतो?",
+            "firstPublished": "2021-05-13T12:34:17.000Z",
+            "link": "https://www.bbc.com/marathi/india-57099674",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/158D6/production/_118487288_53b25bd5-e585-46e5-9546-1e60fa6821dc.jpg",
+            "description": "सलमानचा चित्रपट आणि ईद हे समीकरण इतकं घट्ट झालं आहे की, इतर कोणताही बिग बजेट चित्रपट यावेळी प्रदर्शित होत नाही.",
+            "imageAlt": "सलमान ख़ान",
+            "id": "db1d044b-4e3a-4dcf-939a-f0a9c65fb8b3"
+          },
+          {
+            "type": "article",
+            "title": "काविळ कशामुळे होते? काविळीचे प्रकार कोणते आणि त्याची लक्षणं कशी ओळखायची?",
+            "firstPublished": "2023-04-19T04:27:58.253Z",
+            "link": "https://www.bbc.com/marathi/articles/cv2r2743203o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0fe8/live/b840e6a0-dddf-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "काविळीची अशी वेगवेगळी कारणं असल्यामुळे त्यावरील उपचारही ती कशामुळे झाली यावर अवलंबून असतात. ",
+            "imageAlt": "काविळ",
+            "id": "cv2r2743203o"
+          },
+          {
+            "type": "article",
+            "title": "नरोडा गाव हत्याकांड प्रकरणातून माया कोडनानी आणि बाबू बजरंगी यांची निर्दोष सुटका",
+            "firstPublished": "2023-04-20T13:09:06.597Z",
+            "link": "https://www.bbc.com/marathi/articles/c6pe356j9ygo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/09fa/live/39dc6fc0-df7c-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "माया कोडनानी आणि बाबू बजरंगी ",
+            "id": "c6pe356j9ygo"
+          },
+          {
+            "type": "article",
+            "title": "समलिंगी विवाह सुनावणीशी संबंधित 5 मुलभूत प्रश्नं आणि 5 उत्तरं",
+            "firstPublished": "2023-04-20T12:01:34.107Z",
+            "link": "https://www.bbc.com/marathi/articles/cgx4qx9vnv8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13bf/live/ed748960-df62-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "समलिंगी विवाह ही संकल्पना ‘शहरी किंवा तत्सम’ असल्याचे दर्शवणारी कोणतीही माहिती सरकारकडे नाही, असे सरन्यायाधीश धनंजय चंद्रचूड यांनी नमूद केले आहे.",
+            "imageAlt": "महिला",
+            "id": "cgx4qx9vnv8o"
+          },
+          {
+            "type": "article",
+            "title": "रमजान ईद : ईद-उल-फित्र म्हणजे काय? ईदची तारीख कशी ठरते?",
+            "firstPublished": "2023-04-20T04:21:57.000Z",
+            "link": "https://www.bbc.com/marathi/international-65332910",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F155/production/_129418716_gettyimages-1317419494.jpg",
+            "description": "मुस्लीम धर्मीयांमध्ये ईद हा सण अत्यंत पवित्र मानला जातो. रमजान ईद मुस्लीम धर्मींयांचा सर्वात मोठा सण म्हणूनही ओळखला जातो.",
+            "imageAlt": "नमाज पढणारी मुलगी",
+            "id": "90cdb2b2-8d64-49c4-a455-9b1323c2df2c"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "link": "https://www.bbc.com/marathi/topics/cxnyk3y49x6t",
+        "curationId": "urn:bbc:tipo:list:2e5faf80-82ce-4980-9910-19f4d5abe5c2",
+        "curationType": "tipo-curation",
+        "position": 3,
+        "title": "भारत",
+        "visualProminence": "NORMAL",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "दीड लाख लोकांवर भूतविद्येचा प्रयोग करणारा धर्मोपदेशक, त्याने भूतांबद्दल काय म्हटलं? ",
+            "firstPublished": "2023-04-21T08:10:57.713Z",
+            "link": "https://www.bbc.com/marathi/articles/c9rxpx3g2ndo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0ac0/live/49d21aa0-e013-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "“भूतं पळवून लावण्याच्या विनंत्या सोमवारी संध्याकाळी 6.30 ते 7.30 या वेळेतच स्वीकारल्या जातील. रोमच्या बिशपच्या अख्त्यारित नसलेल्यांनी आपल्या भागातील बिशपकडे जावं.”",
+            "imageAlt": "गॅब्रिएल अमार्थ",
+            "id": "c9rxpx3g2ndo"
+          },
+          {
+            "type": "article",
+            "title": "ट्विटर : पैसे न भरणाऱ्या अकाऊंट्सची ब्ल्यू टिक गायब",
+            "firstPublished": "2022-11-02T05:06:18.000Z",
+            "link": "https://www.bbc.com/marathi/international-63481458",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9815/production/_129433983_gettyimages-1247307955.jpg",
+            "description": "भारतासह जगभरातील अनेक नेते, अभिनेते, पत्रकार, गायक आणि सेलिब्रिटीजचे ब्ल्यू टिक काढण्यास सुरुवात झालीय.",
+            "imageAlt": "इलॉन मस्क",
+            "id": "9a604d82-ce47-42e7-ba9e-6a9ccccde072"
+          },
+          {
+            "type": "article",
+            "title": "कोरडा ब्रेड आणि पिण्यासाठी टॉयलेटमधील नळाचे पाणी; सुदानमध्ये अडकलेल्या भारतीयांचे हाल",
+            "firstPublished": "2023-04-20T15:25:52.906Z",
+            "link": "https://www.bbc.com/marathi/articles/cn3vlgpgmemo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e681/live/5658cd40-df88-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "भारतीय ",
+            "id": "cn3vlgpgmemo"
+          },
+          {
+            "type": "article",
+            "title": "100 ठार, एका भारतीयाचाही मृत्यू: सुदान का पेटलंय? 5 प्रश्न, 5 उत्तरं",
+            "firstPublished": "2023-04-20T02:02:26.524Z",
+            "link": "https://www.bbc.com/marathi/articles/cjqdez8dl4ko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8200/live/7f1e9a00-decc-11ed-8df1-d74cbf1089d7.png",
+            "description": "सुदानमध्ये सध्या देशाचं लष्कर आणि निमलष्करी दल एकमेकांसमोर उभं ठाकलेत.",
+            "imageAlt": "सुदानमध्ये शनिवारपासून हिंसाचार उफाळला आहे",
+            "id": "cjqdez8dl4ko"
+          },
+          {
+            "type": "article",
+            "title": "येमेन : रमजानच्या कार्यक्रमावेळी चेंगराचेंगरी, 78 जण ठार ",
+            "firstPublished": "2023-04-20T02:32:54.723Z",
+            "link": "https://www.bbc.com/marathi/articles/ce42qe8xyl7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7fa2/live/27fb0330-df21-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "रॉयटर्सने दिलेल्या बातमीनुसार एका शाळेत प्रत्येक व्यक्तीला 700 रुपये दान म्हणून मिळणार होते. त्यावेळी अनेक लोक एकत्र आले आणि ही घटना घडली.",
+            "imageAlt": "येमन ",
+            "id": "ce42qe8xyl7o"
+          },
+          {
+            "type": "article",
+            "title": "सुदानमध्ये काय घडतंय, कशावरून निर्माण झाला वाद?",
+            "firstPublished": "2023-04-17T12:24:00.152Z",
+            "link": "https://www.bbc.com/marathi/articles/cll94eln84zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e4a1/live/5d166f80-dc71-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "सुदानची राजधानी खार्तूममध्ये शनिवारी लष्कर आणि निमलष्करी दलांमध्ये झालेल्या गोळीबार आणि स्फोटानंतर परिस्थिती कठीण झाली आहे.",
+            "imageAlt": "सुदान",
+            "id": "cll94eln84zo"
+          },
+          {
+            "type": "article",
+            "title": "अल्पवयीन मुलींवर बलात्कार, गरोदरपणाच्या प्रकरणांचं वाढतं प्रमाण पण आरोपी मोकाट ",
+            "firstPublished": "2023-04-18T15:10:58.380Z",
+            "link": "https://www.bbc.com/marathi/articles/cv2v28r3yk2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/99be/live/34fbd910-dd3c-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "तरुण मुलींच्या लैंगिक शोषणात वाढ झाल्यामुळे हे प्रमाण देखील वाढलंय. पण यातले गुन्हेगार मात्र मोकाट फिरत आहेत. बीबीसी आफ्रिका आयचा रिपोर्ट. ",
+            "imageAlt": "महिला, अत्याचार, सुरक्षा",
+            "id": "cv2v28r3yk2o"
+          },
+          {
+            "type": "article",
+            "title": "आर्टिफिशियल इंटेलिजन्समुळे नोकरी जाईल अशी भीती तुम्हाला वाटते का?",
+            "firstPublished": "2023-04-19T13:59:12.567Z",
+            "link": "https://www.bbc.com/marathi/articles/cn328vnyk1go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/33b0/live/23b0b850-debe-11ed-a633-85787213893a.jpg",
+            "description": "काही कर्मचाऱ्यांच्या मनात अशी चिंता आहे की त्यांच्या नोकरीचं काय होणार. त्यांनी अशा प्रकारची चिंता व्यक्त केल्याची देखील अनेक उदाहरणं आहेत. आपली कौशल्यं ही काळानुसार प्रासंगिक राहतील की नाही, येत्या काही वर्षांत नोकरीच्या बाजारात आपल्या कौशल्यांना काही किंमत राहील की नाही याची चिंता त्यांना भेडसावत आहे.",
+            "imageAlt": "कर्मचारी ",
+            "id": "cn328vnyk1go"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "link": "https://www.bbc.com/marathi/topics/c719d2enyn3t",
+        "curationId": "urn:bbc:tipo:list:907b0119-a1c7-4f03-a6c0-f35018b6e28c",
+        "curationType": "tipo-curation",
+        "position": 4,
+        "title": "जगभरात",
+        "visualProminence": "NORMAL",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "उस्ताद झाकिर हुसैन यांचा तबला बनवणाऱ्या मराठी मुलाला राष्ट्रीय पुरस्कार ",
+            "firstPublished": "2023-04-11T12:03:39.398Z",
+            "link": "https://www.bbc.com/marathi/articles/c0k0jev0rd2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b75/live/898af6f0-d463-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "",
+            "imageAlt": "किशोर व्हटकर पुरस्कारासमवेत ",
+            "id": "c0k0jev0rd2o"
+          },
+          {
+            "type": "article",
+            "title": "मुंबईच्या सफाई कामगाराने मिळवली परदेशी विद्यापीठात Ph.D साठी स्कॉलरशिप",
+            "firstPublished": "2023-04-02T11:20:38.261Z",
+            "link": "https://www.bbc.com/marathi/articles/c51vq78ln17o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0748/live/7c815d30-d113-11ed-8cbd-114449e5a4bd.jpg",
+            "description": "कुटुंबाचा उदरनिर्वाह चालवण्यासाठी मयूरला शिक्षण सोडून सफाई कर्मचाऱ्याची नोकरी करण्याचा निर्णय घ्यावा लागला होता.",
+            "imageAlt": "मयूर हेलिया",
+            "id": "c51vq78ln17o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M59S",
+            "title": "रेशीम शेतीसाठी तुतीच्या रोपांची नर्सरी उभारली आणि केली लाखोंची कमाई ",
+            "firstPublished": "2023-03-21T15:21:14.006Z",
+            "link": "https://www.bbc.com/marathi/articles/c8v745e23ezo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e637/live/ec5d91e0-c7fa-11ed-95f8-0154daa64c44.jpg",
+            "description": "वशिष्ट वासुदेव पिसाळ यांनी बीड जिल्ह्यातल्या कांबी गावात तुतीची नर्सरी सुरू केली आहे.",
+            "imageAlt": "रेशीम शेती",
+            "id": "c8v745e23ezo"
+          },
+          {
+            "type": "article",
+            "title": "क्रिकेटमुळे बळकट होत असलेल्या दिव्यांग महिलांची कहाणी",
+            "firstPublished": "2023-03-17T01:13:30.875Z",
+            "link": "https://www.bbc.com/marathi/articles/c2j789jxy4mo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8754/live/9df49690-c40b-11ed-95f8-0154daa64c44.jpg",
+            "description": "\"घरी बसा, मुलांची काळजी घ्या, घराबाहेर जाण्यात वेळ वाया घालवू नका अशा कित्येक गोष्टी कानावर पडत असतात.\"",
+            "imageAlt": "क्रिकेट",
+            "id": "c2j789jxy4mo"
+          },
+          {
+            "type": "article",
+            "title": "तृतीयपंथी सेक्सवर्कर अलिशा जेव्हा आरोग्यदूत बनते...",
+            "firstPublished": "2023-03-20T01:19:03.330Z",
+            "link": "https://www.bbc.com/marathi/articles/czk8lypr1v9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e3c5/live/8a6923e0-c66b-11ed-95f8-0154daa64c44.jpg",
+            "description": "नटून थटून रात्रीच्या अंधारात रस्त्यावर उभी राहिलेली, गाड्यांच्या आत डोकावणारी अलिशा एक सेक्स वर्कर आहे. ",
+            "imageAlt": "आलिशा",
+            "id": "czk8lypr1v9o"
+          },
+          {
+            "type": "article",
+            "title": "एका खुर्चीपासून ब्युटी पार्लरची सुरुवात, आता मात्र 4 लाखांचा सेटअप",
+            "firstPublished": "2023-02-20T04:33:16.000Z",
+            "link": "https://www.bbc.com/marathi/india-64696093",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/25CD/production/_128677690_p3.jpg",
+            "description": "प्रीती जाधव औरंगाबाद जिल्ह्यामध्ये एका छोटाश्या रांजनगाव गावात राहतात. तिथंच घरातच त्यांनी पार्लर सुरू केलं आहे.",
+            "imageAlt": "प्रीती जाधव",
+            "id": "cb839033-455b-42b0-838d-c871a548a6a9"
+          },
+          {
+            "type": "article",
+            "title": "'शेळीपालनामुळे 10-12 लाखांचं घर झालं, आज माझा संसारगाडा शेळ्यांवरच सुरू आहे'",
+            "firstPublished": "2023-02-11T13:11:54.000Z",
+            "link": "https://www.bbc.com/marathi/india-64610340",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/821E/production/_128601333_36feaf70-6ba1-4fc3-99a2-cee33da008f6.jpg",
+            "description": "\"शेळींनी मला जगण्याचा मार्ग दाखवला. शेळीपालनामुळे 10 ते 12 लाखाचं घर झालं, गाडी झाली. जो काही संसारगाडा चालू आहे, हा फक्त शेळीपालनावरच चालू आहे.\"",
+            "imageAlt": "रवी राजपूत",
+            "id": "8eec5fb2-362d-4baf-9c66-4a3d176aabcf"
+          },
+          {
+            "type": "article",
+            "title": "हुरडा विक्रीतून 'ही' 2 गावं 4 महिन्यात कोट्यवधी रुपये कशी कमावताहेत?",
+            "firstPublished": "2023-01-24T04:47:32.911Z",
+            "link": "https://www.bbc.com/marathi/articles/crgv96n6yd4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b8ad/live/d33a7cc0-9ae4-11ed-af00-ed950259f6d8.jpg",
+            "description": "“ज्वारी 3 ते 4 हजार रुपये क्विंटल जाते. हुरड्याचा दर आम्हाला 200, 120 रुपये प्रती किलो मिळतो. त्याच्यामुळे आम्ही हुरड्यातच विकून टाकतो.”",
+            "imageAlt": "शेतकरी संतोष गावंडे",
+            "id": "crgv96n6yd4o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M36S",
+            "title": "सांगलीमध्ये रिक्षा रिव्हर्स चालवण्याची स्पर्धा पाहिलीत? ",
+            "firstPublished": "2023-01-29T05:07:48.406Z",
+            "link": "https://www.bbc.com/marathi/articles/c1dz47py99ko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d43c/live/a65ce1e0-9f92-11ed-937f-9f0b0599f176.png",
+            "description": "सांगलीमध्ये हरिपूर गावात ‘ऑटो रिक्षा  रिव्हर्स ड्रायव्हिंग स्पर्धा’ पार पडली.",
+            "imageAlt": "रिक्षा ",
+            "id": "c1dz47py99ko"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a62d55b7-5673-4f27-a840-31f482c1b749",
+        "curationType": "tipo-curation",
+        "position": 5,
+        "title": "आशेचे किरण",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:ck2nellj5ppt",
+        "contentType": "index-home",
+        "pageIdentifier": "marathi.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/mundo/homePage/index.json
+++ b/data/mundo/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "Noticias - BBC News Mundo",
-      "description": "BBC Mundo le presenta una selección de contenidos y acontecimientos más importantes de la actualidad. Las últimas noticias e información en materia internacional, sobre América Latina, tecnología, ciencia, salud, economía. Fotos y videos.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Los narcosubmarinos caseros que transportan cocaína de Sudamérica a Europa",
-              "firstPublished": "2023-04-26T11:18:26.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-internacional-65349969",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8D92/production/_129424263_capture4.png",
-              "description": "La BBC tuvo acceso a la embaración secreta que llevó a tres hombres y US$150 millones en drogas desde la selva amazónica hasta España.",
-              "imageAlt": "El submarino casero ahora se encuentra en un estacionamiento en el centro de España.",
-              "id": "5e25e965-3681-46d6-ae11-098c8ebe15a8"
-            },
-            {
-              "type": "article",
-              "title": "\"Cayó un misil enorme a unos 5 minutos de mi casa. Fue lo más fuerte que he oído en mi vida\": el testimonio de una mexicana que fue evacuada de Sudán",
-              "firstPublished": "2023-04-26T11:49:53.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-internacional-65390907",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/B32F/production/_129517854_thumbnail_sudaplate.png",
-              "description": "La mexicana Elizabeth Campero vivió el estallido de la violencia en Sudán desde su hogar en Jartum. Aquí, le cuenta a BBC Mundo cómo fue esa aterradora experiencia y los detalles de la evacuación que la sacó a ella y su familia del país africano.",
-              "imageAlt": "Elizabeth Campero",
-              "id": "9a59e329-4f01-49ff-8296-51edc7d0e47a"
-            },
-            {
-              "type": "article",
-              "title": "El \"inexplicable\" calentamiento de los océanos que alarma a los científicos",
-              "firstPublished": "2023-04-25T16:17:27.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-65388079",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3A4C/production/_129442941_gettyimages-1236993544.jpg",
-              "description": "La superficie del mar alcanzó un nuevo récord de temperatura debido a un aumento que nunca se había producido de manera tan brusca.",
-              "imageAlt": "Sol sobre el océano",
-              "id": "631efe72-a2bc-4a61-98f5-97ca8d85ba89"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:295a530d-b4fc-4747-9ca8-e2896e125568",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "De Newton a Neil Armstrong: 7 frases famosas que realmente nunca se dijeron",
-              "firstPublished": "2023-04-02T19:22:17.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-65090662",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15B18/production/_129165888_gettyimages-1404442799.jpg",
-              "description": "Internet, pero también los libros, están plagados de citas atribuidas a personajes históricos que éstos jamás pronunciaron.",
-              "imageAlt": "El astronauta Neil Amstrong caminando por la Luna en 1969.",
-              "id": "d80aa5d0-e958-4df0-96f9-0b8b68b98436"
-            },
-            {
-              "type": "article",
-              "title": "Quién es Stormy Daniels, la estrella porno que detonó la imputación a Donald Trump",
-              "firstPublished": "2023-03-31T18:53:19.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-internacional-65143844",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7D8F/production/_100034123_mediaitem100034044.jpg",
-              "description": "El expresidente de Estados Unidos será detenido el martes luego de que un gran jurado en Nueva York lo imputara por supuestamente haberle pagado a la exactriz durante su campaña presidencial para silenciar una relación extramatrimonial.",
-              "imageAlt": "La actriz Stormy Daniels posando",
-              "id": "c99b52b7-78e8-4ac9-8792-ffef24d56400"
-            },
-            {
-              "type": "article",
-              "title": "\"Antes estábamos sitiados\": los barrios de El Salvador que se reencuentran tras la \"desaparición\" de las pandillas por la guerra de Bukele",
-              "firstPublished": "2023-03-27T12:54:51.000Z",
-              "link": "https://www.bbc.com/mundo/noticias-america-latina-65059584",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1BB7/production/_129159070_04ffa0db-984b-464c-9b6d-b277ce1ae0e3.jpg",
-              "description": "Entre denuncias por violación de derechos, el estado de excepción en El Salvador cumple un año con sus homicidios en mínimos históricos. ¿Qué tanto se notan los efectos de la \"guerra contra las pandillas\" en las calles?",
-              "imageAlt": "Cancha de deporte en La Campanera",
-              "id": "517b2f96-e804-4c6d-b68b-92c9b6ca0880"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:b2bfa87b-189c-4c25-a254-3851cf49453f",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "No te lo pierdas",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "Noticias - BBC News Mundo",
+    "description": "BBC Mundo le presenta una selección de contenidos y acontecimientos más importantes de la actualidad. Las últimas noticias e información en materia internacional, sobre América Latina, tecnología, ciencia, salud, economía. Fotos y videos.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Los narcosubmarinos caseros que transportan cocaína de Sudamérica a Europa",
+            "firstPublished": "2023-04-26T11:18:26.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-internacional-65349969",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8D92/production/_129424263_capture4.png",
+            "description": "La BBC tuvo acceso a la embaración secreta que llevó a tres hombres y US$150 millones en drogas desde la selva amazónica hasta España.",
+            "imageAlt": "El submarino casero ahora se encuentra en un estacionamiento en el centro de España.",
+            "id": "5e25e965-3681-46d6-ae11-098c8ebe15a8"
+          },
+          {
+            "type": "article",
+            "title": "\"Cayó un misil enorme a unos 5 minutos de mi casa. Fue lo más fuerte que he oído en mi vida\": el testimonio de una mexicana que fue evacuada de Sudán",
+            "firstPublished": "2023-04-26T11:49:53.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-internacional-65390907",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/B32F/production/_129517854_thumbnail_sudaplate.png",
+            "description": "La mexicana Elizabeth Campero vivió el estallido de la violencia en Sudán desde su hogar en Jartum. Aquí, le cuenta a BBC Mundo cómo fue esa aterradora experiencia y los detalles de la evacuación que la sacó a ella y su familia del país africano.",
+            "imageAlt": "Elizabeth Campero",
+            "id": "9a59e329-4f01-49ff-8296-51edc7d0e47a"
+          },
+          {
+            "type": "article",
+            "title": "El \"inexplicable\" calentamiento de los océanos que alarma a los científicos",
+            "firstPublished": "2023-04-25T16:17:27.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-65388079",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3A4C/production/_129442941_gettyimages-1236993544.jpg",
+            "description": "La superficie del mar alcanzó un nuevo récord de temperatura debido a un aumento que nunca se había producido de manera tan brusca.",
+            "imageAlt": "Sol sobre el océano",
+            "id": "631efe72-a2bc-4a61-98f5-97ca8d85ba89"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:295a530d-b4fc-4747-9ca8-e2896e125568",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "De Newton a Neil Armstrong: 7 frases famosas que realmente nunca se dijeron",
+            "firstPublished": "2023-04-02T19:22:17.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-65090662",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15B18/production/_129165888_gettyimages-1404442799.jpg",
+            "description": "Internet, pero también los libros, están plagados de citas atribuidas a personajes históricos que éstos jamás pronunciaron.",
+            "imageAlt": "El astronauta Neil Amstrong caminando por la Luna en 1969.",
+            "id": "d80aa5d0-e958-4df0-96f9-0b8b68b98436"
+          },
+          {
+            "type": "article",
+            "title": "Quién es Stormy Daniels, la estrella porno que detonó la imputación a Donald Trump",
+            "firstPublished": "2023-03-31T18:53:19.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-internacional-65143844",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7D8F/production/_100034123_mediaitem100034044.jpg",
+            "description": "El expresidente de Estados Unidos será detenido el martes luego de que un gran jurado en Nueva York lo imputara por supuestamente haberle pagado a la exactriz durante su campaña presidencial para silenciar una relación extramatrimonial.",
+            "imageAlt": "La actriz Stormy Daniels posando",
+            "id": "c99b52b7-78e8-4ac9-8792-ffef24d56400"
+          },
+          {
+            "type": "article",
+            "title": "\"Antes estábamos sitiados\": los barrios de El Salvador que se reencuentran tras la \"desaparición\" de las pandillas por la guerra de Bukele",
+            "firstPublished": "2023-03-27T12:54:51.000Z",
+            "link": "https://www.bbc.com/mundo/noticias-america-latina-65059584",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1BB7/production/_129159070_04ffa0db-984b-464c-9b6d-b277ce1ae0e3.jpg",
+            "description": "Entre denuncias por violación de derechos, el estado de excepción en El Salvador cumple un año con sus homicidios en mínimos históricos. ¿Qué tanto se notan los efectos de la \"guerra contra las pandillas\" en las calles?",
+            "imageAlt": "Cancha de deporte en La Campanera",
+            "id": "517b2f96-e804-4c6d-b68b-92c9b6ca0880"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:b2bfa87b-189c-4c25-a254-3851cf49453f",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "No te lo pierdas",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c93v2kkze2rt",
+        "contentType": "index-home",
+        "pageIdentifier": "mundo.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/nepali/homePage/index.json
+++ b/data/nepali/homePage/index.json
@@ -1,96 +1,103 @@
 {
-    "data": {
-      "title": "BBC News नेपाली",
-      "description": "बीबीसी नेपाली सेवाले विश्व घटनाका साथै स्थानीय र क्षेत्रीय घटनाका विश्वसनीय समाचार प्रस्तुत गर्दछ।",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "सुडानबाट उम्किएका नेपाली भन्छन्, 'पैसा नभएर अलपत्र परेका साथीहरूको उद्धार होस्'",
-              "firstPublished": "2023-04-26T09:30:57.856Z",
-              "link": "https://www.bbc.com/nepali/articles/c3g9e5l236po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/369c/live/931ddd80-e409-11ed-b1f7-499e17e0d082.jpg",
-              "description": "इजिप्टस्थित नेपाली राजदूतले समस्यामा परेका नेपालीहरूबारे आफूलाई जानकारी भएको र उनीहरूलाई फर्काउन पहल भइरहेको बीबीसीलाई बताएका छन्।",
-              "imageAlt": "तुलसी राम खनाल",
-              "id": "c3g9e5l236po"
-            },
-            {
-              "type": "article",
-              "title": "छत्तीसगढमा 'माओवादी आक्रमण', ११ जनाको मृत्यु",
-              "firstPublished": "2023-04-26T11:26:15.350Z",
-              "link": "https://www.bbc.com/nepali/articles/cq5wzgdvz4go",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/98cb/live/b77c8c40-e421-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "भारतको छत्तीसगढ राज्यको दन्तवाडमा भएको एउटा आक्रमणमा ११ जनाको मृत्यु भएको प्रहरीले जनाएको छ। ",
-              "imageAlt": "दन्तेवाडा",
-              "id": "cq5wzgdvz4go"
-            },
-            {
-              "type": "article",
-              "title": "के अब मधेसका मुख्य राजनीतिक प्रतिस्पर्धी उपेन्द्र यादव र सीके राउत मात्र हुन्?  ",
-              "firstPublished": "2023-04-26T01:33:00.964Z",
-              "link": "https://www.bbc.com/nepali/articles/czd1xd581kxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6b/live/93a980b0-e3d2-11ed-93ff-dfbb5bebbe1d.png",
-              "description": "आम निर्वाचन र अहिलेको उपनिर्वाचनमा ती दलहरूले प्राप्त गरेको मतको विवरणले पनि ती दुई दलबीच नै मधेसमा मुख्य प्रतिस्पर्धा हुने देखिन्छ। ",
-              "imageAlt": "सीके र उपेन्द्र ",
-              "id": "czd1xd581kxo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:6c48b4bc-e6dc-4205-ae31-ca3b82b29f31",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT2M7S",
-              "title": "जसले २० वर्ष प्रत्येक दिन छोराको फोटो खिचे",
-              "firstPublished": "2023-04-03T01:33:38.000Z",
-              "link": "https://www.bbc.com/nepali/news-65097336",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/BEB1/production/_129171884_photo_dad.jpg",
-              "description": "छोराको बाल्यकालको कुनै समय पनि नबिर्सिइयोस् भनेर एक बुवाले गरेको रोचक प्रयास।",
-              "imageAlt": "इयन मक्लिओडका छोराको बाल्यकालको तस्बिर",
-              "id": "ef71a33e-e528-4f0e-8805-38cdb0fa6170"
-            },
-            {
-              "type": "article",
-              "title": "राष्ट्रपतिको अवस्था ‘सुधार हुँदै’, उनमा देखिएको स्वास्थ्य समस्याबारे चिकित्सक के भन्छन्?",
-              "firstPublished": "2023-04-02T08:23:08.138Z",
-              "link": "https://www.bbc.com/nepali/articles/ce74644wkepo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fbbb/live/a50f6b80-d130-11ed-9fcc-4fa74dd10aec.jpg",
-              "description": "शनिवार अस्पताल भर्ना भएका उनको पछिल्लो स्वास्थ्य अवस्थाबारे जानकारी लिन प्रधानमन्त्री पुष्पकमल दाहाल आइतवार बिहान शिक्षण अस्पताल पुगेका थिए। ",
-              "imageAlt": "रामचन्द्र पौडेल",
-              "id": "ce74644wkepo"
-            },
-            {
-              "type": "article",
-              "title": "सुनमा किन लगानीकर्ताहरू आकर्षित भइरहेका छन्, महँगो मूल्य अझै बढ्ला कि घट्ला?",
-              "firstPublished": "2023-04-02T02:34:07.152Z",
-              "link": "https://www.bbc.com/nepali/articles/cp6wy57r28zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/29e6/live/5c4b0fd0-cfa5-11ed-be2e-754a65c11505.jpg",
-              "description": "नेपाल राष्ट्र ब्याङ्कका प्रवक्ता गुणाकर भट्टले पछिल्लो समय दुई ठूला अमेरिकी ब्याङ्कहरू धरासायी भएपछि डलरका लगानीकर्ता पनि सुनतर्फ आकर्षित भएको हुनसक्ने ठान्छन्।\n",
-              "imageAlt": "सुन",
-              "id": "cp6wy57r28zo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:bfdf9f2e-4881-4cf0-9f79-3ca75437dbf4",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "अन‌ि यो पनि",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News नेपाली",
+    "description": "बीबीसी नेपाली सेवाले विश्व घटनाका साथै स्थानीय र क्षेत्रीय घटनाका विश्वसनीय समाचार प्रस्तुत गर्दछ।",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "सुडानबाट उम्किएका नेपाली भन्छन्, 'पैसा नभएर अलपत्र परेका साथीहरूको उद्धार होस्'",
+            "firstPublished": "2023-04-26T09:30:57.856Z",
+            "link": "https://www.bbc.com/nepali/articles/c3g9e5l236po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/369c/live/931ddd80-e409-11ed-b1f7-499e17e0d082.jpg",
+            "description": "इजिप्टस्थित नेपाली राजदूतले समस्यामा परेका नेपालीहरूबारे आफूलाई जानकारी भएको र उनीहरूलाई फर्काउन पहल भइरहेको बीबीसीलाई बताएका छन्।",
+            "imageAlt": "तुलसी राम खनाल",
+            "id": "c3g9e5l236po"
+          },
+          {
+            "type": "article",
+            "title": "छत्तीसगढमा 'माओवादी आक्रमण', ११ जनाको मृत्यु",
+            "firstPublished": "2023-04-26T11:26:15.350Z",
+            "link": "https://www.bbc.com/nepali/articles/cq5wzgdvz4go",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/98cb/live/b77c8c40-e421-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "भारतको छत्तीसगढ राज्यको दन्तवाडमा भएको एउटा आक्रमणमा ११ जनाको मृत्यु भएको प्रहरीले जनाएको छ। ",
+            "imageAlt": "दन्तेवाडा",
+            "id": "cq5wzgdvz4go"
+          },
+          {
+            "type": "article",
+            "title": "के अब मधेसका मुख्य राजनीतिक प्रतिस्पर्धी उपेन्द्र यादव र सीके राउत मात्र हुन्?  ",
+            "firstPublished": "2023-04-26T01:33:00.964Z",
+            "link": "https://www.bbc.com/nepali/articles/czd1xd581kxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e6b/live/93a980b0-e3d2-11ed-93ff-dfbb5bebbe1d.png",
+            "description": "आम निर्वाचन र अहिलेको उपनिर्वाचनमा ती दलहरूले प्राप्त गरेको मतको विवरणले पनि ती दुई दलबीच नै मधेसमा मुख्य प्रतिस्पर्धा हुने देखिन्छ। ",
+            "imageAlt": "सीके र उपेन्द्र ",
+            "id": "czd1xd581kxo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:6c48b4bc-e6dc-4205-ae31-ca3b82b29f31",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT2M7S",
+            "title": "जसले २० वर्ष प्रत्येक दिन छोराको फोटो खिचे",
+            "firstPublished": "2023-04-03T01:33:38.000Z",
+            "link": "https://www.bbc.com/nepali/news-65097336",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/BEB1/production/_129171884_photo_dad.jpg",
+            "description": "छोराको बाल्यकालको कुनै समय पनि नबिर्सिइयोस् भनेर एक बुवाले गरेको रोचक प्रयास।",
+            "imageAlt": "इयन मक्लिओडका छोराको बाल्यकालको तस्बिर",
+            "id": "ef71a33e-e528-4f0e-8805-38cdb0fa6170"
+          },
+          {
+            "type": "article",
+            "title": "राष्ट्रपतिको अवस्था ‘सुधार हुँदै’, उनमा देखिएको स्वास्थ्य समस्याबारे चिकित्सक के भन्छन्?",
+            "firstPublished": "2023-04-02T08:23:08.138Z",
+            "link": "https://www.bbc.com/nepali/articles/ce74644wkepo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fbbb/live/a50f6b80-d130-11ed-9fcc-4fa74dd10aec.jpg",
+            "description": "शनिवार अस्पताल भर्ना भएका उनको पछिल्लो स्वास्थ्य अवस्थाबारे जानकारी लिन प्रधानमन्त्री पुष्पकमल दाहाल आइतवार बिहान शिक्षण अस्पताल पुगेका थिए। ",
+            "imageAlt": "रामचन्द्र पौडेल",
+            "id": "ce74644wkepo"
+          },
+          {
+            "type": "article",
+            "title": "सुनमा किन लगानीकर्ताहरू आकर्षित भइरहेका छन्, महँगो मूल्य अझै बढ्ला कि घट्ला?",
+            "firstPublished": "2023-04-02T02:34:07.152Z",
+            "link": "https://www.bbc.com/nepali/articles/cp6wy57r28zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/29e6/live/5c4b0fd0-cfa5-11ed-be2e-754a65c11505.jpg",
+            "description": "नेपाल राष्ट्र ब्याङ्कका प्रवक्ता गुणाकर भट्टले पछिल्लो समय दुई ठूला अमेरिकी ब्याङ्कहरू धरासायी भएपछि डलरका लगानीकर्ता पनि सुनतर्फ आकर्षित भएको हुनसक्ने ठान्छन्।\n",
+            "imageAlt": "सुन",
+            "id": "cp6wy57r28zo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:bfdf9f2e-4881-4cf0-9f79-3ca75437dbf4",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "अन‌ि यो पनि",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c897lqqz91gt",
+        "contentType": "index-home",
+        "pageIdentifier": "nepali.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/pashto/homePage/index.json
+++ b/data/pashto/homePage/index.json
@@ -1,96 +1,103 @@
 {
-    "data": {
-      "title": "کور پاڼه - BBC News پښتو",
-      "description": "د افغانستان، سیمې او نړۍ په اړه تازه خبرونه، رپوټونه، شننې، څېړنې، مرکې، لوبې، ژوندۍ رادیويي خپرونې، ويډیوګانې، ستاسې نظرونه او نور ډېر په زړه پورې مطالب په بي بي سي پښتو انټرنېټ پاڼه کې.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "روسیه: د طالبانو حکومت په رسمیت نه پېژنو، خو خبرې ورسره ضرور دي  ",
-              "firstPublished": "2023-04-26T12:33:45.566Z",
-              "link": "https://www.bbc.com/pashto/articles/crg3rkrl39ko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e7ff/live/d2d85e90-e42d-11ed-bfcf-0f0f6a84ee61.jpg",
-              "description": "د روسیې د بهرنیو چارو وزیر وايي، مسکو به تر هغې په افغانستان کې د طالبانو حکومت په رسمیت ونه پېژني چې \"نړیوال مسوولیتونه\"  پر ځای نه کړي.\nد روسیې د تاس خبري‌ ژانس په وینا،‌ سرګیې لاوروف دغه‌ څرګندونې په نیویارک کې خبریالانو ته کړې دي. \nښاغلي ‌لاوروف ویلي‌ \"فکر کوو طالبان یو حقیقت دی،‌ له هغوی سره خبرې ضرور دي.\"",
-              "imageAlt": "لاوروف ",
-              "id": "crg3rkrl39ko"
-            },
-            {
-              "type": "article",
-              "title": "طالبان په نشه روږدو راغونډو کړو کسانو ته حرفوي زدکړې ورکوي ",
-              "firstPublished": "2023-04-26T05:24:07.646Z",
-              "link": "https://www.bbc.com/pashto/articles/c190emd732wo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/19b1/live/73a5f2e0-e3b3-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "کابل",
-              "id": "c190emd732wo"
-            },
-            {
-              "type": "article",
-              "title": "سوډان؛ د مخکیني ولسمشر عمر البشیر حکومتي چارواکي له زندانه بهر شوي",
-              "firstPublished": "2023-04-26T08:07:02.000Z",
-              "link": "https://www.bbc.com/pashto/world-65397681",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/E9B6/production/_129503895_harun.jpg",
-              "description": "د سوډان یو شمېر مخکیني حکومتي چارواکي چې په جنګي جرمونو تورن دي د خرطوم له زندانه بهر شوي دي.",
-              "imageAlt": "Harun (left) in 2010 when he was governor of the South Kordofan region",
-              "id": "d19245eb-97c4-44d8-b7da-0906dd510e38"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:e74e8e47-caa7-44f8-b744-4afb53c236b6",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "امریکایۍ پوځي کورنۍ کې د یتیمې افغانې نجلۍ لورولي باطله اعلان شوه",
-              "firstPublished": "2023-04-01T23:31:44.475Z",
-              "link": "https://www.bbc.com/pashto/articles/cz90g7pe616o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8154/live/5aa507d0-d0e0-11ed-b565-c9e23c8c2ac8.png",
-              "description": "",
-              "imageAlt": "نجلۍ",
-              "id": "cz90g7pe616o"
-            },
-            {
-              "type": "article",
-              "title": "د پېښور لوړې محکمې لومړنۍ ښځينه قاضۍ؛ 'مسرت هلالي د حق خبرې کولو جرات لري'",
-              "firstPublished": "2023-04-01T17:11:34.000Z",
-              "link": "https://www.bbc.com/pashto/pakhtunkhwa-65145491",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9D34/production/_129244204_90e097db-8ec7-42e1-a382-4e3aa463206f.jpg",
-              "description": "د خيبر پښتونخوا په قضایي تاريخ کې لومړی ځل يوه ښځینه چې مسرت هلالي نومېږي د پېښور های کورټ يا لوړې محکمي مشره قاضۍ نومول شوې ده. د پېښور د های کورټ له خوا خپرې شوې اعلاميې له مخې نوموړې نن شنبې (د اپرېل لومړۍ) د مشرې قاضۍ په توګه کار پيل کړ. له دې وړاندې روح الامين د يوې ورځې لپاره مشر قاضي غوره شوی و.",
-              "imageAlt": "مسرت هلالي",
-              "id": "2533b486-b40a-4674-b8d6-65cc63432a3a"
-            },
-            {
-              "type": "video",
-              "duration": "PT11M56S",
-              "title": "مېرمن: د دودونو پالل د ښځو ژوند کې څه منفي او مثبت رول لري؟",
-              "firstPublished": "2023-04-01T23:43:08.000Z",
-              "link": "https://www.bbc.com/pashto/afghanistan-65145496",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1220E/production/_129245247_p0fdc8gs.jpg",
-              "description": "د مېرمن د دې اوونۍ خپرونه کې په دې بحث شوی چې د دودونو پالل د ښځو ژوند کې څه منفي او مثبت رول لري؟",
-              "imageAlt": "شازيه مېرمن خپرونه",
-              "id": "28a60bd9-d107-43cc-8b26-8e8eb1a28d38"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:827e2294-1a58-46bd-ac84-8f8f8540b60a",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "ځانګړي مطالب",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from Live tipo"
-  }
+  "data": {
+    "title": "کور پاڼه - BBC News پښتو",
+    "description": "د افغانستان، سیمې او نړۍ په اړه تازه خبرونه، رپوټونه، شننې، څېړنې، مرکې، لوبې، ژوندۍ رادیويي خپرونې، ويډیوګانې، ستاسې نظرونه او نور ډېر په زړه پورې مطالب په بي بي سي پښتو انټرنېټ پاڼه کې.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "روسیه: د طالبانو حکومت په رسمیت نه پېژنو، خو خبرې ورسره ضرور دي  ",
+            "firstPublished": "2023-04-26T12:33:45.566Z",
+            "link": "https://www.bbc.com/pashto/articles/crg3rkrl39ko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e7ff/live/d2d85e90-e42d-11ed-bfcf-0f0f6a84ee61.jpg",
+            "description": "د روسیې د بهرنیو چارو وزیر وايي، مسکو به تر هغې په افغانستان کې د طالبانو حکومت په رسمیت ونه پېژني چې \"نړیوال مسوولیتونه\"  پر ځای نه کړي.\nد روسیې د تاس خبري‌ ژانس په وینا،‌ سرګیې لاوروف دغه‌ څرګندونې په نیویارک کې خبریالانو ته کړې دي. \nښاغلي ‌لاوروف ویلي‌ \"فکر کوو طالبان یو حقیقت دی،‌ له هغوی سره خبرې ضرور دي.\"",
+            "imageAlt": "لاوروف ",
+            "id": "crg3rkrl39ko"
+          },
+          {
+            "type": "article",
+            "title": "طالبان په نشه روږدو راغونډو کړو کسانو ته حرفوي زدکړې ورکوي ",
+            "firstPublished": "2023-04-26T05:24:07.646Z",
+            "link": "https://www.bbc.com/pashto/articles/c190emd732wo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/19b1/live/73a5f2e0-e3b3-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "کابل",
+            "id": "c190emd732wo"
+          },
+          {
+            "type": "article",
+            "title": "سوډان؛ د مخکیني ولسمشر عمر البشیر حکومتي چارواکي له زندانه بهر شوي",
+            "firstPublished": "2023-04-26T08:07:02.000Z",
+            "link": "https://www.bbc.com/pashto/world-65397681",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/E9B6/production/_129503895_harun.jpg",
+            "description": "د سوډان یو شمېر مخکیني حکومتي چارواکي چې په جنګي جرمونو تورن دي د خرطوم له زندانه بهر شوي دي.",
+            "imageAlt": "Harun (left) in 2010 when he was governor of the South Kordofan region",
+            "id": "d19245eb-97c4-44d8-b7da-0906dd510e38"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:e74e8e47-caa7-44f8-b744-4afb53c236b6",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "امریکایۍ پوځي کورنۍ کې د یتیمې افغانې نجلۍ لورولي باطله اعلان شوه",
+            "firstPublished": "2023-04-01T23:31:44.475Z",
+            "link": "https://www.bbc.com/pashto/articles/cz90g7pe616o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8154/live/5aa507d0-d0e0-11ed-b565-c9e23c8c2ac8.png",
+            "description": "",
+            "imageAlt": "نجلۍ",
+            "id": "cz90g7pe616o"
+          },
+          {
+            "type": "article",
+            "title": "د پېښور لوړې محکمې لومړنۍ ښځينه قاضۍ؛ 'مسرت هلالي د حق خبرې کولو جرات لري'",
+            "firstPublished": "2023-04-01T17:11:34.000Z",
+            "link": "https://www.bbc.com/pashto/pakhtunkhwa-65145491",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9D34/production/_129244204_90e097db-8ec7-42e1-a382-4e3aa463206f.jpg",
+            "description": "د خيبر پښتونخوا په قضایي تاريخ کې لومړی ځل يوه ښځینه چې مسرت هلالي نومېږي د پېښور های کورټ يا لوړې محکمي مشره قاضۍ نومول شوې ده. د پېښور د های کورټ له خوا خپرې شوې اعلاميې له مخې نوموړې نن شنبې (د اپرېل لومړۍ) د مشرې قاضۍ په توګه کار پيل کړ. له دې وړاندې روح الامين د يوې ورځې لپاره مشر قاضي غوره شوی و.",
+            "imageAlt": "مسرت هلالي",
+            "id": "2533b486-b40a-4674-b8d6-65cc63432a3a"
+          },
+          {
+            "type": "video",
+            "duration": "PT11M56S",
+            "title": "مېرمن: د دودونو پالل د ښځو ژوند کې څه منفي او مثبت رول لري؟",
+            "firstPublished": "2023-04-01T23:43:08.000Z",
+            "link": "https://www.bbc.com/pashto/afghanistan-65145496",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1220E/production/_129245247_p0fdc8gs.jpg",
+            "description": "د مېرمن د دې اوونۍ خپرونه کې په دې بحث شوی چې د دودونو پالل د ښځو ژوند کې څه منفي او مثبت رول لري؟",
+            "imageAlt": "شازيه مېرمن خپرونه",
+            "id": "28a60bd9-d107-43cc-8b26-8e8eb1a28d38"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:827e2294-1a58-46bd-ac84-8f8f8540b60a",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "ځانګړي مطالب",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c15er11z5g9t",
+        "contentType": "index-home",
+        "pageIdentifier": "pashto.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from Live tipo"
+}

--- a/data/persian/homePage/index.json
+++ b/data/persian/homePage/index.json
@@ -1,95 +1,102 @@
 {
-    "data": {
-      "title": "BBC News فارسی",
-      "description": "سایت فارسی بی‌بی‌سی تازه‌ترین اخبار و گزارش ها درباره ایران و افغانستان و جهان در حوزه سیاست، اقتصاد، جامعه و فرهنگ و همچنین ویدیو، گزارش‌های تصویری و برنامه‌های تلویزیون فارسی را به شما ارائه می‌دهد.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "چرا «انقلاب مهسا» باید به دنبال دادخواهی برود نه خونخواهی؟",
-              "firstPublished": "2023-04-03T20:06:13.000Z",
-              "link": "https://www.bbc.com/persian/iran-65158865",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/16536/production/_129264419_gozar-shirin-ebadi.jpg",
-              "description": "امیر پیام، بی‌بی‌سی، که برای پوشش کنفرانس «گذار به مردمسالاری در ایران» به دانشگاه استنفورد کالیفرنیا سفر کرده بود با چند چهره برجسته حاضر در این رویداد گفتگو کرده که بخش‌هایی از آن را در تلویزیون و شبکه‌های اجتماعی بی‌بی‌سی فارسی طی روزهای گذشته مشاهده کردید. او در مجموعه «یک نگاه» بنا دارد به بخش‌های منتشر نشده این گفتگوها بپردازد. یادداشت زیر نسخه کامل گفتگوی او با شیرین عبادی، حقوقدان و برنده جایزه صلح نوبل است که درباره عدالت محوری و دادخواهی در دوران گذار است.",
-              "imageAlt": "شیرین عبادی",
-              "id": "d07bb776-00d6-40d4-8bdb-4185b59980d3"
-            },
-            {
-              "type": "article",
-              "title": "روایت یک «مهماندار هواپیما» از زیر پل سوخته کابل تا مرکز ترک اعتیاد طالبان ",
-              "firstPublished": "2023-04-03T10:53:20.379Z",
-              "link": "https://www.bbc.com/persian/articles/c51e2wpl9jyo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/600b/live/c1aeafb0-d1ff-11ed-be2e-754a65c11505.jpg",
-              "description": "در ماه‌های اخیر، صدها مرد در سراسر پایتخت، از زیر پل، از پارک‌ها‌ و از بالای تپه‌ها‌، جمع‌آوری شده‌اند. بیشتر آنها به اردوگاهی که قبلا یک پایگاه نظامی‌ آمریکایی بود، برده شده‌اند که اکنون به یک مرکز موقت ترک اعتیاد تبدیل شده است.\nافغانستان، پایتخت اعتیاد به مواد مخدر در جهان است. به گفته اداره بین المللی مواد مخدر، حدود ۳.۵ میلیون نفر، در کشوری با جمعیت حدود ۴۰ میلیونی معتاد به مواد مخدر هستند.",
-              "imageAlt": "محمد عمر می‌گوید او مهماندار هواپیما بود",
-              "id": "c51e2wpl9jyo"
-            },
-            {
-              "type": "article",
-              "title": "گراهام پاتر اخراج شد؛ سرمربی بعدی چلسی کیست؟",
-              "firstPublished": "2023-04-03T14:05:22.571Z",
-              "link": "https://www.bbc.com/persian/articles/cx85y7j3rl9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c940/live/dc5f24d0-d221-11ed-921a-b9310c388ff8.jpg",
-              "description": "در حالی که لیگ برتر فوتبال انگلیس به اوج خود رسیده است، شماری از بزرگ‌ترین مربیان حال حاضر فوتبال جهان در انتظار پیدا کردن شغل جدیدی نشسته‌اند.",
-              "imageAlt": "یولیان ناگلزمن که از بایرن مونیخ اخراج شده یکی از مربیانی است که گفته می‌شود راهی لیگ برتر فوتبال انگلیس خواهد شد",
-              "id": "cx85y7j3rl9o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:794aa745-4de3-44b3-83aa-031aa12f46f3",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "گزارش و تحلیل",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "طالبان از انتقال نخستین گروه از ده‌ها شهروند گیرمانده افغانستان از سودان به عربستان سعودی خبر داد",
-              "firstPublished": "2023-04-27T11:35:21.042Z",
-              "link": "https://www.bbc.com/persian/articles/crge3mg5r8eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/321d/live/aa4ebe30-e4ee-11ed-8685-fd075442e2f0.jpg",
-              "description": "وزارت خارجه طالبان اعلام کرده که اولین گروه از شهروندان گیرمانده افغانستان در سودان به کمک عربستان سعودی به شهر جده منتقل شده و قرار است به زودی به افغانستان برگردند. در پی آغاز مجدد درگیری‌ها در سودان ده‌ها شهروند افغانستان از جمله دانشجویان و کارمندان سازمان‌های بین‌المللی در شهرهای مختلف سودان گیر مانده‌اند، شماری از آنها از خارطوم پایتخت بیرون شده‌اند و تعداد کمی از آنها موفق به ترک سودان شده‌اند. ",
-              "imageAlt": "خارطوم",
-              "id": "crge3mg5r8eo"
-            },
-            {
-              "type": "article",
-              "title": "چطور مجری فاکس‌نیوز بر موج خشم مردم سوار شد",
-              "firstPublished": "2023-04-27T04:55:03.871Z",
-              "link": "https://www.bbc.com/persian/articles/cp35n605n2eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4205/live/40ae74d0-e3ee-11ed-8df1-d74cbf1089d7.png",
-              "description": "تاکر کارلسون، مجری سرشناس فاکس‌نیوز، متهم به برانگیختن نکات نژادپرستانه و ضد مهاجرت و ترویج تئوری‌های توطئه بود. \n",
-              "imageAlt": "تاکر کارلسون",
-              "id": "cp35n605n2eo"
-            },
-            {
-              "type": "article",
-              "title": "صدای آمریکا از امکان آزادی مشروط ۷ میلیارد دلار ایران در کره جنوبی خبر داد",
-              "firstPublished": "2023-04-27T12:04:56.266Z",
-              "link": "https://www.bbc.com/persian/articles/cv2me4jv86eo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/01d9/live/d4ccf4d0-e4ec-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "بخش فارسی صدای آمریکا، رسانه رسمی دولت آمریکا، در گزارشی اختصاصی از چراغ سبز کاخ سفید به آزادی مشروط هفت میلیارد دلار از دارایی‌های بلوکه‌شده ایران در کره جنوبی خبر داده است.\n",
-              "imageAlt": "پرچم ایران و آمریکا",
-              "id": "cv2me4jv86eo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:362895c7-2b82-43d8-8f76-9c8106734bc9",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Top Stories",
-          "visualProminence": "HIGH",
-          "visualStyle": "COLLECTION"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News فارسی",
+    "description": "سایت فارسی بی‌بی‌سی تازه‌ترین اخبار و گزارش ها درباره ایران و افغانستان و جهان در حوزه سیاست، اقتصاد، جامعه و فرهنگ و همچنین ویدیو، گزارش‌های تصویری و برنامه‌های تلویزیون فارسی را به شما ارائه می‌دهد.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "چرا «انقلاب مهسا» باید به دنبال دادخواهی برود نه خونخواهی؟",
+            "firstPublished": "2023-04-03T20:06:13.000Z",
+            "link": "https://www.bbc.com/persian/iran-65158865",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/16536/production/_129264419_gozar-shirin-ebadi.jpg",
+            "description": "امیر پیام، بی‌بی‌سی، که برای پوشش کنفرانس «گذار به مردمسالاری در ایران» به دانشگاه استنفورد کالیفرنیا سفر کرده بود با چند چهره برجسته حاضر در این رویداد گفتگو کرده که بخش‌هایی از آن را در تلویزیون و شبکه‌های اجتماعی بی‌بی‌سی فارسی طی روزهای گذشته مشاهده کردید. او در مجموعه «یک نگاه» بنا دارد به بخش‌های منتشر نشده این گفتگوها بپردازد. یادداشت زیر نسخه کامل گفتگوی او با شیرین عبادی، حقوقدان و برنده جایزه صلح نوبل است که درباره عدالت محوری و دادخواهی در دوران گذار است.",
+            "imageAlt": "شیرین عبادی",
+            "id": "d07bb776-00d6-40d4-8bdb-4185b59980d3"
+          },
+          {
+            "type": "article",
+            "title": "روایت یک «مهماندار هواپیما» از زیر پل سوخته کابل تا مرکز ترک اعتیاد طالبان ",
+            "firstPublished": "2023-04-03T10:53:20.379Z",
+            "link": "https://www.bbc.com/persian/articles/c51e2wpl9jyo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/600b/live/c1aeafb0-d1ff-11ed-be2e-754a65c11505.jpg",
+            "description": "در ماه‌های اخیر، صدها مرد در سراسر پایتخت، از زیر پل، از پارک‌ها‌ و از بالای تپه‌ها‌، جمع‌آوری شده‌اند. بیشتر آنها به اردوگاهی که قبلا یک پایگاه نظامی‌ آمریکایی بود، برده شده‌اند که اکنون به یک مرکز موقت ترک اعتیاد تبدیل شده است.\nافغانستان، پایتخت اعتیاد به مواد مخدر در جهان است. به گفته اداره بین المللی مواد مخدر، حدود ۳.۵ میلیون نفر، در کشوری با جمعیت حدود ۴۰ میلیونی معتاد به مواد مخدر هستند.",
+            "imageAlt": "محمد عمر می‌گوید او مهماندار هواپیما بود",
+            "id": "c51e2wpl9jyo"
+          },
+          {
+            "type": "article",
+            "title": "گراهام پاتر اخراج شد؛ سرمربی بعدی چلسی کیست؟",
+            "firstPublished": "2023-04-03T14:05:22.571Z",
+            "link": "https://www.bbc.com/persian/articles/cx85y7j3rl9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/c940/live/dc5f24d0-d221-11ed-921a-b9310c388ff8.jpg",
+            "description": "در حالی که لیگ برتر فوتبال انگلیس به اوج خود رسیده است، شماری از بزرگ‌ترین مربیان حال حاضر فوتبال جهان در انتظار پیدا کردن شغل جدیدی نشسته‌اند.",
+            "imageAlt": "یولیان ناگلزمن که از بایرن مونیخ اخراج شده یکی از مربیانی است که گفته می‌شود راهی لیگ برتر فوتبال انگلیس خواهد شد",
+            "id": "cx85y7j3rl9o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:794aa745-4de3-44b3-83aa-031aa12f46f3",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "گزارش و تحلیل",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "طالبان از انتقال نخستین گروه از ده‌ها شهروند گیرمانده افغانستان از سودان به عربستان سعودی خبر داد",
+            "firstPublished": "2023-04-27T11:35:21.042Z",
+            "link": "https://www.bbc.com/persian/articles/crge3mg5r8eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/321d/live/aa4ebe30-e4ee-11ed-8685-fd075442e2f0.jpg",
+            "description": "وزارت خارجه طالبان اعلام کرده که اولین گروه از شهروندان گیرمانده افغانستان در سودان به کمک عربستان سعودی به شهر جده منتقل شده و قرار است به زودی به افغانستان برگردند. در پی آغاز مجدد درگیری‌ها در سودان ده‌ها شهروند افغانستان از جمله دانشجویان و کارمندان سازمان‌های بین‌المللی در شهرهای مختلف سودان گیر مانده‌اند، شماری از آنها از خارطوم پایتخت بیرون شده‌اند و تعداد کمی از آنها موفق به ترک سودان شده‌اند. ",
+            "imageAlt": "خارطوم",
+            "id": "crge3mg5r8eo"
+          },
+          {
+            "type": "article",
+            "title": "چطور مجری فاکس‌نیوز بر موج خشم مردم سوار شد",
+            "firstPublished": "2023-04-27T04:55:03.871Z",
+            "link": "https://www.bbc.com/persian/articles/cp35n605n2eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4205/live/40ae74d0-e3ee-11ed-8df1-d74cbf1089d7.png",
+            "description": "تاکر کارلسون، مجری سرشناس فاکس‌نیوز، متهم به برانگیختن نکات نژادپرستانه و ضد مهاجرت و ترویج تئوری‌های توطئه بود. \n",
+            "imageAlt": "تاکر کارلسون",
+            "id": "cp35n605n2eo"
+          },
+          {
+            "type": "article",
+            "title": "صدای آمریکا از امکان آزادی مشروط ۷ میلیارد دلار ایران در کره جنوبی خبر داد",
+            "firstPublished": "2023-04-27T12:04:56.266Z",
+            "link": "https://www.bbc.com/persian/articles/cv2me4jv86eo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/01d9/live/d4ccf4d0-e4ec-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "بخش فارسی صدای آمریکا، رسانه رسمی دولت آمریکا، در گزارشی اختصاصی از چراغ سبز کاخ سفید به آزادی مشروط هفت میلیارد دلار از دارایی‌های بلوکه‌شده ایران در کره جنوبی خبر داده است.\n",
+            "imageAlt": "پرچم ایران و آمریکا",
+            "id": "cv2me4jv86eo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:362895c7-2b82-43d8-8f76-9c8106734bc9",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Top Stories",
+        "visualProminence": "HIGH",
+        "visualStyle": "COLLECTION"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c3rpqvvzem3t",
+        "contentType": "index-home",
+        "pageIdentifier": "persian.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/pidgin/homePage/index.json
+++ b/data/pidgin/homePage/index.json
@@ -6021,7 +6021,14 @@
           ]
         }
       }
-    ]
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c93v2kkz841t",
+        "contentType": "index-home",
+        "pageIdentifier": "pidgin.page"
+      }
+    }
   },
   "contentType": "application/json; charset=utf-8",
   "dataSource": "Data is from live TIPO"

--- a/data/portuguese/homePage/index.json
+++ b/data/portuguese/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "Notícias, vídeos, análise e contexto em português - BBC News Brasil",
-      "description": "Na BBC Brasil você fica por dentro do que acontece no Brasil e no mundo. Com redações em Londres e São Paulo e mais de 200 repórteres internacionais, nossa cobertura leva a você as principais notícias de política, economia, ciência, saúde e comportamento.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "John Wycliffe: a história do homem que foi 'torturado depois de morto' por ter traduzido a Bíblia",
-              "firstPublished": "2023-04-03T10:00:04.115Z",
-              "link": "https://www.bbc.com/portuguese/articles/c88455z0725o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1b86/live/ce109c10-d14f-11ed-a99e-b92595fd4ef3.jpg",
-              "description": "Ele foi condenado pela Igreja Católica por heresia 10 anos após sua morte, em 1384, e quase 30 anos depois, seus restos mortais foram retirados do túmulo e queimados.",
-              "imageAlt": "John Wycliffe",
-              "id": "c88455z0725o"
-            },
-            {
-              "type": "article",
-              "title": "Peixe é filmado a recorde de 8,3 mil metros de profundidade no Japão",
-              "firstPublished": "2023-04-01T19:26:34.122Z",
-              "link": "https://www.bbc.com/portuguese/articles/c98ne7gnn47o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b125/live/1e11e1a0-d0c0-11ed-b323-29280ab4cf4a.jpg",
-              "description": "\"Fico frustrado quando as pessoas dizem que não sabemos nada sobre o fundo do mar. Nós sabemos. As coisas estão mudando muito rápido\", diz o pesquisador Alan Jamieson",
-              "imageAlt": "Peixe gelatinoso ",
-              "id": "c98ne7gnn47o"
-            },
-            {
-              "type": "article",
-              "title": "A síndrome inventada por médicos italianos que salvou dezenas de judeus dos nazistas ",
-              "firstPublished": "2023-03-31T18:28:56.681Z",
-              "link": "https://www.bbc.com/portuguese/articles/cw9rr2jnq0do",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fc25/live/16930ee0-cecc-11ed-be2e-754a65c11505.jpg",
-              "description": "Três médicos de um hospital romano, administrado pela Igreja Católica, levaram os alemães a acreditar que um grupo de judeus havia contraído uma doença mortal e contagiosa.",
-              "imageAlt": "Roma",
-              "id": "cw9rr2jnq0do"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a339175f-b6de-4d46-a00a-237baccd6646",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Leia mais",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "Notícias, vídeos, análise e contexto em português - BBC News Brasil",
+    "description": "Na BBC Brasil você fica por dentro do que acontece no Brasil e no mundo. Com redações em Londres e São Paulo e mais de 200 repórteres internacionais, nossa cobertura leva a você as principais notícias de política, economia, ciência, saúde e comportamento.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "John Wycliffe: a história do homem que foi 'torturado depois de morto' por ter traduzido a Bíblia",
+            "firstPublished": "2023-04-03T10:00:04.115Z",
+            "link": "https://www.bbc.com/portuguese/articles/c88455z0725o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1b86/live/ce109c10-d14f-11ed-a99e-b92595fd4ef3.jpg",
+            "description": "Ele foi condenado pela Igreja Católica por heresia 10 anos após sua morte, em 1384, e quase 30 anos depois, seus restos mortais foram retirados do túmulo e queimados.",
+            "imageAlt": "John Wycliffe",
+            "id": "c88455z0725o"
+          },
+          {
+            "type": "article",
+            "title": "Peixe é filmado a recorde de 8,3 mil metros de profundidade no Japão",
+            "firstPublished": "2023-04-01T19:26:34.122Z",
+            "link": "https://www.bbc.com/portuguese/articles/c98ne7gnn47o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b125/live/1e11e1a0-d0c0-11ed-b323-29280ab4cf4a.jpg",
+            "description": "\"Fico frustrado quando as pessoas dizem que não sabemos nada sobre o fundo do mar. Nós sabemos. As coisas estão mudando muito rápido\", diz o pesquisador Alan Jamieson",
+            "imageAlt": "Peixe gelatinoso ",
+            "id": "c98ne7gnn47o"
+          },
+          {
+            "type": "article",
+            "title": "A síndrome inventada por médicos italianos que salvou dezenas de judeus dos nazistas ",
+            "firstPublished": "2023-03-31T18:28:56.681Z",
+            "link": "https://www.bbc.com/portuguese/articles/cw9rr2jnq0do",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fc25/live/16930ee0-cecc-11ed-be2e-754a65c11505.jpg",
+            "description": "Três médicos de um hospital romano, administrado pela Igreja Católica, levaram os alemães a acreditar que um grupo de judeus havia contraído uma doença mortal e contagiosa.",
+            "imageAlt": "Roma",
+            "id": "cw9rr2jnq0do"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a339175f-b6de-4d46-a00a-237baccd6646",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Leia mais",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c7pe2jj9l7mt",
+        "contentType": "index-home",
+        "pageIdentifier": "portuguese.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/punjabi/homePage/index.json
+++ b/data/punjabi/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News ਪੰਜਾਬੀ",
-      "description": "ਪੰਜਾਬ ਤੇ ਭਾਰਤ ਸਬੰਧੀ ਤੇ ਕੌਮਾਂਤਰੀ ਖ਼ਬਰਾਂ ਲਈ ਬੀਬੀਸੀ ਪੰਜਾਬੀ ’ਤੇ ਆਓ। ਇੱਥੇ ਤੁਹਾਨੂੰ ਸਿਆਸਤ ਤੇ ਸਮਾਜ ਨਾਲ ਜੁੜੀਆਂ ਖ਼ਬਰਾਂ ਤੋਂ ਇਲਾਵਾ ਫੋਟੋ ਫੀਚਰ, ਵੀਡੀਓ ਤੇ ਮਨੋਰਥ ਭਰਪੂਰ ਲੇਖ ਵੀ ਮਿਲਣਗੇ। ਨੌਜਵਾਨਾਂ ਤੇ ਔਰਤਾਂ ਦਾ ਖ਼ਾਸ ਧਿਆਨ ਰੱਖਦੇ ਹੋਏ ਸੋਸ਼ਲ ਮੀਡੀਆ ਰੁਝਾਨਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ ਮਿਲੇਗੀ।",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ਪਾਕਿਸਤਾਨ ਦਾ ਸਿਆਸੀ ਸੰਕਟ ਮੁਲਕ ਨੂੰ ਇੰਝ ਕਰ ਸਕਦਾ ਹੈ ਪ੍ਰਭਾਵਿਤ",
-              "firstPublished": "2023-03-16T08:16:37.069Z",
-              "link": "https://www.bbc.com/punjabi/articles/cxepl74p0mvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4fb5/live/ebd20cf0-c3d7-11ed-95f8-0154daa64c44.jpg",
-              "description": "ਇਮਰਾਨ ਖ਼ਾਨ ਦੀ ਗ਼੍ਰਿਫ਼ਤਾਰੀ ਦਾ ਮੁਲਕ ਦੀ ਸਿਆਸਤ ’ਤੇ ਕੀ ਅਸਰ ਹੋਵੇਗਾ, ਇਹ ਉਨ੍ਹਾਂ ਦਾ ਸਿਆਸੀ ਕਰੀਅਰ ਚਮਕਾਏਗੀ ਜਾਂ ਖ਼ਤਮ ਕਰ ਦੇਵੇਗੀ",
-              "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ",
-              "id": "cxepl74p0mvo"
-            },
-            {
-              "type": "article",
-              "title": "ਇਮਰਾਨ ਖ਼ਾਨ : ਤੋਸ਼ਾਖਾਨਾ ਮਾਮਲੇ 'ਚ 30 ਮਾਰਚ ਤੱਕ ਟਲੀ ਸੁਣਵਾਈ, ਇਮਰਾਨ ਦੀ ਗ੍ਰਿਫ਼ਤਾਰੀ ਦਾ ਵਾਰੰਟ ਵੀ ਰੱਦ",
-              "firstPublished": "2023-03-18T06:30:51.564Z",
-              "link": "https://www.bbc.com/punjabi/articles/cxr06lvvq71o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cb6d/live/cf736b80-c58a-11ed-95f8-0154daa64c44.jpg",
-              "description": "ਅਦਾਲਤ ਨੇ ਕਿਹਾ ਹੈ ਕਿ ਇਮਰਾਨ ਨੂੰ 30 ਮਾਰਚ ਨੂੰ ਪੇਸ਼ ਹੋਣਾ ਪਵੇਗਾ, ਹਾਲਾਂਕਿ ਇਹ ਇੱਕ ਵੱਖਰਾ ਮੁੱਦਾ ਹੈ ਕਿ ਉਸ ਵੇਲੇ ਕੀ ਸਥਿਤੀ ਹੋਵੇਗੀ",
-              "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ ਮਾਮਲਾ",
-              "id": "cxr06lvvq71o"
-            },
-            {
-              "type": "article",
-              "title": "ਇਮਰਾਨ ਖਾਨ : ਤੋਸ਼ਾਖਾਨਾ ਮਾਮਲਾ ਕੀ ਹੈ, ਜਿਸ ਨੇ ਸਾਬਕਾ ਪ੍ਰਧਾਨ ਮੰਤਰੀ ਲਈ ਸੰਕਟ ਖੜ੍ਹਾ ਕੀਤਾ",
-              "firstPublished": "2023-03-05T09:57:45.000Z",
-              "link": "https://www.bbc.com/punjabi/international-64853651",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6F8B/production/_128855582__127289459_gettyimages-994502034.jpg",
-              "description": "ਲਾਹੌਰ ਵਿੱਚ ਪੁਲਿਸ ਇਮਰਾਨ ਖਾਨ ਨੂੰ ਗ੍ਰਿਫਤਾਰ ਕਰਨ ਲਈ ਅਦਾਲਤ ਦਾ ਵਾਰੰਟ ਲੈ ਕੇ ਉਨ੍ਹਾਂ ਦੀ ਰਿਹਾਇਸ਼ ਉੱਤੇ ਪਹੁੰਚੀ ਹੋਈ ਹੈ",
-              "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ",
-              "id": "b4326422-4758-4861-9bad-d9d032eebd18"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:c9d5eeb8-2d23-4658-890b-bfff62dc3492",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "ਦ੍ਰਿਸ਼ਟੀਕੋਣ",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News ਪੰਜਾਬੀ",
+    "description": "ਪੰਜਾਬ ਤੇ ਭਾਰਤ ਸਬੰਧੀ ਤੇ ਕੌਮਾਂਤਰੀ ਖ਼ਬਰਾਂ ਲਈ ਬੀਬੀਸੀ ਪੰਜਾਬੀ ’ਤੇ ਆਓ। ਇੱਥੇ ਤੁਹਾਨੂੰ ਸਿਆਸਤ ਤੇ ਸਮਾਜ ਨਾਲ ਜੁੜੀਆਂ ਖ਼ਬਰਾਂ ਤੋਂ ਇਲਾਵਾ ਫੋਟੋ ਫੀਚਰ, ਵੀਡੀਓ ਤੇ ਮਨੋਰਥ ਭਰਪੂਰ ਲੇਖ ਵੀ ਮਿਲਣਗੇ। ਨੌਜਵਾਨਾਂ ਤੇ ਔਰਤਾਂ ਦਾ ਖ਼ਾਸ ਧਿਆਨ ਰੱਖਦੇ ਹੋਏ ਸੋਸ਼ਲ ਮੀਡੀਆ ਰੁਝਾਨਾਂ ਬਾਰੇ ਜਾਣਕਾਰੀ ਮਿਲੇਗੀ।",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ਪਾਕਿਸਤਾਨ ਦਾ ਸਿਆਸੀ ਸੰਕਟ ਮੁਲਕ ਨੂੰ ਇੰਝ ਕਰ ਸਕਦਾ ਹੈ ਪ੍ਰਭਾਵਿਤ",
+            "firstPublished": "2023-03-16T08:16:37.069Z",
+            "link": "https://www.bbc.com/punjabi/articles/cxepl74p0mvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4fb5/live/ebd20cf0-c3d7-11ed-95f8-0154daa64c44.jpg",
+            "description": "ਇਮਰਾਨ ਖ਼ਾਨ ਦੀ ਗ਼੍ਰਿਫ਼ਤਾਰੀ ਦਾ ਮੁਲਕ ਦੀ ਸਿਆਸਤ ’ਤੇ ਕੀ ਅਸਰ ਹੋਵੇਗਾ, ਇਹ ਉਨ੍ਹਾਂ ਦਾ ਸਿਆਸੀ ਕਰੀਅਰ ਚਮਕਾਏਗੀ ਜਾਂ ਖ਼ਤਮ ਕਰ ਦੇਵੇਗੀ",
+            "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ",
+            "id": "cxepl74p0mvo"
+          },
+          {
+            "type": "article",
+            "title": "ਇਮਰਾਨ ਖ਼ਾਨ : ਤੋਸ਼ਾਖਾਨਾ ਮਾਮਲੇ 'ਚ 30 ਮਾਰਚ ਤੱਕ ਟਲੀ ਸੁਣਵਾਈ, ਇਮਰਾਨ ਦੀ ਗ੍ਰਿਫ਼ਤਾਰੀ ਦਾ ਵਾਰੰਟ ਵੀ ਰੱਦ",
+            "firstPublished": "2023-03-18T06:30:51.564Z",
+            "link": "https://www.bbc.com/punjabi/articles/cxr06lvvq71o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cb6d/live/cf736b80-c58a-11ed-95f8-0154daa64c44.jpg",
+            "description": "ਅਦਾਲਤ ਨੇ ਕਿਹਾ ਹੈ ਕਿ ਇਮਰਾਨ ਨੂੰ 30 ਮਾਰਚ ਨੂੰ ਪੇਸ਼ ਹੋਣਾ ਪਵੇਗਾ, ਹਾਲਾਂਕਿ ਇਹ ਇੱਕ ਵੱਖਰਾ ਮੁੱਦਾ ਹੈ ਕਿ ਉਸ ਵੇਲੇ ਕੀ ਸਥਿਤੀ ਹੋਵੇਗੀ",
+            "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ ਮਾਮਲਾ",
+            "id": "cxr06lvvq71o"
+          },
+          {
+            "type": "article",
+            "title": "ਇਮਰਾਨ ਖਾਨ : ਤੋਸ਼ਾਖਾਨਾ ਮਾਮਲਾ ਕੀ ਹੈ, ਜਿਸ ਨੇ ਸਾਬਕਾ ਪ੍ਰਧਾਨ ਮੰਤਰੀ ਲਈ ਸੰਕਟ ਖੜ੍ਹਾ ਕੀਤਾ",
+            "firstPublished": "2023-03-05T09:57:45.000Z",
+            "link": "https://www.bbc.com/punjabi/international-64853651",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6F8B/production/_128855582__127289459_gettyimages-994502034.jpg",
+            "description": "ਲਾਹੌਰ ਵਿੱਚ ਪੁਲਿਸ ਇਮਰਾਨ ਖਾਨ ਨੂੰ ਗ੍ਰਿਫਤਾਰ ਕਰਨ ਲਈ ਅਦਾਲਤ ਦਾ ਵਾਰੰਟ ਲੈ ਕੇ ਉਨ੍ਹਾਂ ਦੀ ਰਿਹਾਇਸ਼ ਉੱਤੇ ਪਹੁੰਚੀ ਹੋਈ ਹੈ",
+            "imageAlt": "ਇਮਰਾਨ ਖ਼ਾਨ",
+            "id": "b4326422-4758-4861-9bad-d9d032eebd18"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:c9d5eeb8-2d23-4658-890b-bfff62dc3492",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "ਦ੍ਰਿਸ਼ਟੀਕੋਣ",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:ck2nell96g6t",
+        "contentType": "index-home",
+        "pageIdentifier": "punjabi.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/russian/homePage/index.json
+++ b/data/russian/homePage/index.json
@@ -1,53 +1,60 @@
 {
-    "data": {
-      "title": "Главная - BBC News Русская служба",
-      "description": "Русская служба Би-би-си – это непредвзятое освещение событий в России и мире на русском языке.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Священный Карабах. Как сакрализация прошлого мешает мирному процессу между Азербайджаном и Арменией",
-              "firstPublished": "2023-04-02T04:38:24.000Z",
-              "link": "https://www.bbc.com/russian/features-65139784",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F521/production/_129235726_unnamed.jpg",
-              "description": "В марте начались прямые переговоры между Азербайджаном и карабахскими армянами - первый открытый диалог между сторонами конфликта. За три с небольшим десятилетия стараниями не только властей, но и поэтов, писателей и музыкантов между народами выросла такая пропасть, что многие по обе стороны не представляют жизни без нее.",
-              "imageAlt": "Акварельный рисунок - средневековый старец на фоне гор и беспилотника",
-              "id": "289d5c5c-5c3f-494b-a5ec-f1aba5ebecac"
-            },
-            {
-              "type": "video",
-              "duration": "PT11M53S",
-              "title": "\"Жизнь в трех томиках уголовного дела\". История студентки Олеси Кривцовой",
-              "firstPublished": "2023-03-30T12:14:54.000Z",
-              "link": "https://www.bbc.com/russian/media-65126980",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/147C8/production/_129221938_p0fcw054.jpg",
-              "description": "Олеся сбежала в Литву после того, как в России ее в России ее посадили под домашний арест по обвинению в дискредитации армии.",
-              "imageAlt": "Олеся Кривцова",
-              "id": "4a9f8f11-31c0-4ada-a7c0-531d9c9e53bf"
-            },
-            {
-              "type": "article",
-              "title": "У российских мигрантов в Аргентине проблемы с продлением \"безвиза\". Что происходит?",
-              "firstPublished": "2023-04-02T06:26:39.000Z",
-              "link": "https://www.bbc.com/russian/features-65147938",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FD92/production/_129241946_02d7e4bb-798d-4318-b009-89157341362a.jpg",
-              "description": "Группы российских эмигрантов в Аргентине и дипломаты говорят, что российские граждане начали массово получать отказы на пребывание в республике без визы на срок больше, чем 90 дней в течение полугода. Почему так получилось и какие варианты у них есть остаться?",
-              "imageAlt": "Аргентина",
-              "id": "fa898089-98eb-4a8e-b197-53732775367b"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:d2707d21-96bd-4b02-9f9c-3f86edd0aa62",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Не пропустите",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "Главная - BBC News Русская служба",
+    "description": "Русская служба Би-би-си – это непредвзятое освещение событий в России и мире на русском языке.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Священный Карабах. Как сакрализация прошлого мешает мирному процессу между Азербайджаном и Арменией",
+            "firstPublished": "2023-04-02T04:38:24.000Z",
+            "link": "https://www.bbc.com/russian/features-65139784",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/F521/production/_129235726_unnamed.jpg",
+            "description": "В марте начались прямые переговоры между Азербайджаном и карабахскими армянами - первый открытый диалог между сторонами конфликта. За три с небольшим десятилетия стараниями не только властей, но и поэтов, писателей и музыкантов между народами выросла такая пропасть, что многие по обе стороны не представляют жизни без нее.",
+            "imageAlt": "Акварельный рисунок - средневековый старец на фоне гор и беспилотника",
+            "id": "289d5c5c-5c3f-494b-a5ec-f1aba5ebecac"
+          },
+          {
+            "type": "video",
+            "duration": "PT11M53S",
+            "title": "\"Жизнь в трех томиках уголовного дела\". История студентки Олеси Кривцовой",
+            "firstPublished": "2023-03-30T12:14:54.000Z",
+            "link": "https://www.bbc.com/russian/media-65126980",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/147C8/production/_129221938_p0fcw054.jpg",
+            "description": "Олеся сбежала в Литву после того, как в России ее в России ее посадили под домашний арест по обвинению в дискредитации армии.",
+            "imageAlt": "Олеся Кривцова",
+            "id": "4a9f8f11-31c0-4ada-a7c0-531d9c9e53bf"
+          },
+          {
+            "type": "article",
+            "title": "У российских мигрантов в Аргентине проблемы с продлением \"безвиза\". Что происходит?",
+            "firstPublished": "2023-04-02T06:26:39.000Z",
+            "link": "https://www.bbc.com/russian/features-65147938",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FD92/production/_129241946_02d7e4bb-798d-4318-b009-89157341362a.jpg",
+            "description": "Группы российских эмигрантов в Аргентине и дипломаты говорят, что российские граждане начали массово получать отказы на пребывание в республике без визы на срок больше, чем 90 дней в течение полугода. Почему так получилось и какие варианты у них есть остаться?",
+            "imageAlt": "Аргентина",
+            "id": "fa898089-98eb-4a8e-b197-53732775367b"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:d2707d21-96bd-4b02-9f9c-3f86edd0aa62",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Не пропустите",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c7pe2jj9q7zt",
+        "contentType": "index-home",
+        "pageIdentifier": "russian.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/sinhala/homePage/index.json
+++ b/data/sinhala/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News සිංහල",
-      "description": "ශ්‍රී ලංකාව සම්බන්ධ නැවුම් පුවත්, අලුත්ම පුවත්, ක්‍රිකට්, විශේෂ සම්මුඛ සාකච්ඡා, හඬපට, වීඩියෝ පට, ප්‍රවෘත්ති විශ්ලේෂණ, විශේෂාංග, කාලීන ප්‍රවෘත්ති සහ ව්‍යාපාරික හා කලා තොරතුරු දැන ගැනීමට බීබීසී සිංහල වෙබ් අඩවියට පිවිසෙන්න. BBC Sandeshaya, BBC Sinhala",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "'වැඩිහිටි ස්ථුලභාවය සඳහා මූලික අත්තිවාරම යෙදෙන්නේ ළමා කාලෙදි'",
-              "firstPublished": "2023-03-04T02:31:49.381Z",
-              "link": "https://www.bbc.com/sinhala/articles/clkr8grvrvxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0adf/live/4ccce930-b9b5-11ed-8a76-55e4ad82e6e6.jpg",
-              "description": "අධිබර හා ස්ථුලතාව සඳහා දැන් රජයේ රෝහල්වලින් නොමිලයේ ලබාදෙන ප්‍රතිකර්ම තිබෙන අතර, ඒවා ලබාගැනීම ද ඉතාම වැදගත් ය. ඒ ප්‍රතිකර්ම ක්‍රම මොනවාදැ යි ඔබ දන්නවා ද? ඒ ගැන තොරතුරු සියල්ල ඇතුළත්ව ලෝක ස්ථුලතා දිනය වෙනුවෙන් අප සම්පාදනය කළ මේ ලිපිය ඔබට වැදගත් වනු ඇති. ",
-              "imageAlt": "සෑම පුරුෂයින් තිදෙනෙකුගෙන්ම එක් අයෙකු ද, සෑම කාන්තාවන් දෙදෙනෙකුගෙන්ම එක් අයෙකු ද තරබාරු තැනැත්තන් ය",
-              "id": "clkr8grvrvxo"
-            },
-            {
-              "type": "article",
-              "title": "ඩොලරයට මොකද වෙන්නේ ?",
-              "firstPublished": "2023-03-02T11:26:02.442Z",
-              "link": "https://www.bbc.com/sinhala/articles/cxx737n96r5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ac82/live/cefefe40-b8e6-11ed-bd02-87570addd2ae.jpg",
-              "description": "සැබවින්ම ඩොලරයට මොකද වෙන්නේ? ඩොලරයට සාපේක්ෂව රුපියල තවත් ශක්තිමත් වෙයිද? මෙය මුදල් වෙළෙඳපොල කටයුතුවලට කෙසේ බලපායිද? යන්න ගැන බොහෝ දෙනෙකු තුළ ඇත්තේ අවිනිශ්චිත තත්ත්වයකි.",
-              "imageAlt": "ඩොලරයට සාපේක්ෂව රුපියල ශක්තිමත් වෙමින් ඇත",
-              "id": "cxx737n96r5o"
-            },
-            {
-              "type": "article",
-              "title": "ලිංගික සබඳතාවන්ගෙන් තොර සහස්‍රකයන්ගේ විවාහ",
-              "firstPublished": "2023-02-27T05:54:05.500Z",
-              "link": "https://www.bbc.com/sinhala/articles/c1vxkw9elq2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0de5/live/67fa0ca0-b42a-11ed-b4bc-e32919748697.png",
-              "description": "සහස්‍රකයන් ඔවුන්ගේ ජීවිතයේ ලිංගිකත්වයෙන් උච්ච ස්ථානයක හෝ ඒ ආසන්නයේ සිටිය යුතුවුවත් ඒ පරම්පරාවේ සමහරුන් \"ලිංගිකත්වයෙන් ඈත්ව\" වෙසෙන බව ලොව නන් දෙසින් වාර්තා වෙයි.",
-              "imageAlt": "Sexless marriages",
-              "id": "c1vxkw9elq2o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a10379d8-4aa7-47e8-afa7-57973f700ada",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "දැක්ම",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News සිංහල",
+    "description": "ශ්‍රී ලංකාව සම්බන්ධ නැවුම් පුවත්, අලුත්ම පුවත්, ක්‍රිකට්, විශේෂ සම්මුඛ සාකච්ඡා, හඬපට, වීඩියෝ පට, ප්‍රවෘත්ති විශ්ලේෂණ, විශේෂාංග, කාලීන ප්‍රවෘත්ති සහ ව්‍යාපාරික හා කලා තොරතුරු දැන ගැනීමට බීබීසී සිංහල වෙබ් අඩවියට පිවිසෙන්න. BBC Sandeshaya, BBC Sinhala",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "'වැඩිහිටි ස්ථුලභාවය සඳහා මූලික අත්තිවාරම යෙදෙන්නේ ළමා කාලෙදි'",
+            "firstPublished": "2023-03-04T02:31:49.381Z",
+            "link": "https://www.bbc.com/sinhala/articles/clkr8grvrvxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0adf/live/4ccce930-b9b5-11ed-8a76-55e4ad82e6e6.jpg",
+            "description": "අධිබර හා ස්ථුලතාව සඳහා දැන් රජයේ රෝහල්වලින් නොමිලයේ ලබාදෙන ප්‍රතිකර්ම තිබෙන අතර, ඒවා ලබාගැනීම ද ඉතාම වැදගත් ය. ඒ ප්‍රතිකර්ම ක්‍රම මොනවාදැ යි ඔබ දන්නවා ද? ඒ ගැන තොරතුරු සියල්ල ඇතුළත්ව ලෝක ස්ථුලතා දිනය වෙනුවෙන් අප සම්පාදනය කළ මේ ලිපිය ඔබට වැදගත් වනු ඇති. ",
+            "imageAlt": "සෑම පුරුෂයින් තිදෙනෙකුගෙන්ම එක් අයෙකු ද, සෑම කාන්තාවන් දෙදෙනෙකුගෙන්ම එක් අයෙකු ද තරබාරු තැනැත්තන් ය",
+            "id": "clkr8grvrvxo"
+          },
+          {
+            "type": "article",
+            "title": "ඩොලරයට මොකද වෙන්නේ ?",
+            "firstPublished": "2023-03-02T11:26:02.442Z",
+            "link": "https://www.bbc.com/sinhala/articles/cxx737n96r5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ac82/live/cefefe40-b8e6-11ed-bd02-87570addd2ae.jpg",
+            "description": "සැබවින්ම ඩොලරයට මොකද වෙන්නේ? ඩොලරයට සාපේක්ෂව රුපියල තවත් ශක්තිමත් වෙයිද? මෙය මුදල් වෙළෙඳපොල කටයුතුවලට කෙසේ බලපායිද? යන්න ගැන බොහෝ දෙනෙකු තුළ ඇත්තේ අවිනිශ්චිත තත්ත්වයකි.",
+            "imageAlt": "ඩොලරයට සාපේක්ෂව රුපියල ශක්තිමත් වෙමින් ඇත",
+            "id": "cxx737n96r5o"
+          },
+          {
+            "type": "article",
+            "title": "ලිංගික සබඳතාවන්ගෙන් තොර සහස්‍රකයන්ගේ විවාහ",
+            "firstPublished": "2023-02-27T05:54:05.500Z",
+            "link": "https://www.bbc.com/sinhala/articles/c1vxkw9elq2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0de5/live/67fa0ca0-b42a-11ed-b4bc-e32919748697.png",
+            "description": "සහස්‍රකයන් ඔවුන්ගේ ජීවිතයේ ලිංගිකත්වයෙන් උච්ච ස්ථානයක හෝ ඒ ආසන්නයේ සිටිය යුතුවුවත් ඒ පරම්පරාවේ සමහරුන් \"ලිංගිකත්වයෙන් ඈත්ව\" වෙසෙන බව ලොව නන් දෙසින් වාර්තා වෙයි.",
+            "imageAlt": "Sexless marriages",
+            "id": "c1vxkw9elq2o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a10379d8-4aa7-47e8-afa7-57973f700ada",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "දැක්ම",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c3rpqvv9v6xt",
+        "contentType": "index-home",
+        "pageIdentifier": "sinhala.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/somali/homePage/index.json
+++ b/data/somali/homePage/index.json
@@ -1,683 +1,690 @@
 {
-    "data": {
-      "title": "BBC News Somali",
-      "description": "",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Maxay u baahan yihiin ciidamada Soomaaliya si ay amniga ula wareegaan?",
-              "firstPublished": "2023-03-28T13:06:52.289Z",
-              "link": "https://www.bbc.com/somali/articles/cxepxkk4kgeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d2cf/live/0ae37210-cef9-11ed-be2e-754a65c11505.jpg",
-              "description": "Sanadka 2024 ayaa la filayaa in ciidamada nabad ilaalinta Midowga Afrika ay ka baxaan Soomaaliya, taasoo ka dhigan in ciidanka Soomaaliya ay qaadan doonaan mas'uuliyadda sugidda amniga.",
-              "imageAlt": "Tababar ciidan",
-              "id": "cxepxkk4kgeo"
-            },
-            {
-              "type": "commentary",
-              "title": "Dowladda Soomaaliya oo sheegtay inuu isku soo dhiibay hoggaamiye sare oo ka tirsan Al-shabaab",
-              "firstPublished": "2023-03-30T06:37:26.000Z",
-              "link": "https://www.bbc.com/somali/live/65110493",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FC45/production/_129218546_93e7ee03-1f6f-4fea-999d-34ca00485905.jpg",
-              "description": "Ku soo dhawaada tebinta tooska ee BBC Somali",
-              "imageAlt": ".",
-              "id": "8bac1605-14cc-4d60-8bc2-54813f9475e4"
-            },
-            {
-              "type": "article",
-              "title": "Waa kuma safiirka cusub ee uu Mareykanka u soo magacaabay Soomaaliya?",
-              "firstPublished": "2023-03-30T11:18:40.865Z",
-              "link": "https://www.bbc.com/somali/articles/c5188z5lpn4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0c97/live/27f112e0-cee0-11ed-be2e-754a65c11505.jpg",
-              "description": "Madaxweynaha Mareykanka, Joe Biden ayaa Richard H. Riley u soo magaacabay safiirka cusub ee Soomaaliya.",
-              "imageAlt": "Richard H. Riley",
-              "id": "c5188z5lpn4o"
-            },
-            {
-              "type": "article",
-              "title": "Aqalka sare ee Mareykanka: \"Duulaankii Ciraaq khalad buu ahaa\"",
-              "firstPublished": "2023-03-30T05:22:09.845Z",
-              "link": "https://www.bbc.com/somali/articles/c88ggj3nem5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9441/live/eac02a40-ceb8-11ed-be2e-754a65c11505.jpg",
-              "description": "Labaatan sano ayaa laga joogaa markii Maraykanka iyo xulafadiisa ay ku duuleen Ciraaq, ",
-              "imageAlt": "Dagaalkii Ciraaq ",
-              "id": "c88ggj3nem5o"
-            },
-            {
-              "type": "commentary",
-              "title": "Ugu yaraan 20 qof oo cumro u tagay Sacuudiga oo ku dhintay shil",
-              "firstPublished": "2023-03-28T06:26:59.000Z",
-              "link": "https://www.bbc.com/somali/live/65085493",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/E03F/production/_129170475_bad28fdf-8b57-4466-b455-1015d454dc6c.jpg",
-              "description": "Ku soo dhawaada tebinta tooska ee BBC Somali",
-              "imageAlt": ".",
-              "id": "c765e307-3b6f-41d3-801e-75c67581b966"
-            },
-            {
-              "type": "article",
-              "title": "Maxay u baahan yihiin ciidamada Soomaaliya si ay amniga ula wareegaan?",
-              "firstPublished": "2023-03-28T13:06:52.289Z",
-              "link": "https://www.bbc.com/somali/articles/cxepxkk4kgeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d2cf/live/0ae37210-cef9-11ed-be2e-754a65c11505.jpg",
-              "description": "Sanadka 2024 ayaa la filayaa in ciidamada nabad ilaalinta Midowga Afrika ay ka baxaan Soomaaliya, taasoo ka dhigan in ciidanka Soomaaliya ay qaadan doonaan mas'uuliyadda sugidda amniga.",
-              "imageAlt": "Tababar ciidan",
-              "id": "cxepxkk4kgeo"
-            },
-            {
-              "type": "article",
-              "title": "Xamza Yuusuf: Waa kuma ninka Muslimka ah ee loo doortay hoggaamiyaha Scotland? ",
-              "firstPublished": "2023-03-28T11:23:51.190Z",
-              "link": "https://www.bbc.com/somali/articles/cxe73p7ej4lo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ccff/live/7d08cd40-cd50-11ed-be2e-754a65c11505.jpg",
-              "description": "Xamza Yuusuf ayaa loo doortay in uu baddalo Nicola Sturgeon",
-              "imageAlt": "Xamza Yuusuf",
-              "id": "cxe73p7ej4lo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:41367163-36b7-45e1-bb65-082e06b4ad03",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "BBC News Somali Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Doorashada Kenya 2022: Tirinta tooska ah ee codadka iyo halka la kala marayo",
-              "firstPublished": "2022-08-09T18:32:13.000Z",
-              "link": "https://www.bbc.com/somali/war-62451543",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/59E3/production/_126311032_ke_election2022_somali_landing_hero_976.png",
-              "description": "Boggan si toos ah ayuu isu cusbooneysiinayaa, iyadoo ku xiran natiijada saxda ah ee aan ka helno Guddiga Doorashooyinka iyo Xudduudaha ee Kenya (IEBC). Waxaan ugu talagalnay in aan akhristeyaasheenna kula socodsiinno codadka la tiriyo iyo sida ay murashaxiintu u kala helaan.",
-              "imageAlt": "BBC",
-              "id": "4d270ef4-f0b4-41ae-862e-a673f59e8856"
-            },
-            {
-              "type": "article",
-              "title": "Afar arrin oo muhiim ah ka ogow App-ka ay Soomaalidu ku daadatay ee Sweatcoin",
-              "firstPublished": "2022-08-05T11:44:26.969Z",
-              "link": "https://www.bbc.com/somali/articles/c5124lk7yzlo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b8e/live/978f57b0-14a0-11ed-894d-e96102bbb308.jpg",
-              "description": "",
-              "imageAlt": "Sweatcoin",
-              "id": "c5124lk7yzlo"
-            },
-            {
-              "type": "article",
-              "title": "Waa kuma Soomaaligii Ka taliyay Jasiiradda Maldives?",
-              "firstPublished": "2022-06-27T13:24:06.911Z",
-              "link": "https://www.bbc.com/somali/articles/ce5x6jy2ed3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9d5a/live/9ccc4ca0-f61a-11ec-98c6-4d337b46e0c7.jpg",
-              "description": " Sheekh Siciid kii reer Muqdisho (The Sa’id of Mogadishu) ayaa  diin fidin u tagay dhulka Hindiya, Shiinaha iyo guud ahaan bariga fog. ",
-              "imageAlt": "Sheekh Siciid kii reer Muqdisho (The Sa’id of Mogadishu) oo diin fidin u tagay dhulka Hindiya, Shiinaha iyo guud ahaan bariga fog",
-              "id": "ce5x6jy2ed3o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:550df799-2302-499d-844a-8416c7b8be81",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Xul",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT1M12S",
-              "title": "Daawo: Iska hor’imaad booliska Israa’iil iyo Falastiiniyiin ku dhexmaray gudaha masjidka Al-Aqsa",
-              "firstPublished": "2023-04-05T05:11:43.000Z",
-              "link": "https://www.bbc.com/somali/war-65185302",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1B41/production/_129277960_p0fdyjzd.jpg",
-              "description": "Rabshado ka dhacay gudaha masaajidka Al-Aqsa",
-              "imageAlt": "Halkan ka daawo rabashadaha ka dhacay masjidka Aqsa",
-              "id": "569cb571-e205-45af-b1b4-304bd938cb50"
-            },
-            {
-              "type": "video",
-              "duration": "PT5M42S",
-              "title": "Haweeneyda shaqada u fududeysa gabdhaha sanbuuska guryaha ku kariya",
-              "firstPublished": "2023-04-04T09:17:52.000Z",
-              "link": "https://www.bbc.com/somali/war-65161627",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1225/production/_129254640_p0fdqzlf.jpg",
-              "description": "Sanbuuska iyo Soonka",
-              "imageAlt": "Keyframe #1",
-              "id": "8b77b3c9-4269-4bee-958e-250544da736f"
-            },
-            {
-              "type": "video",
-              "duration": "PT13M24S",
-              "title": "Wasiir Juxa oo ka hadlay mowqifkiisa \"muddo-kordhin\" loo sameeyo madaxweyne Deni",
-              "firstPublished": "2022-10-05T04:18:22.000Z",
-              "link": "https://www.bbc.com/somali/war-63140607",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D1FD/production/_126975735_p0d4gjsn.jpg",
-              "description": "Wareysi gaar ah oo aan la yeelannay wasiirka cusub ee Arrimaha Gudaha ee Puntland Cabdi Faarax Juaxa.",
-              "imageAlt": "Keyframe #1",
-              "id": "5f91256e-668e-47c8-a15d-6691d18890b5"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M33S",
-              "title": "Daawo: Muxuu Andrew Tate u ballan qaadaa taageerayaashiisa?",
-              "firstPublished": "2023-01-17T15:32:02.000Z",
-              "link": "https://www.bbc.com/somali/war-64306839",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/460C/production/_128323971_p0dwydvq.jpg",
-              "description": "Ninkan caanka ah ee lagu muransan yahay, isla markaana dadka dhiirrigeliya Andrew Tate ayaa lagu xiray dalka Romania.",
-              "imageAlt": "Andrew",
-              "id": "f36acc67-edc5-43b1-a92f-e64abeb74199"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M26S",
-              "title": "Muuse Biixi: Somaliland ayaa ku filan Laascaanood",
-              "firstPublished": "2023-01-03T13:44:41.000Z",
-              "link": "https://www.bbc.com/somali/64154653",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1A15/production/_128177660_p0dstjtn.jpg",
-              "description": "Xaaladda Magaalada laascaanood ayaa maalintii labaad deggan ka dib rabshadihii ka qarxay Talaadadii.",
-              "imageAlt": "Biixi",
-              "id": "d60ae19d-bfae-4571-9b78-95a3b314b31b"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M42S",
-              "title": "Xagee ku yaallaa hotel Villa Rose?",
-              "firstPublished": "2022-11-30T10:34:53.000Z",
-              "link": "https://www.bbc.com/somali/63807448",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D0A5/production/_127831435_thumbnail.jpg",
-              "description": "Weerar qaatay in ka badan labaatan saacadood ayaa ka dhacay hotel Villa Rose",
-              "imageAlt": "Hotel Villa Rays ee Muqdisho.",
-              "id": "610cf7b4-c110-407c-b369-82a36007ea09"
-            },
-            {
-              "type": "video",
-              "duration": "PT4M20S",
-              "title": "Madaxweyne Muusa Biixi oo ka hadlay ujeedada safarka uu ku joogo Kenya",
-              "firstPublished": "2020-12-15T09:16:09.000Z",
-              "link": "https://www.bbc.com/somali/55314844",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7510/production/_116086992_p091hjvg.jpg",
-              "description": "Madaxweynaha Somaliland Muusa Biixi Cabdi ayaa BBC uga warramay safarka uu ku joogo Nairobi.",
-              "imageAlt": "Musa Biixi",
-              "id": "a22dcfd1-17a8-439e-a097-b71e2d4ab8ce"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M19S",
-              "title": "G",
-              "firstPublished": "2017-12-14T09:48:42.000Z",
-              "link": "https://www.bbc.com/somali/war-42348327",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/63B0/production/_99202552_p05r2k48.jpg",
-              "description": "g",
-              "imageAlt": "Keyframe #1",
-              "id": "c1f1e749-7738-eb40-a0f4-5833415a62aa"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:vivo:curation:c99d9168-d19d-48ea-b33f-34ac002039fe",
-          "curationType": "vivo-stream",
-          "position": 3,
-          "title": "Maqal iyo Muuqaal",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Qadar ma u suurtagaleysaa in ay iibsato Manchester United?",
-              "firstPublished": "2023-02-17T16:54:29.762Z",
-              "link": "https://www.bbc.com/somali/articles/c2x660d1llxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b81/live/25826d60-aee2-11ed-89f4-f3657d2bfa3b.jpg",
-              "description": "",
-              "imageAlt": ".",
-              "id": "c2x660d1llxo"
-            },
-            {
-              "type": "article",
-              "title": "Feeryahanka wacdaraha ka dhigay Kenya ee doortay in uu Soomaaliya ku matalo caalamka",
-              "firstPublished": "2023-01-31T14:09:34.425Z",
-              "link": "https://www.bbc.com/somali/articles/cgrzley8e66o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4096/live/dd8e2140-a084-11ed-88c4-e35151405f7e.jpg",
-              "description": "",
-              "imageAlt": "Khaliifa Yaxye",
-              "id": "cgrzley8e66o"
-            },
-            {
-              "type": "article",
-              "title": "Saddexda magac ee sida weyn u qabsaday suuqa kala iibsiga ciyaartoyda oo maanta xirmaya",
-              "firstPublished": "2023-01-31T09:47:37.694Z",
-              "link": "https://www.bbc.com/somali/articles/cjelrw7pe8vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/51dc/live/1130aa80-a149-11ed-8f65-71bfa0525ce3.jpg",
-              "description": "Magacyada ugu waaweyn ee lagu hadal hayo suuqa kala iibsiga ciyaartoyda.",
-              "imageAlt": "Suuqa kala iibsiga ciyaartoyda",
-              "id": "cjelrw7pe8vo"
-            },
-            {
-              "type": "article",
-              "title": "Waa tee kooxda sugeysa in uu Ronaldo kusoo biiro ka hor dhammaadka Sanadkan?",
-              "firstPublished": "2022-12-21T06:09:03.509Z",
-              "link": "https://www.bbc.com/somali/articles/c4n6n5gr8wro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/adf2/live/aec9ff90-80f5-11ed-90a7-556e529f9f89.jpg",
-              "description": "Ronaldo ayaa isbuucyadii lasoo dhaafay si weyn loogu hadal hayay warbaahinta.",
-              "imageAlt": "Cristiano Ronaldo",
-              "id": "c4n6n5gr8wro"
-            },
-            {
-              "type": "article",
-              "title": "Kooxdee ayuu funaanaddeeda soo xiran doonaa ninka la haray xulalkii ugu awoodda badnaa Koobka Adduunka? ",
-              "firstPublished": "2022-12-14T09:49:01.874Z",
-              "link": "https://www.bbc.com/somali/articles/crgzxyrv1lxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9562/live/7ef7d940-7b91-11ed-90a7-556e529f9f89.jpg",
-              "description": "Muxuu damacsan yahay ninka looga digay in uu caawa soo xirto funaanadda kooxda Morocco",
-              "imageAlt": "MOHAMMED AL HAJRI",
-              "id": "crgzxyrv1lxo"
-            },
-            {
-              "type": "article",
-              "title": "Muxuu Ronaldo ku yiri wiilka xalay booskiisa galay ee wacdaraha dhigay?",
-              "firstPublished": "2022-12-07T09:48:04.318Z",
-              "link": "https://www.bbc.com/somali/articles/c0jg4yq394lo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f836/live/0cb67880-7611-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Goncalo Ramos ayaa dhaliyay saddexleydii ugu horreysay ee Koobka Adduunka Qadar 2022.",
-              "imageAlt": "Ramos iyo Ronaldo",
-              "id": "c0jg4yq394lo"
-            },
-            {
-              "type": "article",
-              "title": "Ninka khashinka aruurin jiray ee sababta u ah wacdarihii ay shalay Sacuudiga ka dhigeen ciyaaraha Koobka Adduunka",
-              "firstPublished": "2022-11-23T10:49:46.055Z",
-              "link": "https://www.bbc.com/somali/articles/cx7q8jewgwgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fa56/live/75cbbe20-6b17-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Ninkan dunida oo dhan laga hadal hayo mar ayuu qashinka ka nadiifin jiray guryaha.",
-              "imageAlt": "Koobka Adduunka ee 2022",
-              "id": "cx7q8jewgwgo"
-            },
-            {
-              "type": "article",
-              "title": "Xagguu u socdaa Cristiano Ronaldo?",
-              "firstPublished": "2022-11-23T09:29:30.981Z",
-              "link": "https://www.bbc.com/somali/articles/c9804pzvdwwo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b5c5/live/f8507fa0-6b0f-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Ronald ayaa sida muuqata ka carooday qaabka uu ula dhaqmay tababaraha cusub ee Manchester United oo kulamo dhowr ah uga tegay kursiga keydka.",
-              "imageAlt": "Cristiano Ronald",
-              "id": "c9804pzvdwwo"
-            },
-            {
-              "type": "article",
-              "title": "Waa kuma wiilka Soomaaliga ah ee hadal heynta dhaliyay markii uu ka ciyaaray Koobka Adduunka?",
-              "firstPublished": "2022-10-15T09:12:55.765Z",
-              "link": "https://www.bbc.com/somali/articles/cek28e2mvp0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/267a/live/9ac14080-6980-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Wiilkan aabihiis wuxuu usoo ciyaaray xulka qaranka Soomaaliya.",
-              "imageAlt": "Akram Cafiif",
-              "id": "cek28e2mvp0o"
-            },
-            {
-              "type": "article",
-              "title": "M﻿axay Fifa ku haysataa dalka lagu qabanayo Koobka Adduunka ee Qadar?",
-              "firstPublished": "2022-11-08T15:39:13.182Z",
-              "link": "https://www.bbc.com/somali/articles/cp0vgn3mgv1o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9333/live/3543ad70-5f7a-11ed-b950-4dadc68f0cfc.jpg",
-              "description": "Bishan ayuu billaabanayaa tartanka Koobka Adduunka ee ay martigelineyso Qadar.",
-              "imageAlt": "Sepp Blatter",
-              "id": "cp0vgn3mgv1o"
-            },
-            {
-              "type": "article",
-              "title": "Antoine Griezmann: Sababta ay Atletico Madrid u ciyaarsiiso 30 daqiiqo oo keliya",
-              "firstPublished": "2022-10-10T05:42:01.012Z",
-              "link": "https://www.bbc.com/somali/articles/cxw08dj9nmvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/086b/live/4547f050-4841-11ed-9ae9-959994b8a64c.png",
-              "description": "",
-              "imageAlt": "Antoine Griezmann",
-              "id": "cxw08dj9nmvo"
-            },
-            {
-              "type": "article",
-              "title": "Maxaa sababay isbuurashada dadka badan ku dhinteen ee ka dhacday Indonesia?",
-              "firstPublished": "2022-10-02T05:23:05.707Z",
-              "link": "https://www.bbc.com/somali/articles/c5101vxlexno",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f524/live/f9abec50-420f-11ed-9ae9-959994b8a64c.jpg",
-              "description": "Ugu yaraan 129 qof ayaa ku dhimatay isbuurasho ka dhacday garoon kubadda cagta ah oo ku yaalla dalka Indonesia, sida ay sheegeen saraakiisha.",
-              "imageAlt": "Booliska oo isku dayay inay ka hortagaan taageerayaasha kusoo xoomay gudaha garoonka",
-              "id": "c5101vxlexno"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 2,
-          "link": "https://www.bbc.com/somali/topics/cpzd4zj1pn2t",
-          "curationId": "urn:bbc:vivo:curation:820a09c4-d46c-490b-b92b-302b93eda9c3",
-          "curationType": "vivo-stream",
-          "position": 4,
-          "title": "Ciyaaraha",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "NASA oo shaacisay magacyada dadka dayaxa aadi doona",
-              "firstPublished": "2023-05-03T16:59:09.579Z",
-              "link": "https://www.bbc.com/somali/articles/c4npkyljj45o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5506/live/ad3825b0-e9d4-11ed-9ff0-1714980264ca.png",
-              "description": "",
-              "imageAlt": "Afarta cirbixiyeen ee dayaxa aadi doona",
-              "id": "c4npkyljj45o"
-            },
-            {
-              "type": "article",
-              "title": "Cilmi-baaris: Faa'iidada ay leedahay go'aan qaadhasha la'aantu",
-              "firstPublished": "2023-04-30T15:01:14.326Z",
-              "link": "https://www.bbc.com/somali/articles/c84r04zjmz0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2e46/live/2883c910-e762-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "In aadan go'aanka ku degdegin waxay kaa caawinaysaa in aadan go'aan qaldan qaadan balse sidoo kale, go'aan waliba wuxuu ka fiican yahay in aadan waxbaba go'aansan",
-              "imageAlt": "Nin taagan laba waddo dhexdood",
-              "id": "c84r04zjmz0o"
-            },
-            {
-              "type": "article",
-              "title": "Maxaa sababa cagaarshowga? see loo aqoonsadaa? maxaana lagu daweeyaa?",
-              "firstPublished": "2023-04-24T14:28:41.965Z",
-              "link": "https://www.bbc.com/somali/articles/c3gpvg0yjg1o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2c4d/live/38646600-e1fe-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Cagaarshowgu waa cudur ku dhaca beerka, waxaana sababa waxyaabo dhowr ah sida...",
-              "imageAlt": "Indha cagaarshow",
-              "id": "c3gpvg0yjg1o"
-            },
-            {
-              "type": "article",
-              "title": "Waa maxay caabuqan inagu badan ee kaadi mareenku? maxaa lagu gartaa?",
-              "firstPublished": "2023-04-16T13:27:40.090Z",
-              "link": "https://www.bbc.com/somali/articles/c0wq0yeggzko",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a0ef/live/dd1304b0-dc57-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Caafimaad: Kaadi badan, Kaadi olol, dibbiro, dhabar xanuun haddii aad astaamahan isku aragto waxaa suurta gal ah inaad qabto caabuqa UTI, halkan kaga bogo wax badan oo ku saabsan.",
-              "imageAlt": "Qof kaadi isku celinaya",
-              "id": "c0wq0yeggzko"
-            },
-            {
-              "type": "article",
-              "title": "Ma ogtahay in telefoonka casriga ah uu yahay mid ka mid ah sababaha keena injirta gasha timaha?",
-              "firstPublished": "2023-04-15T04:53:56.197Z",
-              "link": "https://www.bbc.com/somali/articles/c98nr5wq11po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d441/live/7246ca70-dad3-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "Injirta",
-              "id": "c98nr5wq11po"
-            },
-            {
-              "type": "article",
-              "title": "Cuntooyinka kaa caawin kara   korriinka Timaha",
-              "firstPublished": "2023-04-12T16:22:09.926Z",
-              "link": "https://www.bbc.com/somali/articles/cqle9exj1k0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a723/live/11920200-d93c-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": ".",
-              "id": "cqle9exj1k0o"
-            },
-            {
-              "type": "article",
-              "title": "Toban talo oo ku socota dadka da'doodu u dhexeyso 30 ilaa 40 jir",
-              "firstPublished": "2023-04-07T15:30:53.670Z",
-              "link": "https://www.bbc.com/somali/articles/cv24ekl9m2po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0b1b/live/9b729f70-d54a-11ed-aa8e-31a9f3ff4e07.jpg",
-              "description": "",
-              "imageAlt": ".",
-              "id": "cv24ekl9m2po"
-            },
-            {
-              "type": "article",
-              "title": "Afar dhibaato oo soo wajahda qofka lugaha is dul saarta marka uu fadhiyo",
-              "firstPublished": "2023-04-04T06:32:01.609Z",
-              "link": "https://www.bbc.com/somali/articles/cjmzrr1wk74o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8f35/live/dbba3730-d2ae-11ed-be2e-754a65c11505.jpg",
-              "description": "Dhibaatada caafimaad ee ka dhalan karta in qofka uu lugaha is dul saarto.",
-              "imageAlt": "Dhibaatada ka dhalata in qofka uu lugaha is dul saarto",
-              "id": "cjmzrr1wk74o"
-            },
-            {
-              "type": "article",
-              "title": "Filim ay Rani jishay oo muran ka dhex abuuray laba dal",
-              "firstPublished": "2023-03-30T18:25:10.988Z",
-              "link": "https://www.bbc.com/somali/articles/cpr550ln5eyo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f96d/live/c73488b0-cefd-11ed-be2e-754a65c11505.jpg",
-              "description": "Isku dhac dhanka dhaqanka ah ayaa dhex maray Norway iyo Hindiya kaas oo ka dhashay filim laga sameeyay dhacdo dalka Norway ku qabsatay hooyo Hindi ah.",
-              "imageAlt": "Rani Mukherjee",
-              "id": "cpr550ln5eyo"
-            },
-            {
-              "type": "article",
-              "title": "Afar shay oo muhiim ah in la nadiifiyo balse dadka badanaa aysan ku baraarugsaneyn",
-              "firstPublished": "2023-03-16T15:07:24.878Z",
-              "link": "https://www.bbc.com/somali/articles/c1rgj2n43nzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/641f/live/509dcf70-c40a-11ed-95f8-0154daa64c44.jpg",
-              "description": "",
-              "imageAlt": "Suufka lagu dhaqo weelasha",
-              "id": "c1rgj2n43nzo"
-            },
-            {
-              "type": "article",
-              "title": "Su'aalaha ku gadaaman cudurka Baabasiirka iyo sida loo daweyn karo",
-              "firstPublished": "2023-03-15T13:20:10.350Z",
-              "link": "https://www.bbc.com/somali/articles/cjlxkew0g83o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bf90/live/92646420-c331-11ed-95f8-0154daa64c44.jpg",
-              "description": "Talooyinka dhanka cuntada dadka qaba cudurka Baabasiirka.",
-              "imageAlt": ".",
-              "id": "cjlxkew0g83o"
-            },
-            {
-              "type": "article",
-              "title": "Daraasad: \"Ugxanta taranka oo laga sameeyay unugyo lab ah\"",
-              "firstPublished": "2023-03-12T06:37:21.538Z",
-              "link": "https://www.bbc.com/somali/articles/c2x608d4gkgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fb97/live/dd5f7e80-bff1-11ed-95f8-0154daa64c44.jpg",
-              "description": "Cilmi baare u dhashay dalka Japan ayaa shir wayn oo ku saabsan dhanka hidde-sidaha ka sheegay in uu ukunta taranka ka sameeyay unugyada jiir lab ah.",
-              "imageAlt": "dhaqtar muunado haya",
-              "id": "c2x608d4gkgo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 7,
-          "link": "https://www.bbc.com/somali/topics/cg8382rk20xt",
-          "curationId": "urn:bbc:vivo:curation:ad022d13-416d-47bb-80f3-8e0043edee3c",
-          "curationType": "vivo-stream",
-          "position": 5,
-          "title": "Aqoon Guud",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Madal qabata Shukaansiga muslimiinta oo ku guul darreysatay dacwad ay la gashay mid kale",
-              "firstPublished": "2023-05-05T03:51:27.728Z",
-              "link": "https://www.bbc.com/somali/articles/c727qr93vd0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cc7b/live/6c548940-eaf5-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "",
-              "imageAlt": "Madasha Muzz",
-              "id": "c727qr93vd0o"
-            },
-            {
-              "type": "article",
-              "title": "20 jir sameeyay shirkad muddo kooban ku gaartay bilyan dollar ",
-              "firstPublished": "2023-02-18T04:34:42.288Z",
-              "link": "https://www.bbc.com/somali/articles/cydn6q7pr8po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6748/live/137bdba0-af42-11ed-b930-15f701fbfd41.jpg",
-              "description": "Aadit Palicha iyo saaxiibkii Kaivalya Vohra ayaa bartamihii 2021 sameeyay shirkad khudaarta dadka ugu geysa guryaha oo lagu magacaabo Zepto.",
-              "imageAlt": "Aadit Palicha ",
-              "id": "cydn6q7pr8po"
-            },
-            {
-              "type": "article",
-              "title": "Afrika: Sida Baraha Bulshada loogu isticmaalo xayeysiin ahaan ",
-              "firstPublished": "2023-01-20T13:27:45.243Z",
-              "link": "https://www.bbc.com/somali/articles/clwnpdev30wo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a40a/live/47f3ded0-98c4-11ed-86bf-4b2f5da2cf01.jpg",
-              "description": "Baraha bulshada ayaa muhiimad aad u weyn u leh shirkadaha ganacsiga ee Afrika.",
-              "imageAlt": "Baraha Bulshada",
-              "id": "clwnpdev30wo"
-            },
-            {
-              "type": "article",
-              "title": "Waa kuma ninka ugu taajirsan adduunka ee hadda booska ka qaatay Elon Musk?",
-              "firstPublished": "2022-12-14T05:15:25.522Z",
-              "link": "https://www.bbc.com/somali/articles/cv2d551e3xvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8ad7/live/eb068c40-7b6d-11ed-90a7-556e529f9f89.jpg",
-              "description": "Elon Musk ayaa laga riixay booska ugu sarreeya ee liiska dadka ugu hantida badan caalamka. Haddaba waa kuma ninka ka sare maray?",
-              "imageAlt": "Liiska dadka ugu taajirsan dunida ayaa isbeddelay",
-              "id": "cv2d551e3xvo"
-            },
-            {
-              "type": "article",
-              "title": "Sababtii ay Soomaaliya u diidday inay ku biirto Dalladda Bariga Afrika (EAC)",
-              "firstPublished": "2022-07-22T11:35:54.984Z",
-              "link": "https://www.bbc.com/somali/articles/cl7e2149ey7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/314a/live/a01cfd40-09ad-11ed-93ba-314ede9cd985.jpg",
-              "description": "Wasiirkii hore ee arrimaha dibadda Soomaaliya ayaa ka warramaya xilli ay Soomaaliya diiday in ay ka mid noqoto dalladda EAC.",
-              "imageAlt": "Calamada ururka EAC marka laga reebo ka Soomaaliya",
-              "id": "cl7e2149ey7o"
-            },
-            {
-              "type": "article",
-              "title": "Maxaa lagu doortaa Jaadka Kenya oo uusan lahayn kan Itoobiya?",
-              "firstPublished": "2022-07-18T12:25:46.509Z",
-              "link": "https://www.bbc.com/somali/articles/cxen2em14xdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2097/live/8fcc6db0-0690-11ed-93ba-314ede9cd985.jpg",
-              "description": "Kan labada qaad wanaagsan marka ay noqoto mirqaabka iyo dhanka dhaqaalaha ay ka helaan dadka ka ganacsada ayay dooddu ka taagan tahay.",
-              "imageAlt": "Jaadka Kenya",
-              "id": "cxen2em14xdo"
-            },
-            {
-              "type": "article",
-              "title": "Shiinaha: Shirkadaha iibka dhulka iyo guryaha oo lacag ahaan u qaadanaya qare iyo khudaar kale",
-              "firstPublished": "2022-07-05T09:58:27.460Z",
-              "link": "https://www.bbc.com/somali/articles/c51895gz1jyo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5e16/live/236aa4d0-fc44-11ec-bfa6-89ae37be3a04.jpg",
-              "description": "",
-              "imageAlt": "Gabar qare wadata",
-              "id": "c51895gz1jyo"
-            },
-            {
-              "type": "article",
-              "title": "Gabar maalin keliya Dahab ka iibsatay miraha yicibta",
-              "firstPublished": "2022-06-24T10:01:57.319Z",
-              "link": "https://www.bbc.com/somali/articles/cp3n63mmje0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9d78/live/f973d6e0-f3a3-11ec-bd41-87b161902afa.jpg",
-              "description": "Inkastoo geedka Gudda la sheegay in uu u adkaysan karo jiilaalka iyo qalleylka, haddana xilligan oo ay dalka ka jirto abaaro daran ka mid yahay dhirta midab-doorsoontay.",
-              "imageAlt": "Xaliimo oo Yicib koombo-miiseysa",
-              "id": "cp3n63mmje0o"
-            },
-            {
-              "type": "article",
-              "title": "Waxyaabaha muhiimka ah ee la iska fiiriyo marka dahabka la iibsanayo",
-              "firstPublished": "2022-06-01T05:53:11.000Z",
-              "link": "https://www.bbc.com/somali/war-61655710",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D001/production/_124994235_08d73040-1abd-4f0d-a983-bb72d2e8a15f.jpg",
-              "description": "Waxaa jira waxyaabo badan oo ay tahay in aad ogaato marka aad dahab iibsanayso.",
-              "imageAlt": "Suuqa dahabka",
-              "id": "46ea5df6-69d4-41f7-8407-b818c8422b3e"
-            },
-            {
-              "type": "article",
-              "title": "Shan magaalo oo \"la yaab ay ka tahay\" in aad habeenkii seexato!",
-              "firstPublished": "2021-11-11T10:11:19.000Z",
-              "link": "https://www.bbc.com/somali/war-59244066",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/59B1/production/_121516922__121318634_1b9bdac0-58e1-43a2-ad4a-0c92e00ad5ff.jpg",
-              "description": "Badanaa caasimadaha iyo magaalooyinka marka habeenkii la gaaro, waa firaaqo maxaa yeelay dadka badankood ayaa hurda, balse waxaa jiro kuwo aan laga seexanin.",
-              "imageAlt": ".",
-              "id": "4dcd391a-92ea-44c0-9161-b28d39c9d520"
-            },
-            {
-              "type": "article",
-              "title": "Muxuu Kenyatta ka yiri kashifaadda hantidiisa?",
-              "firstPublished": "2021-10-04T08:22:42.000Z",
-              "link": "https://www.bbc.com/somali/war-58758357",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15BD0/production/_120804098_gettyimages-1187377433.jpg",
-              "description": "Magaca madaxweynaha Kenya, Uhuru Kenyatta, ayaa ka soo muuqday dukumiintiyada lagu magacaabo \"Pandora Papers\" - oo ah xogtii ugu weyneyd abid oo laga fashilo dhinaca dhaqaalaha.",
-              "imageAlt": "Uhuru Kenyatta",
-              "id": "6044113b-a48c-49a0-9657-781f31327c5b"
-            },
-            {
-              "type": "article",
-              "title": "Shanta shaqo ee qarka u saaran in laga waayo dunida",
-              "firstPublished": "2021-09-18T17:06:45.000Z",
-              "link": "https://www.bbc.com/somali/war-58611233",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/DBA7/production/_120613265_35681f03-758f-4ac6-a62c-a9e5846895d9.jpg",
-              "description": "Hadda iska jir shaqooyinka qaar ee qarka u saaran in la waayo sanadaha soo socda.",
-              "imageAlt": ".",
-              "id": "382d01bf-8501-4d5b-b07e-74cd32dc0edd"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "link": "https://www.bbc.com/somali/topics/c2dwqd32v4yt",
-          "curationId": "urn:bbc:vivo:curation:813f8386-835e-4285-b307-2e8708c77822",
-          "curationType": "vivo-stream",
-          "position": 6,
-          "title": "Ganacsi",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "audio",
-              "duration": "PT1H",
-              "title": "Dunida Iyo Maanta",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84lpw8",
-              "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
-              "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
-              "imageAlt": "",
-              "id": "w172z4vrp84lpw8"
-            },
-            {
-              "type": "audio",
-              "duration": "PT1H",
-              "title": "Dunida Iyo Maanta",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84hsz5",
-              "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
-              "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
-              "imageAlt": "",
-              "id": "w172z4vrp84hsz5"
-            },
-            {
-              "type": "audio",
-              "duration": "PT1H",
-              "title": "Dunida Iyo Maanta",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84dx22",
-              "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
-              "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
-              "imageAlt": "",
-              "id": "w172z4vrp84dx22"
-            },
-            {
-              "type": "audio",
-              "duration": "PT1H",
-              "title": "Dunida Iyo Maanta",
-              "firstPublished": "",
-              "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vr9zv0c2m",
-              "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
-              "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
-              "imageAlt": "",
-              "id": "w172z4vr9zv0c2m"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:programmes:available-episodes:p034117k",
-          "curationType": "available-episodes",
-          "position": 7,
-          "title": "Dunida Iyo Maanta",
-          "visualProminence": "LOW"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News Somali",
+    "description": "",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Maxay u baahan yihiin ciidamada Soomaaliya si ay amniga ula wareegaan?",
+            "firstPublished": "2023-03-28T13:06:52.289Z",
+            "link": "https://www.bbc.com/somali/articles/cxepxkk4kgeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d2cf/live/0ae37210-cef9-11ed-be2e-754a65c11505.jpg",
+            "description": "Sanadka 2024 ayaa la filayaa in ciidamada nabad ilaalinta Midowga Afrika ay ka baxaan Soomaaliya, taasoo ka dhigan in ciidanka Soomaaliya ay qaadan doonaan mas'uuliyadda sugidda amniga.",
+            "imageAlt": "Tababar ciidan",
+            "id": "cxepxkk4kgeo"
+          },
+          {
+            "type": "commentary",
+            "title": "Dowladda Soomaaliya oo sheegtay inuu isku soo dhiibay hoggaamiye sare oo ka tirsan Al-shabaab",
+            "firstPublished": "2023-03-30T06:37:26.000Z",
+            "link": "https://www.bbc.com/somali/live/65110493",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/FC45/production/_129218546_93e7ee03-1f6f-4fea-999d-34ca00485905.jpg",
+            "description": "Ku soo dhawaada tebinta tooska ee BBC Somali",
+            "imageAlt": ".",
+            "id": "8bac1605-14cc-4d60-8bc2-54813f9475e4"
+          },
+          {
+            "type": "article",
+            "title": "Waa kuma safiirka cusub ee uu Mareykanka u soo magacaabay Soomaaliya?",
+            "firstPublished": "2023-03-30T11:18:40.865Z",
+            "link": "https://www.bbc.com/somali/articles/c5188z5lpn4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0c97/live/27f112e0-cee0-11ed-be2e-754a65c11505.jpg",
+            "description": "Madaxweynaha Mareykanka, Joe Biden ayaa Richard H. Riley u soo magaacabay safiirka cusub ee Soomaaliya.",
+            "imageAlt": "Richard H. Riley",
+            "id": "c5188z5lpn4o"
+          },
+          {
+            "type": "article",
+            "title": "Aqalka sare ee Mareykanka: \"Duulaankii Ciraaq khalad buu ahaa\"",
+            "firstPublished": "2023-03-30T05:22:09.845Z",
+            "link": "https://www.bbc.com/somali/articles/c88ggj3nem5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9441/live/eac02a40-ceb8-11ed-be2e-754a65c11505.jpg",
+            "description": "Labaatan sano ayaa laga joogaa markii Maraykanka iyo xulafadiisa ay ku duuleen Ciraaq, ",
+            "imageAlt": "Dagaalkii Ciraaq ",
+            "id": "c88ggj3nem5o"
+          },
+          {
+            "type": "commentary",
+            "title": "Ugu yaraan 20 qof oo cumro u tagay Sacuudiga oo ku dhintay shil",
+            "firstPublished": "2023-03-28T06:26:59.000Z",
+            "link": "https://www.bbc.com/somali/live/65085493",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/E03F/production/_129170475_bad28fdf-8b57-4466-b455-1015d454dc6c.jpg",
+            "description": "Ku soo dhawaada tebinta tooska ee BBC Somali",
+            "imageAlt": ".",
+            "id": "c765e307-3b6f-41d3-801e-75c67581b966"
+          },
+          {
+            "type": "article",
+            "title": "Maxay u baahan yihiin ciidamada Soomaaliya si ay amniga ula wareegaan?",
+            "firstPublished": "2023-03-28T13:06:52.289Z",
+            "link": "https://www.bbc.com/somali/articles/cxepxkk4kgeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d2cf/live/0ae37210-cef9-11ed-be2e-754a65c11505.jpg",
+            "description": "Sanadka 2024 ayaa la filayaa in ciidamada nabad ilaalinta Midowga Afrika ay ka baxaan Soomaaliya, taasoo ka dhigan in ciidanka Soomaaliya ay qaadan doonaan mas'uuliyadda sugidda amniga.",
+            "imageAlt": "Tababar ciidan",
+            "id": "cxepxkk4kgeo"
+          },
+          {
+            "type": "article",
+            "title": "Xamza Yuusuf: Waa kuma ninka Muslimka ah ee loo doortay hoggaamiyaha Scotland? ",
+            "firstPublished": "2023-03-28T11:23:51.190Z",
+            "link": "https://www.bbc.com/somali/articles/cxe73p7ej4lo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ccff/live/7d08cd40-cd50-11ed-be2e-754a65c11505.jpg",
+            "description": "Xamza Yuusuf ayaa loo doortay in uu baddalo Nicola Sturgeon",
+            "imageAlt": "Xamza Yuusuf",
+            "id": "cxe73p7ej4lo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:41367163-36b7-45e1-bb65-082e06b4ad03",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "BBC News Somali Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Doorashada Kenya 2022: Tirinta tooska ah ee codadka iyo halka la kala marayo",
+            "firstPublished": "2022-08-09T18:32:13.000Z",
+            "link": "https://www.bbc.com/somali/war-62451543",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/59E3/production/_126311032_ke_election2022_somali_landing_hero_976.png",
+            "description": "Boggan si toos ah ayuu isu cusbooneysiinayaa, iyadoo ku xiran natiijada saxda ah ee aan ka helno Guddiga Doorashooyinka iyo Xudduudaha ee Kenya (IEBC). Waxaan ugu talagalnay in aan akhristeyaasheenna kula socodsiinno codadka la tiriyo iyo sida ay murashaxiintu u kala helaan.",
+            "imageAlt": "BBC",
+            "id": "4d270ef4-f0b4-41ae-862e-a673f59e8856"
+          },
+          {
+            "type": "article",
+            "title": "Afar arrin oo muhiim ah ka ogow App-ka ay Soomaalidu ku daadatay ee Sweatcoin",
+            "firstPublished": "2022-08-05T11:44:26.969Z",
+            "link": "https://www.bbc.com/somali/articles/c5124lk7yzlo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b8e/live/978f57b0-14a0-11ed-894d-e96102bbb308.jpg",
+            "description": "",
+            "imageAlt": "Sweatcoin",
+            "id": "c5124lk7yzlo"
+          },
+          {
+            "type": "article",
+            "title": "Waa kuma Soomaaligii Ka taliyay Jasiiradda Maldives?",
+            "firstPublished": "2022-06-27T13:24:06.911Z",
+            "link": "https://www.bbc.com/somali/articles/ce5x6jy2ed3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9d5a/live/9ccc4ca0-f61a-11ec-98c6-4d337b46e0c7.jpg",
+            "description": " Sheekh Siciid kii reer Muqdisho (The Sa’id of Mogadishu) ayaa  diin fidin u tagay dhulka Hindiya, Shiinaha iyo guud ahaan bariga fog. ",
+            "imageAlt": "Sheekh Siciid kii reer Muqdisho (The Sa’id of Mogadishu) oo diin fidin u tagay dhulka Hindiya, Shiinaha iyo guud ahaan bariga fog",
+            "id": "ce5x6jy2ed3o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:550df799-2302-499d-844a-8416c7b8be81",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Xul",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT1M12S",
+            "title": "Daawo: Iska hor’imaad booliska Israa’iil iyo Falastiiniyiin ku dhexmaray gudaha masjidka Al-Aqsa",
+            "firstPublished": "2023-04-05T05:11:43.000Z",
+            "link": "https://www.bbc.com/somali/war-65185302",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1B41/production/_129277960_p0fdyjzd.jpg",
+            "description": "Rabshado ka dhacay gudaha masaajidka Al-Aqsa",
+            "imageAlt": "Halkan ka daawo rabashadaha ka dhacay masjidka Aqsa",
+            "id": "569cb571-e205-45af-b1b4-304bd938cb50"
+          },
+          {
+            "type": "video",
+            "duration": "PT5M42S",
+            "title": "Haweeneyda shaqada u fududeysa gabdhaha sanbuuska guryaha ku kariya",
+            "firstPublished": "2023-04-04T09:17:52.000Z",
+            "link": "https://www.bbc.com/somali/war-65161627",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1225/production/_129254640_p0fdqzlf.jpg",
+            "description": "Sanbuuska iyo Soonka",
+            "imageAlt": "Keyframe #1",
+            "id": "8b77b3c9-4269-4bee-958e-250544da736f"
+          },
+          {
+            "type": "video",
+            "duration": "PT13M24S",
+            "title": "Wasiir Juxa oo ka hadlay mowqifkiisa \"muddo-kordhin\" loo sameeyo madaxweyne Deni",
+            "firstPublished": "2022-10-05T04:18:22.000Z",
+            "link": "https://www.bbc.com/somali/war-63140607",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D1FD/production/_126975735_p0d4gjsn.jpg",
+            "description": "Wareysi gaar ah oo aan la yeelannay wasiirka cusub ee Arrimaha Gudaha ee Puntland Cabdi Faarax Juaxa.",
+            "imageAlt": "Keyframe #1",
+            "id": "5f91256e-668e-47c8-a15d-6691d18890b5"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M33S",
+            "title": "Daawo: Muxuu Andrew Tate u ballan qaadaa taageerayaashiisa?",
+            "firstPublished": "2023-01-17T15:32:02.000Z",
+            "link": "https://www.bbc.com/somali/war-64306839",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/460C/production/_128323971_p0dwydvq.jpg",
+            "description": "Ninkan caanka ah ee lagu muransan yahay, isla markaana dadka dhiirrigeliya Andrew Tate ayaa lagu xiray dalka Romania.",
+            "imageAlt": "Andrew",
+            "id": "f36acc67-edc5-43b1-a92f-e64abeb74199"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M26S",
+            "title": "Muuse Biixi: Somaliland ayaa ku filan Laascaanood",
+            "firstPublished": "2023-01-03T13:44:41.000Z",
+            "link": "https://www.bbc.com/somali/64154653",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1A15/production/_128177660_p0dstjtn.jpg",
+            "description": "Xaaladda Magaalada laascaanood ayaa maalintii labaad deggan ka dib rabshadihii ka qarxay Talaadadii.",
+            "imageAlt": "Biixi",
+            "id": "d60ae19d-bfae-4571-9b78-95a3b314b31b"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M42S",
+            "title": "Xagee ku yaallaa hotel Villa Rose?",
+            "firstPublished": "2022-11-30T10:34:53.000Z",
+            "link": "https://www.bbc.com/somali/63807448",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D0A5/production/_127831435_thumbnail.jpg",
+            "description": "Weerar qaatay in ka badan labaatan saacadood ayaa ka dhacay hotel Villa Rose",
+            "imageAlt": "Hotel Villa Rays ee Muqdisho.",
+            "id": "610cf7b4-c110-407c-b369-82a36007ea09"
+          },
+          {
+            "type": "video",
+            "duration": "PT4M20S",
+            "title": "Madaxweyne Muusa Biixi oo ka hadlay ujeedada safarka uu ku joogo Kenya",
+            "firstPublished": "2020-12-15T09:16:09.000Z",
+            "link": "https://www.bbc.com/somali/55314844",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7510/production/_116086992_p091hjvg.jpg",
+            "description": "Madaxweynaha Somaliland Muusa Biixi Cabdi ayaa BBC uga warramay safarka uu ku joogo Nairobi.",
+            "imageAlt": "Musa Biixi",
+            "id": "a22dcfd1-17a8-439e-a097-b71e2d4ab8ce"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M19S",
+            "title": "G",
+            "firstPublished": "2017-12-14T09:48:42.000Z",
+            "link": "https://www.bbc.com/somali/war-42348327",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/63B0/production/_99202552_p05r2k48.jpg",
+            "description": "g",
+            "imageAlt": "Keyframe #1",
+            "id": "c1f1e749-7738-eb40-a0f4-5833415a62aa"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:vivo:curation:c99d9168-d19d-48ea-b33f-34ac002039fe",
+        "curationType": "vivo-stream",
+        "position": 3,
+        "title": "Maqal iyo Muuqaal",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Qadar ma u suurtagaleysaa in ay iibsato Manchester United?",
+            "firstPublished": "2023-02-17T16:54:29.762Z",
+            "link": "https://www.bbc.com/somali/articles/c2x660d1llxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9b81/live/25826d60-aee2-11ed-89f4-f3657d2bfa3b.jpg",
+            "description": "",
+            "imageAlt": ".",
+            "id": "c2x660d1llxo"
+          },
+          {
+            "type": "article",
+            "title": "Feeryahanka wacdaraha ka dhigay Kenya ee doortay in uu Soomaaliya ku matalo caalamka",
+            "firstPublished": "2023-01-31T14:09:34.425Z",
+            "link": "https://www.bbc.com/somali/articles/cgrzley8e66o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4096/live/dd8e2140-a084-11ed-88c4-e35151405f7e.jpg",
+            "description": "",
+            "imageAlt": "Khaliifa Yaxye",
+            "id": "cgrzley8e66o"
+          },
+          {
+            "type": "article",
+            "title": "Saddexda magac ee sida weyn u qabsaday suuqa kala iibsiga ciyaartoyda oo maanta xirmaya",
+            "firstPublished": "2023-01-31T09:47:37.694Z",
+            "link": "https://www.bbc.com/somali/articles/cjelrw7pe8vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/51dc/live/1130aa80-a149-11ed-8f65-71bfa0525ce3.jpg",
+            "description": "Magacyada ugu waaweyn ee lagu hadal hayo suuqa kala iibsiga ciyaartoyda.",
+            "imageAlt": "Suuqa kala iibsiga ciyaartoyda",
+            "id": "cjelrw7pe8vo"
+          },
+          {
+            "type": "article",
+            "title": "Waa tee kooxda sugeysa in uu Ronaldo kusoo biiro ka hor dhammaadka Sanadkan?",
+            "firstPublished": "2022-12-21T06:09:03.509Z",
+            "link": "https://www.bbc.com/somali/articles/c4n6n5gr8wro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/adf2/live/aec9ff90-80f5-11ed-90a7-556e529f9f89.jpg",
+            "description": "Ronaldo ayaa isbuucyadii lasoo dhaafay si weyn loogu hadal hayay warbaahinta.",
+            "imageAlt": "Cristiano Ronaldo",
+            "id": "c4n6n5gr8wro"
+          },
+          {
+            "type": "article",
+            "title": "Kooxdee ayuu funaanaddeeda soo xiran doonaa ninka la haray xulalkii ugu awoodda badnaa Koobka Adduunka? ",
+            "firstPublished": "2022-12-14T09:49:01.874Z",
+            "link": "https://www.bbc.com/somali/articles/crgzxyrv1lxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9562/live/7ef7d940-7b91-11ed-90a7-556e529f9f89.jpg",
+            "description": "Muxuu damacsan yahay ninka looga digay in uu caawa soo xirto funaanadda kooxda Morocco",
+            "imageAlt": "MOHAMMED AL HAJRI",
+            "id": "crgzxyrv1lxo"
+          },
+          {
+            "type": "article",
+            "title": "Muxuu Ronaldo ku yiri wiilka xalay booskiisa galay ee wacdaraha dhigay?",
+            "firstPublished": "2022-12-07T09:48:04.318Z",
+            "link": "https://www.bbc.com/somali/articles/c0jg4yq394lo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f836/live/0cb67880-7611-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Goncalo Ramos ayaa dhaliyay saddexleydii ugu horreysay ee Koobka Adduunka Qadar 2022.",
+            "imageAlt": "Ramos iyo Ronaldo",
+            "id": "c0jg4yq394lo"
+          },
+          {
+            "type": "article",
+            "title": "Ninka khashinka aruurin jiray ee sababta u ah wacdarihii ay shalay Sacuudiga ka dhigeen ciyaaraha Koobka Adduunka",
+            "firstPublished": "2022-11-23T10:49:46.055Z",
+            "link": "https://www.bbc.com/somali/articles/cx7q8jewgwgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fa56/live/75cbbe20-6b17-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Ninkan dunida oo dhan laga hadal hayo mar ayuu qashinka ka nadiifin jiray guryaha.",
+            "imageAlt": "Koobka Adduunka ee 2022",
+            "id": "cx7q8jewgwgo"
+          },
+          {
+            "type": "article",
+            "title": "Xagguu u socdaa Cristiano Ronaldo?",
+            "firstPublished": "2022-11-23T09:29:30.981Z",
+            "link": "https://www.bbc.com/somali/articles/c9804pzvdwwo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b5c5/live/f8507fa0-6b0f-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Ronald ayaa sida muuqata ka carooday qaabka uu ula dhaqmay tababaraha cusub ee Manchester United oo kulamo dhowr ah uga tegay kursiga keydka.",
+            "imageAlt": "Cristiano Ronald",
+            "id": "c9804pzvdwwo"
+          },
+          {
+            "type": "article",
+            "title": "Waa kuma wiilka Soomaaliga ah ee hadal heynta dhaliyay markii uu ka ciyaaray Koobka Adduunka?",
+            "firstPublished": "2022-10-15T09:12:55.765Z",
+            "link": "https://www.bbc.com/somali/articles/cek28e2mvp0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/267a/live/9ac14080-6980-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Wiilkan aabihiis wuxuu usoo ciyaaray xulka qaranka Soomaaliya.",
+            "imageAlt": "Akram Cafiif",
+            "id": "cek28e2mvp0o"
+          },
+          {
+            "type": "article",
+            "title": "M﻿axay Fifa ku haysataa dalka lagu qabanayo Koobka Adduunka ee Qadar?",
+            "firstPublished": "2022-11-08T15:39:13.182Z",
+            "link": "https://www.bbc.com/somali/articles/cp0vgn3mgv1o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9333/live/3543ad70-5f7a-11ed-b950-4dadc68f0cfc.jpg",
+            "description": "Bishan ayuu billaabanayaa tartanka Koobka Adduunka ee ay martigelineyso Qadar.",
+            "imageAlt": "Sepp Blatter",
+            "id": "cp0vgn3mgv1o"
+          },
+          {
+            "type": "article",
+            "title": "Antoine Griezmann: Sababta ay Atletico Madrid u ciyaarsiiso 30 daqiiqo oo keliya",
+            "firstPublished": "2022-10-10T05:42:01.012Z",
+            "link": "https://www.bbc.com/somali/articles/cxw08dj9nmvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/086b/live/4547f050-4841-11ed-9ae9-959994b8a64c.png",
+            "description": "",
+            "imageAlt": "Antoine Griezmann",
+            "id": "cxw08dj9nmvo"
+          },
+          {
+            "type": "article",
+            "title": "Maxaa sababay isbuurashada dadka badan ku dhinteen ee ka dhacday Indonesia?",
+            "firstPublished": "2022-10-02T05:23:05.707Z",
+            "link": "https://www.bbc.com/somali/articles/c5101vxlexno",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f524/live/f9abec50-420f-11ed-9ae9-959994b8a64c.jpg",
+            "description": "Ugu yaraan 129 qof ayaa ku dhimatay isbuurasho ka dhacday garoon kubadda cagta ah oo ku yaalla dalka Indonesia, sida ay sheegeen saraakiisha.",
+            "imageAlt": "Booliska oo isku dayay inay ka hortagaan taageerayaasha kusoo xoomay gudaha garoonka",
+            "id": "c5101vxlexno"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 2,
+        "link": "https://www.bbc.com/somali/topics/cpzd4zj1pn2t",
+        "curationId": "urn:bbc:vivo:curation:820a09c4-d46c-490b-b92b-302b93eda9c3",
+        "curationType": "vivo-stream",
+        "position": 4,
+        "title": "Ciyaaraha",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "NASA oo shaacisay magacyada dadka dayaxa aadi doona",
+            "firstPublished": "2023-05-03T16:59:09.579Z",
+            "link": "https://www.bbc.com/somali/articles/c4npkyljj45o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5506/live/ad3825b0-e9d4-11ed-9ff0-1714980264ca.png",
+            "description": "",
+            "imageAlt": "Afarta cirbixiyeen ee dayaxa aadi doona",
+            "id": "c4npkyljj45o"
+          },
+          {
+            "type": "article",
+            "title": "Cilmi-baaris: Faa'iidada ay leedahay go'aan qaadhasha la'aantu",
+            "firstPublished": "2023-04-30T15:01:14.326Z",
+            "link": "https://www.bbc.com/somali/articles/c84r04zjmz0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2e46/live/2883c910-e762-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "In aadan go'aanka ku degdegin waxay kaa caawinaysaa in aadan go'aan qaldan qaadan balse sidoo kale, go'aan waliba wuxuu ka fiican yahay in aadan waxbaba go'aansan",
+            "imageAlt": "Nin taagan laba waddo dhexdood",
+            "id": "c84r04zjmz0o"
+          },
+          {
+            "type": "article",
+            "title": "Maxaa sababa cagaarshowga? see loo aqoonsadaa? maxaana lagu daweeyaa?",
+            "firstPublished": "2023-04-24T14:28:41.965Z",
+            "link": "https://www.bbc.com/somali/articles/c3gpvg0yjg1o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2c4d/live/38646600-e1fe-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Cagaarshowgu waa cudur ku dhaca beerka, waxaana sababa waxyaabo dhowr ah sida...",
+            "imageAlt": "Indha cagaarshow",
+            "id": "c3gpvg0yjg1o"
+          },
+          {
+            "type": "article",
+            "title": "Waa maxay caabuqan inagu badan ee kaadi mareenku? maxaa lagu gartaa?",
+            "firstPublished": "2023-04-16T13:27:40.090Z",
+            "link": "https://www.bbc.com/somali/articles/c0wq0yeggzko",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a0ef/live/dd1304b0-dc57-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Caafimaad: Kaadi badan, Kaadi olol, dibbiro, dhabar xanuun haddii aad astaamahan isku aragto waxaa suurta gal ah inaad qabto caabuqa UTI, halkan kaga bogo wax badan oo ku saabsan.",
+            "imageAlt": "Qof kaadi isku celinaya",
+            "id": "c0wq0yeggzko"
+          },
+          {
+            "type": "article",
+            "title": "Ma ogtahay in telefoonka casriga ah uu yahay mid ka mid ah sababaha keena injirta gasha timaha?",
+            "firstPublished": "2023-04-15T04:53:56.197Z",
+            "link": "https://www.bbc.com/somali/articles/c98nr5wq11po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d441/live/7246ca70-dad3-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "Injirta",
+            "id": "c98nr5wq11po"
+          },
+          {
+            "type": "article",
+            "title": "Cuntooyinka kaa caawin kara   korriinka Timaha",
+            "firstPublished": "2023-04-12T16:22:09.926Z",
+            "link": "https://www.bbc.com/somali/articles/cqle9exj1k0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a723/live/11920200-d93c-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": ".",
+            "id": "cqle9exj1k0o"
+          },
+          {
+            "type": "article",
+            "title": "Toban talo oo ku socota dadka da'doodu u dhexeyso 30 ilaa 40 jir",
+            "firstPublished": "2023-04-07T15:30:53.670Z",
+            "link": "https://www.bbc.com/somali/articles/cv24ekl9m2po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0b1b/live/9b729f70-d54a-11ed-aa8e-31a9f3ff4e07.jpg",
+            "description": "",
+            "imageAlt": ".",
+            "id": "cv24ekl9m2po"
+          },
+          {
+            "type": "article",
+            "title": "Afar dhibaato oo soo wajahda qofka lugaha is dul saarta marka uu fadhiyo",
+            "firstPublished": "2023-04-04T06:32:01.609Z",
+            "link": "https://www.bbc.com/somali/articles/cjmzrr1wk74o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8f35/live/dbba3730-d2ae-11ed-be2e-754a65c11505.jpg",
+            "description": "Dhibaatada caafimaad ee ka dhalan karta in qofka uu lugaha is dul saarto.",
+            "imageAlt": "Dhibaatada ka dhalata in qofka uu lugaha is dul saarto",
+            "id": "cjmzrr1wk74o"
+          },
+          {
+            "type": "article",
+            "title": "Filim ay Rani jishay oo muran ka dhex abuuray laba dal",
+            "firstPublished": "2023-03-30T18:25:10.988Z",
+            "link": "https://www.bbc.com/somali/articles/cpr550ln5eyo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f96d/live/c73488b0-cefd-11ed-be2e-754a65c11505.jpg",
+            "description": "Isku dhac dhanka dhaqanka ah ayaa dhex maray Norway iyo Hindiya kaas oo ka dhashay filim laga sameeyay dhacdo dalka Norway ku qabsatay hooyo Hindi ah.",
+            "imageAlt": "Rani Mukherjee",
+            "id": "cpr550ln5eyo"
+          },
+          {
+            "type": "article",
+            "title": "Afar shay oo muhiim ah in la nadiifiyo balse dadka badanaa aysan ku baraarugsaneyn",
+            "firstPublished": "2023-03-16T15:07:24.878Z",
+            "link": "https://www.bbc.com/somali/articles/c1rgj2n43nzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/641f/live/509dcf70-c40a-11ed-95f8-0154daa64c44.jpg",
+            "description": "",
+            "imageAlt": "Suufka lagu dhaqo weelasha",
+            "id": "c1rgj2n43nzo"
+          },
+          {
+            "type": "article",
+            "title": "Su'aalaha ku gadaaman cudurka Baabasiirka iyo sida loo daweyn karo",
+            "firstPublished": "2023-03-15T13:20:10.350Z",
+            "link": "https://www.bbc.com/somali/articles/cjlxkew0g83o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bf90/live/92646420-c331-11ed-95f8-0154daa64c44.jpg",
+            "description": "Talooyinka dhanka cuntada dadka qaba cudurka Baabasiirka.",
+            "imageAlt": ".",
+            "id": "cjlxkew0g83o"
+          },
+          {
+            "type": "article",
+            "title": "Daraasad: \"Ugxanta taranka oo laga sameeyay unugyo lab ah\"",
+            "firstPublished": "2023-03-12T06:37:21.538Z",
+            "link": "https://www.bbc.com/somali/articles/c2x608d4gkgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fb97/live/dd5f7e80-bff1-11ed-95f8-0154daa64c44.jpg",
+            "description": "Cilmi baare u dhashay dalka Japan ayaa shir wayn oo ku saabsan dhanka hidde-sidaha ka sheegay in uu ukunta taranka ka sameeyay unugyada jiir lab ah.",
+            "imageAlt": "dhaqtar muunado haya",
+            "id": "c2x608d4gkgo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 7,
+        "link": "https://www.bbc.com/somali/topics/cg8382rk20xt",
+        "curationId": "urn:bbc:vivo:curation:ad022d13-416d-47bb-80f3-8e0043edee3c",
+        "curationType": "vivo-stream",
+        "position": 5,
+        "title": "Aqoon Guud",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Madal qabata Shukaansiga muslimiinta oo ku guul darreysatay dacwad ay la gashay mid kale",
+            "firstPublished": "2023-05-05T03:51:27.728Z",
+            "link": "https://www.bbc.com/somali/articles/c727qr93vd0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cc7b/live/6c548940-eaf5-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "",
+            "imageAlt": "Madasha Muzz",
+            "id": "c727qr93vd0o"
+          },
+          {
+            "type": "article",
+            "title": "20 jir sameeyay shirkad muddo kooban ku gaartay bilyan dollar ",
+            "firstPublished": "2023-02-18T04:34:42.288Z",
+            "link": "https://www.bbc.com/somali/articles/cydn6q7pr8po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6748/live/137bdba0-af42-11ed-b930-15f701fbfd41.jpg",
+            "description": "Aadit Palicha iyo saaxiibkii Kaivalya Vohra ayaa bartamihii 2021 sameeyay shirkad khudaarta dadka ugu geysa guryaha oo lagu magacaabo Zepto.",
+            "imageAlt": "Aadit Palicha ",
+            "id": "cydn6q7pr8po"
+          },
+          {
+            "type": "article",
+            "title": "Afrika: Sida Baraha Bulshada loogu isticmaalo xayeysiin ahaan ",
+            "firstPublished": "2023-01-20T13:27:45.243Z",
+            "link": "https://www.bbc.com/somali/articles/clwnpdev30wo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a40a/live/47f3ded0-98c4-11ed-86bf-4b2f5da2cf01.jpg",
+            "description": "Baraha bulshada ayaa muhiimad aad u weyn u leh shirkadaha ganacsiga ee Afrika.",
+            "imageAlt": "Baraha Bulshada",
+            "id": "clwnpdev30wo"
+          },
+          {
+            "type": "article",
+            "title": "Waa kuma ninka ugu taajirsan adduunka ee hadda booska ka qaatay Elon Musk?",
+            "firstPublished": "2022-12-14T05:15:25.522Z",
+            "link": "https://www.bbc.com/somali/articles/cv2d551e3xvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8ad7/live/eb068c40-7b6d-11ed-90a7-556e529f9f89.jpg",
+            "description": "Elon Musk ayaa laga riixay booska ugu sarreeya ee liiska dadka ugu hantida badan caalamka. Haddaba waa kuma ninka ka sare maray?",
+            "imageAlt": "Liiska dadka ugu taajirsan dunida ayaa isbeddelay",
+            "id": "cv2d551e3xvo"
+          },
+          {
+            "type": "article",
+            "title": "Sababtii ay Soomaaliya u diidday inay ku biirto Dalladda Bariga Afrika (EAC)",
+            "firstPublished": "2022-07-22T11:35:54.984Z",
+            "link": "https://www.bbc.com/somali/articles/cl7e2149ey7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/314a/live/a01cfd40-09ad-11ed-93ba-314ede9cd985.jpg",
+            "description": "Wasiirkii hore ee arrimaha dibadda Soomaaliya ayaa ka warramaya xilli ay Soomaaliya diiday in ay ka mid noqoto dalladda EAC.",
+            "imageAlt": "Calamada ururka EAC marka laga reebo ka Soomaaliya",
+            "id": "cl7e2149ey7o"
+          },
+          {
+            "type": "article",
+            "title": "Maxaa lagu doortaa Jaadka Kenya oo uusan lahayn kan Itoobiya?",
+            "firstPublished": "2022-07-18T12:25:46.509Z",
+            "link": "https://www.bbc.com/somali/articles/cxen2em14xdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2097/live/8fcc6db0-0690-11ed-93ba-314ede9cd985.jpg",
+            "description": "Kan labada qaad wanaagsan marka ay noqoto mirqaabka iyo dhanka dhaqaalaha ay ka helaan dadka ka ganacsada ayay dooddu ka taagan tahay.",
+            "imageAlt": "Jaadka Kenya",
+            "id": "cxen2em14xdo"
+          },
+          {
+            "type": "article",
+            "title": "Shiinaha: Shirkadaha iibka dhulka iyo guryaha oo lacag ahaan u qaadanaya qare iyo khudaar kale",
+            "firstPublished": "2022-07-05T09:58:27.460Z",
+            "link": "https://www.bbc.com/somali/articles/c51895gz1jyo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5e16/live/236aa4d0-fc44-11ec-bfa6-89ae37be3a04.jpg",
+            "description": "",
+            "imageAlt": "Gabar qare wadata",
+            "id": "c51895gz1jyo"
+          },
+          {
+            "type": "article",
+            "title": "Gabar maalin keliya Dahab ka iibsatay miraha yicibta",
+            "firstPublished": "2022-06-24T10:01:57.319Z",
+            "link": "https://www.bbc.com/somali/articles/cp3n63mmje0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9d78/live/f973d6e0-f3a3-11ec-bd41-87b161902afa.jpg",
+            "description": "Inkastoo geedka Gudda la sheegay in uu u adkaysan karo jiilaalka iyo qalleylka, haddana xilligan oo ay dalka ka jirto abaaro daran ka mid yahay dhirta midab-doorsoontay.",
+            "imageAlt": "Xaliimo oo Yicib koombo-miiseysa",
+            "id": "cp3n63mmje0o"
+          },
+          {
+            "type": "article",
+            "title": "Waxyaabaha muhiimka ah ee la iska fiiriyo marka dahabka la iibsanayo",
+            "firstPublished": "2022-06-01T05:53:11.000Z",
+            "link": "https://www.bbc.com/somali/war-61655710",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/D001/production/_124994235_08d73040-1abd-4f0d-a983-bb72d2e8a15f.jpg",
+            "description": "Waxaa jira waxyaabo badan oo ay tahay in aad ogaato marka aad dahab iibsanayso.",
+            "imageAlt": "Suuqa dahabka",
+            "id": "46ea5df6-69d4-41f7-8407-b818c8422b3e"
+          },
+          {
+            "type": "article",
+            "title": "Shan magaalo oo \"la yaab ay ka tahay\" in aad habeenkii seexato!",
+            "firstPublished": "2021-11-11T10:11:19.000Z",
+            "link": "https://www.bbc.com/somali/war-59244066",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/59B1/production/_121516922__121318634_1b9bdac0-58e1-43a2-ad4a-0c92e00ad5ff.jpg",
+            "description": "Badanaa caasimadaha iyo magaalooyinka marka habeenkii la gaaro, waa firaaqo maxaa yeelay dadka badankood ayaa hurda, balse waxaa jiro kuwo aan laga seexanin.",
+            "imageAlt": ".",
+            "id": "4dcd391a-92ea-44c0-9161-b28d39c9d520"
+          },
+          {
+            "type": "article",
+            "title": "Muxuu Kenyatta ka yiri kashifaadda hantidiisa?",
+            "firstPublished": "2021-10-04T08:22:42.000Z",
+            "link": "https://www.bbc.com/somali/war-58758357",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/15BD0/production/_120804098_gettyimages-1187377433.jpg",
+            "description": "Magaca madaxweynaha Kenya, Uhuru Kenyatta, ayaa ka soo muuqday dukumiintiyada lagu magacaabo \"Pandora Papers\" - oo ah xogtii ugu weyneyd abid oo laga fashilo dhinaca dhaqaalaha.",
+            "imageAlt": "Uhuru Kenyatta",
+            "id": "6044113b-a48c-49a0-9657-781f31327c5b"
+          },
+          {
+            "type": "article",
+            "title": "Shanta shaqo ee qarka u saaran in laga waayo dunida",
+            "firstPublished": "2021-09-18T17:06:45.000Z",
+            "link": "https://www.bbc.com/somali/war-58611233",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/DBA7/production/_120613265_35681f03-758f-4ac6-a62c-a9e5846895d9.jpg",
+            "description": "Hadda iska jir shaqooyinka qaar ee qarka u saaran in la waayo sanadaha soo socda.",
+            "imageAlt": ".",
+            "id": "382d01bf-8501-4d5b-b07e-74cd32dc0edd"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "link": "https://www.bbc.com/somali/topics/c2dwqd32v4yt",
+        "curationId": "urn:bbc:vivo:curation:813f8386-835e-4285-b307-2e8708c77822",
+        "curationType": "vivo-stream",
+        "position": 6,
+        "title": "Ganacsi",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "audio",
+            "duration": "PT1H",
+            "title": "Dunida Iyo Maanta",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84lpw8",
+            "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
+            "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
+            "imageAlt": "",
+            "id": "w172z4vrp84lpw8"
+          },
+          {
+            "type": "audio",
+            "duration": "PT1H",
+            "title": "Dunida Iyo Maanta",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84hsz5",
+            "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
+            "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
+            "imageAlt": "",
+            "id": "w172z4vrp84hsz5"
+          },
+          {
+            "type": "audio",
+            "duration": "PT1H",
+            "title": "Dunida Iyo Maanta",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vrp84dx22",
+            "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
+            "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
+            "imageAlt": "",
+            "id": "w172z4vrp84dx22"
+          },
+          {
+            "type": "audio",
+            "duration": "PT1H",
+            "title": "Dunida Iyo Maanta",
+            "firstPublished": "",
+            "link": "https://www.bbc.com/somali/bbc_somali_radio/w172z4vr9zv0c2m",
+            "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p08b24tk.png",
+            "description": "Barnaamij aan ku eegno wararkii ugu dambeeyay ee caalamka iyo Soomaalida.",
+            "imageAlt": "",
+            "id": "w172z4vr9zv0c2m"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:programmes:available-episodes:p034117k",
+        "curationType": "available-episodes",
+        "position": 7,
+        "title": "Dunida Iyo Maanta",
+        "visualProminence": "LOW"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cqe6npp928lt",
+        "contentType": "index-home",
+        "pageIdentifier": "somali.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "data is from live TIPO"
+}

--- a/data/swahili/homePage/index.json
+++ b/data/swahili/homePage/index.json
@@ -1,369 +1,376 @@
 {
-    "data": {
-      "title": "BBC News Swahili",
-      "description": "",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Kwa nini makombora ya urani iliyorutubishwa hutumiwa na yana madhara gani?",
-              "firstPublished": "2023-03-28T11:44:37.230Z",
-              "link": "https://www.bbc.com/swahili/articles/ceq5vwqv5d7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bf18/live/15cdbe00-cd56-11ed-be2e-754a65c11505.jpg",
-              "description": "Madini ya Urani yaliyorutubishwa hufanya silaha kuwa na nguvu zaidi, lakini kuna wasiwasi kwamba silaha hizi ni tishio kwa watu wanaoishi katika maeneo ambayo hutumiwa.",
-              "imageAlt": ".",
-              "id": "ceq5vwqv5d7o"
-            },
-            {
-              "type": "article",
-              "title": "Tume ya Umoja wa Afrika yaomba utulivu Kenya baada ya maandamano dhidi ya serikali",
-              "firstPublished": "2023-03-28T03:49:26.000Z",
-              "link": "https://www.bbc.com/swahili/live/habari-65096091",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/11A37/production/_129174227_maandamano-getty.jpg",
-              "description": "Mwenyekiti wa tume ya Umoja wa Afrika AU Moussa faki Mahamat ameonesha wasiwasi wake kuhusu ghasia zilizotokea na kusababisha kifo cha mtu mmoja huku mali ya thamani isiojulikana ikiharibiwa kufuatia maandamano dhidi ya serikali",
-              "imageAlt": ".",
-              "id": "b59c3240-dbb0-4b67-9053-ac0e97b6a83f"
-            },
-            {
-              "type": "article",
-              "title": "Maandamano ya Azimio: Odinga alaani uvamizi wa shamba la rais mstaafu Uhuru Kenyatta ",
-              "firstPublished": "2023-03-28T02:56:27.116Z",
-              "link": "https://www.bbc.com/swahili/articles/cxxr77rn584o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9fc2/live/8627e340-cd67-11ed-be2e-754a65c11505.jpg",
-              "description": "",
-              "imageAlt": ".",
-              "id": "cxxr77rn584o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:fac42fdd-6486-481c-9ee4-d9e2d40647a2",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "BBC News Swahili Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Ramadhan: Nchi gani zina mfungo mrefu au mfupi zaidi duniani?",
-              "firstPublished": "2023-03-27T03:33:55.791Z",
-              "link": "https://www.bbc.com/swahili/articles/cyx0wzn31e2o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f484/live/cfb34b30-cc4f-11ed-be2e-754a65c11505.jpg",
-              "description": "Ramadhan: Nchi gani zina mfungo mrefu au mfupi zaidi duniani?",
-              "imageAlt": "Ramadhan",
-              "id": "cyx0wzn31e2o"
-            },
-            {
-              "type": "article",
-              "title": "'Ninapowaona wavulana wakienda shule, ninaumia'",
-              "firstPublished": "2023-03-27T04:50:42.040Z",
-              "link": "https://www.bbc.com/swahili/articles/c4nz8jw5e8jo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/00eb/live/31bead70-cc3b-11ed-be2e-754a65c11505.png",
-              "description": "Mwaka mmoja na nusu tangu maisha yao kielimu yasitishwe, huzuni yao bado mbichi.",
-              "imageAlt": "Tamana ",
-              "id": "c4nz8jw5e8jo"
-            },
-            {
-              "type": "article",
-              "title": "Faida 5 Kuu za Kiafya za Kufunga",
-              "firstPublished": "2023-03-26T14:35:56.645Z",
-              "link": "https://www.bbc.com/swahili/articles/c2xez5ynpk6o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/737d/live/22916430-c94a-11ed-be2e-754a65c11505.jpg",
-              "description": "Faida 5 Kuu za Kiafya za Kufunga",
-              "imageAlt": ".",
-              "id": "c2xez5ynpk6o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:16e0bbb4-dad0-43b2-a6af-3a76f8d5c7dc",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "Gumzo mitandaoni",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT1M24S",
-              "title": "'Nilijenga nyumba yangu ndogo kwa kutumia plastiki 35,000… ",
-              "firstPublished": "2023-05-10T11:32:14.612Z",
-              "link": "https://www.bbc.com/swahili/articles/c51pper4nzvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/20cb/live/965f06d0-ef22-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "Mwanaharakati ajenga nyumba ya plastiki kuokoa mazingira Indonesia",
-              "imageAlt": ".",
-              "id": "c51pper4nzvo"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M58S",
-              "title": "Dereva 'bodaboda' mwenye ulemavu wa kusikia Tanzania ",
-              "firstPublished": "2023-05-02T10:43:50.676Z",
-              "link": "https://www.bbc.com/swahili/articles/cjm7e9mdd04o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ef27/live/7e022780-e8d2-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "Licha ya ulemavu wake wa kutosikia, Ally Jumanne amekuwa dereva wa 'bodaboda' kwa miaka 11",
-              "imageAlt": "w",
-              "id": "cjm7e9mdd04o"
-            },
-            {
-              "type": "audio",
-              "duration": "PT29M12S",
-              "title": "Unafanyaje kuhakikisha shughuli za kiuchumi hazimkwamishi mtoto kupata elimu?",
-              "firstPublished": "2023-04-30T12:25:38.291Z",
-              "link": "https://www.bbc.com/swahili/articles/cj70e83vm9po",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28b4/live/fb3e7660-e5a6-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "",
-              "imageAlt": "Mifugo",
-              "id": "cj70e83vm9po"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M23S",
-              "title": "Katika eneo la tukio la vifo vya dhehebu tata la Kenya  ",
-              "firstPublished": "2023-04-27T09:59:48.137Z",
-              "link": "https://www.bbc.com/swahili/articles/ce40l414gw8o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/821e/live/58db2c60-e4ac-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Miili ya watu zaidi ya 90 imepatikana katika msitu wa  Shakahola  mashariki mwa Kenya. Wahanga wanadhaniwa kuwa ni wafuasi wa  dhehebu tata la kidini walioshawishiwa kufunga hadi kufa, ili kukutana na Yesu.",
-              "imageAlt": "g",
-              "id": "ce40l414gw8o"
-            },
-            {
-              "type": "video",
-              "duration": "PT2M36S",
-              "title": "Unajua mtama unaweza kupunguza kasi ya uzee na magonjwa?",
-              "firstPublished": "2023-04-27T05:47:39.128Z",
-              "link": "https://www.bbc.com/swahili/articles/cd1gk4wx538o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0592/live/7e0dd4c0-e447-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "",
-              "imageAlt": "w",
-              "id": "cd1gk4wx538o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M7S",
-              "title": "Paul Makenzie: '' Alisema yeye na familia yake watakua wa mwisho kuaga Dunia na kwenda mbinguni''",
-              "firstPublished": "2023-04-26T13:20:06.682Z",
-              "link": "https://www.bbc.com/swahili/articles/cw5k3rg42dwo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a651/live/da27b0e0-e434-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Titus Katana ambaye aliwahi kushiriki katika kundi hilo na baadae kujitoa aliiambia BBC kuwa Mchungaji Makenzie aliwataka waumini waanze kufunga hadi kufa kisha yeye na familia watakua wa mwisho.",
-              "imageAlt": "w",
-              "id": "cw5k3rg42dwo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M23S",
-              "title": "Waislamu wa madhehebu ya Answar Sunnah washeherekea Eid Tanzania",
-              "firstPublished": "2023-04-21T12:48:58.914Z",
-              "link": "https://www.bbc.com/swahili/articles/c6p9453n87do",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Nchini Tanzania, wakati Waislamu wengi bado wanatazamia kusheherekea siku kuu ya Eid Ul-Fitr kesho, madhehebu ya Answar Sunnah leo wameendelea na sherehe hizo. ",
-              "imageAlt": "",
-              "id": "c6p9453n87do"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M27S",
-              "title": "Wanafunzi waliokwama walazimika kumzika rafiki yao Sudan  ",
-              "firstPublished": "2023-04-19T12:25:26.829Z",
-              "link": "https://www.bbc.com/swahili/articles/c2lnknz8ze0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6a1f/live/15f18a20-dea3-11ed-8df1-d74cbf1089d7.jpg",
-              "description": "Wanafunzi na wafanyakazi  katika Chuo Kikuu cha Khartoum wanasema wamekwama katika makabiliano ya silaha kwa siku nne, bila chakula na maji . ",
-              "imageAlt": "g",
-              "id": "c2lnknz8ze0o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M14S",
-              "title": "Kwanini binadamu tunaipenda dhahabu?",
-              "firstPublished": "2023-04-08T13:02:52.310Z",
-              "link": "https://www.bbc.com/swahili/articles/crgqp4jg638o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "Kwa nini tunaona dhahabu inapendeza sana?",
-              "imageAlt": "",
-              "id": "crgqp4jg638o"
-            },
-            {
-              "type": "video",
-              "duration": "PT3M56S",
-              "title": "“Sufuria ya ugali iliniangukia nikiwa mtoto, niliungua mwili mzima”",
-              "firstPublished": "2023-04-08T10:19:58.840Z",
-              "link": "https://www.bbc.com/swahili/articles/c2ln2jgkwqxo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": " Dkt Ipyana Kibona anawahamasisha Wakristo kwamba moyo wa kushukuru kwa matendo mema waliyotendewa na Mungu ni jambo la msingi ",
-              "imageAlt": "",
-              "id": "c2ln2jgkwqxo"
-            },
-            {
-              "type": "video",
-              "duration": "PT44S",
-              "title": "Video: Paka amrukia imamu anayeongoza sala wakati wa ibada ya Ramadhan",
-              "firstPublished": "2023-04-06T03:25:54.000Z",
-              "link": "https://www.bbc.com/swahili/habari-65198205",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5F4E/production/_129289342_p0ff5445.jpg",
-              "description": "Video yamuonyesha paka akiruka juu ya mabega ya imamu wakati wa sala ya Tarawehe ndani ya msikiti.",
-              "imageAlt": "Walid Mehsas na paka katika mabega yake",
-              "id": "3d347202-ae91-47d2-9033-22f9fee4585e"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M2S",
-              "title": "Viboko wa Pablo Escobar kuhamishwa kwa dola milioni 3.5",
-              "firstPublished": "2023-03-31T13:29:23.247Z",
-              "link": "https://www.bbc.com/swahili/articles/cq5ewd0w7p0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b816/live/60665ce0-cf83-11ed-be2e-754a65c11505.jpg",
-              "description": "",
-              "imageAlt": "viboko",
-              "id": "cq5ewd0w7p0o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 5,
-          "link": "https://www.bbc.com/swahili/topics/cz40xlzvj6kt",
-          "curationId": "urn:bbc:vivo:curation:d6d0b811-beda-4ab9-9794-e98bbfca3306",
-          "curationType": "vivo-stream",
-          "position": 2,
-          "title": "Video",
-          "visualProminence": "NORMAL"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Baada ya utafiti wa miaka mitatu mnyama huyu atajwa kuwa chanzo cha Corona ",
-              "firstPublished": "2023-03-25T09:36:03.756Z",
-              "link": "https://www.bbc.com/swahili/articles/clw1g5qp9zvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fa18/live/cede8bd0-caeb-11ed-be2e-754a65c11505.jpg",
-              "description": "Baada ya utafiti wa miaka mitatu mnyama huyu atajwa kuwa chanzo cha Corona ",
-              "imageAlt": "CORONA",
-              "id": "clw1g5qp9zvo"
-            },
-            {
-              "type": "article",
-              "title": "Asili ya Covid: Kwa nini nadharia ya uvujaji wa maabara ya Wuhan inabishaniwa sana?",
-              "firstPublished": "2023-03-02T05:45:21.972Z",
-              "link": "https://www.bbc.com/swahili/articles/cqv81wg5373o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f93b/live/e0625f70-b8b8-11ed-93f1-01f57b5ba1ca.jpg",
-              "description": "Zaidi ya miaka mitatu baada ya Covid-19 kugunduliwa katika jiji la Wuhan, China swali la jinsi virusi hivyo viliibuka kwa mara ya kwanza bado ni kitendawili.",
-              "imageAlt": "Nadharia ya kuvuja kwa maabara imekataliwa vikali na China",
-              "id": "cqv81wg5373o"
-            },
-            {
-              "type": "article",
-              "title": "Kwa nini Covid-19 itaendelea kuwepo sana?",
-              "firstPublished": "2023-01-13T05:59:07.859Z",
-              "link": "https://www.bbc.com/swahili/articles/cxrndw50xdvo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/96b8/live/ba861e10-9264-11ed-9a1a-f3662015ae8e.jpg",
-              "description": "Kwa nini Covid-19 itaendelea kuwepo sana?",
-              "imageAlt": "w",
-              "id": "cxrndw50xdvo"
-            },
-            {
-              "type": "article",
-              "title": "Ni nini kinachojulikana kuhusu aina mpya ya Covid XBB.1.5? ",
-              "firstPublished": "2023-01-11T02:18:09.654Z",
-              "link": "https://www.bbc.com/swahili/articles/cxx4ygrlxlno",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d9c4/live/c8869db0-9150-11ed-9a1a-f3662015ae8e.jpg",
-              "description": "Aina mpya ya Covid inasababisha wasiwasi huko Marekani ambapo inaenea haraka.",
-              "imageAlt": "w",
-              "id": "cxx4ygrlxlno"
-            },
-            {
-              "type": "article",
-              "title": "Jinsi Covid inavyoathiri uwezo wa kuzaa kwa wanaume",
-              "firstPublished": "2023-01-02T10:22:17.000Z",
-              "link": "https://www.bbc.com/swahili/habari-64144356",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C491/production/_122612305_gettyimages-824853668.jpg",
-              "description": "Ni miaka miwili sasa tangu virusi vya Covid vigundulike duniani na baadaye kuwa janga, lakini ni sasa ambapo uwezekano wa athari za ugonjwa huu kwa uzazi wa wanaume zimefichuliwa.",
-              "imageAlt": "පිරිමින්ගේ සරුභාවයට කොවිඩ්වලින් බලපෑමක්",
-              "id": "ca8a7024-2184-4d70-b4c3-7b40fec4cb3d"
-            },
-            {
-              "type": "article",
-              "title": "Mambo matano makubwa zaidi ya mwaka 2022 tuliyojifunza kuhusu mapenzi na ngono",
-              "firstPublished": "2022-12-24T10:56:46.790Z",
-              "link": "https://www.bbc.com/swahili/articles/c9e19739z2yo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fe75/live/bf378b30-81dc-11ed-90a7-556e529f9f89.jpg",
-              "description": "Jinsi tunavyofikiri kuhusu ngono na upendo daima zinabadilika, zimeathiriwa mara kwa mara na matukio ya kitamaduni, kisiasa na kimataifa.",
-              "imageAlt": "Kuachana ilikuwa rahisi na ngumu zaidi mnamo 2022",
-              "id": "c9e19739z2yo"
-            },
-            {
-              "type": "article",
-              "title": "Kwanini kuna misururu ya kuchoma miili ya wafu China?",
-              "firstPublished": "2022-12-22T10:43:03.880Z",
-              "link": "https://www.bbc.com/swahili/articles/cd1518xlyy0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28cb/live/42328d00-80f7-11ed-90a7-556e529f9f89.jpg",
-              "description": "Huku China ikipambana na wimbi la visa vya Covid, wafanyakazi katika maeneo ya uchomaji wa miili ya wafu  kote nchini Uchina wanasema wanahangaika kushughulikia miili ya wafu inayoletwa  kwa ajili ya kuchomwa.   ",
-              "imageAlt": "g",
-              "id": "cd1518xlyy0o"
-            },
-            {
-              "type": "article",
-              "title": "Miji ghali zaidi duniani kuishi 2022",
-              "firstPublished": "2022-12-02T06:38:16.798Z",
-              "link": "https://www.bbc.com/swahili/articles/ck54e6858dgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/79d1/live/e8795aa0-720a-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Miji ghali zaidi duniani ni New York na Singapore, kulingana na utafiti wa kila mwaka wa Kitengo cha Ujasusi cha Economist (EIU).",
-              "imageAlt": ".",
-              "id": "ck54e6858dgo"
-            },
-            {
-              "type": "article",
-              "title": "Jinsi uwepo wa Covid unavyo wakosesha China shamrashamra za Kombe la Dunia ",
-              "firstPublished": "2022-11-24T10:44:47.933Z",
-              "link": "https://www.bbc.com/swahili/articles/cmm654vgj0zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5732/live/6cabc710-6bab-11ed-94b2-efbc7109d3dd.jpg",
-              "description": "Vyombo vya habari vimeangazia pakubwa Kombe la Dunia wiki hii , lakini mechi zimechochea hasira kwamba watu nchini humo wamezuiwa kusherehekea.  ",
-              "imageAlt": "g",
-              "id": "cmm654vgj0zo"
-            },
-            {
-              "type": "article",
-              "title": "Utafiti wabaini sababu za homa ya ini kwa watoto",
-              "firstPublished": "2022-07-27T04:52:13.816Z",
-              "link": "https://www.bbc.com/swahili/articles/c8488v7jrk9o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/605c/live/e47e36e0-0cee-11ed-93ba-314ede9cd985.jpg",
-              "description": "Watafiti wanaamini kuwa nyuma ya mlipuko huo mpya kuna virusi viwili vya kawaida ambavyo vimerudi baada ya kumalizika kwa marufuku ya kutoka nje kufuatia mlipuko wa corona",
-              "imageAlt": "ggg",
-              "id": "c8488v7jrk9o"
-            },
-            {
-              "type": "article",
-              "title": "Urusi inavyotumia pesa nyingi kumlinda Putin dhidi ya Covid",
-              "firstPublished": "2022-07-19T03:29:23.964Z",
-              "link": "https://www.bbc.com/swahili/articles/c19m3vkn02zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4765/live/b8a39f10-0712-11ed-93ba-314ede9cd985.jpg",
-              "description": "Vipimo vya matibabu, ikiwa ni pamoja na katika baadhi ya visa  sampuli za kinyesi vinafanywa. Je, mfumo unaolinda afya ya Vladimir Putin unafanya kazi vipi?",
-              "imageAlt": "th",
-              "id": "c19m3vkn02zo"
-            },
-            {
-              "type": "article",
-              "title": "Korea Kaskazini yapambana na Covid kwa maji ya chumvi na tangawizi",
-              "firstPublished": "2022-05-20T11:09:02.000Z",
-              "link": "https://www.bbc.com/swahili/habari-61524344",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2335/production/_124831090_978d7935-cd85-4cd0-903c-e98a54d10b1c.jpg",
-              "description": "Korea Kaskazini inapambana kupunguza maambukizi ya Covid kwa raia wake ambao hawajachanjwa.",
-              "imageAlt": "ggg",
-              "id": "ffd4c465-6d23-4b4a-b308-6f9fc7d6e137"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 12,
-          "link": "https://www.bbc.com/swahili/topics/c8jvpjklx1dt",
-          "curationId": "urn:bbc:vivo:curation:5fb3375d-f7ba-41c4-bf92-67e379be83fe",
-          "curationType": "vivo-stream",
-          "position": 3,
-          "title": "Taarifa kuhusu Coronavirus",
-          "visualProminence": "NORMAL"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News Swahili",
+    "description": "",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Kwa nini makombora ya urani iliyorutubishwa hutumiwa na yana madhara gani?",
+            "firstPublished": "2023-03-28T11:44:37.230Z",
+            "link": "https://www.bbc.com/swahili/articles/ceq5vwqv5d7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/bf18/live/15cdbe00-cd56-11ed-be2e-754a65c11505.jpg",
+            "description": "Madini ya Urani yaliyorutubishwa hufanya silaha kuwa na nguvu zaidi, lakini kuna wasiwasi kwamba silaha hizi ni tishio kwa watu wanaoishi katika maeneo ambayo hutumiwa.",
+            "imageAlt": ".",
+            "id": "ceq5vwqv5d7o"
+          },
+          {
+            "type": "article",
+            "title": "Tume ya Umoja wa Afrika yaomba utulivu Kenya baada ya maandamano dhidi ya serikali",
+            "firstPublished": "2023-03-28T03:49:26.000Z",
+            "link": "https://www.bbc.com/swahili/live/habari-65096091",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/11A37/production/_129174227_maandamano-getty.jpg",
+            "description": "Mwenyekiti wa tume ya Umoja wa Afrika AU Moussa faki Mahamat ameonesha wasiwasi wake kuhusu ghasia zilizotokea na kusababisha kifo cha mtu mmoja huku mali ya thamani isiojulikana ikiharibiwa kufuatia maandamano dhidi ya serikali",
+            "imageAlt": ".",
+            "id": "b59c3240-dbb0-4b67-9053-ac0e97b6a83f"
+          },
+          {
+            "type": "article",
+            "title": "Maandamano ya Azimio: Odinga alaani uvamizi wa shamba la rais mstaafu Uhuru Kenyatta ",
+            "firstPublished": "2023-03-28T02:56:27.116Z",
+            "link": "https://www.bbc.com/swahili/articles/cxxr77rn584o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9fc2/live/8627e340-cd67-11ed-be2e-754a65c11505.jpg",
+            "description": "",
+            "imageAlt": ".",
+            "id": "cxxr77rn584o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:fac42fdd-6486-481c-9ee4-d9e2d40647a2",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "BBC News Swahili Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Ramadhan: Nchi gani zina mfungo mrefu au mfupi zaidi duniani?",
+            "firstPublished": "2023-03-27T03:33:55.791Z",
+            "link": "https://www.bbc.com/swahili/articles/cyx0wzn31e2o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f484/live/cfb34b30-cc4f-11ed-be2e-754a65c11505.jpg",
+            "description": "Ramadhan: Nchi gani zina mfungo mrefu au mfupi zaidi duniani?",
+            "imageAlt": "Ramadhan",
+            "id": "cyx0wzn31e2o"
+          },
+          {
+            "type": "article",
+            "title": "'Ninapowaona wavulana wakienda shule, ninaumia'",
+            "firstPublished": "2023-03-27T04:50:42.040Z",
+            "link": "https://www.bbc.com/swahili/articles/c4nz8jw5e8jo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/00eb/live/31bead70-cc3b-11ed-be2e-754a65c11505.png",
+            "description": "Mwaka mmoja na nusu tangu maisha yao kielimu yasitishwe, huzuni yao bado mbichi.",
+            "imageAlt": "Tamana ",
+            "id": "c4nz8jw5e8jo"
+          },
+          {
+            "type": "article",
+            "title": "Faida 5 Kuu za Kiafya za Kufunga",
+            "firstPublished": "2023-03-26T14:35:56.645Z",
+            "link": "https://www.bbc.com/swahili/articles/c2xez5ynpk6o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/737d/live/22916430-c94a-11ed-be2e-754a65c11505.jpg",
+            "description": "Faida 5 Kuu za Kiafya za Kufunga",
+            "imageAlt": ".",
+            "id": "c2xez5ynpk6o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:16e0bbb4-dad0-43b2-a6af-3a76f8d5c7dc",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "Gumzo mitandaoni",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT1M24S",
+            "title": "'Nilijenga nyumba yangu ndogo kwa kutumia plastiki 35,000… ",
+            "firstPublished": "2023-05-10T11:32:14.612Z",
+            "link": "https://www.bbc.com/swahili/articles/c51pper4nzvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/20cb/live/965f06d0-ef22-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "Mwanaharakati ajenga nyumba ya plastiki kuokoa mazingira Indonesia",
+            "imageAlt": ".",
+            "id": "c51pper4nzvo"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M58S",
+            "title": "Dereva 'bodaboda' mwenye ulemavu wa kusikia Tanzania ",
+            "firstPublished": "2023-05-02T10:43:50.676Z",
+            "link": "https://www.bbc.com/swahili/articles/cjm7e9mdd04o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ef27/live/7e022780-e8d2-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "Licha ya ulemavu wake wa kutosikia, Ally Jumanne amekuwa dereva wa 'bodaboda' kwa miaka 11",
+            "imageAlt": "w",
+            "id": "cjm7e9mdd04o"
+          },
+          {
+            "type": "audio",
+            "duration": "PT29M12S",
+            "title": "Unafanyaje kuhakikisha shughuli za kiuchumi hazimkwamishi mtoto kupata elimu?",
+            "firstPublished": "2023-04-30T12:25:38.291Z",
+            "link": "https://www.bbc.com/swahili/articles/cj70e83vm9po",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28b4/live/fb3e7660-e5a6-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "",
+            "imageAlt": "Mifugo",
+            "id": "cj70e83vm9po"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M23S",
+            "title": "Katika eneo la tukio la vifo vya dhehebu tata la Kenya  ",
+            "firstPublished": "2023-04-27T09:59:48.137Z",
+            "link": "https://www.bbc.com/swahili/articles/ce40l414gw8o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/821e/live/58db2c60-e4ac-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Miili ya watu zaidi ya 90 imepatikana katika msitu wa  Shakahola  mashariki mwa Kenya. Wahanga wanadhaniwa kuwa ni wafuasi wa  dhehebu tata la kidini walioshawishiwa kufunga hadi kufa, ili kukutana na Yesu.",
+            "imageAlt": "g",
+            "id": "ce40l414gw8o"
+          },
+          {
+            "type": "video",
+            "duration": "PT2M36S",
+            "title": "Unajua mtama unaweza kupunguza kasi ya uzee na magonjwa?",
+            "firstPublished": "2023-04-27T05:47:39.128Z",
+            "link": "https://www.bbc.com/swahili/articles/cd1gk4wx538o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/0592/live/7e0dd4c0-e447-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "",
+            "imageAlt": "w",
+            "id": "cd1gk4wx538o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M7S",
+            "title": "Paul Makenzie: '' Alisema yeye na familia yake watakua wa mwisho kuaga Dunia na kwenda mbinguni''",
+            "firstPublished": "2023-04-26T13:20:06.682Z",
+            "link": "https://www.bbc.com/swahili/articles/cw5k3rg42dwo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a651/live/da27b0e0-e434-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Titus Katana ambaye aliwahi kushiriki katika kundi hilo na baadae kujitoa aliiambia BBC kuwa Mchungaji Makenzie aliwataka waumini waanze kufunga hadi kufa kisha yeye na familia watakua wa mwisho.",
+            "imageAlt": "w",
+            "id": "cw5k3rg42dwo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M23S",
+            "title": "Waislamu wa madhehebu ya Answar Sunnah washeherekea Eid Tanzania",
+            "firstPublished": "2023-04-21T12:48:58.914Z",
+            "link": "https://www.bbc.com/swahili/articles/c6p9453n87do",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Nchini Tanzania, wakati Waislamu wengi bado wanatazamia kusheherekea siku kuu ya Eid Ul-Fitr kesho, madhehebu ya Answar Sunnah leo wameendelea na sherehe hizo. ",
+            "imageAlt": "",
+            "id": "c6p9453n87do"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M27S",
+            "title": "Wanafunzi waliokwama walazimika kumzika rafiki yao Sudan  ",
+            "firstPublished": "2023-04-19T12:25:26.829Z",
+            "link": "https://www.bbc.com/swahili/articles/c2lnknz8ze0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/6a1f/live/15f18a20-dea3-11ed-8df1-d74cbf1089d7.jpg",
+            "description": "Wanafunzi na wafanyakazi  katika Chuo Kikuu cha Khartoum wanasema wamekwama katika makabiliano ya silaha kwa siku nne, bila chakula na maji . ",
+            "imageAlt": "g",
+            "id": "c2lnknz8ze0o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M14S",
+            "title": "Kwanini binadamu tunaipenda dhahabu?",
+            "firstPublished": "2023-04-08T13:02:52.310Z",
+            "link": "https://www.bbc.com/swahili/articles/crgqp4jg638o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "Kwa nini tunaona dhahabu inapendeza sana?",
+            "imageAlt": "",
+            "id": "crgqp4jg638o"
+          },
+          {
+            "type": "video",
+            "duration": "PT3M56S",
+            "title": "“Sufuria ya ugali iliniangukia nikiwa mtoto, niliungua mwili mzima”",
+            "firstPublished": "2023-04-08T10:19:58.840Z",
+            "link": "https://www.bbc.com/swahili/articles/c2ln2jgkwqxo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": " Dkt Ipyana Kibona anawahamasisha Wakristo kwamba moyo wa kushukuru kwa matendo mema waliyotendewa na Mungu ni jambo la msingi ",
+            "imageAlt": "",
+            "id": "c2ln2jgkwqxo"
+          },
+          {
+            "type": "video",
+            "duration": "PT44S",
+            "title": "Video: Paka amrukia imamu anayeongoza sala wakati wa ibada ya Ramadhan",
+            "firstPublished": "2023-04-06T03:25:54.000Z",
+            "link": "https://www.bbc.com/swahili/habari-65198205",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5F4E/production/_129289342_p0ff5445.jpg",
+            "description": "Video yamuonyesha paka akiruka juu ya mabega ya imamu wakati wa sala ya Tarawehe ndani ya msikiti.",
+            "imageAlt": "Walid Mehsas na paka katika mabega yake",
+            "id": "3d347202-ae91-47d2-9033-22f9fee4585e"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M2S",
+            "title": "Viboko wa Pablo Escobar kuhamishwa kwa dola milioni 3.5",
+            "firstPublished": "2023-03-31T13:29:23.247Z",
+            "link": "https://www.bbc.com/swahili/articles/cq5ewd0w7p0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b816/live/60665ce0-cf83-11ed-be2e-754a65c11505.jpg",
+            "description": "",
+            "imageAlt": "viboko",
+            "id": "cq5ewd0w7p0o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 5,
+        "link": "https://www.bbc.com/swahili/topics/cz40xlzvj6kt",
+        "curationId": "urn:bbc:vivo:curation:d6d0b811-beda-4ab9-9794-e98bbfca3306",
+        "curationType": "vivo-stream",
+        "position": 2,
+        "title": "Video",
+        "visualProminence": "NORMAL"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Baada ya utafiti wa miaka mitatu mnyama huyu atajwa kuwa chanzo cha Corona ",
+            "firstPublished": "2023-03-25T09:36:03.756Z",
+            "link": "https://www.bbc.com/swahili/articles/clw1g5qp9zvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fa18/live/cede8bd0-caeb-11ed-be2e-754a65c11505.jpg",
+            "description": "Baada ya utafiti wa miaka mitatu mnyama huyu atajwa kuwa chanzo cha Corona ",
+            "imageAlt": "CORONA",
+            "id": "clw1g5qp9zvo"
+          },
+          {
+            "type": "article",
+            "title": "Asili ya Covid: Kwa nini nadharia ya uvujaji wa maabara ya Wuhan inabishaniwa sana?",
+            "firstPublished": "2023-03-02T05:45:21.972Z",
+            "link": "https://www.bbc.com/swahili/articles/cqv81wg5373o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f93b/live/e0625f70-b8b8-11ed-93f1-01f57b5ba1ca.jpg",
+            "description": "Zaidi ya miaka mitatu baada ya Covid-19 kugunduliwa katika jiji la Wuhan, China swali la jinsi virusi hivyo viliibuka kwa mara ya kwanza bado ni kitendawili.",
+            "imageAlt": "Nadharia ya kuvuja kwa maabara imekataliwa vikali na China",
+            "id": "cqv81wg5373o"
+          },
+          {
+            "type": "article",
+            "title": "Kwa nini Covid-19 itaendelea kuwepo sana?",
+            "firstPublished": "2023-01-13T05:59:07.859Z",
+            "link": "https://www.bbc.com/swahili/articles/cxrndw50xdvo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/96b8/live/ba861e10-9264-11ed-9a1a-f3662015ae8e.jpg",
+            "description": "Kwa nini Covid-19 itaendelea kuwepo sana?",
+            "imageAlt": "w",
+            "id": "cxrndw50xdvo"
+          },
+          {
+            "type": "article",
+            "title": "Ni nini kinachojulikana kuhusu aina mpya ya Covid XBB.1.5? ",
+            "firstPublished": "2023-01-11T02:18:09.654Z",
+            "link": "https://www.bbc.com/swahili/articles/cxx4ygrlxlno",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d9c4/live/c8869db0-9150-11ed-9a1a-f3662015ae8e.jpg",
+            "description": "Aina mpya ya Covid inasababisha wasiwasi huko Marekani ambapo inaenea haraka.",
+            "imageAlt": "w",
+            "id": "cxx4ygrlxlno"
+          },
+          {
+            "type": "article",
+            "title": "Jinsi Covid inavyoathiri uwezo wa kuzaa kwa wanaume",
+            "firstPublished": "2023-01-02T10:22:17.000Z",
+            "link": "https://www.bbc.com/swahili/habari-64144356",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/C491/production/_122612305_gettyimages-824853668.jpg",
+            "description": "Ni miaka miwili sasa tangu virusi vya Covid vigundulike duniani na baadaye kuwa janga, lakini ni sasa ambapo uwezekano wa athari za ugonjwa huu kwa uzazi wa wanaume zimefichuliwa.",
+            "imageAlt": "පිරිමින්ගේ සරුභාවයට කොවිඩ්වලින් බලපෑමක්",
+            "id": "ca8a7024-2184-4d70-b4c3-7b40fec4cb3d"
+          },
+          {
+            "type": "article",
+            "title": "Mambo matano makubwa zaidi ya mwaka 2022 tuliyojifunza kuhusu mapenzi na ngono",
+            "firstPublished": "2022-12-24T10:56:46.790Z",
+            "link": "https://www.bbc.com/swahili/articles/c9e19739z2yo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/fe75/live/bf378b30-81dc-11ed-90a7-556e529f9f89.jpg",
+            "description": "Jinsi tunavyofikiri kuhusu ngono na upendo daima zinabadilika, zimeathiriwa mara kwa mara na matukio ya kitamaduni, kisiasa na kimataifa.",
+            "imageAlt": "Kuachana ilikuwa rahisi na ngumu zaidi mnamo 2022",
+            "id": "c9e19739z2yo"
+          },
+          {
+            "type": "article",
+            "title": "Kwanini kuna misururu ya kuchoma miili ya wafu China?",
+            "firstPublished": "2022-12-22T10:43:03.880Z",
+            "link": "https://www.bbc.com/swahili/articles/cd1518xlyy0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/28cb/live/42328d00-80f7-11ed-90a7-556e529f9f89.jpg",
+            "description": "Huku China ikipambana na wimbi la visa vya Covid, wafanyakazi katika maeneo ya uchomaji wa miili ya wafu  kote nchini Uchina wanasema wanahangaika kushughulikia miili ya wafu inayoletwa  kwa ajili ya kuchomwa.   ",
+            "imageAlt": "g",
+            "id": "cd1518xlyy0o"
+          },
+          {
+            "type": "article",
+            "title": "Miji ghali zaidi duniani kuishi 2022",
+            "firstPublished": "2022-12-02T06:38:16.798Z",
+            "link": "https://www.bbc.com/swahili/articles/ck54e6858dgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/79d1/live/e8795aa0-720a-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Miji ghali zaidi duniani ni New York na Singapore, kulingana na utafiti wa kila mwaka wa Kitengo cha Ujasusi cha Economist (EIU).",
+            "imageAlt": ".",
+            "id": "ck54e6858dgo"
+          },
+          {
+            "type": "article",
+            "title": "Jinsi uwepo wa Covid unavyo wakosesha China shamrashamra za Kombe la Dunia ",
+            "firstPublished": "2022-11-24T10:44:47.933Z",
+            "link": "https://www.bbc.com/swahili/articles/cmm654vgj0zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/5732/live/6cabc710-6bab-11ed-94b2-efbc7109d3dd.jpg",
+            "description": "Vyombo vya habari vimeangazia pakubwa Kombe la Dunia wiki hii , lakini mechi zimechochea hasira kwamba watu nchini humo wamezuiwa kusherehekea.  ",
+            "imageAlt": "g",
+            "id": "cmm654vgj0zo"
+          },
+          {
+            "type": "article",
+            "title": "Utafiti wabaini sababu za homa ya ini kwa watoto",
+            "firstPublished": "2022-07-27T04:52:13.816Z",
+            "link": "https://www.bbc.com/swahili/articles/c8488v7jrk9o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/605c/live/e47e36e0-0cee-11ed-93ba-314ede9cd985.jpg",
+            "description": "Watafiti wanaamini kuwa nyuma ya mlipuko huo mpya kuna virusi viwili vya kawaida ambavyo vimerudi baada ya kumalizika kwa marufuku ya kutoka nje kufuatia mlipuko wa corona",
+            "imageAlt": "ggg",
+            "id": "c8488v7jrk9o"
+          },
+          {
+            "type": "article",
+            "title": "Urusi inavyotumia pesa nyingi kumlinda Putin dhidi ya Covid",
+            "firstPublished": "2022-07-19T03:29:23.964Z",
+            "link": "https://www.bbc.com/swahili/articles/c19m3vkn02zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4765/live/b8a39f10-0712-11ed-93ba-314ede9cd985.jpg",
+            "description": "Vipimo vya matibabu, ikiwa ni pamoja na katika baadhi ya visa  sampuli za kinyesi vinafanywa. Je, mfumo unaolinda afya ya Vladimir Putin unafanya kazi vipi?",
+            "imageAlt": "th",
+            "id": "c19m3vkn02zo"
+          },
+          {
+            "type": "article",
+            "title": "Korea Kaskazini yapambana na Covid kwa maji ya chumvi na tangawizi",
+            "firstPublished": "2022-05-20T11:09:02.000Z",
+            "link": "https://www.bbc.com/swahili/habari-61524344",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/2335/production/_124831090_978d7935-cd85-4cd0-903c-e98a54d10b1c.jpg",
+            "description": "Korea Kaskazini inapambana kupunguza maambukizi ya Covid kwa raia wake ambao hawajachanjwa.",
+            "imageAlt": "ggg",
+            "id": "ffd4c465-6d23-4b4a-b308-6f9fc7d6e137"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 12,
+        "link": "https://www.bbc.com/swahili/topics/c8jvpjklx1dt",
+        "curationId": "urn:bbc:vivo:curation:5fb3375d-f7ba-41c4-bf92-67e379be83fe",
+        "curationType": "vivo-stream",
+        "position": 3,
+        "title": "Taarifa kuhusu Coronavirus",
+        "visualProminence": "NORMAL"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cw95pllwe11t",
+        "contentType": "index-home",
+        "pageIdentifier": "swahili.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/tamil/homePage/index.json
+++ b/data/tamil/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "முகப்பு - BBC News தமிழ்",
-      "description": "தமிழ்நாடு, இந்தியா, இலங்கை மற்றும் சர்வதேச செய்திகளையும், ஆழமான கண்ணோட்டங்களையும் அறிந்துகொள்ள.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ஹிட்லருக்காக 'ஆரிய' கர்ப்பிணிகள் பிரசவித்த பல ஆயிரம் குழந்தைகள் - அதிகம் அறியப்படாத வரலாறு",
-              "firstPublished": "2021-10-03T06:25:30.000Z",
-              "link": "https://www.bbc.com/tamil/global-58766073",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7B46/production/_120785513_gettyimages-105211758.jpg",
-              "description": "துணைவரைத் தேர்வு செய்யும்போது உங்களுடைய தலை முடி நிறமும் அவரது கண்களும் கிட்டத்தட்ட ஒரே மாதிரியாக இருக்கும் வகையில் பார்த்துக் கொள்ளுங்கள் என்றும் பெண்களுக்கு அறிவுறுத்தப்பட்டது. இப்படி பழகும் எந்தவொரு ஆண் வீரர் அல்லது அதிகாரியின் பெயரும் அந்த பெண்களிடம் பகிரப்படவில்லை. அதுதான் லெபென்ஸ்போர்ன் திட்டத்தின் அடிப்படை.",
-              "imageAlt": "German Women Carrying Children On An Alleged Aryan Purity In A Lebensborn, Selection Center Births By Methods Eugenicists During The Second World War. (Photo by Keystone-France/Gamma-Keystone via Getty Images)",
-              "id": "8ed5f5aa-3f8f-4efc-8b68-c45275a5f34b"
-            },
-            {
-              "type": "article",
-              "title": "பறையா பருந்தும் பிராமினி பருந்தும்: பறவைகளுக்கு சாதிப் பெயர் சூட்டப்பட்டது ஏன்?",
-              "firstPublished": "2019-09-03T04:53:03.000Z",
-              "link": "https://www.bbc.com/tamil/india-49509651",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1020B/production/_108595066_gettyimages-167643368.jpg",
-              "description": "இந்த ஆங்கிலச் சொல்லின் வேர்ச்சொல் எது? அது தமிழ்நாட்டில் தீண்டப்படாதவர்களாக நடத்தப்பட்ட மக்களை குறிக்கும் சொல்லில் இருந்து பிறந்ததா என்கிற மொழி ஆராய்ச்சி ஒருபுறம் இருக்கிறது.",
-              "imageAlt": "கருடன் அல்லது செம்பருந்து.",
-              "id": "7c5e4544-636b-0a4b-b684-96a43190ed9f"
-            },
-            {
-              "type": "article",
-              "title": "மக்கள் ஏன் 'வாயு'வை வெளியேற்றுகிறார்கள்? அதை தடுக்க முடியுமா?",
-              "firstPublished": "2018-02-23T07:55:15.000Z",
-              "link": "https://www.bbc.com/tamil/india-43166184",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/27BE/production/_100147101_5afc7374-ce81-49c3-9d6f-d00159d4a2f3.jpg",
-              "description": "மலக்குடலில் இருந்து காற்று வெளியேற்றுவதில் உங்களுக்கு சிரமம் ஏற்பட்டிருந்தாலோ அல்லது அது குறித்து கேலி கிண்டலுக்கு ஆளாகியிருந்தாலோ இந்த கட்டுரையை படித்த பிறகு தெளிவு ஏற்படலாம்.",
-              "imageAlt": "மக்கள் ஏன் வாயுவை வெளியேற்றுகிறார்கள்? அதை தடுக்க முடியுமா?",
-              "id": "bfd55039-2265-a64c-881b-e65cd6472990"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:8390f780-9e33-42c8-9381-f9efc96ea1f8",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "சிறப்புச் செய்திகள்",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "முகப்பு - BBC News தமிழ்",
+    "description": "தமிழ்நாடு, இந்தியா, இலங்கை மற்றும் சர்வதேச செய்திகளையும், ஆழமான கண்ணோட்டங்களையும் அறிந்துகொள்ள.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ஹிட்லருக்காக 'ஆரிய' கர்ப்பிணிகள் பிரசவித்த பல ஆயிரம் குழந்தைகள் - அதிகம் அறியப்படாத வரலாறு",
+            "firstPublished": "2021-10-03T06:25:30.000Z",
+            "link": "https://www.bbc.com/tamil/global-58766073",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/7B46/production/_120785513_gettyimages-105211758.jpg",
+            "description": "துணைவரைத் தேர்வு செய்யும்போது உங்களுடைய தலை முடி நிறமும் அவரது கண்களும் கிட்டத்தட்ட ஒரே மாதிரியாக இருக்கும் வகையில் பார்த்துக் கொள்ளுங்கள் என்றும் பெண்களுக்கு அறிவுறுத்தப்பட்டது. இப்படி பழகும் எந்தவொரு ஆண் வீரர் அல்லது அதிகாரியின் பெயரும் அந்த பெண்களிடம் பகிரப்படவில்லை. அதுதான் லெபென்ஸ்போர்ன் திட்டத்தின் அடிப்படை.",
+            "imageAlt": "German Women Carrying Children On An Alleged Aryan Purity In A Lebensborn, Selection Center Births By Methods Eugenicists During The Second World War. (Photo by Keystone-France/Gamma-Keystone via Getty Images)",
+            "id": "8ed5f5aa-3f8f-4efc-8b68-c45275a5f34b"
+          },
+          {
+            "type": "article",
+            "title": "பறையா பருந்தும் பிராமினி பருந்தும்: பறவைகளுக்கு சாதிப் பெயர் சூட்டப்பட்டது ஏன்?",
+            "firstPublished": "2019-09-03T04:53:03.000Z",
+            "link": "https://www.bbc.com/tamil/india-49509651",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1020B/production/_108595066_gettyimages-167643368.jpg",
+            "description": "இந்த ஆங்கிலச் சொல்லின் வேர்ச்சொல் எது? அது தமிழ்நாட்டில் தீண்டப்படாதவர்களாக நடத்தப்பட்ட மக்களை குறிக்கும் சொல்லில் இருந்து பிறந்ததா என்கிற மொழி ஆராய்ச்சி ஒருபுறம் இருக்கிறது.",
+            "imageAlt": "கருடன் அல்லது செம்பருந்து.",
+            "id": "7c5e4544-636b-0a4b-b684-96a43190ed9f"
+          },
+          {
+            "type": "article",
+            "title": "மக்கள் ஏன் 'வாயு'வை வெளியேற்றுகிறார்கள்? அதை தடுக்க முடியுமா?",
+            "firstPublished": "2018-02-23T07:55:15.000Z",
+            "link": "https://www.bbc.com/tamil/india-43166184",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/27BE/production/_100147101_5afc7374-ce81-49c3-9d6f-d00159d4a2f3.jpg",
+            "description": "மலக்குடலில் இருந்து காற்று வெளியேற்றுவதில் உங்களுக்கு சிரமம் ஏற்பட்டிருந்தாலோ அல்லது அது குறித்து கேலி கிண்டலுக்கு ஆளாகியிருந்தாலோ இந்த கட்டுரையை படித்த பிறகு தெளிவு ஏற்படலாம்.",
+            "imageAlt": "மக்கள் ஏன் வாயுவை வெளியேற்றுகிறார்கள்? அதை தடுக்க முடியுமா?",
+            "id": "bfd55039-2265-a64c-881b-e65cd6472990"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:8390f780-9e33-42c8-9381-f9efc96ea1f8",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "சிறப்புச் செய்திகள்",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cvp5j113jjwt",
+        "contentType": "index-home",
+        "pageIdentifier": "tamil.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/telugu/homePage/index.json
+++ b/data/telugu/homePage/index.json
@@ -1,53 +1,60 @@
 {
-    "data": {
-      "title": "BBC News తెలుగు",
-      "description": "ప్రపంచం నలుమూలలా విస్తరించిన బీబీసీ నెట్‌వర్క్ అందించే నిస్పాక్షికమైన వార్తలు, సామాజిక ఆర్థిక రాజకీయ రంగాలపై లోతైన విశ్లేషణలు, ఆరోగ్యం- శాస్ర్త సాంకేతిక అంశాలపై సునిశితమైన కథనాలు, గ్రౌండ్ రిపోర్ట్స్, వీడియోలు, ఫొటోగ్యాలరీలు, ఇంకా మీరు కోరుకునే మరెన్నో ఫీచర్ల కోసం బీబీసీ న్యూస్ తెలుగు చూడండి.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT2M27S",
-              "title": "అదృష్టం అంటే అతడిదే.. ఆ ఒక్క రాయి కోటీశ్వరుణ్ని చేసింది",
-              "firstPublished": "2023-04-03T15:55:25.555Z",
-              "link": "https://www.bbc.com/telugu/articles/c72qx7n732vo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d6dc/live/39a30230-d234-11ed-be2e-754a65c11505.jpg",
-              "description": "ఆ రాయి నాలుగున్నర కిలోల బరువు ఉంది. దాన్ని కొంచెం పరీక్షించి చూడగా, అందులో బంగారం ఉందని ఆయనకు తెలిసింది. దాని విలువ 5 లక్షల రూపాయల వరకైనా ఉంటుందని తెగ సంతోషపడ్డాడు. దాన్ని బంగారం వ్యాపారి దగ్గరికి వెళ్లి చూపించగా తెలిసింది.. దాని విలువ లక్షలు కాదు.. కోట్లు అని. ",
-              "imageAlt": "బంగారం రాయి",
-              "id": "c72qx7n732vo"
-            },
-            {
-              "type": "article",
-              "title": "పుతిన్‌‌ను అరెస్టు చేయడం సాధ్యమేనా, అయితే ఎవరు చేస్తారు, ఎలా చేస్తారు?",
-              "firstPublished": "2023-04-02T14:35:03.951Z",
-              "link": "https://www.bbc.com/telugu/articles/czvwp1ed1ero",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a355/live/82365740-d158-11ed-be2e-754a65c11505.jpg",
-              "description": "‘‘సాక్ష్యాధారాల కొరత లేదు. ప్రజల్ని చంపడం, బాంబులు వేయడం, యుద్ధ ప్రాంతాల్లోకి ప్రజల్ని ఈడ్చుకెళ్లడం వంటి ఘటనలకు సంబంధించి మా వద్ద వీడియో ఫుటేజీ ఉంది’’",
-              "imageAlt": "వ్లాదిమిర్ పుతిన్ ",
-              "id": "czvwp1ed1ero"
-            },
-            {
-              "type": "article",
-              "title": "క్యాన్సర్: సర్జరీ తర్వాత కీమో థెరపీ అవసరమేనా? ఈ రక్త పరీక్ష చెప్పేస్తుంది",
-              "firstPublished": "2023-04-03T07:34:25.700Z",
-              "link": "https://www.bbc.com/telugu/articles/c4nj7er6plqo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/044c/live/fa6e4890-cfc2-11ed-be2e-754a65c11505.jpg",
-              "description": "బ్రిటన్‌లో బోవెల్ క్యాన్సర్ బాధితులపై ఒక అధ్యయనం జరుగుతోంది. సర్జరీతో రోగుల్లోని అన్ని కణితులను తొలగించారో లేదో నిర్ధారించేందుకు ఈ పరీక్షను నిర్వహిస్తున్నారు.",
-              "imageAlt": "కీమోథెరపీ",
-              "id": "c4nj7er6plqo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:fbd507af-e3e2-4c50-a085-a73de25c38ce",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "ఫీచర్లు",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News తెలుగు",
+    "description": "ప్రపంచం నలుమూలలా విస్తరించిన బీబీసీ నెట్‌వర్క్ అందించే నిస్పాక్షికమైన వార్తలు, సామాజిక ఆర్థిక రాజకీయ రంగాలపై లోతైన విశ్లేషణలు, ఆరోగ్యం- శాస్ర్త సాంకేతిక అంశాలపై సునిశితమైన కథనాలు, గ్రౌండ్ రిపోర్ట్స్, వీడియోలు, ఫొటోగ్యాలరీలు, ఇంకా మీరు కోరుకునే మరెన్నో ఫీచర్ల కోసం బీబీసీ న్యూస్ తెలుగు చూడండి.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT2M27S",
+            "title": "అదృష్టం అంటే అతడిదే.. ఆ ఒక్క రాయి కోటీశ్వరుణ్ని చేసింది",
+            "firstPublished": "2023-04-03T15:55:25.555Z",
+            "link": "https://www.bbc.com/telugu/articles/c72qx7n732vo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/d6dc/live/39a30230-d234-11ed-be2e-754a65c11505.jpg",
+            "description": "ఆ రాయి నాలుగున్నర కిలోల బరువు ఉంది. దాన్ని కొంచెం పరీక్షించి చూడగా, అందులో బంగారం ఉందని ఆయనకు తెలిసింది. దాని విలువ 5 లక్షల రూపాయల వరకైనా ఉంటుందని తెగ సంతోషపడ్డాడు. దాన్ని బంగారం వ్యాపారి దగ్గరికి వెళ్లి చూపించగా తెలిసింది.. దాని విలువ లక్షలు కాదు.. కోట్లు అని. ",
+            "imageAlt": "బంగారం రాయి",
+            "id": "c72qx7n732vo"
+          },
+          {
+            "type": "article",
+            "title": "పుతిన్‌‌ను అరెస్టు చేయడం సాధ్యమేనా, అయితే ఎవరు చేస్తారు, ఎలా చేస్తారు?",
+            "firstPublished": "2023-04-02T14:35:03.951Z",
+            "link": "https://www.bbc.com/telugu/articles/czvwp1ed1ero",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a355/live/82365740-d158-11ed-be2e-754a65c11505.jpg",
+            "description": "‘‘సాక్ష్యాధారాల కొరత లేదు. ప్రజల్ని చంపడం, బాంబులు వేయడం, యుద్ధ ప్రాంతాల్లోకి ప్రజల్ని ఈడ్చుకెళ్లడం వంటి ఘటనలకు సంబంధించి మా వద్ద వీడియో ఫుటేజీ ఉంది’’",
+            "imageAlt": "వ్లాదిమిర్ పుతిన్ ",
+            "id": "czvwp1ed1ero"
+          },
+          {
+            "type": "article",
+            "title": "క్యాన్సర్: సర్జరీ తర్వాత కీమో థెరపీ అవసరమేనా? ఈ రక్త పరీక్ష చెప్పేస్తుంది",
+            "firstPublished": "2023-04-03T07:34:25.700Z",
+            "link": "https://www.bbc.com/telugu/articles/c4nj7er6plqo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/044c/live/fa6e4890-cfc2-11ed-be2e-754a65c11505.jpg",
+            "description": "బ్రిటన్‌లో బోవెల్ క్యాన్సర్ బాధితులపై ఒక అధ్యయనం జరుగుతోంది. సర్జరీతో రోగుల్లోని అన్ని కణితులను తొలగించారో లేదో నిర్ధారించేందుకు ఈ పరీక్షను నిర్వహిస్తున్నారు.",
+            "imageAlt": "కీమోథెరపీ",
+            "id": "c4nj7er6plqo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:fbd507af-e3e2-4c50-a085-a73de25c38ce",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "ఫీచర్లు",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cp54eww9emgt",
+        "contentType": "index-home",
+        "pageIdentifier": "telugu.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/thai/homePage/index.json
+++ b/data/thai/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "ข่าว ข่าววันนี้ ข่าวล่าสุด วีดีโอ - BBC News ไทย",
-      "description": "บีบีซีไทย นำเสนอข่าวสารที่เชื่อถือได้จากไทยและทุกมุมโลก",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "เกิดอะไรขึ้นกับผืนโลก เมื่อฝนกระหน่ำลงมาไม่หยุด 2 ล้านปี",
-              "firstPublished": "2023-04-01T10:14:42.208Z",
-              "link": "https://www.bbc.com/thai/articles/cz9jr9l94mzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3bef/live/9a1a4f80-d075-11ed-be2e-754a65c11505.png",
-              "description": "ฝนที่ตกหนักอย่างเหลือเชื่อเมื่อ 234 ล้านปีก่อน เปิดทางให้เผ่าพันธุ์ไดโนเสาร์ขึ้นมาครองโลก",
-              "imageAlt": "ไดโนเสาร์กลางฝน",
-              "id": "cz9jr9l94mzo"
-            },
-            {
-              "type": "article",
-              "title": "แมลงสาบไม่กินหวานวิวัฒนาการไปอีกขั้น ใช้เทคนิคใหม่จับคู่ผสมพันธุ์ได้เร็วขึ้น",
-              "firstPublished": "2023-04-01T06:52:32.249Z",
-              "link": "https://www.bbc.com/thai/articles/cn0q1p9lpnro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1cb3/live/083e8d20-d033-11ed-be2e-754a65c11505.png",
-              "description": "แมลงสาบตัวผู้ที่ไม่ติดรสหวาน หลอกล่อตัวเมียที่มีรสนิยมแบบเดียวกันด้วยของเหลวชนิดพิเศษ พร้อมทั้งจู่โจมอย่างรวดเร็ว จนมีโอกาสผสมพันธุ์ได้สำเร็จมากกว่าแมลงสาบที่ยังกินน้ำตาลกลูโคสอยู่หลายเท่า",
-              "imageAlt": "แมลงสาป",
-              "id": "cn0q1p9lpnro"
-            },
-            {
-              "type": "article",
-              "title": "โดนัลด์ ทรัมป์ : อดีตประธานาธิบดีสหรัฐฯ คนแรกที่เผชิญคดีอาญา และเสี่ยงติดคุก",
-              "firstPublished": "2023-03-31T07:48:59.921Z",
-              "link": "https://www.bbc.com/thai/articles/cn32v0r83mzo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/887e/live/d85a59b0-cf95-11ed-b8b7-a345b6f2573f.jpg",
-              "description": "",
-              "imageAlt": "Getty Images",
-              "id": "cn32v0r83mzo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:a6e371ac-447d-46bf-a2dd-cc67df72eb79",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "เรื่องน่าสนใจ",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "ข่าว ข่าววันนี้ ข่าวล่าสุด วีดีโอ - BBC News ไทย",
+    "description": "บีบีซีไทย นำเสนอข่าวสารที่เชื่อถือได้จากไทยและทุกมุมโลก",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "เกิดอะไรขึ้นกับผืนโลก เมื่อฝนกระหน่ำลงมาไม่หยุด 2 ล้านปี",
+            "firstPublished": "2023-04-01T10:14:42.208Z",
+            "link": "https://www.bbc.com/thai/articles/cz9jr9l94mzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3bef/live/9a1a4f80-d075-11ed-be2e-754a65c11505.png",
+            "description": "ฝนที่ตกหนักอย่างเหลือเชื่อเมื่อ 234 ล้านปีก่อน เปิดทางให้เผ่าพันธุ์ไดโนเสาร์ขึ้นมาครองโลก",
+            "imageAlt": "ไดโนเสาร์กลางฝน",
+            "id": "cz9jr9l94mzo"
+          },
+          {
+            "type": "article",
+            "title": "แมลงสาบไม่กินหวานวิวัฒนาการไปอีกขั้น ใช้เทคนิคใหม่จับคู่ผสมพันธุ์ได้เร็วขึ้น",
+            "firstPublished": "2023-04-01T06:52:32.249Z",
+            "link": "https://www.bbc.com/thai/articles/cn0q1p9lpnro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/1cb3/live/083e8d20-d033-11ed-be2e-754a65c11505.png",
+            "description": "แมลงสาบตัวผู้ที่ไม่ติดรสหวาน หลอกล่อตัวเมียที่มีรสนิยมแบบเดียวกันด้วยของเหลวชนิดพิเศษ พร้อมทั้งจู่โจมอย่างรวดเร็ว จนมีโอกาสผสมพันธุ์ได้สำเร็จมากกว่าแมลงสาบที่ยังกินน้ำตาลกลูโคสอยู่หลายเท่า",
+            "imageAlt": "แมลงสาป",
+            "id": "cn0q1p9lpnro"
+          },
+          {
+            "type": "article",
+            "title": "โดนัลด์ ทรัมป์ : อดีตประธานาธิบดีสหรัฐฯ คนแรกที่เผชิญคดีอาญา และเสี่ยงติดคุก",
+            "firstPublished": "2023-03-31T07:48:59.921Z",
+            "link": "https://www.bbc.com/thai/articles/cn32v0r83mzo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/887e/live/d85a59b0-cf95-11ed-b8b7-a345b6f2573f.jpg",
+            "description": "",
+            "imageAlt": "Getty Images",
+            "id": "cn32v0r83mzo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:a6e371ac-447d-46bf-a2dd-cc67df72eb79",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "เรื่องน่าสนใจ",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cjln1ww9v13t",
+        "contentType": "index-home",
+        "pageIdentifier": "thai.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/tigrinya/homePage/index.json
+++ b/data/tigrinya/homePage/index.json
@@ -1,194 +1,201 @@
 {
-    "data": {
-      "title": "ዜና - BBC News ትግርኛ",
-      "description": "ብድምጽን ስእልን ጽሑፍን ንዝቐርብ: ዕለታውን ሰበር ዜናታትን ዛንታታት ቢቢሲን ንምክትታል፡ ናብ ድሕረ ገጻት መርበብ ሓበሬታና ብጽሑ። ቢቢሲ፡ ርጡብን እሙንን ዘቤታውን ዓለማውን ዜናታትን ኣመለኻኸታን የቕርብ። ከምኡ እውን ዘዛኒ መደባት፡ ንቢዝነስ፡ ሳይንስ፡ ቴክኖሎጂን ጥዕናን ዝምልከት ትሕዝቶታት የቕርብ እዩ’ሞ ንኽትከታትሉና ናብ መርበብ ሓበሬታ ቢቢሲ ንዕድመኩም",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ውጕኣት ሓይልታት ትግራይ ኣብ ከመይ ኵነታት ኣለዉ?",
-              "firstPublished": "2023-04-04T06:12:04.163Z",
-              "link": "https://www.bbc.com/tigrinya/articles/crgellj98n4o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e7d6/live/0e633cf0-d2bd-11ed-b68c-95ed3a1ad527.jpg",
-              "description": "ታደለ ተኸስተ፡ ኣብ ኣግሩ ጉድኣት ዘጋጠሞ ኣባል ሰራዊት ትግራይ ኰይኑ፡ ብ 3 ጥቅምቲ ኣብ ዓዲ ዳዕሮ ምስ ተወቕዐ ኣብ መዓስክር ማእከል ኣሪድ ኣትዩ ነይሩ። ንሱ’ውን፡ “እቲ ኵነታት ዘሕጉስ ስለ ዘይነበረ ብውልቀይ እየ ተሓኪመ። ካብ ቤተሰብ፡ ካብ ደገን ካብ ውሽጥን ሓጊዞምኒ ይሕከም ኣለኹ፡” ይብል። ",
-              "imageAlt": "ጉዱኣት ሓይልታት ትግራይ ኣብ ሰላማዊ ሰልፊ ",
-              "id": "crgellj98n4o"
-            },
-            {
-              "type": "article",
-              "title": "ሚኒስተር ዑስማን ሳልሕ ኣብ ደቡብ ሱዳን ምብጻሕ ኣካይዱ",
-              "firstPublished": "2023-04-04T08:58:25.856Z",
-              "link": "https://www.bbc.com/tigrinya/articles/c1ek0xkq7xgo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9dbd/live/faafb160-d2c2-11ed-9b9f-439b7db451e9.jpg",
-              "description": "ሚኒስተር ጉዳያት ወጻኢ ኤርትራን ኣማኻሪ ፕረዚደንት የማን ገብረኣብን ዝምራሕ ልኡኽ ኤርትራ ትማሊ ናብ ደቡብ ሱዳን ብምኻድ ምስ ፕረዚደንት ደቡብ ሱዳን ሳልቫ ኪር ማያርዲት ከምዝተራኸበ ሚኒስትር ዜና ኤርትራ የማነ ገብረመስቀል ብትዊተር ሓቢሩ።",
-              "imageAlt": "ሚኒስተር ዑድማን ሳልሕ ምስ ፕረዚደንት ሳልቫ ኪር ",
-              "id": "c1ek0xkq7xgo"
-            },
-            {
-              "type": "article",
-              "title": "ባይቶ ወከልቲ ህዝቢ ናይ ዘይምኽሳስ መሰል ሓደ ኣባሉ ኣልዒሉ",
-              "firstPublished": "2023-04-04T04:57:09.527Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cevn8j40059o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a70f/live/5926f620-d30b-11ed-be2e-754a65c11505.jpg",
-              "description": "ባይቶ ወከልቲ ህዝቢ ናይ ዘይምኽሳስ መሰል ሓደ ኣባል ባይቶ ከልዕል ምዃኑ ተፈሊጡ።እዚ ብምንታይ ምኽንያት ከም ዝዀነ ዝሃቦ ዝርዝር ሓበሬታ ግን የለን።ባይቶ ወከልቲ ህዝቢ ፈደራል፡ ሹመት ተተካእቲ ቅድሚ ክልተ ሰሙን ብወለንታኦም ካብ ሓላፍነቶም ወሪዶም ናይ ዝተባህሉ ፕረዚደንትን ምኽትልን ላዕለዋይ ቤት ፍርዲ ፈደራል ከጽድቕ እዩ።",
-              "imageAlt": "ናይ ቡሌ ሆራ ዩኒቨርሲቲ ፕረዚደንት ዝነበረ ዶክተር ጫላ ",
-              "id": "cevn8j40059o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:d8a9ce0b-d718-4ac2-8d10-c81d5cbc0e67",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Tigrinya Top Stories",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "ሰብሰርሖ ብልሒ ‘ኤኣይ’ ስራሕ 300 ሚልዮን ሰባት ክትክእ ከምዝኽእል ተገሊጹ",
-              "firstPublished": "2023-03-29T06:32:37.004Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cw4wwlw2r3ro",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e368/live/63bbf4d0-cdf4-11ed-be2e-754a65c11505.jpg",
-              "description": "ጽልዋ ሰብሰርሖ ብልሒ ኣብ ዝተፈላለዩ ጽላታት ዝፈላለ ምዃኑ ዝሕብር እቲ ጸብጻብ፡ 46 ሚእታዊት ዕማማት ኣብ ምምሕዳራዊ፣ ኣብ ዓውደ-ስራሕ ሕጊ ድማ 44 ሚእታዊት በቲ ቴክኖሎጂ ክሳለ ይኽእሉ እዮም። ",
-              "imageAlt": "ባኮ ዝተሸከመ ሰብ",
-              "id": "cw4wwlw2r3ro"
-            },
-            {
-              "type": "article",
-              "title": "ምጾታት ፈሪሖም ናብ ኢትዮጵያ ፈሊሶም ዝተባህሉ ዩጋንዳውያን  ",
-              "firstPublished": "2023-04-01T06:20:07.657Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cp6wywyld43o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/800e/live/5426eab0-d1f6-11ed-be2e-754a65c11505.jpg",
-              "description": "“ ክሳብ ንሕና ንመጽእ ዝናብ ኣይነበረን። ስለዚ ዝናብ ክሳብ ዝዘንብ ብምጽናሕ ዘሪኢ ሂብናኹም ኢና እንከይድ፡ እቲ እግዚኣብሄር ዝሃበና መልእኽቲ እዚ እዩ”",
-              "imageAlt": "ቅዱስ መጽሓፍ",
-              "id": "cp6wywyld43o"
-            },
-            {
-              "type": "article",
-              "title": "ትራምፕ ‘ምእሳሩ’ ዝገልጽ ስእልታት ሓቀኛ ከምዘይኮነ ብኸመይ ምልላይ ይከኣል?",
-              "firstPublished": "2023-03-27T04:31:25.231Z",
-              "link": "https://www.bbc.com/tigrinya/articles/clmdz09ydrpo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a6ac/live/caaf98c0-cc57-11ed-8c6a-6d3a4b504edf.png",
-              "description": "ብሓሙስ፡ ትራምፕ እውን ንባዕሉ ሓደ ብኣርተፊሻላዊ ብልሒ ዝተዳለወ ስእሊ ኣብቲ ናቱ ማሕበራዊ መራኸቢ ‘ትሩዝ ሶሻል’ ዘርጊሑ። እቲ ፕረዚደንት ነበር ተንበርኪኩ እናጸለየ ዘርኢ እዩ። ብኣርተፊሻላዊ ብልሒ (ኤኣይ) ንዝተዳለወ ስእሊ ክነለልየሉ እንኽእል ምልክታት ኣሎ ዶ? ብኸመይ ኢና ኸ ነቲ ሓቀኛ ካብቲ ስኑዕ ክንፈልዮ እንኽእል?",
-              "imageAlt": "ትራምፕ ኣብ ቀይዲ እናኣተወ ዘርኢ ስኑዕ ስእሊ",
-              "id": "clmdz09ydrpo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:01980d36-ea6b-49bc-876d-10019b213025",
-          "curationType": "tipo-curation",
-          "position": 1,
-          "title": "ኣዘራረብቲ ዛዕባታት",
-          "visualProminence": "HIGH"
-        },
-        {
-          "summaries": [
-            {
-              "type": "video",
-              "duration": "PT2M39S",
-              "title": "ቱርኪ ኣብ ግዜ መሪሕነት ፕረዚደንት ጠይብ ኤርዶጋን እንታይ ለውጢ ኣርእያ?",
-              "firstPublished": "2023-05-10T11:15:23.623Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cz9rr23y4z6o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "“ኣደነታ ዘይትቕበልን ገዛኣ ዘይትናብን ጓል ኣነስተይቲ ዋላ’ኳ ኣብ ሞያኣ ዕውትቲ ትኽን ፍርቂ ሰበይቲ’ያ” ብዝብል እምነቱ ዝፍለጥ ፕረዚደንት ቱርኪ ጠይብ ኤርዶጋን፡ ደቀ’ንስትዮ ህዝባዊ ኣገልግሎታት ኣብ ዝወሃበሎም ቦታታት ጉልባብ ክዕመማ ዘገድድ ሕጊ እታ ሃገር ኣልዒሉ’ዩ። ",
-              "imageAlt": "",
-              "id": "cz9rr23y4z6o"
-            },
-            {
-              "type": "video",
-              "duration": "PT55S",
-              "title": "ኣንፈታ ስሒታ ካብ ዝነፈጸት መኪና ንስክላ ዝደሓነ ፖሊስ",
-              "firstPublished": "2023-05-10T10:50:55.030Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cldkkx479x5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ሓደ ፖሊስ ኣብ ኣሜሪካ ግዝኣት ቨርጂንያ ካብ ሓንቲ ካብ ቍጽጽር ዘዋሪኣ ወጻእ ዝዀነት መኪና ንስክላ ድሒኑ። እቲ ወዲ 17 ዓመት ዘዋሪ መኪና ብሸለልታዊ ኣዘዋውራ መኪና ተኸሲሱ ኣሎ። ",
-              "imageAlt": "",
-              "id": "cldkkx479x5o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M56S",
-              "title": "ክልተ ኣእጋሩ ሰንኪሉ እምባ ኤቨረስት ክሓኩር ዝህቅን ሰብኣይ ",
-              "firstPublished": "2023-05-09T10:28:42.464Z",
-              "link": "https://www.bbc.com/tigrinya/articles/ceq669lyz8zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ኔፓላዊ ሃሪ ቡድሃ ኣብ 2010 ኣባል ሰራዊት ብሪጣንያ ኰይኑ የገልግል ኣብ ዝነበረሉ ግዜ ብሓደጋ ምፍንጃር ነታጕ ኣእጋሩ’ኳ እንተተቘርጸ፡ እምባ ኤቨረስት ንምሕኳር ካብ ምሕላም ግን ዓዲ ኣይወዓለን። ንሱ ‘እቲ ደረት ሰማይ ጥራይ’ዩ’ ዝብል እምነት እዩ ዘለዎ። ",
-              "imageAlt": "",
-              "id": "ceq669lyz8zo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M24S",
-              "title": "35 ሽሕ ዘገልገለ ፕላስቲክ ተጠቒሙ ገዛኡ ዝሰርሐ ኢንዶኔዥያዊ",
-              "firstPublished": "2023-05-09T10:03:15.348Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cy6vvn0qep0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ኢንዶኔዥያ ካብ ዓለም ኣዝዮም ዝተበከሉ ሩባታት ዝሓዘት ሃገር’ያ። ኣብታ ሃገር ተሓላቒ ከባቢያዊ ኣየር ጋሪ ግን ነቲ ጸገም ንምቅላል ሓደ ምንቅስቓስ ጀሚሩ፤ 35 ሽሕ ፕላስቲክ ተጠቒሙ ገዛኡ ሰሪሑ። ",
-              "imageAlt": "",
-              "id": "cy6vvn0qep0o"
-            },
-            {
-              "type": "video",
-              "duration": "PT20M42S",
-              "title": "ስነጥበባዊ ተመስገን ተወልደ ብዛዕባ ስነጥበብ እንታይ ይብል?",
-              "firstPublished": "2023-05-08T09:53:38.336Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cedkyk5qgq5o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ኣብ ንኡስ ዕድመኡ፡ ኣብ ስነጥበብ ብፍላይ ኣብ ምጽሓፍን ተዋስኦን ድራማታት እናነጠፈ፡ ተፈላጥነቱ እናዕበየ ዝመጽእ ዘሎ ንኡስ ስነጥበባዊ እዩ - ተመስገን ተወልደ።",
-              "imageAlt": "",
-              "id": "cedkyk5qgq5o"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M48S",
-              "title": "ንስነ-ስርዓት ንግስነት ንጉስ ቻርለስ ዝተዳለዋ ወርቃዊ ሰረገላታት",
-              "firstPublished": "2023-05-05T10:34:32.237Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cyxkw4pd4zeo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ንስነ-ስርዓት ንግስነት ንጉስ ቻርለስ ዝተዳለዋ ወርቃዊ ሰረገላታት",
-              "imageAlt": "",
-              "id": "cyxkw4pd4zeo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M37S",
-              "title": "ኣብ ክንዲ እናኣረግካ እናንኣስካ ምኻድ ክውን ንምግባር ሚልዮናት ዶላር ዘፍስስ ዘሎ ሰብኣይ",
-              "firstPublished": "2023-05-02T04:42:10.567Z",
-              "link": "https://www.bbc.com/tigrinya/articles/c10qmelz0eyo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
-              "description": "ሚልዮነር በዓል ሞያ ቴክኖሎጂ ብርያን ጆንሰን ባዮሎጂካዊ ዕድሚኡ ንምጉዳልን ንእሽቶ ንምምሳልን ብዙሕ ገንዘብ የውጽእ ኣሎ። እቲ ወዲ 45 ዓመት ከቢድ ኣካላዊ ምንቅስቓስ ክትትልን ብዙሕ ሕክምናን ይገብር።",
-              "imageAlt": "",
-              "id": "c10qmelz0eyo"
-            },
-            {
-              "type": "video",
-              "duration": "PT1M23S",
-              "title": "ንእየሱስ ክረኽቡ: ክሳዕ ሞት ናይ ዝጾሙ ምዃኑ ዝግለጽ ኣስከሬን ተፋሒሩ ይወጽእ ኣሎ",
-              "firstPublished": "2023-04-29T05:32:28.962Z",
-              "link": "https://www.bbc.com/tigrinya/articles/cl52701n37zo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd67/live/0690ee40-e65a-11ed-a142-ab0e42bfd9c3.jpg",
-              "description": "እቶም ግዳያት ተኸተልቲ ናይ 'ጉድ ኒውስ ኢንተርናሽናል ቸርች' ምዃኖምን ምስ የሱስ ክራኸቡ ክሳዕ ሞት ምጻሞምን ይግለጽ።",
-              "imageAlt": "ክሳብ ሞት ጾለት ዝገብሩ",
-              "id": "cl52701n37zo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 5,
-          "link": "https://www.bbc.com/tigrinya/topics/crldzm9n4rdt",
-          "curationId": "urn:bbc:vivo:curation:b61785cb-8e3c-48a2-8a12-fa5bdc92b7a2",
-          "curationType": "vivo-stream",
-          "position": 2,
-          "title": "ቪድዮ",
-          "visualProminence": "NORMAL",
-          "visualStyle": "FEED"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "data is from live TIPO"
-  }
+  "data": {
+    "title": "ዜና - BBC News ትግርኛ",
+    "description": "ብድምጽን ስእልን ጽሑፍን ንዝቐርብ: ዕለታውን ሰበር ዜናታትን ዛንታታት ቢቢሲን ንምክትታል፡ ናብ ድሕረ ገጻት መርበብ ሓበሬታና ብጽሑ። ቢቢሲ፡ ርጡብን እሙንን ዘቤታውን ዓለማውን ዜናታትን ኣመለኻኸታን የቕርብ። ከምኡ እውን ዘዛኒ መደባት፡ ንቢዝነስ፡ ሳይንስ፡ ቴክኖሎጂን ጥዕናን ዝምልከት ትሕዝቶታት የቕርብ እዩ’ሞ ንኽትከታትሉና ናብ መርበብ ሓበሬታ ቢቢሲ ንዕድመኩም",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ውጕኣት ሓይልታት ትግራይ ኣብ ከመይ ኵነታት ኣለዉ?",
+            "firstPublished": "2023-04-04T06:12:04.163Z",
+            "link": "https://www.bbc.com/tigrinya/articles/crgellj98n4o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e7d6/live/0e633cf0-d2bd-11ed-b68c-95ed3a1ad527.jpg",
+            "description": "ታደለ ተኸስተ፡ ኣብ ኣግሩ ጉድኣት ዘጋጠሞ ኣባል ሰራዊት ትግራይ ኰይኑ፡ ብ 3 ጥቅምቲ ኣብ ዓዲ ዳዕሮ ምስ ተወቕዐ ኣብ መዓስክር ማእከል ኣሪድ ኣትዩ ነይሩ። ንሱ’ውን፡ “እቲ ኵነታት ዘሕጉስ ስለ ዘይነበረ ብውልቀይ እየ ተሓኪመ። ካብ ቤተሰብ፡ ካብ ደገን ካብ ውሽጥን ሓጊዞምኒ ይሕከም ኣለኹ፡” ይብል። ",
+            "imageAlt": "ጉዱኣት ሓይልታት ትግራይ ኣብ ሰላማዊ ሰልፊ ",
+            "id": "crgellj98n4o"
+          },
+          {
+            "type": "article",
+            "title": "ሚኒስተር ዑስማን ሳልሕ ኣብ ደቡብ ሱዳን ምብጻሕ ኣካይዱ",
+            "firstPublished": "2023-04-04T08:58:25.856Z",
+            "link": "https://www.bbc.com/tigrinya/articles/c1ek0xkq7xgo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9dbd/live/faafb160-d2c2-11ed-9b9f-439b7db451e9.jpg",
+            "description": "ሚኒስተር ጉዳያት ወጻኢ ኤርትራን ኣማኻሪ ፕረዚደንት የማን ገብረኣብን ዝምራሕ ልኡኽ ኤርትራ ትማሊ ናብ ደቡብ ሱዳን ብምኻድ ምስ ፕረዚደንት ደቡብ ሱዳን ሳልቫ ኪር ማያርዲት ከምዝተራኸበ ሚኒስትር ዜና ኤርትራ የማነ ገብረመስቀል ብትዊተር ሓቢሩ።",
+            "imageAlt": "ሚኒስተር ዑድማን ሳልሕ ምስ ፕረዚደንት ሳልቫ ኪር ",
+            "id": "c1ek0xkq7xgo"
+          },
+          {
+            "type": "article",
+            "title": "ባይቶ ወከልቲ ህዝቢ ናይ ዘይምኽሳስ መሰል ሓደ ኣባሉ ኣልዒሉ",
+            "firstPublished": "2023-04-04T04:57:09.527Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cevn8j40059o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a70f/live/5926f620-d30b-11ed-be2e-754a65c11505.jpg",
+            "description": "ባይቶ ወከልቲ ህዝቢ ናይ ዘይምኽሳስ መሰል ሓደ ኣባል ባይቶ ከልዕል ምዃኑ ተፈሊጡ።እዚ ብምንታይ ምኽንያት ከም ዝዀነ ዝሃቦ ዝርዝር ሓበሬታ ግን የለን።ባይቶ ወከልቲ ህዝቢ ፈደራል፡ ሹመት ተተካእቲ ቅድሚ ክልተ ሰሙን ብወለንታኦም ካብ ሓላፍነቶም ወሪዶም ናይ ዝተባህሉ ፕረዚደንትን ምኽትልን ላዕለዋይ ቤት ፍርዲ ፈደራል ከጽድቕ እዩ።",
+            "imageAlt": "ናይ ቡሌ ሆራ ዩኒቨርሲቲ ፕረዚደንት ዝነበረ ዶክተር ጫላ ",
+            "id": "cevn8j40059o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:d8a9ce0b-d718-4ac2-8d10-c81d5cbc0e67",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Tigrinya Top Stories",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "ሰብሰርሖ ብልሒ ‘ኤኣይ’ ስራሕ 300 ሚልዮን ሰባት ክትክእ ከምዝኽእል ተገሊጹ",
+            "firstPublished": "2023-03-29T06:32:37.004Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cw4wwlw2r3ro",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e368/live/63bbf4d0-cdf4-11ed-be2e-754a65c11505.jpg",
+            "description": "ጽልዋ ሰብሰርሖ ብልሒ ኣብ ዝተፈላለዩ ጽላታት ዝፈላለ ምዃኑ ዝሕብር እቲ ጸብጻብ፡ 46 ሚእታዊት ዕማማት ኣብ ምምሕዳራዊ፣ ኣብ ዓውደ-ስራሕ ሕጊ ድማ 44 ሚእታዊት በቲ ቴክኖሎጂ ክሳለ ይኽእሉ እዮም። ",
+            "imageAlt": "ባኮ ዝተሸከመ ሰብ",
+            "id": "cw4wwlw2r3ro"
+          },
+          {
+            "type": "article",
+            "title": "ምጾታት ፈሪሖም ናብ ኢትዮጵያ ፈሊሶም ዝተባህሉ ዩጋንዳውያን  ",
+            "firstPublished": "2023-04-01T06:20:07.657Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cp6wywyld43o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/800e/live/5426eab0-d1f6-11ed-be2e-754a65c11505.jpg",
+            "description": "“ ክሳብ ንሕና ንመጽእ ዝናብ ኣይነበረን። ስለዚ ዝናብ ክሳብ ዝዘንብ ብምጽናሕ ዘሪኢ ሂብናኹም ኢና እንከይድ፡ እቲ እግዚኣብሄር ዝሃበና መልእኽቲ እዚ እዩ”",
+            "imageAlt": "ቅዱስ መጽሓፍ",
+            "id": "cp6wywyld43o"
+          },
+          {
+            "type": "article",
+            "title": "ትራምፕ ‘ምእሳሩ’ ዝገልጽ ስእልታት ሓቀኛ ከምዘይኮነ ብኸመይ ምልላይ ይከኣል?",
+            "firstPublished": "2023-03-27T04:31:25.231Z",
+            "link": "https://www.bbc.com/tigrinya/articles/clmdz09ydrpo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/a6ac/live/caaf98c0-cc57-11ed-8c6a-6d3a4b504edf.png",
+            "description": "ብሓሙስ፡ ትራምፕ እውን ንባዕሉ ሓደ ብኣርተፊሻላዊ ብልሒ ዝተዳለወ ስእሊ ኣብቲ ናቱ ማሕበራዊ መራኸቢ ‘ትሩዝ ሶሻል’ ዘርጊሑ። እቲ ፕረዚደንት ነበር ተንበርኪኩ እናጸለየ ዘርኢ እዩ። ብኣርተፊሻላዊ ብልሒ (ኤኣይ) ንዝተዳለወ ስእሊ ክነለልየሉ እንኽእል ምልክታት ኣሎ ዶ? ብኸመይ ኢና ኸ ነቲ ሓቀኛ ካብቲ ስኑዕ ክንፈልዮ እንኽእል?",
+            "imageAlt": "ትራምፕ ኣብ ቀይዲ እናኣተወ ዘርኢ ስኑዕ ስእሊ",
+            "id": "clmdz09ydrpo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:01980d36-ea6b-49bc-876d-10019b213025",
+        "curationType": "tipo-curation",
+        "position": 1,
+        "title": "ኣዘራረብቲ ዛዕባታት",
+        "visualProminence": "HIGH"
+      },
+      {
+        "summaries": [
+          {
+            "type": "video",
+            "duration": "PT2M39S",
+            "title": "ቱርኪ ኣብ ግዜ መሪሕነት ፕረዚደንት ጠይብ ኤርዶጋን እንታይ ለውጢ ኣርእያ?",
+            "firstPublished": "2023-05-10T11:15:23.623Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cz9rr23y4z6o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "“ኣደነታ ዘይትቕበልን ገዛኣ ዘይትናብን ጓል ኣነስተይቲ ዋላ’ኳ ኣብ ሞያኣ ዕውትቲ ትኽን ፍርቂ ሰበይቲ’ያ” ብዝብል እምነቱ ዝፍለጥ ፕረዚደንት ቱርኪ ጠይብ ኤርዶጋን፡ ደቀ’ንስትዮ ህዝባዊ ኣገልግሎታት ኣብ ዝወሃበሎም ቦታታት ጉልባብ ክዕመማ ዘገድድ ሕጊ እታ ሃገር ኣልዒሉ’ዩ። ",
+            "imageAlt": "",
+            "id": "cz9rr23y4z6o"
+          },
+          {
+            "type": "video",
+            "duration": "PT55S",
+            "title": "ኣንፈታ ስሒታ ካብ ዝነፈጸት መኪና ንስክላ ዝደሓነ ፖሊስ",
+            "firstPublished": "2023-05-10T10:50:55.030Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cldkkx479x5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ሓደ ፖሊስ ኣብ ኣሜሪካ ግዝኣት ቨርጂንያ ካብ ሓንቲ ካብ ቍጽጽር ዘዋሪኣ ወጻእ ዝዀነት መኪና ንስክላ ድሒኑ። እቲ ወዲ 17 ዓመት ዘዋሪ መኪና ብሸለልታዊ ኣዘዋውራ መኪና ተኸሲሱ ኣሎ። ",
+            "imageAlt": "",
+            "id": "cldkkx479x5o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M56S",
+            "title": "ክልተ ኣእጋሩ ሰንኪሉ እምባ ኤቨረስት ክሓኩር ዝህቅን ሰብኣይ ",
+            "firstPublished": "2023-05-09T10:28:42.464Z",
+            "link": "https://www.bbc.com/tigrinya/articles/ceq669lyz8zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ኔፓላዊ ሃሪ ቡድሃ ኣብ 2010 ኣባል ሰራዊት ብሪጣንያ ኰይኑ የገልግል ኣብ ዝነበረሉ ግዜ ብሓደጋ ምፍንጃር ነታጕ ኣእጋሩ’ኳ እንተተቘርጸ፡ እምባ ኤቨረስት ንምሕኳር ካብ ምሕላም ግን ዓዲ ኣይወዓለን። ንሱ ‘እቲ ደረት ሰማይ ጥራይ’ዩ’ ዝብል እምነት እዩ ዘለዎ። ",
+            "imageAlt": "",
+            "id": "ceq669lyz8zo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M24S",
+            "title": "35 ሽሕ ዘገልገለ ፕላስቲክ ተጠቒሙ ገዛኡ ዝሰርሐ ኢንዶኔዥያዊ",
+            "firstPublished": "2023-05-09T10:03:15.348Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cy6vvn0qep0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ኢንዶኔዥያ ካብ ዓለም ኣዝዮም ዝተበከሉ ሩባታት ዝሓዘት ሃገር’ያ። ኣብታ ሃገር ተሓላቒ ከባቢያዊ ኣየር ጋሪ ግን ነቲ ጸገም ንምቅላል ሓደ ምንቅስቓስ ጀሚሩ፤ 35 ሽሕ ፕላስቲክ ተጠቒሙ ገዛኡ ሰሪሑ። ",
+            "imageAlt": "",
+            "id": "cy6vvn0qep0o"
+          },
+          {
+            "type": "video",
+            "duration": "PT20M42S",
+            "title": "ስነጥበባዊ ተመስገን ተወልደ ብዛዕባ ስነጥበብ እንታይ ይብል?",
+            "firstPublished": "2023-05-08T09:53:38.336Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cedkyk5qgq5o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ኣብ ንኡስ ዕድመኡ፡ ኣብ ስነጥበብ ብፍላይ ኣብ ምጽሓፍን ተዋስኦን ድራማታት እናነጠፈ፡ ተፈላጥነቱ እናዕበየ ዝመጽእ ዘሎ ንኡስ ስነጥበባዊ እዩ - ተመስገን ተወልደ።",
+            "imageAlt": "",
+            "id": "cedkyk5qgq5o"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M48S",
+            "title": "ንስነ-ስርዓት ንግስነት ንጉስ ቻርለስ ዝተዳለዋ ወርቃዊ ሰረገላታት",
+            "firstPublished": "2023-05-05T10:34:32.237Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cyxkw4pd4zeo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ንስነ-ስርዓት ንግስነት ንጉስ ቻርለስ ዝተዳለዋ ወርቃዊ ሰረገላታት",
+            "imageAlt": "",
+            "id": "cyxkw4pd4zeo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M37S",
+            "title": "ኣብ ክንዲ እናኣረግካ እናንኣስካ ምኻድ ክውን ንምግባር ሚልዮናት ዶላር ዘፍስስ ዘሎ ሰብኣይ",
+            "firstPublished": "2023-05-02T04:42:10.567Z",
+            "link": "https://www.bbc.com/tigrinya/articles/c10qmelz0eyo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/36D1/production/_127933041__63970643_bbc-news-world-service-logo-nc.png",
+            "description": "ሚልዮነር በዓል ሞያ ቴክኖሎጂ ብርያን ጆንሰን ባዮሎጂካዊ ዕድሚኡ ንምጉዳልን ንእሽቶ ንምምሳልን ብዙሕ ገንዘብ የውጽእ ኣሎ። እቲ ወዲ 45 ዓመት ከቢድ ኣካላዊ ምንቅስቓስ ክትትልን ብዙሕ ሕክምናን ይገብር።",
+            "imageAlt": "",
+            "id": "c10qmelz0eyo"
+          },
+          {
+            "type": "video",
+            "duration": "PT1M23S",
+            "title": "ንእየሱስ ክረኽቡ: ክሳዕ ሞት ናይ ዝጾሙ ምዃኑ ዝግለጽ ኣስከሬን ተፋሒሩ ይወጽእ ኣሎ",
+            "firstPublished": "2023-04-29T05:32:28.962Z",
+            "link": "https://www.bbc.com/tigrinya/articles/cl52701n37zo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/dd67/live/0690ee40-e65a-11ed-a142-ab0e42bfd9c3.jpg",
+            "description": "እቶም ግዳያት ተኸተልቲ ናይ 'ጉድ ኒውስ ኢንተርናሽናል ቸርች' ምዃኖምን ምስ የሱስ ክራኸቡ ክሳዕ ሞት ምጻሞምን ይግለጽ።",
+            "imageAlt": "ክሳብ ሞት ጾለት ዝገብሩ",
+            "id": "cl52701n37zo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 5,
+        "link": "https://www.bbc.com/tigrinya/topics/crldzm9n4rdt",
+        "curationId": "urn:bbc:vivo:curation:b61785cb-8e3c-48a2-8a12-fa5bdc92b7a2",
+        "curationType": "vivo-stream",
+        "position": 2,
+        "title": "ቪድዮ",
+        "visualProminence": "NORMAL",
+        "visualStyle": "FEED"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c6zr6pp4e4xt",
+        "contentType": "index-home",
+        "pageIdentifier": "tigrinya.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "data is from live TIPO"
+}

--- a/data/turkce/homePage/index.json
+++ b/data/turkce/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "Haberler - BBC News Türkçe",
-      "description": "Türkiye ve dünya gündemindeki son gelişmeler, son dakika haberleri, video, analiz, teknoloji haberleri, sağlık haberleri, spor haberleri, ekonomi haberleri, fotoğraf albümleri, canlı yayınlar BBC Türkçe sayfalarında.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "Hissedilen enflasyon: Kişisel enflasyonunuzu hesaplayın",
-              "firstPublished": "2023-03-30T08:55:53.000Z",
-              "link": "https://www.bbc.com/turkce/haberler-turkiye-64876429",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4B33/production/_129215291_index_549.png",
-              "description": "Açıklanan enflasyonun, hissettiğiniz enflasyondan yüksek olduğunu mu düşünüyorsunuz? Tüketici enflasyonu hesaplanırken kullanılan harcama sepeti sizi yansıtmıyor olabilir. Kişisel enflasyon hesaplayıcımızla, kendi harcamalarınıza göre enflasyon oranını hesaplayabilirsiniz.",
-              "imageAlt": "grafik",
-              "id": "f7265ccd-92c1-4562-b2cc-c97bf70f612f"
-            },
-            {
-              "type": "article",
-              "title": "Türkiye'de seçmenlerin kişisel verileri manipülasyon için kullanılıyor mu?",
-              "firstPublished": "2023-03-30T04:37:15.479Z",
-              "link": "https://www.bbc.com/turkce/articles/c84mm9lvzv0o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b33f/live/0b755da0-ce50-11ed-8790-0b6b0487822e.jpg",
-              "description": "Yüksek Seçim Kurulu'nun (YSK) Mart ortasında yayımladığı propaganda dönemi esasları ve yayın ilkeleri ağırlıkla TV yayıncılığına odaklanıyor. Seçim düzenlemelerinde \"sosyal medya ve dijital pazarlamanın etkisinin gözardı edilmesi\" seçmenlerin manipülasyonu açısından endişe yaratıyor. \n",
-              "imageAlt": "hedefleme ",
-              "id": "c84mm9lvzv0o"
-            },
-            {
-              "type": "article",
-              "title": "Trump ile eski porno yıldızı Stormy Daniels arasında ne yaşandı, neden ceza davası açıldı?",
-              "firstPublished": "2023-03-31T10:00:02.024Z",
-              "link": "https://www.bbc.com/turkce/articles/cyd68q0vrqdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4557/live/c9e670c0-cf96-11ed-9374-e7827bf8df49.jpg",
-              "description": "ABD eski başkanı Donald Trump ile kendisiyle 2006 yılında cinsel ilişki yaşadığı ve bu nedenle susturulmak için ödeme yapıldığını iddia eden Stormy Daniels arasında bugüne kadar neler yaşandığını araştırdık. ",
-              "imageAlt": "Trump ve Daniels ",
-              "id": "cyd68q0vrqdo"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:eb6ca135-cf1e-48aa-ad76-aaa5f4975aaa",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Seçtiklerimiz",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "Haberler - BBC News Türkçe",
+    "description": "Türkiye ve dünya gündemindeki son gelişmeler, son dakika haberleri, video, analiz, teknoloji haberleri, sağlık haberleri, spor haberleri, ekonomi haberleri, fotoğraf albümleri, canlı yayınlar BBC Türkçe sayfalarında.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "Hissedilen enflasyon: Kişisel enflasyonunuzu hesaplayın",
+            "firstPublished": "2023-03-30T08:55:53.000Z",
+            "link": "https://www.bbc.com/turkce/haberler-turkiye-64876429",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4B33/production/_129215291_index_549.png",
+            "description": "Açıklanan enflasyonun, hissettiğiniz enflasyondan yüksek olduğunu mu düşünüyorsunuz? Tüketici enflasyonu hesaplanırken kullanılan harcama sepeti sizi yansıtmıyor olabilir. Kişisel enflasyon hesaplayıcımızla, kendi harcamalarınıza göre enflasyon oranını hesaplayabilirsiniz.",
+            "imageAlt": "grafik",
+            "id": "f7265ccd-92c1-4562-b2cc-c97bf70f612f"
+          },
+          {
+            "type": "article",
+            "title": "Türkiye'de seçmenlerin kişisel verileri manipülasyon için kullanılıyor mu?",
+            "firstPublished": "2023-03-30T04:37:15.479Z",
+            "link": "https://www.bbc.com/turkce/articles/c84mm9lvzv0o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/b33f/live/0b755da0-ce50-11ed-8790-0b6b0487822e.jpg",
+            "description": "Yüksek Seçim Kurulu'nun (YSK) Mart ortasında yayımladığı propaganda dönemi esasları ve yayın ilkeleri ağırlıkla TV yayıncılığına odaklanıyor. Seçim düzenlemelerinde \"sosyal medya ve dijital pazarlamanın etkisinin gözardı edilmesi\" seçmenlerin manipülasyonu açısından endişe yaratıyor. \n",
+            "imageAlt": "hedefleme ",
+            "id": "c84mm9lvzv0o"
+          },
+          {
+            "type": "article",
+            "title": "Trump ile eski porno yıldızı Stormy Daniels arasında ne yaşandı, neden ceza davası açıldı?",
+            "firstPublished": "2023-03-31T10:00:02.024Z",
+            "link": "https://www.bbc.com/turkce/articles/cyd68q0vrqdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4557/live/c9e670c0-cf96-11ed-9374-e7827bf8df49.jpg",
+            "description": "ABD eski başkanı Donald Trump ile kendisiyle 2006 yılında cinsel ilişki yaşadığı ve bu nedenle susturulmak için ödeme yapıldığını iddia eden Stormy Daniels arasında bugüne kadar neler yaşandığını araştırdık. ",
+            "imageAlt": "Trump ve Daniels ",
+            "id": "cyd68q0vrqdo"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:eb6ca135-cf1e-48aa-ad76-aaa5f4975aaa",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Seçtiklerimiz",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cmvw7884exet",
+        "contentType": "index-home",
+        "pageIdentifier": "turkce.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/ukrainian/homePage/index.json
+++ b/data/ukrainian/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News Україна",
-      "description": "Останні новини України та світу, новини дня на BBC Україна",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "\"Ми з Путіним ні перед чим не зупинимося\": Лукашенко про ядерну зброю та війну",
-              "firstPublished": "2023-03-31T16:22:43.000Z",
-              "link": "https://www.bbc.com/ukrainian/news-65142884",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/38D9/production/_129235541_923904a9-5688-4a0f-91d1-1ad3f4a68a25.jpg",
-              "description": "Олександр Лукашенко, який утримує пост президента Білорусі, виступив зі щорічним зверненням до народу та парламенту через кілька днів після заяви російського президента про плани розміщення в цій країні тактичної ядерної зброї.",
-              "imageAlt": "Лукашенко оглашает послание 31 марта 2023 года",
-              "id": "203256d0-5016-4731-9531-48ed9a37ae2f"
-            },
-            {
-              "type": "article",
-              "title": "Росія стає головою Ради безпеки ООН. Як це може нашкодити Україні і як можна виключити РФ звідти?",
-              "firstPublished": "2023-03-31T05:04:29.014Z",
-              "link": "https://www.bbc.com/ukrainian/articles/cv2440434zdo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4d7a/live/5a802600-cf04-11ed-80a2-db8af845af66.jpg",
-              "description": "Росія 1 квітня стає головою Ради безпеки ООН. Чи може вона нашкодити Україні під час свого голосування в Радбезі ООН, чому Україна наполягає, що Росія є нелегальним членом ООН взагалі і які шанси її звідти виключити.",
-              "imageAlt": "Небензя",
-              "id": "cv2440434zdo"
-            },
-            {
-              "type": "article",
-              "title": "Росія почала масово використовувати крилаті авіабомби. Що це?",
-              "firstPublished": "2023-03-30T13:55:22.814Z",
-              "link": "https://www.bbc.com/ukrainian/articles/cg311eq33z1o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/58d7/live/0abfc800-cefa-11ed-ac1d-cda45811f187.jpg",
-              "description": "Росія почала активно застосовувати в України нові авіабомби. Чим вони небезпечні?",
-              "imageAlt": "авдіівка",
-              "id": "cg311eq33z1o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:b47027e0-08a8-420e-b032-a5f755c4ff99",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Докладно",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News Україна",
+    "description": "Останні новини України та світу, новини дня на BBC Україна",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "\"Ми з Путіним ні перед чим не зупинимося\": Лукашенко про ядерну зброю та війну",
+            "firstPublished": "2023-03-31T16:22:43.000Z",
+            "link": "https://www.bbc.com/ukrainian/news-65142884",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/38D9/production/_129235541_923904a9-5688-4a0f-91d1-1ad3f4a68a25.jpg",
+            "description": "Олександр Лукашенко, який утримує пост президента Білорусі, виступив зі щорічним зверненням до народу та парламенту через кілька днів після заяви російського президента про плани розміщення в цій країні тактичної ядерної зброї.",
+            "imageAlt": "Лукашенко оглашает послание 31 марта 2023 года",
+            "id": "203256d0-5016-4731-9531-48ed9a37ae2f"
+          },
+          {
+            "type": "article",
+            "title": "Росія стає головою Ради безпеки ООН. Як це може нашкодити Україні і як можна виключити РФ звідти?",
+            "firstPublished": "2023-03-31T05:04:29.014Z",
+            "link": "https://www.bbc.com/ukrainian/articles/cv2440434zdo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4d7a/live/5a802600-cf04-11ed-80a2-db8af845af66.jpg",
+            "description": "Росія 1 квітня стає головою Ради безпеки ООН. Чи може вона нашкодити Україні під час свого голосування в Радбезі ООН, чому Україна наполягає, що Росія є нелегальним членом ООН взагалі і які шанси її звідти виключити.",
+            "imageAlt": "Небензя",
+            "id": "cv2440434zdo"
+          },
+          {
+            "type": "article",
+            "title": "Росія почала масово використовувати крилаті авіабомби. Що це?",
+            "firstPublished": "2023-03-30T13:55:22.814Z",
+            "link": "https://www.bbc.com/ukrainian/articles/cg311eq33z1o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/58d7/live/0abfc800-cefa-11ed-ac1d-cda45811f187.jpg",
+            "description": "Росія почала активно застосовувати в України нові авіабомби. Чим вони небезпечні?",
+            "imageAlt": "авдіівка",
+            "id": "cg311eq33z1o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:b47027e0-08a8-420e-b032-a5f755c4ff99",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Докладно",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:cl13j7792ljt",
+        "contentType": "index-home",
+        "pageIdentifier": "ukrainian.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/urdu/homePage/index.json
+++ b/data/urdu/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News اردو",
-      "description": "تازہ ترین خبروں، ویڈیوز اور آڈیوز کے لیے بی بی سی اردو پر آئیے۔ بی بی سی اردو دنیا بھر کی خبروں کے حصول کے لیے ایک قابلِ اعتماد ویب سائٹ ہے۔",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "قسطنطنیہ کی فتح، جسے یورپ آج تک نہیں بھولا",
-              "firstPublished": "2018-05-29T00:51:51.000Z",
-              "link": "https://www.bbc.com/urdu/world-44281943",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13FF/production/_101791150_be14e796-3901-491b-8032-77f75e575cd1.jpg",
-              "description": "29 مئی 1453 کو مسلمانوں نے سات سو برسوں کی کوششوں کے بعد بالآخر قسطنطنیہ (موجودہ استنبول) کو فتح کرنے میں کامیابی حاصل کی۔ بظاہر یہ واقعہ یورپ آج تک نہیں بھولا۔",
-              "imageAlt": "سلطان فاتح",
-              "id": "5c8166c4-9434-d349-a6f8-ef47d2bde6fd"
-            },
-            {
-              "type": "article",
-              "title": "کراٹے کامبیٹ لیگ کے بین الاقوامی مقابلے میں فتح حاصل کرنے والے ’پہلے پاکستانی‘ شاہ زیب رند کون ہیں؟",
-              "firstPublished": "2023-04-03T08:13:37.960Z",
-              "link": "https://www.bbc.com/urdu/articles/cv2rjyywwd3o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e7c/live/56d94400-d1f7-11ed-b561-11aeba3662af.jpg",
-              "description": "شاہ زیب رند نے امریکہ میں کراٹے کامبیٹ لیگ میں لائٹ ویٹ کیٹیگری میں وینزویلا سے تعلق رکھنے والے کھلاڑی گابوڈیازکو شکست سے دوچار کیا۔",
-              "imageAlt": "شاہ زیب رند",
-              "id": "cv2rjyywwd3o"
-            },
-            {
-              "type": "article",
-              "title": "پاکستان کی ’خونی‘ ہائی وے: کراچی سے واپسی پر بیٹی کا رشتہ طے ہونا تھا لیکن اُس کی جلی ہوئی لاش واپس گھر پہنچی‘",
-              "firstPublished": "2023-04-03T03:58:27.148Z",
-              "link": "https://www.bbc.com/urdu/articles/c98nedld1p7o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8ea9/live/c0ef4b00-d175-11ed-9526-036efd25851d.jpg",
-              "description": "گذشتہ ساڑھے تین سال کے دوران کوئٹہ، کراچی ہائی وے پر ہونے والے ٹریفک حادثات کے نتیجے میں 477 افراد ہلاک ہوئے ہیں جن میں سے بیشتر کی میتیں جلنے کے باعث ناقابل شناخت ہوئیں۔ مگر اس شاہراہ پر اتنے زیادہ اور بڑے حادثات ہونے کی وجوہات کیا ہیں؟",
-              "imageAlt": "پاکستان",
-              "id": "c98nedld1p7o"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:047e70d2-d1f0-460c-9d00-4a3a3f9c1cdf",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "فیچر اور تجزیے",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News اردو",
+    "description": "تازہ ترین خبروں، ویڈیوز اور آڈیوز کے لیے بی بی سی اردو پر آئیے۔ بی بی سی اردو دنیا بھر کی خبروں کے حصول کے لیے ایک قابلِ اعتماد ویب سائٹ ہے۔",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "قسطنطنیہ کی فتح، جسے یورپ آج تک نہیں بھولا",
+            "firstPublished": "2018-05-29T00:51:51.000Z",
+            "link": "https://www.bbc.com/urdu/world-44281943",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/13FF/production/_101791150_be14e796-3901-491b-8032-77f75e575cd1.jpg",
+            "description": "29 مئی 1453 کو مسلمانوں نے سات سو برسوں کی کوششوں کے بعد بالآخر قسطنطنیہ (موجودہ استنبول) کو فتح کرنے میں کامیابی حاصل کی۔ بظاہر یہ واقعہ یورپ آج تک نہیں بھولا۔",
+            "imageAlt": "سلطان فاتح",
+            "id": "5c8166c4-9434-d349-a6f8-ef47d2bde6fd"
+          },
+          {
+            "type": "article",
+            "title": "کراٹے کامبیٹ لیگ کے بین الاقوامی مقابلے میں فتح حاصل کرنے والے ’پہلے پاکستانی‘ شاہ زیب رند کون ہیں؟",
+            "firstPublished": "2023-04-03T08:13:37.960Z",
+            "link": "https://www.bbc.com/urdu/articles/cv2rjyywwd3o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/9e7c/live/56d94400-d1f7-11ed-b561-11aeba3662af.jpg",
+            "description": "شاہ زیب رند نے امریکہ میں کراٹے کامبیٹ لیگ میں لائٹ ویٹ کیٹیگری میں وینزویلا سے تعلق رکھنے والے کھلاڑی گابوڈیازکو شکست سے دوچار کیا۔",
+            "imageAlt": "شاہ زیب رند",
+            "id": "cv2rjyywwd3o"
+          },
+          {
+            "type": "article",
+            "title": "پاکستان کی ’خونی‘ ہائی وے: کراچی سے واپسی پر بیٹی کا رشتہ طے ہونا تھا لیکن اُس کی جلی ہوئی لاش واپس گھر پہنچی‘",
+            "firstPublished": "2023-04-03T03:58:27.148Z",
+            "link": "https://www.bbc.com/urdu/articles/c98nedld1p7o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/8ea9/live/c0ef4b00-d175-11ed-9526-036efd25851d.jpg",
+            "description": "گذشتہ ساڑھے تین سال کے دوران کوئٹہ، کراچی ہائی وے پر ہونے والے ٹریفک حادثات کے نتیجے میں 477 افراد ہلاک ہوئے ہیں جن میں سے بیشتر کی میتیں جلنے کے باعث ناقابل شناخت ہوئیں۔ مگر اس شاہراہ پر اتنے زیادہ اور بڑے حادثات ہونے کی وجوہات کیا ہیں؟",
+            "imageAlt": "پاکستان",
+            "id": "c98nedld1p7o"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:047e70d2-d1f0-460c-9d00-4a3a3f9c1cdf",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "فیچر اور تجزیے",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c44evpp9wp1t",
+        "contentType": "index-home",
+        "pageIdentifier": "urdu.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/vietnamese/homePage/index.json
+++ b/data/vietnamese/homePage/index.json
@@ -1,52 +1,59 @@
 {
-    "data": {
-      "title": "BBC News Tiếng Việt",
-      "description": "BBC Tiếng Việt đem lại tin tức trung thực, khách quan về thế giới và Việt Nam.",
-      "pageType": "home",
-      "curations": [
-        {
-          "summaries": [
-            {
-              "type": "article",
-              "title": "OpenAI ra mắt GPT-4, 'cao thủ hơn' ChatGPT",
-              "firstPublished": "2023-03-15T11:39:42.549Z",
-              "link": "https://www.bbc.com/vietnamese/articles/c84dvwq4890o",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/91f6/live/1a2fd480-c322-11ed-95f8-0154daa64c44.jpg",
-              "description": "Bản thứ tư của chatbot AI có thể xử lý cả hình ảnh và văn bản.",
-              "imageAlt": "GPT-4",
-              "id": "c84dvwq4890o"
-            },
-            {
-              "type": "article",
-              "title": "Cua sốt ớt: Người phụ nữ đằng sau món ăn đặc sản của Singapore",
-              "firstPublished": "2023-02-18T03:53:28.761Z",
-              "link": "https://www.bbc.com/vietnamese/articles/ckr4yzd3jjpo",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e838/live/ac111ff0-af3e-11ed-89f4-f3657d2bfa3b.png",
-              "description": "Bà Cher Yam Tian, người sáng tạo ra món cua sốt ớt nổi tiếng thế giới đã qua đời hôm 15/2 tại Singapore ở tuổi 90.",
-              "imageAlt": "Bà Cher Yam Tian và con trai Roland Lim, ảnh chụp năm 2009",
-              "id": "ckr4yzd3jjpo"
-            },
-            {
-              "type": "article",
-              "title": "Hiệp ước đại dương: Thỏa thuận lịch sử đạt được sau 10 năm đàm phán",
-              "firstPublished": "2023-03-05T15:28:21.000Z",
-              "link": "https://www.bbc.com/vietnamese/world-64856389",
-              "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3D1D/production/_128854651_gettyimages-452418175.jpg",
-              "description": "Hiệp ước Biển cả nhằm mục đích đặt 30% diện tích biển vào các khu vực được bảo vệ vào năm 2030 để bảo vệ và phục hồi thiên nhiên biển.",
-              "imageAlt": "Whale shark",
-              "id": "6bcd95bb-17a4-4ff8-a589-8b720a2d5eaa"
-            }
-          ],
-          "activePage": 1,
-          "pageCount": 1,
-          "curationId": "urn:bbc:tipo:list:86432177-ed72-4b00-b27c-f6529e1d8c4a",
-          "curationType": "tipo-curation",
-          "position": 0,
-          "title": "Góc nhìn và chuyên mục",
-          "visualProminence": "HIGH"
-        }
-      ]
-    },
-    "contentType": "application/json; charset=utf-8",
-    "dataSource": "Data is from live TIPO"
-  }
+  "data": {
+    "title": "BBC News Tiếng Việt",
+    "description": "BBC Tiếng Việt đem lại tin tức trung thực, khách quan về thế giới và Việt Nam.",
+    "pageType": "home",
+    "curations": [
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "OpenAI ra mắt GPT-4, 'cao thủ hơn' ChatGPT",
+            "firstPublished": "2023-03-15T11:39:42.549Z",
+            "link": "https://www.bbc.com/vietnamese/articles/c84dvwq4890o",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/91f6/live/1a2fd480-c322-11ed-95f8-0154daa64c44.jpg",
+            "description": "Bản thứ tư của chatbot AI có thể xử lý cả hình ảnh và văn bản.",
+            "imageAlt": "GPT-4",
+            "id": "c84dvwq4890o"
+          },
+          {
+            "type": "article",
+            "title": "Cua sốt ớt: Người phụ nữ đằng sau món ăn đặc sản của Singapore",
+            "firstPublished": "2023-02-18T03:53:28.761Z",
+            "link": "https://www.bbc.com/vietnamese/articles/ckr4yzd3jjpo",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/e838/live/ac111ff0-af3e-11ed-89f4-f3657d2bfa3b.png",
+            "description": "Bà Cher Yam Tian, người sáng tạo ra món cua sốt ớt nổi tiếng thế giới đã qua đời hôm 15/2 tại Singapore ở tuổi 90.",
+            "imageAlt": "Bà Cher Yam Tian và con trai Roland Lim, ảnh chụp năm 2009",
+            "id": "ckr4yzd3jjpo"
+          },
+          {
+            "type": "article",
+            "title": "Hiệp ước đại dương: Thỏa thuận lịch sử đạt được sau 10 năm đàm phán",
+            "firstPublished": "2023-03-05T15:28:21.000Z",
+            "link": "https://www.bbc.com/vietnamese/world-64856389",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/3D1D/production/_128854651_gettyimages-452418175.jpg",
+            "description": "Hiệp ước Biển cả nhằm mục đích đặt 30% diện tích biển vào các khu vực được bảo vệ vào năm 2030 để bảo vệ và phục hồi thiên nhiên biển.",
+            "imageAlt": "Whale shark",
+            "id": "6bcd95bb-17a4-4ff8-a589-8b720a2d5eaa"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:86432177-ed72-4b00-b27c-f6529e1d8c4a",
+        "curationType": "tipo-curation",
+        "position": 0,
+        "title": "Góc nhìn và chuyên mục",
+        "visualProminence": "HIGH"
+      }
+    ],
+    "metadata": {
+      "analytics": {
+        "contentId": "urn:bbc:tipo:topic:c93v2kk9r7lt",
+        "contentType": "index-home",
+        "pageIdentifier": "vietnamese.page"
+      }
+    }
+  },
+  "contentType": "application/json; charset=utf-8",
+  "dataSource": "Data is from live TIPO"
+}

--- a/data/yoruba/homePage/index.json
+++ b/data/yoruba/homePage/index.json
@@ -361,7 +361,14 @@
           "title": "Eré Ìdárayá",
           "visualProminence": "NORMAL"
         }
-      ]
+      ],
+      "metadata": {
+        "analytics": {
+          "contentId": "urn:bbc:tipo:topic:cw95pllwv8rt",
+          "contentType": "index-home",
+          "pageIdentifier": "yoruba.page"
+        }
+      }
     },
     "contentType": "application/json; charset=utf-8",
     "dataSource": "Data is from live TIPO"


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-433](https://jira.dev.bbc.co.uk/browse/WSTEAMA-433)

Overall changes
======

Add ATI data blocks to local Homepage fixtures to replicate the Simorgh BFF
response containing analytics data for page reporting.

Code changes
======

- Adds metadata blocks to local Homepage fixtures corresponding to the data served
by Simorgh BFF.
- Doesn't include serbian, ukchina, uzbek or zhongwen.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
