### PR TITLE
Remove `externalDir` option in favour of `transpilePackages`

### DIFF
--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -27,6 +27,11 @@ module.exports = {
   },
   generateEtags: false,
   output: 'standalone',
+  /*
+   Requires pages that are routed to have the .page extension, e.g. [variant].page.tsx,
+   which allows for co-locating components within the pages directory, e.g. styles.ts
+   - https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions#including-non-page-files-in-the-pages-directory
+  */
   pageExtensions: ['page.tsx', 'page.ts'],
   poweredByHeader: false,
   reactStrictMode: true,

--- a/ws-nextjs-app/next.config.js
+++ b/ws-nextjs-app/next.config.js
@@ -12,38 +12,26 @@ const assetPrefix =
 
 /** @type {import('next').NextConfig} */
 module.exports = {
-  reactStrictMode: true,
-  distDir: 'build',
-  output: 'standalone',
   assetPrefix: clientEnvVars.SIMORGH_PUBLIC_STATIC_ASSETS_ORIGIN.includes(
     'localhost',
   )
     ? undefined
     : assetPrefix,
-  poweredByHeader: false,
-  generateEtags: false,
-  experimental: {
-    externalDir: true,
-  },
-  env: { ...clientEnvVars, LOG_TO_CONSOLE: 'true', NEXTJS: 'true' },
   compiler: {
     emotion: true,
   },
+  distDir: 'build',
+  env: { ...clientEnvVars, LOG_TO_CONSOLE: 'true', NEXTJS: 'true' },
   eslint: {
     ignoreDuringBuilds: true,
   },
-  /*
-   Requires pages that are routed to have the .page extension, e.g. [variant].page.tsx,
-   which allows for co-locating components within the pages directory, e.g. styles.ts
-   - https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions#including-non-page-files-in-the-pages-directory
-  */
+  generateEtags: false,
+  output: 'standalone',
   pageExtensions: ['page.tsx', 'page.ts'],
+  poweredByHeader: false,
+  reactStrictMode: true,
+  transpilePackages: [],
   webpack: (config, { webpack, isServer }) => {
-    config.resolve.fallback = {
-      ...config.resolve.fallback,
-      fs: false,
-    };
-
     config.plugins.push(
       new MomentTimezoneInclude({ startYear: 2010, endYear: 2025 }),
     );
@@ -64,6 +52,11 @@ module.exports = {
         ),
       );
     }
+
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+    };
 
     return config;
   },


### PR DESCRIPTION
Overall changes
======
- Removes the experimental `externalDir` option from the Next.js config in favour of using `transpilePackages`. This is set to an empty array, as under-the-hood Next.js enables `externalDir` when `transpilePackages` is defined, see: `https://github.com/vercel/next.js/pull/54860#issue-1876268215`. Not totally necessary to do this, but saves us maintaining and checking the deprecation of an experimental setting.
- Alphabetises the config as well

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
