### PR TITLE
Cookie Banner E2E test fixes

### DIFF
--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -93,7 +93,10 @@ export default ({ service, variant, pageType, path }) => {
 
       visitPage(path, pageType);
 
-      cy.wait(1000);
+      cy.wait(3000);
+
+      getCookieBannerCanonical(service, variant).should('not.exist');
+      getPrivacyBanner(service, variant).should('not.exist');
 
       assertCookieHasOneOfValues(
         'ckns_explicit',
@@ -102,8 +105,6 @@ export default ({ service, variant, pageType, path }) => {
       assertCookieHasValue('ckns_privacy', 'july2019');
       assertCookieHasValue('ckns_policy', '000');
 
-      getCookieBannerCanonical(service, variant).should('not.exist');
-      getPrivacyBanner(service, variant).should('not.exist');
 
       ensureCookieExpiryDates();
     });

--- a/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
+++ b/cypress/integration/specialFeatures/cookieBanner/testsForCanonicalOnly.js
@@ -104,8 +104,6 @@ export default ({ service, variant, pageType, path }) => {
       );
       assertCookieHasValue('ckns_privacy', 'july2019');
       assertCookieHasValue('ckns_policy', '000');
-
-
       ensureCookieExpiryDates();
     });
 


### PR DESCRIPTION
Overall changes
======
Attempting to stabilise the cookie banner tests which run as part of the CD pipeline and as part of scheduled E2E tests.

Code changes
======
- Increase wait after revisiting the page to allow cookie values to refresh 
- Reorder the assertions in the test to see if this has any impact.

- _A bullet point list of key code changes that have been made._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
