### PR TITLE
WSTEAM1-525: Latest Media section now displayed on Optimo media pages

### DIFF
--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -4,6 +4,7 @@ import * as fetchPageData from '../../utils/fetchPageData';
 import nodeLogger from '../../../../testHelpers/loggerMock';
 import { BFF_FETCH_ERROR } from '../../../lib/logger.const';
 import getInitialData from '.';
+import pidginArticleWithLatestMedia from '../../../../../data/pidgin/articles/cw0x29n2pvqo.json';
 
 process.env.BFF_PATH = 'https://mock-bff-path';
 
@@ -25,6 +26,7 @@ const bffArticleJson = {
       topStories: [],
       features: [],
       mostRead: [],
+      latestMedia: [],
     },
   },
 };
@@ -291,5 +293,33 @@ describe('Articles - BFF Fetching', () => {
       message: 'Article data is malformed',
       status: 500,
     });
+  });
+
+  it('should transform response as expected', async () => {
+    const fetchDataSpy = jest.spyOn(fetchPageData, 'default');
+
+    fetchDataSpy.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        json: pidginArticleWithLatestMedia,
+      }),
+    );
+
+    const { pageData } = await getInitialData({
+      path: '/kyrgyz/articles/c0000000000o',
+      getAgent,
+      service: 'kyrgyz',
+      pageType: 'article',
+    });
+
+    expect(pageData).toHaveProperty('content');
+    expect(pageData).toHaveProperty('metadata');
+    expect(pageData).toHaveProperty('promo');
+    expect(pageData).toHaveProperty('secondaryColumn');
+    expect(pageData.secondaryColumn).toHaveProperty('topStories');
+    expect(pageData.secondaryColumn).toHaveProperty('features');
+    expect(pageData.secondaryColumn).toHaveProperty('latestMedia');
+    expect(pageData).toHaveProperty('mostRead');
+    expect(pageData).toHaveProperty('mostWatched');
   });
 });

--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -305,12 +305,12 @@ describe('Articles - BFF Fetching', () => {
       }),
     );
 
-    const { pageData } = await getInitialData({
+    const { pageData } = (await getInitialData({
       path: '/kyrgyz/articles/c0000000000o',
       getAgent,
       service: 'kyrgyz',
       pageType: 'article',
-    });
+    })) as { pageData: Record<string, unknown> };
 
     expect(pageData).toHaveProperty('content');
     expect(pageData).toHaveProperty('metadata');

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Agent } from 'https';
-import omit from 'ramda/src/omit';
 import getEnvironment from '#app/routes/utils/getEnvironment';
 import nodeLogger from '../../../lib/logger.node';
 import { BFF_FETCH_ERROR } from '../../../lib/logger.const';

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Agent } from 'https';
+import omit from 'ramda/src/omit';
 import getEnvironment from '#app/routes/utils/getEnvironment';
 import nodeLogger from '../../../lib/logger.node';
 import { BFF_FETCH_ERROR } from '../../../lib/logger.const';
