### PR TITLE
WSTEAM1-576 - Adjusts russian disclaimer link coverage on text

### DIFF
--- a/src/app/lib/config/services/russian.ts
+++ b/src/app/lib/config/services/russian.ts
@@ -304,13 +304,12 @@ export const service: DefaultServiceConfig = {
       },
     },
     disclaimer: {
-      para1: 'Подпишитесь на нашу рассылку «',
-      para2: {
-        text: 'Контекст',
+      para1: {
+        text: 'Подпишитесь на нашу рассылку «Контекст»:',
         url: 'https://www.bbc.com/russian/resources/idt-b34bb7dd-f094-4722-92eb-cf7aff8cc1bc',
         isExternal: false,
       },
-      para3: '»: она поможет вам разобраться в событиях.',
+      para2: ' она поможет вам разобраться в событиях.',
     },
     radioSchedule: {
       hasRadioSchedule: false,

--- a/src/app/models/types/serviceConfig.ts
+++ b/src/app/models/types/serviceConfig.ts
@@ -74,13 +74,12 @@ export type ServiceConfig = {
   showRelatedTopics: boolean;
   podcastPromo?: PodcastPromo;
   disclaimer?: {
-    para1: string;
-    para2: {
+    para1: {
       text: string;
       url: string;
       isExternal: boolean;
     };
-    para3: string;
+    para2: string;
   };
   translations: Translations;
   mostRead: MostRead;


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-576](https://jira.dev.bbc.co.uk/browse/WSTEAM1-576)

Overall changes
======
Extends link context for Russian disclaimer

Before:
![image](https://github.com/bbc/simorgh/assets/4706195/04add5f4-8ae8-47d4-8256-430f614f8bf4)

After:
![image](https://github.com/bbc/simorgh/assets/4706195/5ea17c78-3219-41d5-8985-4f72bb61fdda)


Code changes
======

- Removes para3 from disclaimer json object
- Merges Link to appear across more of the disclaimer text

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
