### PR TITLE
WSTEAMA-649 - Add view and click tracking to radio schedule component

### DIFF
--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -12,6 +12,7 @@ import {
 } from '#psammead/psammead-styles/src/font-styles';
 import { getPica } from '#psammead/gel-foundations/src/typography';
 import { GEL_SPACING } from '#psammead/gel-foundations/src/spacings';
+import useClickTrackerHandler from '#app/hooks/useClickTrackerHandler';
 import VisuallyHiddenText from '../../../../components/VisuallyHiddenText';
 import { ServiceContext } from '../../../../contexts/ServiceContext';
 import durationDictionary, { programStateConfig } from '../utilities';
@@ -66,6 +67,12 @@ const ScheduleItemHeader = ({
 
   const isLive = state === 'live';
   const isNext = state === 'next';
+
+  const eventTrackingData = {
+    componentName: `radio-schedule-${state}`,
+  };
+
+  const clickTrackerHandler = useClickTrackerHandler(eventTrackingData);
 
   const listenLive = pathOr(
     'Listen Live',
@@ -153,6 +160,7 @@ const ScheduleItemHeader = ({
       as={linkComponent}
       {...linkProps}
       className="focusIndicatorDisplayBlock"
+      onClick={clickTrackerHandler}
     >
       {content}
     </StyledLink>

--- a/src/app/legacy/components/RadioSchedule/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.jsx
@@ -8,6 +8,7 @@ import {
 import { grid } from '#psammead/psammead-styles/src/detection';
 import Grid from '#psammead/psammead-grid/src';
 import { arrayOf, number, shape, string } from 'prop-types';
+import useViewTracker from '#app/hooks/useViewTracker';
 import { ServiceContext } from '../../../contexts/ServiceContext';
 import ProgramCard from './ProgramCard';
 import StartTime from './StartTime';
@@ -66,8 +67,21 @@ const programGridProps = {
 
 const RadioSchedule = ({ schedule, ...props }) => {
   const { dir } = useContext(ServiceContext);
+
+  const eventTrackingData = {
+    componentName: 'radio-schedule',
+  };
+
+  const viewRef = useViewTracker(eventTrackingData);
+
   return (
-    <StyledGrid forwardedAs="ul" dir={dir} {...schedulesGridProps} role="list">
+    <StyledGrid
+      forwardedAs="ul"
+      dir={dir}
+      {...schedulesGridProps}
+      role="list"
+      ref={viewRef}
+    >
       {schedule.map(({ id, ...program }) => (
         <StyledFlexGrid
           dir={dir}

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -37,7 +37,7 @@ describe('RadioSchedule', () => {
   });
 
   describe('Event Tracking', () => {
-    const blockLevelEventTrackingData = {
+    const eventTrackingData = {
       componentName: 'radio-schedule',
     };
 
@@ -53,7 +53,7 @@ describe('RadioSchedule', () => {
         }),
       );
 
-      expect(viewTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
+      expect(viewTrackerSpy).toHaveBeenCalledWith(eventTrackingData);
     });
 
     it('should call the click tracking hook with the correct params', () => {

--- a/src/app/legacy/components/RadioSchedule/index.test.jsx
+++ b/src/app/legacy/components/RadioSchedule/index.test.jsx
@@ -1,6 +1,9 @@
 import { render } from '../../../components/react-testing-library-with-providers';
 import arabic from '../../../components/ThemeProvider/fontScripts/arabic';
+import latin from '../../../components/ThemeProvider/fontScripts/latin';
 import { renderRadioSchedule } from './testHelpers/helper';
+import * as viewTracking from '../../../hooks/useViewTracker';
+import * as clickTracking from '../../../hooks/useClickTrackerHandler';
 
 describe('RadioSchedule', () => {
   it('should render ltr radio schedules correctly', () => {
@@ -31,5 +34,46 @@ describe('RadioSchedule', () => {
     expect(
       container.getElementsByTagName('aside')[0].getAttribute('to'),
     ).toEqual('/news/articles/cn7k01xp8kxo');
+  });
+
+  describe('Event Tracking', () => {
+    const blockLevelEventTrackingData = {
+      componentName: 'radio-schedule',
+    };
+
+    it('should call the view tracking hook with the correct params', () => {
+      const viewTrackerSpy = jest.spyOn(viewTracking, 'default');
+      render(
+        renderRadioSchedule({
+          service: 'hausa',
+          script: latin,
+          dir: 'ltr',
+          locale: 'ha',
+          selectedService: 'hausa',
+        }),
+      );
+
+      expect(viewTrackerSpy).toHaveBeenCalledWith(blockLevelEventTrackingData);
+    });
+
+    it('should call the click tracking hook with the correct params', () => {
+      const clickTrackerSpy = jest.spyOn(clickTracking, 'default');
+      render(
+        renderRadioSchedule({
+          service: 'hausa',
+          script: latin,
+          dir: 'ltr',
+          locale: 'ha',
+          selectedService: 'hausa',
+        }),
+      );
+
+      expect(clickTrackerSpy).toHaveBeenNthCalledWith(1, {
+        componentName: 'radio-schedule-live',
+      });
+      expect(clickTrackerSpy).toHaveBeenNthCalledWith(2, {
+        componentName: 'radio-schedule-onDemand',
+      });
+    });
   });
 });


### PR DESCRIPTION
Resolves JIRA [[649](https://jira.dev.bbc.co.uk/browse/WSTEAMA-649)]

Overall changes
======

This PR aims to add ATI view and click tracking to our radio schedule component. 

Code changes
======

- View tracking added inside radio schedule component
- Click tracking added inside component link

Testing
======
Adding new unit tests to account for both view and click trackers and also tested locally by navigating to urls for each page type affected, and checking that both trackers work as expected. URLs below:
- Front Page [http://localhost:7080/hausa?renderer_env=live](http://localhost:7080/hausa?renderer_env=live)
- Live Radio Page [http://localhost:7080/afrique/bbc_afrique_radio/liveradio?renderer_env=live](http://localhost:7080/afrique/bbc_afrique_radio/liveradio?renderer_env=live)
- On Demand Audio Page [http://localhost:7080/swahili/bbc_swahili_radio/w172x94ky63591m?renderer_env=live](http://localhost:7080/swahili/bbc_swahili_radio/w172x94ky63591m?renderer_env=live)
- IDX Page [http://localhost:7080/persian/afghanistan?renderer_env=live](http://localhost:7080/persian/afghanistan?renderer_env=live)

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
