### PR TITLE
WSTEAMA-771 - Batch services Indonesia, Thai, Vietnamese go live for new Home Pages

### DIFF
--- a/src/app/routes/utils/regex/index.test.js
+++ b/src/app/routes/utils/regex/index.test.js
@@ -560,6 +560,7 @@ describe('frontPage -> homePage migration', () => {
     'gahuza',
     'gujarati',
     'igbo',
+    'indonesia',
     'kyrgyz',
     'marathi',
     'nepali',
@@ -569,8 +570,10 @@ describe('frontPage -> homePage migration', () => {
     'somali',
     'tamil',
     'telugu',
+    'thai',
     'tigrinya',
     'urdu',
+    'vietnamese',
     'yoruba',
   ];
   const migratedWorldServiceRoutes = migratedServices.map(serviceToRoute);

--- a/src/app/routes/utils/regex/utils/index.js
+++ b/src/app/routes/utils/regex/utils/index.js
@@ -43,6 +43,7 @@ const homePageServices = [
   'gahuza',
   'gujarati',
   'igbo',
+  'indonesia',
   'kyrgyz',
   'marathi',
   'nepali',
@@ -52,8 +53,10 @@ const homePageServices = [
   'somali',
   'tamil',
   'telugu',
+  'thai',
   'tigrinya',
   'urdu',
+  'vietnamese',
   'yoruba',
 ];
 


### PR DESCRIPTION
Resolves JIRA [[771](https://jira.dev.bbc.co.uk/browse/WSTEAMA-771)] & [[775](https://jira.dev.bbc.co.uk/browse/WSTEAMA-775)] & [[771](https://jira.dev.bbc.co.uk/browse/WSTEAMA-771)]

Overall changes
======

Currently there is logic in Simorgh to determine whether to render a frontpage or a homepage, based on the service & the environment.

This PR aims to update this logic to ensure that on all environments - local, test, live, that the homepage is rendered when `service=indonesia` and when `service=thai` and when `service=vietnamese`

Code changes
======

- Indonesia, Thai and Vietnamese services added to array of migrated services inside frontpage to homepage migration test.
- Updates logic to ensure that when navigating to `/indonesia` or `/thai` or `vietnamese`, a homepage is rendered instead of a frontpage.


Testing
======

Helpful Links
======

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)