### PR TITLE
South Asia sites: Navigation and Features box updates after Tipo migration 

### DIFF
--- a/src/app/lib/config/services/bengali.ts
+++ b/src/app/lib/config/services/bengali.ts
@@ -247,7 +247,7 @@ export const service: DefaultServiceConfig = {
         linkText: 'View the full version of the page to see all the content.',
       },
       topStoriesTitle: 'প্রধান খবর',
-      featuresAnalysisTitle: 'চিঠিপত্র ও মতামত',
+      featuresAnalysisTitle: 'নির্বাচিত খবর',
       latestMediaTitle: 'সর্বশেষ',
     },
     mostRead: {
@@ -346,6 +346,10 @@ export const service: DefaultServiceConfig = {
       {
         title: 'ভিডিও',
         url: '/bengali/topics/cxy7jg418e7t',
+      },
+      {
+        title: 'সর্বাধিক পঠিত',
+        url: '/bengali/popular/read',
       },
     ],
   },

--- a/src/app/lib/config/services/marathi.ts
+++ b/src/app/lib/config/services/marathi.ts
@@ -263,7 +263,7 @@ export const service: DefaultServiceConfig = {
         linkText: 'View the full version of the page to see all the content.',
       },
       topStoriesTitle: 'मोठ्या बातम्या',
-      featuresAnalysisTitle: 'Features',
+      featuresAnalysisTitle: 'बीबीसी मराठी स्पेशल',
       latestMediaTitle: 'नवीनतम',
     },
     mostRead: {

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -315,8 +315,12 @@ export const service: DefaultServiceConfig = {
         url: '/sinhala/topics/c83plvepnq1t',
       },
       {
-        title: 'විශේෂාංග',
-        url: '/sinhala/51727586',
+        title: 'වීඩියෝ',
+        url: '/sinhala/topics/crldzm9n2lnt',
+      },
+      {
+        title: 'කලා',
+        url: '/sinhala/topics/c7zp5zxk8jxt',
       },
     ],
   },

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -341,10 +341,6 @@ export const service: DefaultServiceConfig = {
         url: '/urdu/topics/cjgn7n9zzq7t',
       },
       {
-        title: 'الیکشن 2023',
-        url: '/urdu/topics/cynd7qxprq0t',
-      },
-      {
         title: 'آس پاس',
         url: '/urdu/topics/cl8l9mveql2t',
       },

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
@@ -223,47 +223,40 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2023",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,40 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2023",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/amp.test.js.snap
@@ -223,8 +223,15 @@ exports[`AMP Sinhala Live Radio Page Header Navigation link should match text an
 
 exports[`AMP Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "විශේෂාංග",
-  "url": "/sinhala/51727586",
+  "text": "වීඩියෝ",
+  "url": "/sinhala/topics/crldzm9n2lnt",
+}
+`;
+
+exports[`AMP Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
+{
+  "text": "කලා",
+  "url": "/sinhala/topics/c7zp5zxk8jxt",
 }
 `;
 

--- a/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/liveRadio/sinhala/__snapshots__/canonical.test.js.snap
@@ -82,8 +82,15 @@ exports[`Canonical Sinhala Live Radio Page Header Navigation link should match t
 
 exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "විශේෂාංග",
-  "url": "/sinhala/51727586",
+  "text": "වීඩියෝ",
+  "url": "/sinhala/topics/crldzm9n2lnt",
+}
+`;
+
+exports[`Canonical Sinhala Live Radio Page Header Navigation link should match text and url 5`] = `
+{
+  "text": "කලා",
+  "url": "/sinhala/topics/c7zp5zxk8jxt",
 }
 `;
 

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
@@ -212,47 +212,40 @@ exports[`AMP Most Watched Page Header Navigation link should match text and url 
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2023",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,47 +82,40 @@ exports[`Canonical Most Watched Page Header Navigation link should match text an
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 3`] = `
 {
-  "text": "الیکشن 2023",
-  "url": "/urdu/topics/cynd7qxprq0t",
-}
-`;
-
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
-{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 9`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",


### PR DESCRIPTION
Resolves JIRA n/a

Upated the navigation bar of Bengali, Sinhala, and Urdu to reflect changes required by editorial after the sites have migrated to Tipo. Fixed/Updated the Bengali and Marathi headings of the Features box on articles


Code changes
======

- Removed election topic link from Navigation section of src/app/lib/config/services/urdu.ts
- Removed link to FIX and added links to Art and Video topics in the navigation section of src/app/lib/config/services/sinhala.ts
- Added Most read lnk to the Navigation section of src/app/lib/config/services/bengali.ts
- Replaced Incorrect English text in featuresAnalysisTitle: on  src/app/lib/config/services/marathi.ts
- Replaced text in featuresAnalysisTitle: on  src/app/lib/config/services/bengali.ts so that it matches the new section heading on the front page

Testing
======
1. Open bbc.com/urdu third link on the nav bar, there should be no link to الیکشن 2023 (https://www.bbc.com/urdu/topics/cynd7qxprq0t)
2. Open bbc.com/bengali, last link on the nav bar should point to /bengali/popular/read
3. Open bbc.com/sinhala, last two links on the nav bar should point to /sinhala/topics/crldzm9n2lnt and /sinhala/topics/c7zp5zxk8jxt
4. Open an article on bbc.com/marathi. On the right hand column the heading of the Features box under Top stories should be 'बीबीसी मराठी स्पेशल' not 'Features'
5. Open an article on bbc.com/bengali. On the right hand column the heading of the Features box under Top stories should be 'নির্বাচিত খবর'


