### PR TITLE
WSTEAM1-610: Add response to context object

### DIFF
--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -16,6 +16,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   const { headers: reqHeaders } = context.req;
 
+  context.res.statusCode = 404;
   return {
     props: {
       bbcOrigin: reqHeaders['bbc-origin'] || null,

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
@@ -123,6 +123,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     pageType: LIVE_PAGE,
   });
 
+  context.res.statusCode = data.status;
   return {
     props: {
       bbcOrigin: reqHeaders['bbc-origin'] || null,


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Adds the status to the context object, so that this can be fed back to the AWS load balancer.

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
