### PR TITLE
WSTEAM1-465: Update Live Page to pass a page number 

### DIFF
--- a/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
@@ -32,6 +32,12 @@ interface PageDataParams extends ParsedUrlQuery {
 
 const logger = nodeLogger(__filename);
 
+const isValidPage = (page: string) => {
+  const parsedPageNumber = parseInt(page, 10);
+
+  return parsedPageNumber >= 1 && parsedPageNumber <= 40;
+};
+
 const getPageData = async ({
   id,
   page,
@@ -96,10 +102,25 @@ export const getServerSideProps: GetServerSideProps = async context => {
     service,
     variant,
     // renderer_env: rendererEnv,
-    page,
+    page = '1',
   } = context.query as PageDataParams;
 
   const { headers: reqHeaders } = context.req;
+
+  if (!isValidPage(page)) {
+    context.res.statusCode = 404;
+    return {
+      props: {
+        bbcOrigin: reqHeaders['bbc-origin'] || null,
+        isNextJs: true,
+        service,
+        status: 404,
+        timeOnServer: Date.now(),
+        variant: variant?.[0] || null,
+        ...extractHeaders(reqHeaders),
+      },
+    };
+  }
 
   logger.info(SERVER_SIDE_RENDER_REQUEST_RECEIVED, {
     url: context.resolvedUrl,

--- a/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/new_live/[id]/[[...variant]].page.tsx
@@ -20,6 +20,7 @@ import getAgent from '../../../../utilities/undiciAgent';
 
 import LivePageLayout from './LivePageLayout';
 import extractHeaders from '../../../../../src/server/utilities/extractHeaders';
+import isValidPageNumber from '../../../../utilities/pageQueryValidator';
 
 interface PageDataParams extends ParsedUrlQuery {
   id: string;
@@ -31,12 +32,6 @@ interface PageDataParams extends ParsedUrlQuery {
 }
 
 const logger = nodeLogger(__filename);
-
-const isValidPage = (page: string) => {
-  const parsedPageNumber = parseInt(page, 10);
-
-  return parsedPageNumber >= 1 && parsedPageNumber <= 40;
-};
 
 const getPageData = async ({
   id,
@@ -107,7 +102,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   const { headers: reqHeaders } = context.req;
 
-  if (!isValidPage(page)) {
+  if (!isValidPageNumber(page)) {
     context.res.statusCode = 404;
     return {
       props: {

--- a/ws-nextjs-app/utilities/pageQueryValidator/index.test.ts
+++ b/ws-nextjs-app/utilities/pageQueryValidator/index.test.ts
@@ -1,0 +1,15 @@
+import isValidPageNumber from '.';
+
+describe('Query Validator', () => {
+  it.each([
+    ['-1', false],
+    ['1', true],
+    ['40', true],
+    ['41', false],
+  ])(
+    'should evaluate a page number %s to %s',
+    (pageNumber, expectedValidationResult) => {
+      expect(isValidPageNumber(pageNumber)).toBe(expectedValidationResult);
+    },
+  );
+});

--- a/ws-nextjs-app/utilities/pageQueryValidator/index.test.ts
+++ b/ws-nextjs-app/utilities/pageQueryValidator/index.test.ts
@@ -4,8 +4,8 @@ describe('Query Validator', () => {
   it.each([
     ['-1', false],
     ['1', true],
-    ['40', true],
-    ['41', false],
+    ['50', true],
+    ['51', false],
   ])(
     'should evaluate a page number %s to %s',
     (pageNumber, expectedValidationResult) => {

--- a/ws-nextjs-app/utilities/pageQueryValidator/index.ts
+++ b/ws-nextjs-app/utilities/pageQueryValidator/index.ts
@@ -1,0 +1,7 @@
+const isValidPageNumber = (page: string) => {
+  const parsedPageNumber = parseInt(page, 10);
+
+  return parsedPageNumber >= 1 && parsedPageNumber <= 40;
+};
+
+export default isValidPageNumber;

--- a/ws-nextjs-app/utilities/pageQueryValidator/index.ts
+++ b/ws-nextjs-app/utilities/pageQueryValidator/index.ts
@@ -1,7 +1,13 @@
+const MINIMUM_PAGE_NUMBER = 1;
+const MAXIMUM_PAGE_NUMBER = 50;
+
 const isValidPageNumber = (page: string) => {
   const parsedPageNumber = parseInt(page, 10);
 
-  return parsedPageNumber >= 1 && parsedPageNumber <= 40;
+  return (
+    parsedPageNumber >= MINIMUM_PAGE_NUMBER &&
+    parsedPageNumber <= MAXIMUM_PAGE_NUMBER
+  );
 };
 
 export default isValidPageNumber;


### PR DESCRIPTION
Resolves JIRA  [WSTEAM1-465](https://jira.dev.bbc.co.uk/browse/WSTEAM1-465)

Overall changes
======
Update page number support for the Live Page.

Code changes
======

- Set the Live Page to render page 1 as a default.
- Serve a 404 for page requests below 1 and above 50.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
