### PR TITLE
Re-add `role=text` to Copyright component

### DIFF
--- a/src/app/components/Copyright/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Copyright/__snapshots__/index.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`should render Copyright with news service context 1`] = `
 <div>
   <p
     class="emotion-0"
+    role="text"
   >
     <span
       class="emotion-1"
@@ -113,6 +114,7 @@ exports[`should render Copyright with persian service context 1`] = `
 <div>
   <p
     class="emotion-0"
+    role="text"
   >
     <span
       class="emotion-1"

--- a/src/app/components/Copyright/index.tsx
+++ b/src/app/components/Copyright/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/aria-role */
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
@@ -11,7 +12,13 @@ const CopyrightContainer = ({ children }: PropsWithChildren) => {
   const { imageCopyrightOffscreenText, lang } = useContext(ServiceContext);
 
   return (
-    <Text as="p" fontVariant="sansRegular" size="minion" css={styles.copyright}>
+    <Text
+      as="p"
+      role="text"
+      fontVariant="sansRegular"
+      size="minion"
+      css={styles.copyright}
+    >
       {imageCopyrightOffscreenText ? (
         <VisuallyHiddenText>{imageCopyrightOffscreenText}</VisuallyHiddenText>
       ) : null}

--- a/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/ImageWithCaption/__snapshots__/index.test.tsx.snap
@@ -262,6 +262,7 @@ exports[`Image with data should render an image with alt text and offscreen copy
       </picture>
       <p
         class="emotion-3"
+        role="text"
       >
         <span
           class="emotion-4"
@@ -383,6 +384,7 @@ exports[`Image with data should render an image with other originCode - this wou
       </picture>
       <p
         class="emotion-3"
+        role="text"
       >
         <span
           class="emotion-4"

--- a/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/MediaAssetPage/__snapshots__/index.test.jsx.snap
@@ -1320,6 +1320,7 @@ exports[`Media Asset Page AV player should render version (live audio stream) 1`
                     </picture>
                     <p
                       class="emotion-113"
+                      role="text"
                     >
                       <span
                         class="emotion-4"
@@ -3493,6 +3494,7 @@ exports[`Media Asset Page should render component 1`] = `
                     </picture>
                     <p
                       class="emotion-106"
+                      role="text"
                     >
                       <span
                         class="emotion-4"
@@ -3549,6 +3551,7 @@ exports[`Media Asset Page should render component 1`] = `
                     </picture>
                     <p
                       class="emotion-106"
+                      role="text"
                     >
                       <span
                         class="emotion-4"

--- a/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/PhotoGalleryPage/__snapshots__/index.test.jsx.snap
@@ -5354,6 +5354,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5410,6 +5411,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5466,6 +5468,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5522,6 +5525,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5578,6 +5582,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5634,6 +5639,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -5690,6 +5696,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with no onwa
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7169,6 +7176,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7225,6 +7233,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7281,6 +7290,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7337,6 +7347,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7393,6 +7404,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7449,6 +7461,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7505,6 +7518,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7561,6 +7575,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7617,6 +7632,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7673,6 +7689,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7729,6 +7746,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7785,6 +7803,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7841,6 +7860,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7897,6 +7917,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -7953,6 +7974,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -8009,6 +8031,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -8065,6 +8088,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -8121,6 +8145,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"
@@ -8177,6 +8202,7 @@ exports[`Photo Gallery Page snapshots should match snapshot for PGL with non-CPS
                     </picture>
                     <p
                       class="emotion-22"
+                      role="text"
                     >
                       <span
                         class="emotion-23"

--- a/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/StoryPage/__snapshots__/index.test.jsx.snap
@@ -1888,6 +1888,7 @@ exports[`Story Page should render correctly when the secondary column data is no
                       </picture>
                       <p
                         class="emotion-29"
+                        role="text"
                       >
                         <span
                           class="emotion-30"
@@ -2055,6 +2056,7 @@ exports[`Story Page should render correctly when the secondary column data is no
                       </picture>
                       <p
                         class="emotion-29"
+                        role="text"
                       >
                         <span
                           class="emotion-30"
@@ -4975,6 +4977,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </picture>
                       <p
                         class="emotion-29"
+                        role="text"
                       >
                         <span
                           class="emotion-30"
@@ -5142,6 +5145,7 @@ exports[`Story Page snapshots should match snapshot for STY 1`] = `
                       </picture>
                       <p
                         class="emotion-29"
+                        role="text"
                       >
                         <span
                           class="emotion-30"


### PR DESCRIPTION
Overall changes
======
- Re-adds the `role='text'` attribute to the `<Copyright />` component that was uplifted. I missed that this attribute was getting set in the `defaultProps` of the old component: https://github.com/bbc/simorgh/blob/a30ef5e3b4daa586b3b6923ebc4ca00c6d000b6f/src/app/legacy/psammead/psammead-copyright/src/index.jsx#L29-L32

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
