### PR TITLE
Increase Puppeteer timeout

### DIFF
--- a/puppeteer/bundleRequests.test.js
+++ b/puppeteer/bundleRequests.test.js
@@ -15,7 +15,7 @@ let requests = [];
 
 const isJsBundle = url => url.includes(localBaseUrl);
 
-jest.setTimeout(10000); // overriding the default jest timeout
+jest.setTimeout(20000); // overriding the default jest timeout
 
 const getServiceBundleRegex = service => {
   const SHARED_RUSSIAN_UKRAINIAN = 'shared-russian-ukrainian';

--- a/puppeteer/rich-text-transforms.test.js
+++ b/puppeteer/rich-text-transforms.test.js
@@ -15,7 +15,7 @@ let requests = [];
 
 const richTextTransformsBundleRegex = /rich-text-transforms.*\.js/;
 
-jest.setTimeout(10000); // overriding the default jest timeout
+jest.setTimeout(20000); // overriding the default jest timeout
 
 describe('rich-text-transforms JS bundle request', () => {
   beforeAll(async () => {
@@ -24,7 +24,7 @@ describe('rich-text-transforms JS bundle request', () => {
     });
     page = await browser.newPage();
 
-    page.on('request', (request) => {
+    page.on('request', request => {
       requests.push(request.url());
     });
   });
@@ -33,15 +33,15 @@ describe('rich-text-transforms JS bundle request', () => {
     await browser.close();
   });
 
-  Object.keys(config).forEach((service) => {
+  Object.keys(config).forEach(service => {
     Object.keys(config[service].pageTypes)
       .filter(
-        (pageType) =>
+        pageType =>
           pageType === 'mediaAssetPage' &&
           shouldSmokeTest(pageType, service) &&
           serviceHasPageType(service, pageType),
       )
-      .forEach((pageType) => {
+      .forEach(pageType => {
         const paths = getPaths(service, pageType);
 
         if (paths.length > 0) {
@@ -60,9 +60,7 @@ describe('rich-text-transforms JS bundle request', () => {
 
             it('does not load the rich-text-transforms bundle on initial page load', async () => {
               expect(
-                requests.some((url) =>
-                  url.match(richTextTransformsBundleRegex),
-                ),
+                requests.some(url => url.match(richTextTransformsBundleRegex)),
               ).toEqual(false);
             });
 
@@ -81,14 +79,12 @@ describe('rich-text-transforms JS bundle request', () => {
                 page.waitForNavigation({ waitUntil: 'networkidle2' }),
               ]);
 
-              await page.waitForRequest((request) =>
+              await page.waitForRequest(request =>
                 request.url().match(richTextTransformsBundleRegex),
               );
 
               expect(
-                requests.some((url) =>
-                  url.match(richTextTransformsBundleRegex),
-                ),
+                requests.some(url => url.match(richTextTransformsBundleRegex)),
               ).toEqual(true);
             });
           });


### PR DESCRIPTION
Overall changes
======
- Puppeteer actions have been fairly consistently failing since the Node 18 upgrade due to timeouts. Re-runs _typically_ make it pass, but its a bit annoying to do. This increases the overall time from 10secs to 20secs to see if it will mitigate the issue.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
