### PR TITLE
Don't publish storybook permalink unless Chromatic tests have passed

### DIFF
--- a/.github/workflows/simorgh-misc-checks.yml
+++ b/.github/workflows/simorgh-misc-checks.yml
@@ -40,7 +40,28 @@ jobs:
       - name: Install Node Modules
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./scripts/installNodeModules.sh
+       
+      - name: Chromatic UI Tests
+        uses: chromaui/action@v1
+        if: github.ref != 'refs/heads/latest' && github.event.pull_request.head.repo.full_name == 'bbc/simorgh' # Only run when not on latest or not a fork.
+        with:
+          token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          buildScriptName: 'build:storybook'
+          exitOnceUploaded: true
+          onlyChanged: true
 
+      - name: Chromatic UI Tests - Latest
+        uses: chromaui/action@v1
+        if: github.ref == 'refs/heads/latest' # Only run on latest branch
+        with:
+          token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
+          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          buildScriptName: 'build:storybook'
+          exitOnceUploaded: true
+          onlyChanged: true
+          autoAcceptChanges: true # Auto accept changes to accept a new baseline when merging to latest
+          
       - name: Get Storybook Branch Permalink
         uses: actions/github-script@v6
         id: get-storybook-permalink
@@ -66,27 +87,6 @@ jobs:
             "target_url": "${{ steps.get-storybook-permalink.outputs.STORYBOOK_PERMALINK }}"
           }' \
           --fail
-
-      - name: Chromatic UI Tests
-        uses: chromaui/action@v1
-        if: github.ref != 'refs/heads/latest' && github.event.pull_request.head.repo.full_name == 'bbc/simorgh' # Only run when not on latest or not a fork.
-        with:
-          token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-          buildScriptName: 'build:storybook'
-          exitOnceUploaded: true
-          onlyChanged: true
-
-      - name: Chromatic UI Tests - Latest
-        uses: chromaui/action@v1
-        if: github.ref == 'refs/heads/latest' # Only run on latest branch
-        with:
-          token: ${{ secrets.SIMORGH_DEV_STORYBOOK_RELEASE }}
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-          buildScriptName: 'build:storybook'
-          exitOnceUploaded: true
-          onlyChanged: true
-          autoAcceptChanges: true # Auto accept changes to accept a new baseline when merging to latest
 
       - name: Duplicate Dependency Checker
         run: yarn test:dependencies


### PR DESCRIPTION
Overall changes
======
If Chromatic tests are unable to run for the first time on a PR (e.g. due to failing build / typecheck errors), then the Storybook Permalink task will be marked a success, but the link will return a 404.

This ensures that the link to the branch is not published unless the Chromatic tests have run

Code changes
======

Change order of Storybook Publish tasks in the `Simorgh CI - Licences, Dependencies, Lint, Chromatic UI, NPM Audit` PR check

Testing
======
N/A

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
