### PR TITLE
WSTEAMA-823 - Include Psammead LiveLabel component in Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,6 +22,7 @@ module.exports = {
     './DocsDecorator/**/*.stories.@(t|j)sx',
     './StorybookComponents/**/*.stories.@(t|j)sx',
     './SidebarLabel/**/*.stories.@(t|j)sx',
+    '../src/app/legacy/psammead/psammead-live-label/src/index.stories.jsx',
   ],
   addons: [
     '@storybook/addon-knobs',


### PR DESCRIPTION
Resolves JIRA [[823](https://jira.dev.bbc.co.uk/browse/WSTEAMA-823)]

Overall changes
======

PR to add the legacy LiveLabel component onto Storybook so we have a comparison while we migrate/add the component to the New Components menu.

Code changes
======

- Adds a path to the legacy LiveLabel component inside stories array to include and display the component on Storybook.

Testing
======

- Run `yarn storybook` from your terminal while checked out to the branch to see the component in your browser.
- Or visit [https://wsteama-823-include-psammead-live-lab--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/components-livelabel--with-english-live-text](https://wsteama-823-include-psammead-live-lab--5d28eb3fe163f6002046d6fa.chromatic.com/?path=/story/components-livelabel--with-english-live-text) to just view the component in your browser.
