### PR TITLE
WSTEAMA-525: Updates most read tests for STY pages on AMP

### DIFF
--- a/cypress/integration/pages/storyPage/testsForAMPOnly.js
+++ b/cypress/integration/pages/storyPage/testsForAMPOnly.js
@@ -94,7 +94,7 @@ export const testsThatAlwaysRunForAMPOnly = ({
                   appConfig[config[service].name][variant].mostRead
                     .numberOfItems;
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .children('li')
                   .should('have.length', expectedMostReadItems);
               }
@@ -113,7 +113,7 @@ export const testsThatAlwaysRunForAMPOnly = ({
               if (mostReadIsEnabled && mostReadRecords >= 5) {
                 const expectedMostReadRank = serviceNumerals(service);
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .find('li span')
                   .each(($el, index) => {
                     expect($el.text()).equal(expectedMostReadRank[index + 1]);
@@ -133,7 +133,7 @@ export const testsThatAlwaysRunForAMPOnly = ({
               );
               if (mostReadIsEnabled && mostReadRecords >= 5) {
                 cy.get('[data-e2e="most-read"]').scrollIntoView();
-                cy.get('[data-e2e="most-read"] > amp-list div')
+                cy.get('[data-e2e="most-read"] > amp-script > amp-list div')
                   .next()
                   .within(() => {
                     cy.get('a').should('have.attr', 'href');


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-525

Overall changes
======
Updates Cypress E2E tests for STY pages to ensure that the Most Read component can be found on the page

Code changes
======

Update xpath for most read component

Testing
======
- [x] `CYPRESS_APP_ENV=test yarn cypress:interactive` & select the StoryPage tests - all pass as expected

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
