### PR TITLE
WSTEAMA-876 - Amend Radio Schedule to match UX designs

### DIFF
--- a/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -168,7 +168,7 @@ exports[`ProgramCard should render correctly for live 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #006666;
   outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
@@ -384,7 +384,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -464,7 +464,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -489,7 +489,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
 }
 
 .emotion-17>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -1341,7 +1341,7 @@ exports[`ProgramCard should render correctly without summary 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #006666;
   outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }

--- a/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/ProgramCard/__snapshots__/index.test.jsx.snap
@@ -384,7 +384,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -464,7 +464,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -489,7 +489,7 @@ exports[`ProgramCard should render correctly for next 1`] = `
 }
 
 .emotion-17>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -36,7 +36,7 @@ const StyledLink = styled(Link)`
 const NextLabel = styled.span`
   ${({ service }) => service && getSansBold(service)}
   ${({ script }) => script && getPica(script)}
-  color: ${props => props.theme.palette.LIVE_DARK};
+  color: ${props => props.theme.palette.POSTBOX};
   display: inline-block;
   ${({ dir }) =>
     dir === 'rtl'

--- a/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
+++ b/src/app/legacy/components/RadioSchedule/ScheduleItemHeader/index.jsx
@@ -36,7 +36,7 @@ const StyledLink = styled(Link)`
 const NextLabel = styled.span`
   ${({ service }) => service && getSansBold(service)}
   ${({ script }) => script && getPica(script)}
-  color: ${props => props.theme.palette.KINGFISHER};
+  color: ${props => props.theme.palette.LIVE_DARK};
   display: inline-block;
   ${({ dir }) =>
     dir === 'rtl'

--- a/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -612,7 +612,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -666,7 +666,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -691,7 +691,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 .emotion-150>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -1859,7 +1859,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -1913,7 +1913,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1938,7 +1938,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 .emotion-150>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/components/RadioSchedule/__snapshots__/index.test.jsx.snap
@@ -496,7 +496,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-size: 0.75rem;
   line-height: 1rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #006666;
   outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
@@ -612,7 +612,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -666,7 +666,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -691,7 +691,7 @@ exports[`RadioSchedule should render ltr radio schedules correctly 1`] = `
 }
 
 .emotion-150>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -1743,7 +1743,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-size: 0.75rem;
   line-height: 1.125rem;
   padding: 0.5rem;
-  background-color: #B80000;
+  background-color: #006666;
   outline: 0.0625rem solid transparent;
   color: #FFFFFF;
 }
@@ -1859,7 +1859,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -1913,7 +1913,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1938,7 +1938,7 @@ exports[`RadioSchedule should render rtl radio schedules correctly 1`] = `
 }
 
 .emotion-150>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/legacy/components/RadioSchedule/utilities/index.js
+++ b/src/app/legacy/components/RadioSchedule/utilities/index.js
@@ -1,16 +1,16 @@
 import { formatDuration } from '#psammead/psammead-timestamp-container/src/utilities';
 import {
   KINGFISHER,
-  POSTBOX,
   EBON,
   SHADOW,
   WHITE,
   METAL,
+  LIVE_DARK,
 } from '../../../../components/ThemeProvider/palette';
 
 export const programStateConfig = {
   live: {
-    backgroundColor: POSTBOX,
+    backgroundColor: LIVE_DARK,
     headerTextColor: EBON,
     titleColor: SHADOW,
     durationColor: WHITE,

--- a/src/app/legacy/components/RadioSchedule/utilities/index.js
+++ b/src/app/legacy/components/RadioSchedule/utilities/index.js
@@ -5,6 +5,7 @@ import {
   WHITE,
   METAL,
   LIVE_DARK,
+  POSTBOX,
 } from '../../../../components/ThemeProvider/palette';
 
 export const programStateConfig = {
@@ -18,7 +19,7 @@ export const programStateConfig = {
     backgroundColor: WHITE,
     headerTextColor: METAL,
     titleColor: METAL,
-    durationColor: LIVE_DARK,
+    durationColor: POSTBOX,
   },
   onDemand: {
     backgroundColor: EBON,

--- a/src/app/legacy/components/RadioSchedule/utilities/index.js
+++ b/src/app/legacy/components/RadioSchedule/utilities/index.js
@@ -1,6 +1,5 @@
 import { formatDuration } from '#psammead/psammead-timestamp-container/src/utilities';
 import {
-  KINGFISHER,
   EBON,
   SHADOW,
   WHITE,
@@ -19,7 +18,7 @@ export const programStateConfig = {
     backgroundColor: WHITE,
     headerTextColor: METAL,
     titleColor: METAL,
-    durationColor: KINGFISHER,
+    durationColor: LIVE_DARK,
   },
   onDemand: {
     backgroundColor: EBON,

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -566,7 +566,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -646,7 +646,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -671,7 +671,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-50>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -2007,7 +2007,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -2087,7 +2087,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2112,7 +2112,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 .emotion-50>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
+++ b/src/app/legacy/containers/RadioSchedule/Canonical/__snapshots__/index.test.jsx.snap
@@ -566,7 +566,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -646,7 +646,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -671,7 +671,7 @@ exports[`Canonical RadioSchedule With initial data renders correctly for a servi
 }
 
 .emotion-50>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;
@@ -2007,7 +2007,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -2087,7 +2087,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2112,7 +2112,7 @@ exports[`Canonical RadioSchedule Without initial data renders correctly for a se
 }
 
 .emotion-50>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -2167,7 +2167,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -2247,7 +2247,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2272,7 +2272,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-576>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/IdxPage/__snapshots__/index.test.jsx.snap
@@ -2167,7 +2167,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.5rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-left: 0.5rem;
 }
@@ -2247,7 +2247,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -2272,7 +2272,7 @@ exports[`IdxPage - Persian Snapshots should render a persian idx page correctly 
 }
 
 .emotion-576>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -1519,7 +1519,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #006666;
+  color: #B80000;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -1573,7 +1573,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #006666;
+  color: #B80000;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1598,7 +1598,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 .emotion-186>svg {
-  color: #006666;
+  color: #B80000;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;

--- a/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
+++ b/src/app/pages/LiveRadioPage/__snapshots__/index.test.jsx.snap
@@ -1519,7 +1519,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   font-style: normal;
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  color: #11708C;
+  color: #006666;
   display: inline-block;
   margin-right: 0.5rem;
 }
@@ -1573,7 +1573,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
   padding: 0.5rem;
   background-color: #FFFFFF;
   outline: 0.0625rem solid transparent;
-  color: #11708C;
+  color: #006666;
 }
 
 @media (min-width: 20rem) and (max-width: 37.4375rem) {
@@ -1598,7 +1598,7 @@ exports[`Radio Page Main should match snapshot for Canonical 1`] = `
 }
 
 .emotion-186>svg {
-  color: #11708C;
+  color: #006666;
   fill: currentColor;
   width: 1.0625rem;
   height: 0.75rem;


### PR DESCRIPTION
Resolves JIRA [[876](https://jira.dev.bbc.co.uk/browse/WSTEAMA-876)]

Overall changes
======

Since the Live Label is now `LIVE_DARK` Teal (see [WSTEAMA-840](https://jira.dev.bbc.co.uk/browse/WSTEAMA-840)), the radio schedule needs to be updated accordingly to match.

Code changes
======

- Background colour for `live` changed to `LIVE_DARK`
- NextLabel changed to `POSTBOX`
- Updated snapshots
