### PR TITLE
FIX: some map files missing when URLs contained special chars

### DIFF
--- a/scripts/bundleSize/pageTypeBundleExtractor.test.js
+++ b/scripts/bundleSize/pageTypeBundleExtractor.test.js
@@ -34,16 +34,16 @@ const modernBundleReport = {
         { name: 'static/js/modern.commons-92a4fe01.6f43e2d7.js' },
         { name: 'static/js/modern.commons-92a4fe01.6f43e2d7.js.map' },
         {
-          name: 'static/js/modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA=-31ecd969.898fb3aa.js',
+          name: 'static/js/modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA-31ecd969.898fb3aa.js',
         },
         {
-          name: 'static/js/modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA=-31ecd969.898fb3aa.js.map',
+          name: 'static/js/modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA-31ecd969.898fb3aa.js.map',
         },
         {
-          name: 'static/js/modern.shared-nj6qIml+EtJxDVgSunxJydSAIpY=-253ae210.3f8a9c3a.js',
+          name: 'static/js/modern.shared-nj6qImlEtJxDVgSunxJydSAIpY-253ae210.3f8a9c3a.js',
         },
         {
-          name: 'static/js/modern.shared-nj6qIml+EtJxDVgSunxJydSAIpY=-253ae210.3f8a9c3a.js.map',
+          name: 'static/js/modern.shared-nj6qImlEtJxDVgSunxJydSAIpY-253ae210.3f8a9c3a.js.map',
         },
         { name: 'static/js/modern.ArticlePage-31ecd969.ee810b86.js' },
         { name: 'static/js/modern.ArticlePage-31ecd969.ee810b86.js.map' },
@@ -73,8 +73,8 @@ describe('pageTypeBundleExtractor', () => {
       'modern.commons-7d359b94.ced895c9.js',
       'modern.commons-8493eda2.7bb97fc0.js',
       'modern.commons-92a4fe01.6f43e2d7.js',
-      'modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA=-31ecd969.898fb3aa.js',
-      'modern.shared-nj6qIml+EtJxDVgSunxJydSAIpY=-253ae210.3f8a9c3a.js',
+      'modern.shared-UddsGWzeoXsaLwaRPMwTQELcfA-31ecd969.898fb3aa.js',
+      'modern.shared-nj6qImlEtJxDVgSunxJydSAIpY-253ae210.3f8a9c3a.js',
       'modern.ArticlePage-31ecd969.ee810b86.js',
     ]);
   });

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -170,7 +170,9 @@ module.exports = ({
               return [
                 'shared',
                 chunkName === 'russian-ukrainian' ? chunkName : cryptoName,
-              ].join('-').replace(/[=\+\/]/g, '');
+              ]
+                .join('-')
+                .replace(/[=+\/]/g, '');
             },
             priority: 10,
             minChunks: 2,

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -165,13 +165,12 @@ module.exports = ({
               const cryptoName = crypto
                 .createHash('sha1')
                 .update(chunkName)
-                .digest('base64')
-                .replace(/\//g, '');
+                .digest('base64');
 
               return [
                 'shared',
                 chunkName === 'russian-ukrainian' ? chunkName : cryptoName,
-              ].join('-');
+              ].join('-').replace(/[=\+\/]/g, '');
             },
             priority: 10,
             minChunks: 2,

--- a/webpack.config.client.js
+++ b/webpack.config.client.js
@@ -172,7 +172,7 @@ module.exports = ({
                 chunkName === 'russian-ukrainian' ? chunkName : cryptoName,
               ]
                 .join('-')
-                .replace(/[=+\/]/g, '');
+                .replace(/[=+/]/g, '');
             },
             priority: 10,
             minChunks: 2,


### PR DESCRIPTION
every now and again we have a bunch of map files that 404 / 403

e.g. today we have 3, one of which is https://static.files.bbci.co.uk/ws/simorgh-assets/public/static/js/modern.shared-DY2+CQjI7FwSmiRJuk8BPQTudEo=.b61f6030.js.map

I wondered why that was and then realised it was urlencoding..

The JS file is being served as https://static.files.bbci.co.uk/ws/simorgh-assets/public/static/js/modern.shared-DY2%2BCQjI7FwSmiRJuk8BPQTudEo%3D.b61f6030.js and the request going through the pipes needs to be https://static.files.bbci.co.uk/ws/simorgh-assets/public/static/js/modern.shared-DY2%2BCQjI7FwSmiRJuk8BPQTudEo%3D.b61f6030.js.map

Anyway, instead of sorting out a hellhole of things to allow the use of + and = in URLs (JS and sourcemap files) I have just removed them from the chunk name string.