### PR TITLE
Pin `cypress-io` GitHub Action version for Next.JS app

### DIFF
--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
           start: yarn start
 
       - name: Run Simorgh NextJS E2Es
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v5.8.1
         with:
           working-directory: ws-nextjs-app
           build: yarn build

--- a/.github/workflows/simorgh-e2e-tests.yml
+++ b/.github/workflows/simorgh-e2e-tests.yml
@@ -47,4 +47,3 @@ jobs:
           working-directory: ws-nextjs-app
           build: yarn build
           start: yarn start
-          wait-on: 'http://localhost:7081'


### PR DESCRIPTION
Overall changes
======
Pins the version of the Cypress GitHub action to `5.8.1` for the Next.JS E2Es. `5.8.2` appears to have introduced a breaking change for us: https://github.com/cypress-io/github-action/releases/tag/v5.8.2 , so we will need to investigate further.

This unblocks the build pipeline for now at least.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
