### PR TITLE
Increase test timeout to stabilise flaky unit test

### DIFF
--- a/src/app/routes/index.test.jsx
+++ b/src/app/routes/index.test.jsx
@@ -437,7 +437,7 @@ describe('Main page routes', () => {
     expect(
       await screen.findByText(EXPECTED_TEXT_RENDERED_IN_DOCUMENT),
     ).toBeInTheDocument();
-  }, 10000);
+  }, 15000);
 
   it('should route to and render an index page', async () => {
     process.env.SIMORGH_APP_ENV = 'local';


### PR DESCRIPTION
Overall changes
======
The following test has been failing a lot recently:

```
FAIL  src/app/routes/index.test.jsx (56.694 s)
  ● Main page routes › should route to and render a story page
```
![image](https://github.com/bbc/simorgh/assets/58214768/8ac515f5-122d-4bfe-a4c6-08cc2496da38)

Code changes
======
Increase timeout for the test

Testing
======
- [ ] Unit tests pass consistently

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
