### PR TITLE
Fix pathing to Optimo image blocks in FrostedGlassPromo

### DIFF
--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -47,3 +47,4 @@ jobs:
           working-directory: ws-nextjs-app
           build: yarn build
           start: yarn start
+          wait-on: 'http://localhost:7081'


### PR DESCRIPTION
Overall changes
======
Fixes pathing to the `defaultPromoImage` block for Optimo promos, as there were assumptions made about the positioning of the blocks within this object to extract the data

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
