### PR TITLE
WSTEAMA-666 & WSTEAMA-674: Migrate gahuza and somali to tipo homepage (Thurs 7th September)

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -1604,23 +1604,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      frontPage: {
-        environments: {
-          live: {
-            paths: ['/gahuza'],
-            enabled: false,
-          },
-          test: {
-            paths: ['/gahuza'],
-            enabled: false,
-          },
-          local: {
-            paths: ['/gahuza'],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      frontPage: { environments: undefined, smoke: false },
       liveRadio: {
         environments: {
           live: {
@@ -6363,23 +6347,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      frontPage: {
-        environments: {
-          live: {
-            paths: ['/somali'],
-            enabled: false,
-          },
-          test: {
-            paths: ['/somali'],
-            enabled: false,
-          },
-          local: {
-            paths: ['/somali'],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      frontPage: { environments: undefined, smoke: false },
       liveRadio: {
         environments: {
           live: {

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -555,10 +555,12 @@ describe('frontPage -> homePage migration', () => {
     'amharic',
     'azeri',
     'burmese',
+    'gahuza',
     'gujarati',
     'igbo',
     'kyrgyz',
     'pidgin',
+    'somali',
     'tigrinya',
     'yoruba',
   ];

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -39,10 +39,12 @@ const homePageServices = [
   'amharic',
   'azeri',
   'burmese',
+  'gahuza',
   'gujarati',
   'igbo',
   'kyrgyz',
   'pidgin',
+  'somali',
   'tigrinya',
   'yoruba',
 ];


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-666 & https://jira.dev.bbc.co.uk/browse/WSTEAMA-674

Overall changes
======
Migrates Gahuza & Somali to the new Tipo Homepage

Code changes
======
- Add gahuza and somali to the list of migrated frontpages
- Remove gahuza & somali front page cypress tests
- Update tests

Testing
======


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
