### PR TITLE
WSTEAMA-420 - Remove isLive check from Most Read component

### DIFF
--- a/src/app/components/MostRead/index.test.tsx
+++ b/src/app/components/MostRead/index.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import isLive from '#app/lib/utilities/isLive';
 import { RequestContextProvider } from '../../contexts/RequestContext';
 import { ToggleContextProvider } from '../../contexts/ToggleContext';
 import pidginMostReadData from '../../../../data/pidgin/mostRead/pidgin.json';
@@ -245,42 +244,5 @@ describe('MostRead', () => {
         });
       },
     );
-  });
-
-  describe('Presence on live environment', () => {
-    const originalEnvironment = process.env.SIMORGH_APP_ENV;
-
-    const toggles = {
-      mostRead: { enabled: true },
-    };
-
-    afterEach(() => {
-      process.env.SIMORGH_APP_ENV = originalEnvironment;
-    });
-
-    it('should render a most read component when the environment is live', () => {
-      process.env.SIMORGH_APP_ENV = 'live';
-
-      // if isLive is true, show most read component
-      const { container } = render(
-        <MostRead data={pidginMostReadData.data} columnLayout="twoColumn" />,
-        { toggles },
-      );
-
-      expect(container).not.toBeEmptyDOMElement();
-      expect(isLive()).toBe(true);
-    });
-
-    it('should render a most read component when the environment is not live', () => {
-      process.env.SIMORGH_APP_ENV = 'non-live';
-
-      // if isLive is false, show most read component
-      const { container } = render(
-        <MostRead data={pidginMostReadData.data} columnLayout="twoColumn" />,
-        { toggles },
-      );
-      expect(container).not.toBeEmptyDOMElement();
-      expect(isLive()).toBe(false);
-    });
   });
 });

--- a/src/app/components/MostRead/index.test.tsx
+++ b/src/app/components/MostRead/index.test.tsx
@@ -258,16 +258,16 @@ describe('MostRead', () => {
       process.env.SIMORGH_APP_ENV = originalEnvironment;
     });
 
-    it('should not render a most read component when the environment is live', () => {
+    it('should render a most read component when the environment is live', () => {
       process.env.SIMORGH_APP_ENV = 'live';
 
-      // if isLive is true, DO NOT show most read component
+      // if isLive is true, show most read component
       const { container } = render(
         <MostRead data={pidginMostReadData.data} columnLayout="twoColumn" />,
         { toggles },
       );
 
-      expect(container).toBeEmptyDOMElement();
+      expect(container).not.toBeEmptyDOMElement();
       expect(isLive()).toBe(true);
     });
 

--- a/src/app/components/MostRead/index.tsx
+++ b/src/app/components/MostRead/index.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { RequestContext } from '#contexts/RequestContext';
 import useToggle from '#hooks/useToggle';
 import { getMostReadEndpoint } from '#app/lib/utilities/getUrlHelpers/getMostReadUrls';
-import isLive from '#app/lib/utilities/isLive';
 import { ServiceContext } from '../../contexts/ServiceContext';
 import Canonical from './Canonical';
 import Amp from './Amp';
@@ -54,10 +53,6 @@ const MostRead = ({
 
   // Do not render most read when a toggle is disabled
   if (!mostReadToggleEnabled) {
-    return null;
-  }
-
-  if (isLive()) {
     return null;
   }
 


### PR DESCRIPTION
Resolves [JIRA [420]](https://jira.dev.bbc.co.uk/browse/WSTEAMA-420)

Overall changes
======

Removes an `isLive` check to allow the Most Read component to be able to render on live Homepages.

Code changes
======

- Removes `isLive` check from the MostRead index file. 
- Updates existing unit tests to reflect the above change.

Testing
======


Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
