### PR TITLE
Post Tipo migration fixes for si and vi plus updates for ur, pt and hi

### DIFF
--- a/src/app/lib/config/services/hindi.ts
+++ b/src/app/lib/config/services/hindi.ts
@@ -47,16 +47,16 @@ export const service: DefaultServiceConfig = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'पॉडकास्ट',
-      brandTitle: 'छोटी उम्र बड़ी ज़िंदगी',
+      brandTitle: 'दिनभर: पूरा दिन,पूरी ख़बर (Dinbhar)',
       brandDescription:
-        'उन चमकते सितारों की कहानी जिन्हें दुनिया अभी और देखना और सुनना चाहती थी.',
+        'वो राष्ट्रीय और अंतरराष्ट्रीय ख़बरें जो दिनभर सुर्खियां बनीं.',
       image: {
-        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p0fmrcw1.jpg',
-        alt: 'छोटी उम्र बड़ी ज़िंदगी',
+        src: 'https://ichef.bbci.co.uk/images/ic/$recipe/p09ds7cb.jpg',
+        alt: 'दिनभर',
       },
       linkLabel: {
         text: 'दिनभर: पूरा दिन,पूरी ख़बर',
-        href: 'https://www.bbc.com/hindi/podcasts/p0fmrg25',
+        href: 'https://www.bbc.com/hindi/podcasts/p09ds7zx',
       },
       skipLink: {
         text: 'छोड़कर %title% आगे बढ़ें',

--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -49,16 +49,15 @@ export const service: DefaultServiceConfig = {
     showRelatedTopics: true,
     podcastPromo: {
       title: 'Podcast',
-      brandTitle: 'Brasil Partido',
-      brandDescription:
-        'João Fellet tenta entender como brasileiros chegaram ao grau atual de divisão.',
+      brandTitle: 'BBC Lê',
+      brandDescription: 'Podcast traz áudios com reportagens selecionadas.',
       image: {
-        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p0d67gkg.jpg',
-        alt: 'Logo: Brasil Partido',
+        src: 'https://ichef.bbc.co.uk/images/ic/$recipe/p09qw181.jpg',
+        alt: 'Logo: BBC Lê',
       },
       linkLabel: {
         text: 'Episódios',
-        href: 'https://www.bbc.com/portuguese/podcasts/p0cyhvny',
+        href: 'https://www.bbc.com/portuguese/topics/cxndrr1qgllt',
       },
       skipLink: {
         text: 'Pule %title% e continue lendo',

--- a/src/app/lib/config/services/sinhala.ts
+++ b/src/app/lib/config/services/sinhala.ts
@@ -245,7 +245,7 @@ export const service: DefaultServiceConfig = {
         linkText: 'අන්තර්ගතයේ සියල්ල දැක ගැනීමට පිටුවේ සම්පූර්ණ අනුවාදය බලන්න',
       },
       topStoriesTitle: 'ප්‍රධාන පුවත',
-      featuresAnalysisTitle: 'දැක්ම',
+      featuresAnalysisTitle: 'විශේෂාංග',
       latestMediaTitle: 'අලුත්ම',
     },
     mostRead: {

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -345,6 +345,10 @@ export const service: DefaultServiceConfig = {
         url: '/urdu/topics/cl8l9mveql2t',
       },
       {
+        title: 'الیکشن 2024',
+        url: '/urdu/topics/cynd7qxprq0t',
+      },
+      {
         title: 'ورلڈ',
         url: '/urdu/topics/cw57v2pmll9t',
       },

--- a/src/app/lib/config/services/urdu.ts
+++ b/src/app/lib/config/services/urdu.ts
@@ -341,12 +341,12 @@ export const service: DefaultServiceConfig = {
         url: '/urdu/topics/cjgn7n9zzq7t',
       },
       {
-        title: 'آس پاس',
-        url: '/urdu/topics/cl8l9mveql2t',
-      },
-      {
         title: 'الیکشن 2024',
         url: '/urdu/topics/cynd7qxprq0t',
+      },
+      {
+        title: 'آس پاس',
+        url: '/urdu/topics/cl8l9mveql2t',
       },
       {
         title: 'ورلڈ',

--- a/src/app/lib/config/services/vietnamese.ts
+++ b/src/app/lib/config/services/vietnamese.ts
@@ -246,7 +246,7 @@ export const service: DefaultServiceConfig = {
         linkText: 'Xin xem bản đầy đủ.',
       },
       topStoriesTitle: 'Tin chính',
-      featuresAnalysisTitle: 'Góc nhìn và chuyên mục',
+      featuresAnalysisTitle: 'BBC giới thiệu',
       latestMediaTitle: 'Mới nhất',
     },
     mostRead: {
@@ -323,10 +323,6 @@ export const service: DefaultServiceConfig = {
       {
         title: 'Thế giới',
         url: '/vietnamese/topics/cnlv9j1ekq0t',
-      },
-      {
-        title: 'Diễn đàn',
-        url: '/vietnamese/forum-54540875',
       },
       {
         title: 'Kinh tế',

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/amp.test.js.snap
@@ -223,40 +223,47 @@ exports[`AMP Feature Index page Header Navigation link should match text and url
 
 exports[`AMP Feature Index page Header Navigation link should match text and url 3`] = `
 {
+  "text": "الیکشن 2024",
+  "url": "/urdu/topics/cynd7qxprq0t",
+}
+`;
+
+exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`AMP Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/featureIdxPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,40 +82,47 @@ exports[`Canonical Feature Index page Header Navigation link should match text a
 
 exports[`Canonical Feature Index page Header Navigation link should match text and url 3`] = `
 {
+  "text": "الیکشن 2024",
+  "url": "/urdu/topics/cynd7qxprq0t",
+}
+`;
+
+exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Feature Index page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Feature Index page Header Navigation link should match text and url 9`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/amp.test.js.snap
@@ -230,33 +230,26 @@ exports[`AMP Most Read Page Header Navigation link should match text and url 3`]
 
 exports[`AMP Most Read Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Diễn đàn",
-  "url": "/vietnamese/forum-54540875",
-}
-`;
-
-exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Kinh tế",
   "url": "/vietnamese/topics/cez1ey7nzj3t",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Nhịp sống mới",
   "url": "/vietnamese/magazine-54029179",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Thể thao",
   "url": "/vietnamese/topics/ckdxnx1k7zxt",
 }
 `;
 
-exports[`AMP Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Video",
   "url": "/vietnamese/topics/cl29j0ekkvdt",

--- a/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostReadPage/vietnamese/__snapshots__/canonical.test.js.snap
@@ -89,33 +89,26 @@ exports[`Canonical Most Read Page Header Navigation link should match text and u
 
 exports[`Canonical Most Read Page Header Navigation link should match text and url 4`] = `
 {
-  "text": "Diễn đàn",
-  "url": "/vietnamese/forum-54540875",
-}
-`;
-
-exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
-{
   "text": "Kinh tế",
   "url": "/vietnamese/topics/cez1ey7nzj3t",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Nhịp sống mới",
   "url": "/vietnamese/magazine-54029179",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Thể thao",
   "url": "/vietnamese/topics/ckdxnx1k7zxt",
 }
 `;
 
-exports[`Canonical Most Read Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Read Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Video",
   "url": "/vietnamese/topics/cl29j0ekkvdt",

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/amp.test.js.snap
@@ -212,40 +212,47 @@ exports[`AMP Most Watched Page Header Navigation link should match text and url 
 
 exports[`AMP Most Watched Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "الیکشن 2024",
+  "url": "/urdu/topics/cynd7qxprq0t",
+}
+`;
+
+exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
+{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 4`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`AMP Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`AMP Most Watched Page Header Navigation link should match text and url 9`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",

--- a/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/mostWatchedPage/urdu/__snapshots__/canonical.test.js.snap
@@ -82,40 +82,47 @@ exports[`Canonical Most Watched Page Header Navigation link should match text an
 
 exports[`Canonical Most Watched Page Header Navigation link should match text and url 3`] = `
 {
+  "text": "الیکشن 2024",
+  "url": "/urdu/topics/cynd7qxprq0t",
+}
+`;
+
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
+{
   "text": "آس پاس",
   "url": "/urdu/topics/cl8l9mveql2t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
 {
   "text": "ورلڈ",
   "url": "/urdu/topics/cw57v2pmll9t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
 {
   "text": "کھیل",
   "url": "/urdu/topics/c340q0p2585t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
 {
   "text": "فن فنکار",
   "url": "/urdu/topics/ckdxnx900n5t",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 7`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
 {
   "text": "سائنس",
   "url": "/urdu/topics/c40379e2ymxt",
 }
 `;
 
-exports[`Canonical Most Watched Page Header Navigation link should match text and url 8`] = `
+exports[`Canonical Most Watched Page Header Navigation link should match text and url 9`] = `
 {
   "text": "ویڈیو",
   "url": "/urdu/topics/c1e0mzr3r2yt",


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Update the Vietnamese navigaton and the feature box heading for Vietnamese and Sinhala. Add link to election topic to Urdu navigation. Update podcast promos for Brasil and Hindi

Code changes
======
- changed DefaultServiceConfig > default > translations > featuresAnalysisTitle in src/app/lib/config/services/sinhala.ts
- changed DefaultServiceConfig > default > translations > featuresAnalysisTitle and removed fourth link (Diễn đàn) in the navigation section of src/app/lib/config/services/vietnamese.ts
- added link to /urdu/topics/cynd7qxprq0t to the navigaton section of src/app/lib/config/services/urdu.ts
- updated pocastPromo in src/app/lib/config/services/portuguese.ts
- updated pocastPromo in src/app/lib/config/services/hindi.ts
- updated spanshots


Testing
======
1. Open an article on BBC Sinhala on the right hand side column the heading of the Feautures box should be 'විශේෂාංග',
2. Open the front page of BBC Vietnamese, Diễn đàn (/vietnamese/forum-54540875) should no longer appear as fourth item in the navigation
3. Open an article on BBC Vietnamese on the right hand side column the heading of the Feautures box should be 'BBC giới thiệu'
4.  Open an article on BBC Portuguese the podcast promo should show the BBC Lê podcast and point to /portuguese/topics/cxndrr1qgllt
5. Open an article on BBC Hindi the podcast promo should show the Dinbhar podcast and point to https://www.bbc.com/hindi/podcasts/p09ds7zx



Helpful Links
======


[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
