### PR TITLE
WSTEAMA-478 - Launch: Simorgh - Route azeri to Homepage on live environment

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1008,23 +1008,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      frontPage: {
-        environments: {
-          live: {
-            paths: ['/azeri'],
-            enabled: false,
-          },
-          test: {
-            paths: ['/azeri'],
-            enabled: false,
-          },
-          local: {
-            paths: ['/azeri'],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      frontPage: { environments: undefined, smoke: false },
       liveRadio: { environments: undefined, smoke: false },
       onDemandAudio: { environments: undefined, smoke: false },
       onDemandTV: { environments: undefined, smoke: false },

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -550,7 +550,7 @@ describe('frontPage -> homePage migration', () => {
     .filter(service => !servicesWithVariants.includes(service))
     .map(serviceToRoute);
 
-  const migratedServices = ['kyrgyz'];
+  const migratedServices = ['kyrgyz', 'azeri'];
   const migratedWorldServiceRoutes = migratedServices.map(serviceToRoute);
 
   const liveFrontPageServices = worldServices.filter(

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -550,7 +550,7 @@ describe('frontPage -> homePage migration', () => {
     .filter(service => !servicesWithVariants.includes(service))
     .map(serviceToRoute);
 
-  const migratedServices = ['kyrgyz', 'azeri'];
+  const migratedServices = ['azeri', 'kyrgyz'];
   const migratedWorldServiceRoutes = migratedServices.map(serviceToRoute);
 
   const liveFrontPageServices = worldServices.filter(

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -34,7 +34,7 @@ export const getArticleManifestRegex = services => {
   return `/:service(${serviceRegex})/:local(${articleLocalRegex})/manifest.json`;
 };
 
-const homePageServices = ['kyrgyz', 'azeri'];
+const homePageServices = ['azeri', 'kyrgyz'];
 
 const servicesWithVariants = ['serbian', 'ukchina', 'zhongwen'];
 

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -34,7 +34,7 @@ export const getArticleManifestRegex = services => {
   return `/:service(${serviceRegex})/:local(${articleLocalRegex})/manifest.json`;
 };
 
-const homePageServices = ['kyrgyz'];
+const homePageServices = ['kyrgyz', 'azeri'];
 
 const servicesWithVariants = ['serbian', 'ukchina', 'zhongwen'];
 


### PR DESCRIPTION
Resolves JIRA [WSTEAMA-478]

Overall changes
======
Updates the logic to ensure that on all environments - local, test, live, that the homepage is rendered when service=azeri

Code changes
======

- Updated test so that /azeri renders a homepage not a frontpage
- Updated logic so that /azeri renders a homepage not a frontpage 
- Removed /azeri from cypress tests for frontpage on live environment by removing configuration and replacing with the 'empty' config as we won't need it for azeri anymore, but the object still needs to be present.


Testing
======
Test failed before Azeri was added to migratedServices in index.js, and now passes now that it is also added to migratedServices in the test.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
