### PR TITLE
Prevent `@types/ramda` package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
       "matchPackagePatterns": ["^@bbc/psammead"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["^@types/ramda"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,7 @@
     },
     {
       "matchPackagePatterns": ["^@types/ramda"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Overall changes
======
Prevent Renovate from attempting to update major/minor versions of `@types/ramda`, as we are using a patched version of Ramda. See https://github.com/bbc/simorgh/pull/11028

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