@@ -74,16 +75,14 @@ export default async ({
       logger.error('Recommendations JSON malformed', error);
     }
 
-    const { topStories, features, mostRead, mostWatched } = secondaryData;
+    const { mostRead, mostWatched } = secondaryData;
+    const secondaryColumn = omit(['mostRead', 'mostWatched'], secondaryData);
 
     const response = {
       status,
       pageData: {
         ...article,
-        secondaryColumn: {
-          topStories,
-          features,
-        },
+        secondaryColumn,
         mostRead,
         mostWatched,
         ...(wsojData && wsojData),

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -75,14 +75,18 @@ export default async ({
       logger.error('Recommendations JSON malformed', error);
     }
 
-    const { mostRead, mostWatched } = secondaryData;
-    const secondaryColumn = omit(['mostRead', 'mostWatched'], secondaryData);
+    const { mostRead, mostWatched, topStories, features, latestMedia } =
+      secondaryData;
 
     const response = {
       status,
       pageData: {
         ...article,
-        secondaryColumn,
+        secondaryColumn: {
+          topStories,
+          features,
+          latestMedia,
+        },
         mostRead,
         mostWatched,
         ...(wsojData && wsojData),

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -74,7 +74,7 @@ export default async ({
       logger.error('Recommendations JSON malformed', error);
     }
 
-    const { mostRead, mostWatched, topStories, features, latestMedia } =
+    const { topStories, features, latestMedia, mostRead, mostWatched } =
       secondaryData;
 
     const response = {

--- a/src/integration/pages/mediaArticlePage/crossPlatformTests.js
+++ b/src/integration/pages/mediaArticlePage/crossPlatformTests.js
@@ -31,4 +31,32 @@ export default service => {
       });
     }
   });
+
+  describe('Latest Media', () => {
+    const latestMediaLinks = document.querySelectorAll(
+      '[data-testid="latest-media"] a',
+    );
+
+    if (latestMediaLinks) {
+      latestMediaLinks.forEach(latestMediaLink => {
+        const latestMediaText = latestMediaLink.textContent;
+        const latestMediaUrl = latestMediaLink.getAttribute('href');
+
+        it('should be in the document', () => {
+          expect(latestMediaLink).toBeInTheDocument();
+        });
+
+        it('should contain text', () => {
+          expect(latestMediaText).toBeTruthy();
+        });
+
+        it('should match text and url', () => {
+          expect({
+            text: latestMediaText,
+            url: latestMediaUrl,
+          }).toMatchSnapshot();
+        });
+      });
+    }
+  });
 };

--- a/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/amp.test.js.snap
@@ -263,6 +263,34 @@ Object {
 }
 `;
 
+exports[`AMP Media Article Page Latest Media should match text and url 1`] = `
+Object {
+  "text": "Video, How to vote for Nigeria general election, Duration 1,46",
+  "url": "/pidgin/tori-64758904",
+}
+`;
+
+exports[`AMP Media Article Page Latest Media should match text and url 2`] = `
+Object {
+  "text": "Video, Wetin e take to win election for Nigeria, Duration 3,59",
+  "url": "/pidgin/64626014",
+}
+`;
+
+exports[`AMP Media Article Page Latest Media should match text and url 3`] = `
+Object {
+  "text": "Video, Tins you go do during election wey go land you for INEC hot soup, Duration 1,33",
+  "url": "/pidgin/tori-64534844",
+}
+`;
+
+exports[`AMP Media Article Page Latest Media should match text and url 4`] = `
+Object {
+  "text": "Video, 'We dey good to go for dis election' - INEC Boss, Duration 6,17",
+  "url": "/pidgin/articles/cw0x29n2pvqo",
+}
+`;
+
 exports[`AMP Media Article Page Main heading should match text 1`] = `"'We dey good to go for dis election' - INEC Boss"`;
 
 exports[`AMP Media Article Page Related Content should match text and url 1`] = `

--- a/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mediaArticlePage/pidgin/__snapshots__/canonical.test.js.snap
@@ -122,6 +122,34 @@ Object {
 }
 `;
 
+exports[`Canonical Media Article Page Latest Media should match text and url 1`] = `
+Object {
+  "text": "Video, How to vote for Nigeria general election, Duration 1,46",
+  "url": "/pidgin/tori-64758904",
+}
+`;
+
+exports[`Canonical Media Article Page Latest Media should match text and url 2`] = `
+Object {
+  "text": "Video, Wetin e take to win election for Nigeria, Duration 3,59",
+  "url": "/pidgin/64626014",
+}
+`;
+
+exports[`Canonical Media Article Page Latest Media should match text and url 3`] = `
+Object {
+  "text": "Video, Tins you go do during election wey go land you for INEC hot soup, Duration 1,33",
+  "url": "/pidgin/tori-64534844",
+}
+`;
+
+exports[`Canonical Media Article Page Latest Media should match text and url 4`] = `
+Object {
+  "text": "Video, 'We dey good to go for dis election' - INEC Boss, Duration 6,17",
+  "url": "/pidgin/articles/cw0x29n2pvqo",
+}
+`;
+
 exports[`Canonical Media Article Page Main heading should match text 1`] = `"'We dey good to go for dis election' - INEC Boss"`;
 
 exports[`Canonical Media Article Page Related Content should match text and url 1`] = `


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAM1-525

Overall changes
======
Ensures all fields on the secondaryData returned from the BFF are included in the secondary column.


Code changes
======
Spread all fields from the secondaryData -> secondaryColumn, apart from mostRead and mostWatched
  

Testing
======
- [ ] Add unit test to ensure data transformed correctly
- [ ] Test asset with latestMedia in BFF response e.g.  http://localhost:7080/hausa/articles/cw43vy8zdjvo or http://localhost:7080/pidgin/articles/c881llnevmeo?renderer_env=live -> latest media section is now displayed as expected

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
