### PR TITLE
Fix e2e checking Topics page 2

### DIFF
--- a/cypress/integration/pages/topicPage/tests.js
+++ b/cypress/integration/pages/topicPage/tests.js
@@ -165,7 +165,9 @@ export default ({ service, pageType, variant }) => {
             .click();
 
           cy.url().should('include', '?page=2');
-          cy.get('[data-testid="topic-promos"] li');
+          cy.get('[data-testid="curation-grid-normal"]')
+            .should('have.class', 'promo-image')
+            .and('have.class', 'promo-text');
         } else {
           cy.log('No pagination as there is only one page');
         }


### PR DESCRIPTION
The test gets the promo list. If there is only one item there is no list and on the topics page being tested data has been added that means there is now 1 item on the 2nd page. I changed it so that the test now gets the curation grid. I then check it has the classes for text and image, because the grid could potentially be empty? (might not be true), and this ensures it has a promo in the grid.