### PR TITLE
Hide promo timestamp if visual prominence is low and visual style is links

### DIFF
--- a/data/kyrgyz/homePage/index.json
+++ b/data/kyrgyz/homePage/index.json
@@ -823,6 +823,62 @@
         "title": "Vivo feed limitation to 8 Feed/Normal",
         "visualProminence": "NORMAL",
         "visualStyle": "FEED"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "BBC News Русская служба",
+            "firstPublished": "2023-06-12T08:41:37.000Z",
+            "lastPublished": "2023-06-12T18:10:06.000Z",
+            "link": "https://www.bbc.com/russian",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cff8/live/50f3bff0-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "На 87-м году жизни умер Сильвио Берлускони, бывший премьер-министр Италии.",
+            "imageAlt": "BBC News Russian",
+            "id": "af8aec60-3ff7-46ca-b2d2-125082c35310"
+          },
+          {
+            "type": "article",
+            "title": "BBC News Azərbaycanca",
+            "firstPublished": "2023-06-10T08:37:49.000Z",
+            "lastPublished": "2023-06-12T06:59:49.000Z",
+            "link": "https://www.bbc.com/azeri",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ddfa/live/79ea5a40-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Bu gün Ukrayna ordusunun əks-hücum nəticəsində ələ keçirdiyi bir neçə kənddə şadyanalıq etdiyi görüntülər yayılıb. Bu yazıda, həmçinin BBC müxbiri Paul Adams Ukraynanın cənubunda hərbi baxımdan vacib olan vəziyyəti təhlil edir.",
+            "imageAlt": "BBC News Azerbaijean",
+            "id": "fe4c336e-2a26-4764-86c3-d55a9c34d902"
+          },
+          {
+            "type": "article",
+            "title": "BBC News Türkçe",
+            "firstPublished": "2023-06-12T01:34:13.000Z",
+            "lastPublished": "2023-06-12T01:34:13.000Z",
+            "link": "https://www.bbc.com/turkce",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f932/live/a29e6d50-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Cumhurbaşkanı Recep Tayyip Erdoğan, yeniden göreve seçilmesinin ardından ilk yurt dışı ziyaretini Kuzey Kıbrıs'a yaptı. Erdoğan, \"Müzakere masasına geri dönülecekse, bunun yolu Kuzey Kıbrıs Türk Cumhuriyeti'nin tanınmasından geçmektedir\" ifadelerini kullandı. Gelişmeler canlı anlatım sayfamızda.",
+            "imageAlt": "BBC News Türkçe",
+            "id": "a8abee2b-dff0-4254-b0b8-160dd82bf374"
+          },
+          {
+            "type": "article",
+            "title": "BBC News O‘zbek",
+            "firstPublished": "2023-06-12T10:32:19.000Z",
+            "lastPublished": "2023-06-12T10:32:19.000Z",
+            "link": "https://www.bbc.com/uzbek",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4758/live/d4d16110-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Афғонистон расмийлари кўкнори етиштиришга қарши ўзлари чиқарган қарорни қандай бажармоқда? Тадқиқот кутилмаган натижаларни кўрсатди.",
+            "imageAlt": "BBC News O‘zbek",
+            "id": "7d9665d6-ba24-4e98-9c34-1f3e9552a276"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:f5bc486d-7a76-4af5-9c0f-bdd28f04817d",
+        "curationType": "tipo-curation",
+        "position": 7,
+        "title": "Тектеш сайттар",
+        "visualProminence": "LOW",
+        "visualStyle": "LINKS"
       }
     ],
     "metadata": {

--- a/src/app/components/Curation/CurationGrid/index.styles.tsx
+++ b/src/app/components/Curation/CurationGrid/index.styles.tsx
@@ -70,8 +70,11 @@ const styles = {
         },
       },
     }),
-  hideTimestamp: css({
+  hideTimestampAndImage: css({
     '.promo-timestamp': {
+      display: 'none',
+    },
+    '.promo-image': {
       display: 'none',
     },
   }),

--- a/src/app/components/Curation/CurationGrid/index.styles.tsx
+++ b/src/app/components/Curation/CurationGrid/index.styles.tsx
@@ -70,6 +70,11 @@ const styles = {
         },
       },
     }),
