### PR TITLE
Fixes failing amp most read tests 

### DIFF
--- a/cypress/integration/pages/articles/testsForAMPOnly.js
+++ b/cypress/integration/pages/articles/testsForAMPOnly.js
@@ -97,7 +97,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
                   appConfig[config[service].name][variant].mostRead
                     .numberOfItems;
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .children('li')
                   .should('have.length', expectedMostReadItems);
               }
@@ -116,7 +116,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
               if (mostReadIsEnabled && mostReadRecords >= 5) {
                 const expectedMostReadRank = serviceNumerals(service);
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .find('li span')
                   .each(($el, index) => {
                     expect($el.text()).equal(expectedMostReadRank[index + 1]);
@@ -135,7 +135,7 @@ export const testsThatFollowSmokeTestConfigForAMPOnly = ({
               );
               if (mostReadIsEnabled && mostReadRecords >= 5) {
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .next()
                   .within(() => {
                     cy.get('a').each($el => {


### PR DESCRIPTION
For the new most read the structure of the elements has changed, so the test needed to change.

Now cy.get('[data-e2e="most-read"] > amp-script > amp-list div') instead of cy.get('[data-e2e="most-read"] > amp-list div')