### PR TITLE
Remove igbo test article and disable E2E article tests on live environment

### DIFF
--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -2388,9 +2388,7 @@ module.exports = () => ({
       articles: {
         environments: {
           live: {
-            paths: [
-              '/igbo/articles/c0jgdy9d841o',
-            ],
+            paths: ['/igbo/articles/c0jgdy9d841o'],
             enabled: false,
           },
           test: {

--- a/cypress/support/config/settings.js
+++ b/cypress/support/config/settings.js
@@ -2389,10 +2389,9 @@ module.exports = () => ({
         environments: {
           live: {
             paths: [
-              '/igbo/articles/ckjn8jnrn75o',
               '/igbo/articles/c0jgdy9d841o',
             ],
-            enabled: true,
+            enabled: false,
           },
           test: {
             paths: ['/igbo/articles/cr1lw620ygjo'],


### PR DESCRIPTION
The most read tests often fail due to the test article appearing in the list without a title

Resolves JIRA 

Overall changes
======
Since Igbo is one of the smaller services, running scheduled E2Es often results in the test article appearing in the most read list, but because it does not have a title (but even if it did have a title, it means "test article please ignore" in Igbo - which we would not want appearing on the homepage anyway). 



Code changes
======

Testing
======


Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