+  hideTimestamp: css({
+    '.promo-timestamp': {
+      display: 'none',
+    },
+  }),
 };
 
 export default styles;

--- a/src/app/components/Curation/CurationGrid/index.tsx
+++ b/src/app/components/Curation/CurationGrid/index.tsx
@@ -27,7 +27,7 @@ const CurationGrid = ({
     visualProminence === VISUAL_PROMINENCE.LOW &&
     visualStyle === VISUAL_STYLE.LINKS
   ) {
-    listCss.push(styles.hideTimestamp);
+    listCss.push(styles.hideTimestampAndImage);
   }
 
   return (

--- a/src/app/components/Curation/CurationGrid/index.tsx
+++ b/src/app/components/Curation/CurationGrid/index.tsx
@@ -1,20 +1,39 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
+import {
+  VISUAL_PROMINENCE,
+  VISUAL_STYLE,
+} from '#app/models/types/curationData';
 import styles from './index.styles';
 import CurationPromo from '../CurationPromo';
 import { CurationGridProps } from '../types';
 
-const CurationGrid = ({ promos, headingLevel }: CurationGridProps) => {
+const CurationGrid = ({
+  promos,
+  headingLevel,
+  visualProminence,
+  visualStyle,
+}: CurationGridProps) => {
   const hasMultiplePromos = promos.length > 1;
   const firstPromo = promos[0];
 
   if (promos.length === 0) {
     return null;
   }
+
+  const listCss = [styles.list];
+
+  if (
+    visualProminence === VISUAL_PROMINENCE.LOW &&
+    visualStyle === VISUAL_STYLE.LINKS
+  ) {
+    listCss.push(styles.hideTimestamp);
+  }
+
   return (
     <div data-testid="curation-grid-normal">
       {hasMultiplePromos ? (
-        <ul css={styles.list} role="list" data-testid="topic-promos">
+        <ul css={listCss} role="list" data-testid="topic-promos">
           {promos.map((promo, index) => {
             const isFirstPromo = index === 0;
 

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -72,7 +72,9 @@ const CurationPromo = ({
           </Promo.A>
         )}
       </Promo.Heading>
-      <Promo.Timestamp>{lastPublished}</Promo.Timestamp>
+      <Promo.Timestamp className="promo-timestamp">
+        {lastPublished}
+      </Promo.Timestamp>
     </Promo>
   );
 };

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -95,10 +95,17 @@ const Curation = ({
           <GridComponent
             promos={promos}
             headingLevel={isFirstCuration ? 3 : headingLevel}
+            visualProminence={visualProminence}
+            visualStyle={visualStyle}
           />
         </section>
       ) : (
-        <GridComponent promos={promos} headingLevel={headingLevel} />
+        <GridComponent
+          promos={promos}
+          headingLevel={headingLevel}
+          visualProminence={visualProminence}
+          visualStyle={visualStyle}
+        />
       );
   }
 };

--- a/src/app/components/Curation/types.ts
+++ b/src/app/components/Curation/types.ts
@@ -1,4 +1,8 @@
-import { Summary } from '#app/models/types/curationData';
+import {
+  Summary,
+  VisualProminence,
+  VisualStyle,
+} from '#app/models/types/curationData';
 
 export interface Promo extends Summary {
   mediaType?: 'audio' | 'video' | 'photogallery';
@@ -10,4 +14,6 @@ export interface Promo extends Summary {
 export interface CurationGridProps {
   promos: Promo[];
   headingLevel?: number;
+  visualProminence?: VisualProminence;
+  visualStyle?: VisualStyle;
 }


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Hides the timestamp from all promos in a curation, if the visual prominence is low and the visual style is links. 

Before:
![image](https://github.com/bbc/simorgh/assets/58214768/f5f856a6-58b9-4cab-8829-38a9000f8835)

After:
![image](https://github.com/bbc/simorgh/assets/58214768/566f78b1-3189-41e5-8c7f-db8063254ccf)

See [Kyrgyz Homepage on Storybook](https://hide-timestamp-useful-links--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=kyrgyz&id=pages-home-page--kyrgyz)

Code changes
======
- Use visual prominence and visual style to determine whether to hide the timestamp from the promo
- Update kyrgyz fixture data to match the useful links on live 

Testing
======

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
