### PR TITLE
Remove russian from most read E2E tests

### DIFF
--- a/cypress/integration/pages/mostReadPage/mostReadAssertions.js
+++ b/cypress/integration/pages/mostReadPage/mostReadAssertions.js
@@ -6,7 +6,7 @@ import getAppEnv from '../../../support/helpers/getAppEnv';
 import ampOnlyServices from '../../../support/helpers/ampOnlyServices';
 
 // news, newsround, and sport are services we serve on amp, but do not want to run most read tests on
-const MOST_READ_EXCLUDED_SERVICES = [...ampOnlyServices, 'ukchina'];
+const MOST_READ_EXCLUDED_SERVICES = [...ampOnlyServices, 'ukchina', 'russian'];
 
 export const crossPlatform = ({ service, variant }) => {
   const serviceID = config[service]?.name || service;


### PR DESCRIPTION
Resolves JIRA https://jira.dev.bbc.co.uk/browse/WSTEAMA-828

Overall changes
======
Do not run Most Read E2E tests for russian, as currently only 9 results are being displayed instead of 10

Code changes
======

- Add russian to the `MOST_READ_EXCLUDED_SERVICES` list

Testing
======
- [ ]
