### PR TITLE
WSTEAM1-495/496 - Overrides Live Reporting Header Font Size

### DIFF
--- a/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/LivePageLayout.tsx
@@ -84,10 +84,10 @@ const LivePage = ({
           description={description}
         />
         <div css={styles.outerGrid}>
-          <div css={styles.leftSection}>
+          <div css={styles.firstSection}>
             <Summary summaryBlocks={summaryContent?.model.blocks} />
           </div>
-          <div css={styles.rightSection}>
+          <div css={styles.secondSection}>
             <Stream streamContent={liveTextStream.content} />
             <pre css={styles.code}>
               <Heading level={4}>Headers</Heading>

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/Stream/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/Stream/styles.tsx
@@ -10,10 +10,11 @@ export default {
       marginBlock: 0,
       paddingInline: 0,
     }),
-  heading: ({ mq, spacings }: Theme) =>
+  heading: ({ mq, spacings, fontSizes }: Theme) =>
     css({
       padding: `${spacings.DOUBLE}rem 0 ${spacings.DOUBLE}rem`,
       [mq.GROUP_3_MIN_WIDTH]: {
+        ...fontSizes.doublePica,
         padding: `${spacings.TRIPLE}rem 0 ${spacings.DOUBLE}rem`,
       },
     }),

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
@@ -184,16 +184,6 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
-.emotion-9 {
-  grid-column: 1/13;
-}
-
-@media (min-width: 63rem) {
-  .emotion-9 {
-    grid-column: 1/5;
-  }
-}
-
 .emotion-10 {
   color: #141414;
   font-size: 1.25rem;
@@ -363,16 +353,6 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 .emotion-13 {
   margin-bottom: 1rem;
-}
-
-.emotion-15 {
-  grid-column: 1/13;
-}
-
-@media (min-width: 63rem) {
-  .emotion-15 {
-    grid-column: 5/13;
-  }
 }
 
 .emotion-16 {
@@ -932,7 +912,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
         </div>
       </div>
       <div
-        class="emotion-15"
+        class="emotion-9"
       >
         <div>
           <h2

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
@@ -184,6 +184,22 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   }
 }
 
+.emotion-9 {
+  grid-column: 1/13;
+}
+
+@media (min-width: 63rem) {
+  .emotion-9 {
+    grid-column: 1/5;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-9 {
+    grid-column: 1/4;
+  }
+}
+
 .emotion-10 {
   color: #141414;
   font-size: 1.25rem;
@@ -353,6 +369,22 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 .emotion-13 {
   margin-bottom: 1rem;
+}
+
+.emotion-15 {
+  grid-column: 1/13;
+}
+
+@media (min-width: 63rem) {
+  .emotion-15 {
+    grid-column: 5/13;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-15 {
+    grid-column: 4/13;
+  }
 }
 
 .emotion-16 {
@@ -912,7 +944,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
         </div>
       </div>
       <div
-        class="emotion-9"
+        class="emotion-15"
       >
         <div>
           <h2

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
@@ -384,7 +384,23 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 
 @media (min-width: 37.5rem) {
   .emotion-16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
     padding: 1.5rem 0 1rem;
+  }
+
+  @media (min-width: 20rem) and (max-width: 37.4375rem) {
+    .emotion-16 {
+      font-size: 1.25rem;
+      line-height: 1.5rem;
+    }
+  }
+
+  @media (min-width: 37.5rem) {
+    .emotion-16 {
+      font-size: 1.5rem;
+      line-height: 1.75rem;
+    }
   }
 }
 

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/styles.ts
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/styles.ts
@@ -45,20 +45,26 @@ export default {
         columnGap: `${spacings.DOUBLE}rem`,
       },
     }),
-  leftSection: ({ mq }: Theme) =>
+  firstSection: ({ mq }: Theme) =>
     css({
       gridColumn: '1 / 13',
 
       [mq.GROUP_4_MIN_WIDTH]: {
         gridColumn: '1 / 5',
       },
+      [mq.GROUP_5_MIN_WIDTH]: {
+        gridColumn: '1 / 4',
+      },
     }),
-  rightSection: ({ mq }: Theme) =>
+  secondSection: ({ mq }: Theme) =>
     css({
       gridColumn: '1 / 13',
 
       [mq.GROUP_4_MIN_WIDTH]: {
         gridColumn: '5 / 13',
+      },
+      [mq.GROUP_5_MIN_WIDTH]: {
+        gridColumn: '4 / 13',
       },
     }),
 };


### PR DESCRIPTION
Follow up to https://github.com/bbc/simorgh/pull/10922 after UX review

Overall changes
======
Adds styling tweaks

Code changes
======

- Adds font size change for group 3 breakpoints and above for live reporting header
- Updates column spans to match header
- Updates snapshot

Testing
======
https://wsteam1-495-496-adds-stream-component--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/pages-live-page--example

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
