### PR TITLE
UX Fix: Update live page header columns

### DIFF
--- a/ws-nextjs-app/pages/[service]/new_live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/Header/styles.tsx
@@ -45,8 +45,11 @@ export default {
       marginBottom: `${pixelsToRem(16)}rem`,
       [mq.GROUP_4_MIN_WIDTH]: {
         paddingInlineStart: `${pixelsToRem(16)}rem`,
-        gridColumn: '1 / span 3',
+        gridColumn: '1 / span 4',
         marginBottom: 0,
+      },
+      [mq.GROUP_5_MIN_WIDTH]: {
+        gridColumn: '1 / span 3',
       },
     }),
   title: ({ palette }: Theme) =>
@@ -67,6 +70,9 @@ export default {
     css({
       [mq.GROUP_4_MIN_WIDTH]: {
         gridColumn: '5 / span 8',
+      },
+      [mq.GROUP_5_MIN_WIDTH]: {
+        gridColumn: '4 / span 9',
       },
     }),
 };

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/__snapshots__/live.test.tsx.snap
@@ -79,8 +79,14 @@ exports[`Live Page creates snapshot of the live page 1`] = `
   .emotion-4 {
     -webkit-padding-start: 1rem;
     padding-inline-start: 1rem;
-    grid-column: 1/span 3;
+    grid-column: 1/span 4;
     margin-bottom: 0;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-4 {
+    grid-column: 1/span 3;
   }
 }
 
@@ -103,6 +109,12 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 @media (min-width: 63rem) {
   .emotion-6 {
     grid-column: 5/span 8;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-6 {
+    grid-column: 4/span 9;
   }
 }
 
@@ -136,6 +148,12 @@ exports[`Live Page creates snapshot of the live page 1`] = `
 @media (min-width: 63rem) {
   .emotion-7 {
     grid-column: 5/span 8;
+  }
+}
+
+@media (min-width: 80rem) {
+  .emotion-7 {
+    grid-column: 4/span 9;
   }
 }
 


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
- Update to column widths on largest screen sizes (1280px+). Live label should take up 3 columns not 4. Header without a live label is not affected.

Code changes
======

- Add new media query for larger screen sizes
- Fix typo in existing media query that set live label width at 3 columns and not 4 (the title was set to start at column 5 so there is no visual change, I have just fixed the typo so it makes more logical sense.)
- Update snapshot

Testing
======
Storybook Preview links:
- [Title and live label (LTR)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-only-with-live-label&viewMode=story)
- [Title and description and live label (LTR)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&id=new-components-livepageheader--title-and-description-with-live-label&viewMode=story)
- [Title and description and live label (RTL)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=arabic&id=new-components-livepageheader--right-to-left-with-live-label&viewMode=story)
- [Title without live label (LTR)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=news&id=new-components-livepageheader--title-only-without-live-label&viewMode=story)
- [Title and description without live label (LTR)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=news&id=new-components-livepageheader--title-and-description-without-live-label&viewMode=story)
- [Title and description without live label (RTL)](https://update-live-page-header-columns--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=arabic&id=new-components-livepageheader--right-to-left-without-live-label&viewMode=story)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

This is the orginal PR: https://github.com/bbc/simorgh/pull/10901

Design (click “control + G” to see grid) - https://www.figma.com/file/ozHsWG5R9tETw6lBOU740V/Live-mvp-header---handover?type=design&node-id=95-266&mode=design

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
