### PR TITLE
WSTEAMA-678 & WSTEAMA-682: Migrate punjabi and sinhala to tipo homepage (Tues 12th Sept)

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -5364,23 +5364,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      frontPage: {
-        environments: {
-          live: {
-            paths: ['/punjabi'],
-            enabled: false,
-          },
-          test: {
-            paths: ['/punjabi'],
-            enabled: false,
-          },
-          local: {
-            paths: ['/punjabi'],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      frontPage: { environments: undefined, smoke: false },
       liveRadio: { environments: undefined, smoke: false },
       onDemandAudio: { environments: undefined, smoke: false },
       onDemandTV: { environments: undefined, smoke: false },
@@ -6171,23 +6155,7 @@ module.exports = () => ({
         },
         smoke: false,
       },
-      frontPage: {
-        environments: {
-          live: {
-            paths: ['/sinhala'],
-            enabled: false,
-          },
-          test: {
-            paths: ['/sinhala'],
-            enabled: false,
-          },
-          local: {
-            paths: ['/sinhala'],
-            enabled: false,
-          },
-        },
-        smoke: false,
-      },
+      frontPage: { environments: undefined, smoke: false },
       liveRadio: { environments: undefined, smoke: false },
       onDemandAudio: { environments: undefined, smoke: false },
       onDemandTV: { environments: undefined, smoke: false },

--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -560,6 +560,8 @@ describe('frontPage -> homePage migration', () => {
     'igbo',
     'kyrgyz',
     'pidgin',
+    'punjabi',
+    'sinhala',
     'somali',
     'tigrinya',
     'yoruba',

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -44,6 +44,8 @@ const homePageServices = [
   'igbo',
   'kyrgyz',
   'pidgin',
+  'punjabi',
+  'sinhala',
   'somali',
   'tigrinya',
   'yoruba',


### PR DESCRIPTION
Resolves JIRA  https://jira.dev.bbc.co.uk/browse/WSTEAMA-678 and https://jira.dev.bbc.co.uk/browse/WSTEAMA-682

Overall changes
======
Migrates Punjabi & Sinhala to the new Tipo Homepage

Code changes
======
- Add punjabi and sinhala to the list of migrated frontpages
- Remove punjabi & sinhala front page cypress tests
- Update tests

Testing
======


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
