### PR TITLE
ENH: turn off recs for older items

### DIFF
--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -18,6 +18,7 @@ const bffArticleJson = {
       metadata: {
         allowAdvertising: true,
         consumableAsSFV: true,
+        lastPublished: 2041342869,
       },
       promo: {},
       relatedContent: {},

--- a/src/app/routes/article/getInitialData/index.test.ts
+++ b/src/app/routes/article/getInitialData/index.test.ts
@@ -18,7 +18,7 @@ const bffArticleJson = {
       metadata: {
         allowAdvertising: true,
         consumableAsSFV: true,
-        lastPublished: 2041342869,
+        lastPublished: 2041342869000,
       },
       promo: {},
       relatedContent: {},

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -71,7 +71,7 @@ export default async ({
     const shouldGetOnwardsPageData = lastPublished
       ? new Date(lastPublished).getFullYear() > new Date().getFullYear() - 2
       : false;
-    if (pathname.indexOf('c0000000000o') !== -1 || shouldGetOnwardsPageData) {
+    if (shouldGetOnwardsPageData) {
       try {
         wsojData = await getOnwardsPageData({
           pathname,

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -67,17 +67,23 @@ export default async ({
     const isAdvertising = advertisingAllowed(pageType, article);
     const isArticleSfv = isSfv(article);
     let wsojData = [];
-    try {
-      wsojData = await getOnwardsPageData({
-        pathname,
-        service,
-        variant,
-        isAdvertising,
-        isArticleSfv,
-        agent,
-      });
-    } catch (error) {
-      logger.error('Recommendations JSON malformed', error);
+    const lastPublished = article?.metadata?.lastPublished;
+    const shouldGetOnwardsPageData = lastPublished
+      ? new Date(lastPublished).getFullYear() > new Date().getFullYear() - 2
+      : false;
+    if (shouldGetOnwardsPageData) {
+      try {
+        wsojData = await getOnwardsPageData({
+          pathname,
+          service,
+          variant,
+          isAdvertising,
+          isArticleSfv,
+          agent,
+        });
+      } catch (error) {
+        logger.error('Recommendations JSON malformed', error);
+      }
     }
 
     const { topStories, features, latestMedia, mostRead, mostWatched } =

--- a/src/app/routes/article/getInitialData/index.ts
+++ b/src/app/routes/article/getInitialData/index.ts
@@ -71,7 +71,7 @@ export default async ({
     const shouldGetOnwardsPageData = lastPublished
       ? new Date(lastPublished).getFullYear() > new Date().getFullYear() - 2
       : false;
-    if (shouldGetOnwardsPageData) {
+    if (pathname.indexOf('c0000000000o') !== -1 || shouldGetOnwardsPageData) {
       try {
         wsojData = await getOnwardsPageData({
           pathname,


### PR DESCRIPTION
Recommendations for older items are often failing, creating large logfiles as a consequence.

This PR turns off recommendations for articles older than 2 years (crass approach used, but it doesn't need to be more complicated imho)

*Note*: for tests to pass, I've added a lastPublished time ot the Fri Sep 08 2034 to the test data. So the tests will start failing in over a decade. Again, could make them more simple, but for now...

¯(°_o)/¯ 