### PR TITLE
FIX: Surface BFF fetch 404s

### DIFF
--- a/src/app/routes/cpsAsset/getInitialData/index.js
+++ b/src/app/routes/cpsAsset/getInitialData/index.js
@@ -5,6 +5,7 @@ import {
   STORY_PAGE,
   PHOTO_GALLERY_PAGE,
 } from '#app/routes/utils/pageTypes';
+import handleError from '../../utils/handleError';
 import {
   augmentWithTimestamp,
   addIdsToBlocks,
@@ -110,13 +111,17 @@ export default async ({
 
     const {
       status,
-      pageData: { secondaryColumn, recommendations, ...article },
+      pageData: { secondaryColumn, recommendations, ...article } = {},
     } = await getArticleInitialData({
       path: derivedPath,
       service: derivedService,
       variant,
       pageType: 'cpsAsset',
     });
+
+    if (status !== 200) {
+      throw handleError('CPS asset data fetch error', status);
+    }
 
     const { mostWatched } = processMostWatched({
       data: article,


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Surface BFF 404s instead of the current 500.



Code changes
======
- Following withdrawal of the article below, Simorgh is returning a 500 instead of a 404.
`https://www.bbc.co.uk/news/uk-england-birmingham-67216380.amp`
This PR ensures 404s from the BFF and Simorgh by extension, are served back to upstream
services.

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
