### PR TITLE
Updates to the Tukrce, Indonesia and Somali navigation bars 

### DIFF
--- a/src/app/lib/config/services/indonesia.ts
+++ b/src/app/lib/config/services/indonesia.ts
@@ -344,6 +344,10 @@ export const service: DefaultServiceConfig = {
         url: '/indonesia',
       },
       {
+        title: 'Pemilu 2024',
+        url: '/indonesia/topics/ck0mgrlgyplt',
+      },
+      {
         title: 'Indonesia',
         url: '/indonesia/topics/cjgn7k8yx4gt',
       },

--- a/src/app/lib/config/services/somali.ts
+++ b/src/app/lib/config/services/somali.ts
@@ -337,7 +337,7 @@ export const service: DefaultServiceConfig = {
       },
       {
         title: 'Barnaamijyada Idaacadda',
-        url: '/somali/media-54071665',
+        url: '/somali/topics/cn6rqlrkm0pt',
       },
     ],
   },

--- a/src/app/lib/config/services/turkce.ts
+++ b/src/app/lib/config/services/turkce.ts
@@ -314,14 +314,6 @@ export const service: DefaultServiceConfig = {
         url: '/turkce',
       },
       {
-        title: '14 Mayıs Seçimleri',
-        url: '/turkce/topics/cg5mgyyvjd0t',
-      },
-      {
-        title: '6 Şubat Depremi',
-        url: '/turkce/topics/c383emwewmqt',
-      },
-      {
         title: 'Türkiye',
         url: '/turkce/topics/ckdxn2xk95gt',
       },

--- a/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/amp.test.js.snap
@@ -209,33 +209,40 @@ exports[`AMP On Demand Audio Page Header Navigation link should match text and u
 
 exports[`AMP On Demand Audio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Pemilu 2024",
+  "url": "/indonesia/topics/ck0mgrlgyplt",
+}
+`;
+
+exports[`AMP On Demand Audio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Indonesia",
   "url": "/indonesia/topics/cjgn7k8yx4gt",
 }
 `;
 
-exports[`AMP On Demand Audio Page Header Navigation link should match text and url 3`] = `
+exports[`AMP On Demand Audio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Dunia",
   "url": "/indonesia/topics/cyz8evpl224t",
 }
 `;
 
-exports[`AMP On Demand Audio Page Header Navigation link should match text and url 4`] = `
+exports[`AMP On Demand Audio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Viral",
   "url": "/indonesia/topics/cn5w7g2nq6dt",
 }
 `;
 
-exports[`AMP On Demand Audio Page Header Navigation link should match text and url 5`] = `
+exports[`AMP On Demand Audio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Liputan Mendalam",
   "url": "/indonesia/laporan-khusus-51267199",
 }
 `;
 
-exports[`AMP On Demand Audio Page Header Navigation link should match text and url 6`] = `
+exports[`AMP On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Majalah",
   "url": "/indonesia/majalah-51456120",

--- a/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandAudioPage/indonesia/__snapshots__/canonical.test.js.snap
@@ -75,33 +75,40 @@ exports[`Canonical On Demand Audio Page Header Navigation link should match text
 
 exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 2`] = `
 {
+  "text": "Pemilu 2024",
+  "url": "/indonesia/topics/ck0mgrlgyplt",
+}
+`;
+
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 3`] = `
+{
   "text": "Indonesia",
   "url": "/indonesia/topics/cjgn7k8yx4gt",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 3`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 4`] = `
 {
   "text": "Dunia",
   "url": "/indonesia/topics/cyz8evpl224t",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 4`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Viral",
   "url": "/indonesia/topics/cn5w7g2nq6dt",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 5`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 6`] = `
 {
   "text": "Liputan Mendalam",
   "url": "/indonesia/laporan-khusus-51267199",
 }
 `;
 
-exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 6`] = `
+exports[`Canonical On Demand Audio Page Header Navigation link should match text and url 7`] = `
 {
   "text": "Majalah",
   "url": "/indonesia/majalah-51456120",

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/amp.test.js.snap
@@ -231,7 +231,7 @@ exports[`AMP On Demand T V Page Header Navigation link should match text and url
 exports[`AMP On Demand T V Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Barnaamijyada Idaacadda",
-  "url": "/somali/media-54071665",
+  "url": "/somali/topics/cn6rqlrkm0pt",
 }
 `;
 

--- a/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
+++ b/src/integration/pages/onDemandTVPage/somali/__snapshots__/canonical.test.js.snap
@@ -97,7 +97,7 @@ exports[`Canonical On Demand T V Page Header Navigation link should match text a
 exports[`Canonical On Demand T V Page Header Navigation link should match text and url 5`] = `
 {
   "text": "Barnaamijyada Idaacadda",
-  "url": "/somali/media-54071665",
+  "url": "/somali/topics/cn6rqlrkm0pt",
 }
 `;
 


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Updated BBC Turkce's navigation bar to remove items no longer needed, dded Elections link to the Indonesia navigation and edited the Radio programmes link on the Somali nav bar to spare user's the redirect.

Code changes
======
- removed to items in the navigation section of src/app/lib/config/services/turkce.ts
- added Pelimu 2024 (/indonesia/topics/ck0mgrlgyplt) link to the navigation section of src/app/lib/config/services/turkce.ts
- replaced the link to media-54071665 with /somali/topics/cn6rqlrkm0pt
- updated snapshots
- _A bullet point list of key code changes that have been made._

Testing
======
1. Open BBC Turkce front page, the nav should contain only the following items: Haberler | Türkiye | Rusya-Ukrayna | Savaşı | Ekonomi | Sağlık | Bilim | Teknoloji 
2. Open the BBC Indonesia front page: the second item in the navigation bar should be Pelimu 2024 (/indonesia/topics/ck0mgrlgyplt) 
3. Open the BBC Somali front page the last item in the nav should point to /somali/topics/cn6rqlrkm0pt


Helpful Links
======

