### PR TITLE
Add log to record empty toggle responses

### DIFF
--- a/src/app/lib/logger.const.js
+++ b/src/app/lib/logger.const.js
@@ -58,6 +58,7 @@ const logCodes = {
   CONFIG_REQUEST_RECEIVED: 'config_request_received',
   CONFIG_FETCH_ERROR: 'config_fetch_error',
   CONFIG_ERROR: 'config_error',
+  CONFIG_RESPONSE_EMPTY_ERROR: 'config_response_empty_error',
 
   // Block Types
   UNSUPPORTED_BLOCK_TYPE: 'unsupported_block_type',

--- a/src/app/lib/utilities/getToggles/index.js
+++ b/src/app/lib/utilities/getToggles/index.js
@@ -6,6 +6,7 @@ import {
   CONFIG_FETCH_ERROR,
   CONFIG_ERROR,
   TOGGLE_API_RESPONSE_TIME,
+  CONFIG_RESPONSE_EMPTY_ERROR
 } from '#lib/logger.const';
 import getOriginContext from '#contexts/RequestContext/getOriginContext';
 
@@ -46,6 +47,14 @@ const getToggles = async (service, cache) => {
   const url = constructTogglesEndpoint(service, origin);
 
   const cachedResponse = cache && cache.get(url);
+
+  if (cachedResponse === "") {
+    logger.error(CONFIG_RESPONSE_EMPTY_ERROR, {
+      url,
+      service,
+    });
+  }
+
   if (cachedResponse) {
     return {
       ...localToggles,

--- a/src/app/lib/utilities/getToggles/index.js
+++ b/src/app/lib/utilities/getToggles/index.js
@@ -6,7 +6,7 @@ import {
   CONFIG_FETCH_ERROR,
   CONFIG_ERROR,
   TOGGLE_API_RESPONSE_TIME,
-  CONFIG_RESPONSE_EMPTY_ERROR
+  CONFIG_RESPONSE_EMPTY_ERROR,
 } from '#lib/logger.const';
 import getOriginContext from '#contexts/RequestContext/getOriginContext';
 
@@ -48,7 +48,7 @@ const getToggles = async (service, cache) => {
 
   const cachedResponse = cache && cache.get(url);
 
-  if (cachedResponse === "") {
+  if (cachedResponse === '') {
     logger.error(CONFIG_RESPONSE_EMPTY_ERROR, {
       url,
       service,


### PR DESCRIPTION
Part of WSTEAM1-568

Adds a log to record if we receive blank responses from the toggle service.

We appear to be making requests like this that yield empty responses in the browser: https://config.api.bbci.co.uk/?application=simorgh&service=zhongwen&__amp_source_origin=https://www.bbc.co.uk 

We may instead want to make requests with a different `__amp_source_origin`:
https://config.api.bbci.co.uk/?application=simorgh&service=zhongwen&__amp_source_origin=https://www.bbc.com

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
