### PR TITLE
WSTEAM1-658 Show contributors if supplied

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -20,7 +20,10 @@ type ComponentProps = {
     description?: string;
     isLive: boolean;
     summaryPoints: { content: KeyPointsResponse | null };
-    liveTextStream: { content: StreamResponse | null };
+    liveTextStream: {
+      content: StreamResponse | null;
+      contributors: string | null;
+    };
   };
 };
 
@@ -75,7 +78,10 @@ const LivePage = ({ pageData }: ComponentProps) => {
             )}
           </div>
           <div css={styles.secondSection}>
-            <Stream streamContent={liveTextStream.content} />
+            <Stream
+              streamContent={liveTextStream.content}
+              contributors={liveTextStream.contributors}
+            />
           </div>
         </div>
         <Pagination

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
@@ -75,7 +75,7 @@ describe('Live Page Stream', () => {
         />,
       );
     });
-    expect(screen.queryByRole('paragraph')).toBeInTheDocument();
+    expect(screen.queryByTestId('paragraph')).toBeInTheDocument();
   });
 
   it('should not render contributors when they are null', async () => {
@@ -85,6 +85,6 @@ describe('Live Page Stream', () => {
       );
     });
 
-    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('paragraph')).not.toBeInTheDocument();
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
@@ -75,7 +75,7 @@ describe('Live Page Stream', () => {
         />,
       );
     });
