### PR TITLE
WSTEAM1-514 - Passes isAmp to image component

### DIFF
--- a/src/app/components/Embeds/EmbedImages/index.test.tsx
+++ b/src/app/components/Embeds/EmbedImages/index.test.tsx
@@ -37,12 +37,15 @@ describe('EmbedImages', () => {
     });
   });
   describe('AMP', () => {
-    it('should render a 1280px width image', async () => {
-      render(<EmbedImages blocks={chartEmbedImages.blocks} />, {
-        isAmp: true,
-      });
+    it('should render a 1280px width amp-image', async () => {
+      const { container } = render(
+        <EmbedImages blocks={chartEmbedImages.blocks} />,
+        {
+          isAmp: true,
+        },
+      );
 
-      const chartEmbedImage = screen.queryByRole('img');
+      const chartEmbedImage = container.getElementsByTagName('amp-img')[0];
       expect(chartEmbedImage).toHaveAttribute('width', '1280');
     });
   });

--- a/src/app/components/Embeds/EmbedImages/index.tsx
+++ b/src/app/components/Embeds/EmbedImages/index.tsx
@@ -30,7 +30,7 @@ const EmbedImages = ({ blocks: embedImages }: PropsWithChildren<Props>) => {
 
   return (
     <div css={styles.embedDiv}>
-      <Image src={src} alt={alt} width={width} height={height} />
+      <Image src={src} alt={alt} width={width} height={height} isAmp={isAmp} />
     </div>
   );
 };


### PR DESCRIPTION
Resolves JIRA N/A

Overall changes
======
Small fix to enable amp-img for IDT2 includes on Optimo

Code changes
======

-  Passes isAmp to image component
- Updates unit test

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
