### PR TITLE
Do not render image and timestamp if visual prominence is low and visual style is links

### DIFF
--- a/data/kyrgyz/homePage/index.json
+++ b/data/kyrgyz/homePage/index.json
@@ -9,7 +9,7 @@
           {
             "type": "audio",
             "title": "Headline  edited in promo itself test May 2023",
-            "firstPublished": "2023-03-06T13:10:39.425Z",
+            "lastPublished": "2023-03-06T13:10:39.425Z",
             "link": "https://www.test.bbc.com/kyrgyz/articles/c1ldk6kl66wo",
             "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/1575/test/0167c910-f8a3-11ed-bbce-5b0f68ecdb7b.png",
             "description": "Summary edited in promo itself  test May 2023",
@@ -19,7 +19,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 2\r",
-            "firstPublished": "2023-02-02T10:06:00.977Z",
+            "lastPublished": "2023-02-02T10:06:00.977Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cy0pvvd9jvpo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -29,7 +29,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 3\r",
-            "firstPublished": "2023-02-02T10:06:57.156Z",
+            "lastPublished": "2023-02-02T10:06:57.156Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cemg3359nwro",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -39,7 +39,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 4\r",
-            "firstPublished": "2023-02-02T10:07:37.729Z",
+            "lastPublished": "2023-02-02T10:07:37.729Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cp56zz9mg01o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -49,7 +49,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 5\r",
-            "firstPublished": "2023-02-02T10:08:28.652Z",
+            "lastPublished": "2023-02-02T10:08:28.652Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cnk299l1mdgo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -59,7 +59,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 6\r",
-            "firstPublished": "2023-02-02T10:09:07.061Z",
+            "lastPublished": "2023-02-02T10:09:07.061Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c2qz889lr6do",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -69,7 +69,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 7\r",
-            "firstPublished": "2023-02-02T10:09:45.580Z",
+            "lastPublished": "2023-02-02T10:09:45.580Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cy0z22ny3jwo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -79,7 +79,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 8\r",
-            "firstPublished": "2023-02-02T10:10:40.111Z",
+            "lastPublished": "2023-02-02T10:10:40.111Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c0n933z8qnyo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -89,7 +89,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 9\r",
-            "firstPublished": "2023-02-02T10:11:19.977Z",
+            "lastPublished": "2023-02-02T10:11:19.977Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cndr228x0y4o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -99,7 +99,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 10\r",
-            "firstPublished": "2023-02-02T10:11:56.211Z",
+            "lastPublished": "2023-02-02T10:11:56.211Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cx9exxrn6wlo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -109,7 +109,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 11\r",
-            "firstPublished": "2023-02-02T10:13:18.938Z",
+            "lastPublished": "2023-02-02T10:13:18.938Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c12pxxzkzjdo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -119,7 +119,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 12\r",
-            "firstPublished": "2023-02-02T10:13:50.742Z",
+            "lastPublished": "2023-02-02T10:13:50.742Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c4xljjkewl1o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -299,7 +299,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 3\r",
-            "firstPublished": "2023-02-02T10:06:57.156Z",
+            "lastPublished": "2023-02-02T10:06:57.156Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cemg3359nwro",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -309,7 +309,7 @@
           {
             "type": "article",
             "title": "“Баланы сабады деп аялымды камап салышарын өзүм да билген эмесмин”. Кадамжайда токмоктолгон наристенин атасы 2\r",
-            "firstPublished": "2023-02-02T10:06:00.977Z",
+            "lastPublished": "2023-02-02T10:06:00.977Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cy0pvvd9jvpo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/2105/test/a7436f40-a2dd-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -319,7 +319,7 @@
           {
             "type": "article",
             "title": "Article tagged with Trump",
-            "firstPublished": "2023-03-06T13:10:39.425Z",
+            "lastPublished": "2023-03-06T13:10:39.425Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c1ldk6kl66wo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/81e4/test/a035c580-bc1f-11ed-a129-59679bbc34c6.jpg",
             "description": "summary of article",
@@ -329,7 +329,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 4",
-            "firstPublished": "2023-02-02T11:41:09.361Z",
+            "lastPublished": "2023-02-02T11:41:09.361Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cmel5j6wwk2o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -339,7 +339,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 5",
-            "firstPublished": "2023-02-02T11:41:54.105Z",
+            "lastPublished": "2023-02-02T11:41:54.105Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cd0x1jwnw66o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -349,7 +349,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 6",
-            "firstPublished": "2023-02-02T11:42:38.776Z",
+            "lastPublished": "2023-02-02T11:42:38.776Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c65eglnzz1vo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -359,7 +359,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 7",
-            "firstPublished": "2023-02-02T11:43:14.865Z",
+            "lastPublished": "2023-02-02T11:43:14.865Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cj2r5lzp6k0o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -369,7 +369,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 8",
-            "firstPublished": "2023-02-02T11:43:47.440Z",
+            "lastPublished": "2023-02-02T11:43:47.440Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c2qz8l2zn5eo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -379,7 +379,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 9",
-            "firstPublished": "2023-02-02T11:44:19.096Z",
+            "lastPublished": "2023-02-02T11:44:19.096Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cm18pzwq691o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -389,7 +389,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 10",
-            "firstPublished": "2023-02-02T11:45:03.037Z",
+            "lastPublished": "2023-02-02T11:45:03.037Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cr89pqv3el2o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/fedf/test/679106e0-a2ed-11ed-9015-6935ab4fa6ca.jpg",
             "description": "",
@@ -411,7 +411,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар",
-            "firstPublished": "2023-02-06T13:36:00.218Z",
+            "lastPublished": "2023-02-06T13:36:00.218Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cr9p5rw62j7o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -421,7 +421,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 2",
-            "firstPublished": "2023-02-06T13:37:11.912Z",
+            "lastPublished": "2023-02-06T13:37:11.912Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cnk23wye4kyo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -431,7 +431,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 3",
-            "firstPublished": "2023-02-06T13:37:48.118Z",
+            "lastPublished": "2023-02-06T13:37:48.118Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c0n89302mwdo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -441,7 +441,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 4",
-            "firstPublished": "2023-02-06T13:38:21.709Z",
+            "lastPublished": "2023-02-06T13:38:21.709Z",
             "link": "https://www.bbc.com/kyrgyz/articles/clygdvn0vepo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -451,7 +451,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 5",
-            "firstPublished": "2023-02-06T13:38:53.193Z",
+            "lastPublished": "2023-02-06T13:38:53.193Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c0n2glkxx13o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -461,7 +461,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 6",
-            "firstPublished": "2023-02-06T13:39:22.009Z",
+            "lastPublished": "2023-02-06T13:39:22.009Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c85pqkmwkw5o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -471,7 +471,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 7",
-            "firstPublished": "2023-02-06T13:39:55.607Z",
+            "lastPublished": "2023-02-06T13:39:55.607Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c85pqkmz8e2o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -481,7 +481,7 @@
           {
             "type": "article",
             "title": "Кыргыз-өзбек алакаcы: сандар жана фактылар 8",
-            "firstPublished": "2023-02-06T13:40:23.909Z",
+            "lastPublished": "2023-02-06T13:40:23.909Z",
             "link": "https://www.bbc.com/kyrgyz/articles/ck42g152vl6o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/9c84/test/00e66a00-a623-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Өзбекстандын президенти Шавкат Мирзиёев 26-27-январь күндөрү Кыргызстанга мамлекеттик сапар менен келет.",
@@ -504,7 +504,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү",
-            "firstPublished": "2023-02-06T13:45:17.207Z",
+            "lastPublished": "2023-02-06T13:45:17.207Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c6x9vjk8zy2o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -514,7 +514,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 2",
-            "firstPublished": "2023-02-06T13:47:06.980Z",
+            "lastPublished": "2023-02-06T13:47:06.980Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cw1kzjme384o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -524,7 +524,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 3",
-            "firstPublished": "2023-02-06T13:47:34.717Z",
+            "lastPublished": "2023-02-06T13:47:34.717Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c3d1vyrdx21o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -534,7 +534,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 4",
-            "firstPublished": "2023-02-06T13:48:04.311Z",
+            "lastPublished": "2023-02-06T13:48:04.311Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c86jzl31jm5o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -544,7 +544,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 5",
-            "firstPublished": "2023-02-06T13:48:35.778Z",
+            "lastPublished": "2023-02-06T13:48:35.778Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cp567nq7kx6o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -554,7 +554,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 6",
-            "firstPublished": "2023-02-06T13:49:01.557Z",
+            "lastPublished": "2023-02-06T13:49:01.557Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cv748vmk2pno",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -564,7 +564,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 7",
-            "firstPublished": "2023-02-06T13:49:31.970Z",
+            "lastPublished": "2023-02-06T13:49:31.970Z",
             "link": "https://www.bbc.com/kyrgyz/articles/ck9yxzvv7deo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -574,7 +574,7 @@
           {
             "type": "article",
             "title": "Кытайдын жаңы ачык саясаты. Си Цзиньпин саясий багытын өзгөрттү 8",
-            "firstPublished": "2023-02-06T13:50:08.108Z",
+            "lastPublished": "2023-02-06T13:50:08.108Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c380rxlx2z9o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/1ce1/test/49d62d80-a624-11ed-9015-6935ab4fa6ca.jpg",
             "description": "Кытайда кайрадан чоң өзгөрүүлөр орун алууда. КЭРдин төрагасы Си Цзиньпин бир нече жылга созулган катаал саясий нуктан кайра баш тартууда. ",
@@ -597,7 +597,7 @@
           {
             "type": "link",
             "title": "Би-Би-Си ТВ жаңылыктары",
-            "firstPublished": "",
+            "lastPublished": "",
             "link": "https://www.bbc.com/kyrgyz/bbc_kyrgyz_tv/tv_programmes/w13xttqx?limit=4",
             "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/0af7/test/5a5151c0-a3aa-11ed-9015-6935ab4fa6ca.png",
             "description": "Би-Би-Си Кыргыз кызматынын эл аралык жаңылыктарын көрүңүз.",
@@ -620,7 +620,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө",
-            "firstPublished": "2023-02-07T14:51:20.980Z",
+            "lastPublished": "2023-02-07T14:51:20.980Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cr91pzee4dro",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/ae4d/test/a12d7570-a6f6-11ed-9015-6935ab4fa6ca.jpg",
             "description": "\"Эмне үчүн бизди жок кылгысы келди? Бизге эмнеге кыргын салышты?\" - деп суроо салат 83 жаштагы \"цыган Холокостунан\" аман калган Хинта Георге.",
@@ -630,7 +630,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 2",
-            "firstPublished": "2023-02-07T14:52:16.175Z",
+            "lastPublished": "2023-02-07T14:52:16.175Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cd0nevdy25vo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/ae4d/test/a12d7570-a6f6-11ed-9015-6935ab4fa6ca.jpg",
             "description": "\"Эмне үчүн бизди жок кылгысы келди? Бизге эмнеге кыргын салышты?\" - деп суроо салат 83 жаштагы \"цыган Холокостунан\" аман калган Хинта Георге.",
@@ -640,7 +640,7 @@
           {
             "type": "article",
             "title": "Холокостту эскерүү күнү: Унутулган цыган курмандыктары эстеликтерди сактап калуу үчүн күрөшүүдө 3",
-            "firstPublished": "2023-02-07T14:52:44.188Z",
+            "lastPublished": "2023-02-07T14:52:44.188Z",
             "link": "https://www.bbc.com/kyrgyz/articles/czmnz5184jeo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/ae4d/test/a12d7570-a6f6-11ed-9015-6935ab4fa6ca.jpg",
             "description": "\"Эмне үчүн бизди жок кылгысы келди? Бизге эмнеге кыргын салышты?\" - деп суроо салат 83 жаштагы \"цыган Холокостунан\" аман калган Хинта Георге.",
@@ -663,7 +663,7 @@
             "type": "audio",
             "duration": "PT5M52S",
             "title": "Би-Би-Си дүрбүсүндө",
-            "firstPublished": "",
+            "lastPublished": "",
             "link": "https://www.bbc.com/kyrgyz/podcasts/p0c80v81/p0fpqkrq",
             "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0c80xlp.jpg",
             "description": "Кадыр Кошалиев: Курманбек Бакиевди актоо максатым эмес...",
@@ -674,7 +674,7 @@
             "type": "audio",
             "duration": "PT1M39S",
             "title": "Би-Би-Си дүрбүсүндө",
-            "firstPublished": "",
+            "lastPublished": "",
             "link": "https://www.bbc.com/kyrgyz/podcasts/p0c80v81/p0fnzmkf",
             "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0c80xlp.jpg",
             "description": "Батыштагы жетекчилер украин армиясы контрчабуулга күчөтүлгөн даярдык жөнүндө билдирүүдө",
@@ -685,7 +685,7 @@
             "type": "audio",
             "duration": "PT3M12S",
             "title": "Би-Би-Си дүрбүсүндө",
-            "firstPublished": "",
+            "lastPublished": "",
             "link": "https://www.bbc.com/kyrgyz/podcasts/p0c80v81/p0fnb85d",
             "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0c80xlp.jpg",
             "description": "Британия Украинага 250 км алыс учкан Storm Shadow ракеталарын берет",
@@ -696,7 +696,7 @@
             "type": "audio",
             "duration": "PT4M48S",
             "title": "Би-Би-Си дүрбүсүндө",
-            "firstPublished": "",
+            "lastPublished": "",
             "link": "https://www.bbc.com/kyrgyz/podcasts/p0c80v81/p0fkxv40",
             "imageUrl": "https://ichef.bbci.co.uk/images/ic/{width}xn/p0c80xlp.jpg",
             "description": "АКШ чалгын кызматы: Украинада 20 миң россиялык курман болду",
@@ -720,7 +720,7 @@
             "type": "video",
             "duration": "PT30S",
             "title": "\"Сапар\": Дүйнөнү өзгөрткөн айымдар",
-            "firstPublished": "2023-02-02T11:56:17.767Z",
+            "lastPublished": "2023-02-02T11:56:17.767Z",
             "link": "https://www.bbc.com/kyrgyz/articles/c6rgpy2y00qo",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/566e/test/6a6de0b0-a2f0-11ed-b0be-cf2bcb458493.png",
             "description": "",
@@ -731,7 +731,7 @@
             "type": "video",
             "duration": "PT30S",
             "title": "\"Сапар\": Дүйнөнү өзгөрткөн айымдар 2",
-            "firstPublished": "2023-02-02T11:56:49.913Z",
+            "lastPublished": "2023-02-02T11:56:49.913Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cd0nz6e5lj0o",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/566e/test/6a6de0b0-a2f0-11ed-b0be-cf2bcb458493.png",
             "description": "",
@@ -742,7 +742,7 @@
             "type": "video",
             "duration": "PT30S",
             "title": "\"Сапар\": Дүйнөнү өзгөрткөн айымдар 3",
-            "firstPublished": "2023-02-02T11:57:11.013Z",
+            "lastPublished": "2023-02-02T11:57:11.013Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cle6ylr495ko",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/566e/test/6a6de0b0-a2f0-11ed-b0be-cf2bcb458493.png",
             "description": "",
@@ -753,7 +753,7 @@
             "type": "video",
             "duration": "PT30S",
             "title": "\"Сапар\": Дүйнөнү өзгөрткөн айымдар 4",
-            "firstPublished": "2023-02-02T11:57:24.839Z",
+            "lastPublished": "2023-02-02T11:57:24.839Z",
             "link": "https://www.bbc.com/kyrgyz/articles/cd0qkxer6rko",
             "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsdevpb/566e/test/6a6de0b0-a2f0-11ed-b0be-cf2bcb458493.png",
             "description": "",
@@ -775,7 +775,7 @@
           {
             "type": "article",
             "title": "Kyrgyzstanda soz erkindigi buzuluuda",
-            "firstPublished": "2016-11-07T08:16:20.000Z",
+            "lastPublished": "2016-11-07T08:16:20.000Z",
             "link": "https://www.bbc.com/kyrgyz/world-23089413",
             "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/17324/test/_63521059_0362cabb-9d4d-4a6f-b538-2b314913c31a.jpg",
             "description": "Soz erkindigin chektoo turaluu jiyin ottu",
@@ -785,7 +785,7 @@
           {
             "type": "article",
             "title": "Үй-бүлөдөгү зомбулуктан эң көп аялдар жабыркайт",
-            "firstPublished": "2016-11-03T14:43:31.000Z",
+            "lastPublished": "2016-11-03T14:43:31.000Z",
             "link": "https://www.bbc.com/kyrgyz/kyrgyzstan-23088783",
             "imageUrl": "https://ichef.test.bbci.co.uk/ace/standard/{width}/cpsdevpb/06A6/test/_63520710_23088783.jpg",
             "description": "Үй-бүлөдөгү зомбулуктан эң көп аялдар жабыркайт",
@@ -823,6 +823,62 @@
         "title": "Vivo feed limitation to 8 Feed/Normal",
         "visualProminence": "NORMAL",
         "visualStyle": "FEED"
+      },
+      {
+        "summaries": [
+          {
+            "type": "article",
+            "title": "BBC News Русская служба",
+            "firstPublished": "2023-06-12T08:41:37.000Z",
+            "lastPublished": "2023-06-12T18:10:06.000Z",
+            "link": "https://www.bbc.com/russian",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/cff8/live/50f3bff0-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "На 87-м году жизни умер Сильвио Берлускони, бывший премьер-министр Италии.",
+            "imageAlt": "BBC News Russian",
+            "id": "af8aec60-3ff7-46ca-b2d2-125082c35310"
+          },
+          {
+            "type": "article",
+            "title": "BBC News Azərbaycanca",
+            "firstPublished": "2023-06-10T08:37:49.000Z",
+            "lastPublished": "2023-06-12T06:59:49.000Z",
+            "link": "https://www.bbc.com/azeri",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/ddfa/live/79ea5a40-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Bu gün Ukrayna ordusunun əks-hücum nəticəsində ələ keçirdiyi bir neçə kənddə şadyanalıq etdiyi görüntülər yayılıb. Bu yazıda, həmçinin BBC müxbiri Paul Adams Ukraynanın cənubunda hərbi baxımdan vacib olan vəziyyəti təhlil edir.",
+            "imageAlt": "BBC News Azerbaijean",
+            "id": "fe4c336e-2a26-4764-86c3-d55a9c34d902"
+          },
+          {
+            "type": "article",
+            "title": "BBC News Türkçe",
+            "firstPublished": "2023-06-12T01:34:13.000Z",
+            "lastPublished": "2023-06-12T01:34:13.000Z",
+            "link": "https://www.bbc.com/turkce",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/f932/live/a29e6d50-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Cumhurbaşkanı Recep Tayyip Erdoğan, yeniden göreve seçilmesinin ardından ilk yurt dışı ziyaretini Kuzey Kıbrıs'a yaptı. Erdoğan, \"Müzakere masasına geri dönülecekse, bunun yolu Kuzey Kıbrıs Türk Cumhuriyeti'nin tanınmasından geçmektedir\" ifadelerini kullandı. Gelişmeler canlı anlatım sayfamızda.",
+            "imageAlt": "BBC News Türkçe",
+            "id": "a8abee2b-dff0-4254-b0b8-160dd82bf374"
+          },
+          {
+            "type": "article",
+            "title": "BBC News O‘zbek",
+            "firstPublished": "2023-06-12T10:32:19.000Z",
+            "lastPublished": "2023-06-12T10:32:19.000Z",
+            "link": "https://www.bbc.com/uzbek",
+            "imageUrl": "https://ichef.bbci.co.uk/ace/standard/{width}/cpsprodpb/4758/live/d4d16110-091c-11ee-b5af-25e80c61c11a.png",
+            "description": "Афғонистон расмийлари кўкнори етиштиришга қарши ўзлари чиқарган қарорни қандай бажармоқда? Тадқиқот кутилмаган натижаларни кўрсатди.",
+            "imageAlt": "BBC News O‘zbek",
+            "id": "7d9665d6-ba24-4e98-9c34-1f3e9552a276"
+          }
+        ],
+        "activePage": 1,
+        "pageCount": 1,
+        "curationId": "urn:bbc:tipo:list:f5bc486d-7a76-4af5-9c0f-bdd28f04817d",
+        "curationType": "tipo-curation",
+        "position": 7,
+        "title": "Тектеш сайттар",
+        "visualProminence": "LOW",
+        "visualStyle": "LINKS"
       }
     ],
     "metadata": {

--- a/src/app/components/Curation/CurationGrid/index.tsx
+++ b/src/app/components/Curation/CurationGrid/index.tsx
@@ -1,16 +1,30 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
+import {
+  VISUAL_PROMINENCE,
+  VISUAL_STYLE,
+} from '#app/models/types/curationData';
 import styles from './index.styles';
 import CurationPromo from '../CurationPromo';
 import { CurationGridProps } from '../types';
 
-const CurationGrid = ({ promos, headingLevel }: CurationGridProps) => {
+const CurationGrid = ({
+  promos,
+  headingLevel,
+  visualProminence,
+  visualStyle,
+}: CurationGridProps) => {
   const hasMultiplePromos = promos.length > 1;
   const firstPromo = promos[0];
 
   if (promos.length === 0) {
     return null;
   }
+
+  const isLowProminenceLinks =
+    visualProminence === VISUAL_PROMINENCE.LOW &&
+    visualStyle === VISUAL_STYLE.LINKS;
+
   return (
     <div data-testid="curation-grid-normal">
       {hasMultiplePromos ? (
@@ -24,6 +38,8 @@ const CurationGrid = ({ promos, headingLevel }: CurationGridProps) => {
                   {...promo}
                   headingLevel={headingLevel}
                   lazy={!isFirstPromo}
+                  hideImage={isLowProminenceLinks}
+                  hideTimestamp={isLowProminenceLinks}
                 />
               </li>
             );
@@ -31,7 +47,11 @@ const CurationGrid = ({ promos, headingLevel }: CurationGridProps) => {
         </ul>
       ) : (
         <div css={styles.item} key={firstPromo.id}>
-          <CurationPromo {...firstPromo} />
+          <CurationPromo
+            {...firstPromo}
+            hideImage={isLowProminenceLinks}
+            hideTimestamp={isLowProminenceLinks}
+          />
         </div>
       )}
     </div>

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/aria-role */
-import React, { useContext } from 'react';
+import React, { Fragment, useContext } from 'react';
 import moment from 'moment';
 import path from 'ramda/src/path';
 import formatDuration from '#app/lib/utilities/formatDuration';
@@ -20,6 +20,8 @@ const CurationPromo = ({
   type,
   duration: mediaDuration,
   headingLevel = 2,
+  hideImage = false,
+  hideTimestamp = false,
 }: CurationPromoProps) => {
   const { isAmp } = useContext(RequestContext);
   const { translations } = useContext(ServiceContext);
@@ -36,6 +38,9 @@ const CurationPromo = ({
   const durationString = `${durationTranslation}, ${formattedDuration}`;
 
   const showDuration = mediaDuration && ['video', 'audio'].includes(type);
+  const showTimestamp = !hideTimestamp;
+  const showImage = !hideImage;
+
   const isMedia = ['video', 'audio', 'photogallery'].includes(type);
   const typeTranslated =
     (type === 'audio' && `${audioTranslation}, `) ||
@@ -44,11 +49,21 @@ const CurationPromo = ({
 
   return (
     <Promo>
-      <Promo.Image src={imageUrl} alt={imageAlt} lazyLoad={lazy} isAmp={isAmp}>
-        <Promo.MediaIcon type={type}>
-          {showDuration ? mediaDuration : ''}
-        </Promo.MediaIcon>
-      </Promo.Image>
+      {/* @ts-expect-error HACK */}
+      {showImage && (
+        <Promo.Image
+          src={imageUrl}
+          alt={imageAlt}
+          lazyLoad={lazy}
+          isAmp={isAmp}
+        >
+          <Promo.MediaIcon type={type}>
+            {showDuration ? mediaDuration : ''}
+          </Promo.MediaIcon>
+        </Promo.Image>
+      )}
+
+      {/* @ts-expect-error HACK */}
       <Promo.Heading as={`h${headingLevel}`}>
         {isMedia ? (
           <Promo.A
@@ -72,7 +87,11 @@ const CurationPromo = ({
           </Promo.A>
         )}
       </Promo.Heading>
-      <Promo.Timestamp>{lastPublished}</Promo.Timestamp>
+      {showTimestamp && (
+        <Promo.Timestamp className="promo-timestamp">
+          {lastPublished}
+        </Promo.Timestamp>
+      )}
     </Promo>
   );
 };

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -49,8 +49,7 @@ const CurationPromo = ({
 
   return (
     <Promo>
-      {/* @ts-expect-error HACK */}
-      {showImage && (
+      {showImage ? (
         <Promo.Image
           src={imageUrl}
           alt={imageAlt}
@@ -61,9 +60,9 @@ const CurationPromo = ({
             {showDuration ? mediaDuration : ''}
           </Promo.MediaIcon>
         </Promo.Image>
+      ) : (
+        <></>
       )}
-
-      {/* @ts-expect-error HACK */}
       <Promo.Heading as={`h${headingLevel}`}>
         {isMedia ? (
           <Promo.A
@@ -87,10 +86,12 @@ const CurationPromo = ({
           </Promo.A>
         )}
       </Promo.Heading>
-      {showTimestamp && (
+      {showTimestamp ? (
         <Promo.Timestamp className="promo-timestamp">
           {lastPublished}
         </Promo.Timestamp>
+      ) : (
+        <></>
       )}
     </Promo>
   );

--- a/src/app/components/Curation/CurationPromo/index.tsx
+++ b/src/app/components/Curation/CurationPromo/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/aria-role */
-import React, { Fragment, useContext } from 'react';
+import React, { useContext } from 'react';
 import moment from 'moment';
 import path from 'ramda/src/path';
 import formatDuration from '#app/lib/utilities/formatDuration';

--- a/src/app/components/Curation/index.tsx
+++ b/src/app/components/Curation/index.tsx
@@ -95,10 +95,17 @@ const Curation = ({
           <GridComponent
             promos={promos}
             headingLevel={isFirstCuration ? 3 : headingLevel}
+            visualProminence={visualProminence}
+            visualStyle={visualStyle}
           />
         </section>
       ) : (
-        <GridComponent promos={promos} headingLevel={headingLevel} />
+        <GridComponent
+          promos={promos}
+          headingLevel={headingLevel}
+          visualProminence={visualProminence}
+          visualStyle={visualStyle}
+        />
       );
   }
 };

--- a/src/app/components/Curation/types.ts
+++ b/src/app/components/Curation/types.ts
@@ -1,13 +1,21 @@
-import { Summary } from '#app/models/types/curationData';
+import {
+  Summary,
+  VisualProminence,
+  VisualStyle,
+} from '#app/models/types/curationData';
 
 export interface Promo extends Summary {
   mediaType?: 'audio' | 'video' | 'photogallery';
   duration?: string | number;
   lazy?: boolean;
   headingLevel?: number;
+  hideTimestamp?: boolean;
+  hideImage?: boolean;
 }
 
 export interface CurationGridProps {
   promos: Promo[];
   headingLevel?: number;
+  visualProminence?: VisualProminence;
+  visualStyle?: VisualStyle;
 }


### PR DESCRIPTION
Overall changes
======
Hides the timestamp from all promos in a curation, if the visual prominence is low and the visual style is links. 

Before:
![image](https://github.com/bbc/simorgh/assets/58214768/f5f856a6-58b9-4cab-8829-38a9000f8835)

After:
![image](https://github.com/bbc/simorgh/assets/58214768/566f78b1-3189-41e5-8c7f-db8063254ccf)


See [Kyrgyz Homepage on Storybook](https://remove-timestamp-image-useful-links--5d28eb3fe163f6002046d6fa.chromatic.com/iframe.html?args=&knob-Select%20a%20service=kyrgyz&id=pages-home-page--kyrgyz)

Code changes
======
- Use visual prominence and visual style to determine whether to hide the timestamp from the promo
- Update kyrgyz fixture data to match the useful links on live 

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