-    expect(screen.queryByTestId('paragraph')).toBeInTheDocument();
+    expect(screen.queryByTestId('live-contributors')).toBeInTheDocument();
   });
 
   it('should not render contributors when they are null', async () => {
@@ -85,6 +85,6 @@ describe('Live Page Stream', () => {
       );
     });
 
-    expect(screen.queryByTestId('paragraph')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('live-contributors')).not.toBeInTheDocument();
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.test.tsx
@@ -25,7 +25,9 @@ const mockStreamContentMoreThanOne = {
 describe('Live Page Stream', () => {
   it('should return null with no stream content posts', async () => {
     await act(async () => {
-      render(<Stream streamContent={mockStreamContentEmpty} />);
+      render(
+        <Stream streamContent={mockStreamContentEmpty} contributors={null} />,
+      );
     });
 
     expect(screen.queryByRole('heading')).not.toBeInTheDocument();
@@ -33,7 +35,9 @@ describe('Live Page Stream', () => {
 
   it('should render a single stream content post with no ordered list', async () => {
     await act(async () => {
-      render(<Stream streamContent={mockStreamContentSingle} />);
+      render(
+        <Stream streamContent={mockStreamContentSingle} contributors={null} />,
+      );
     });
 
     expect(
@@ -46,7 +50,12 @@ describe('Live Page Stream', () => {
 
   it('should render a more than one stream content posts within a list', async () => {
     await act(async () => {
-      render(<Stream streamContent={mockStreamContentMoreThanOne} />);
+      render(
+        <Stream
+          streamContent={mockStreamContentMoreThanOne}
+          contributors={null}
+        />,
+      );
     });
 
     expect(
@@ -55,5 +64,27 @@ describe('Live Page Stream', () => {
       }),
     ).toHaveLength(2);
     expect(screen.queryByRole('list')).toBeInTheDocument();
+  });
+
+  it('should render contributors when supplied', async () => {
+    await act(async () => {
+      render(
+        <Stream
+          streamContent={mockStreamContentSingle}
+          contributors="Not a random dude"
+        />,
+      );
+    });
+    expect(screen.queryByRole('paragraph')).toBeInTheDocument();
+  });
+
+  it('should not render contributors when they are null', async () => {
+    await act(async () => {
+      render(
+        <Stream streamContent={mockStreamContentSingle} contributors={null} />,
+      );
+    });
+
+    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
   });
 });

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
@@ -30,7 +30,7 @@ const Stream = ({
         Live Reporting
       </Heading>
       {contributors && (
-        <Paragraph role="paragraph" css={styles.subHeading}>
+        <Paragraph data-testid="paragraph" css={styles.subHeading}>
           {contributors}
         </Paragraph>
       )}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
@@ -30,7 +30,9 @@ const Stream = ({
         Live Reporting
       </Heading>
       {contributors && (
-        <Paragraph css={styles.subHeading}>{contributors}</Paragraph>
+        <Paragraph role="paragraph" css={styles.subHeading}>
+          {contributors}
+        </Paragraph>
       )}
 
       {hasSinglePost ? (

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
@@ -8,8 +8,10 @@ import styles from './styles';
 
 const Stream = ({
   streamContent,
+  contributors,
 }: {
   streamContent: StreamResponse | null;
+  contributors: string | null;
 }) => {
   if (!streamContent) return null;
   const { results: streamResults } = streamContent?.data;
@@ -21,10 +23,16 @@ const Stream = ({
 
   return (
     <div>
-      <Heading css={styles.heading} level={2}>
+      <Heading
+        css={contributors ? styles.heading : styles.headingNoContributors}
+        level={2}
+      >
         Live Reporting
       </Heading>
-      <Paragraph css={styles.subHeading}>By a random dude</Paragraph>
+      {contributors && (
+        <Paragraph css={styles.subHeading}>{contributors}</Paragraph>
+      )}
+
       {hasSinglePost ? (
         <Post post={streamResults[0]} />
       ) : (

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
@@ -30,7 +30,7 @@ const Stream = ({
         Live Reporting
       </Heading>
       {contributors && (
-        <Paragraph data-testid="paragraph" css={styles.subHeading}>
+        <Paragraph data-testid="live-contributors" css={styles.subHeading}>
           {contributors}
         </Paragraph>
       )}

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/index.tsx
@@ -24,7 +24,10 @@ const Stream = ({
   return (
     <div>
       <Heading
-        css={contributors ? styles.heading : styles.headingNoContributors}
+        css={[
+          styles.heading,
+          !contributors && styles.headingNoContributorsPadding,
+        ]}
         level={2}
       >
         Live Reporting

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/styles.tsx
@@ -21,6 +21,18 @@ export default {
         paddingTop: `${spacings.DOUBLE}rem`,
       },
     }),
+  headingNoContributors: ({ mq, spacings, fontSizes }: Theme) =>
+    css({
+      padding: `${spacings.DOUBLE}rem 0 ${spacings.DOUBLE}rem`,
+      [mq.GROUP_3_MIN_WIDTH]: {
+        ...fontSizes.doublePica,
+        paddingTop: `${spacings.TRIPLE}rem`,
+        paddingBottom: `${spacings.TRIPLE}rem`,
+      },
+      [mq.GROUP_4_MIN_WIDTH]: {
+        paddingTop: `${spacings.DOUBLE}rem`,
+      },
+    }),
   subHeading: ({ mq, spacings }: Theme) =>
     css({
       paddingBottom: `${spacings.DOUBLE}rem`,

--- a/ws-nextjs-app/pages/[service]/live/[id]/Stream/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Stream/styles.tsx
@@ -21,16 +21,10 @@ export default {
         paddingTop: `${spacings.DOUBLE}rem`,
       },
     }),
-  headingNoContributors: ({ mq, spacings, fontSizes }: Theme) =>
+  headingNoContributorsPadding: ({ mq, spacings }: Theme) =>
     css({
-      padding: `${spacings.DOUBLE}rem 0 ${spacings.DOUBLE}rem`,
       [mq.GROUP_3_MIN_WIDTH]: {
-        ...fontSizes.doublePica,
-        paddingTop: `${spacings.TRIPLE}rem`,
         paddingBottom: `${spacings.TRIPLE}rem`,
-      },
-      [mq.GROUP_4_MIN_WIDTH]: {
-        paddingTop: `${spacings.DOUBLE}rem`,
       },
     }),
   subHeading: ({ mq, spacings }: Theme) =>

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -1243,7 +1243,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
           </h2>
           <p
             class="emotion-20"
-            role="paragraph"
+            data-testid="paragraph"
           >
             Not a random dude
           </p>

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -1244,7 +1244,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
           <p
             class="emotion-20"
           >
-            By a random dude
+            Not a random dude
           </p>
           <ol
             class="emotion-21"

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -1243,7 +1243,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
           </h2>
           <p
             class="emotion-20"
-            data-testid="paragraph"
+            data-testid="live-contributors"
           >
             Not a random dude
           </p>

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -1243,6 +1243,7 @@ exports[`Live Page creates snapshot of the live page 1`] = `
           </h2>
           <p
             class="emotion-20"
+            role="paragraph"
           >
             Not a random dude
           </p>

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.stories.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.stories.tsx
@@ -8,6 +8,7 @@ const mockPageData = {
   ...liveFixture.data,
   liveTextStream: {
     content: postFixture,
+    contributors: 'Not a random dude',
   },
   someResponse: {
     block: 'Its a block',

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -23,6 +23,7 @@ const mockPageData = {
         },
       },
     },
+    contributors: 'Not a random dude',
   },
 };
 
@@ -33,6 +34,7 @@ const mockPageDataWithPosts = {
   },
   liveTextStream: {
     content: postFixture,
+    contributors: 'Not a random dude',
   },
 };
 
@@ -47,6 +49,7 @@ const mockPageDataWithoutKeyPoints = {
   },
   liveTextStream: {
     content: postFixture,
+    contributors: 'Not a random dude',
   },
 };
 


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-658](https://jira.dev.bbc.co.uk/browse/WSTEAM1-658)

Overall changes
======
Displays contributors to a Live page if they are supplied.

Code changes
======

- Passes and confitionally renders `contributors` to the Stream component
- Applies extra padding to the `Heading` from Group 3 + breakpoints when contributors are not supplied

Testing
======
1. cd into ws-nextjs-app and yarn dev
2. Visit http://localhost:7081/pidgin/live/c07zr0zwjnnt and view page with contributors
3. Visit http://localhost:7081/pidgin/live/c0mrezv7rd0t and view page without contributors, check from breakpoints 3+ for extra `padding-bottom` on the heading component

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
