### PR TITLE
WSTEAM1-550: Update logger

### DIFF
--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -37,7 +37,7 @@ const consoleLogFormat = printf(data => {
 
 const expressFormatOptions = [prettyPrint(), colorize(), consoleLogFormat];
 
-const nextJSFormatOptions = [prettyPrint(), consoleLogFormat];
+const nextJSFormatOptions = [json()];
 
 const loggerOptions = {
   file: {

--- a/src/app/lib/logger.node.js
+++ b/src/app/lib/logger.node.js
@@ -35,6 +35,10 @@ const consoleLogFormat = printf(data => {
   return `${data.timestamp} ${data.level} ${JSON.stringify(logMessage)}`;
 });
 
+const expressFormatOptions = [prettyPrint(), colorize(), consoleLogFormat];
+
+const nextJSFormatOptions = [prettyPrint(), consoleLogFormat];
+
 const loggerOptions = {
   file: {
     filename: logLocation,
@@ -51,7 +55,10 @@ const loggerOptions = {
     humanReadableUnhandledException: true,
     level: LOG_LEVEL,
     timestamp: true,
-    format: combine(prettyPrint(), colorize(), consoleLogFormat),
+    format:
+      PLATFORM === 'NEXTJS'
+        ? combine(...nextJSFormatOptions)
+        : combine(...expressFormatOptions),
   },
 };
 

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -184,6 +184,7 @@ describe('Logger node - for the server', () => {
             transports: [{}],
           });
         });
+        
         it('is configured correctly for NextJS', () => {
           process.env.NEXTJS = 'true';
           const loggerNode = require('./logger.node');

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -148,7 +148,7 @@ describe('Logger node - for the server', () => {
       });
 
       describe('createLogger', () => {
-        it('is configured correctly', () => {
+        it('is configured correctly for Express', () => {
           const loggerNode = require('./logger.node');
           loggerNode('path/file/foo.js');
 
@@ -161,6 +161,42 @@ describe('Logger node - for the server', () => {
             2,
             'PrettyPrint Mock',
             'Colorize Mock',
+            'Printf Mock',
+          );
+
+          expect(winston.format.combine).toHaveBeenNthCalledWith(
+            3,
+            'Simple Mock',
+            'Timestamp Mock',
+            'Label Mock',
+            'Metadata Mock',
+          );
+
+          expect(winston.format.simple).toHaveBeenCalled();
+          expect(winston.format.timestamp).toHaveBeenCalledWith({
+            format: 'YYYY-MM-DD HH:mm:ss.SSS',
+          });
+          expect(winston.format.metadata).toHaveBeenCalledWith({
+            fillExcept: ['timestamp', 'level', 'message'],
+          });
+          expect(winston.createLogger).toHaveBeenCalledWith({
+            format: 'Combine Mock',
+            transports: [{}],
+          });
+        });
+        it('is configured correctly for NextJS', () => {
+          process.env.NEXTJS = 'true';
+          const loggerNode = require('./logger.node');
+          loggerNode('path/file/foo.js');
+
+          expect(winston.format.combine).toHaveBeenNthCalledWith(
+            1,
+            'Json Mock',
+          );
+
+          expect(winston.format.combine).toHaveBeenNthCalledWith(
+            2,
+            'PrettyPrint Mock',
             'Printf Mock',
           );
 

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -184,6 +184,7 @@ describe('Logger node - for the server', () => {
             transports: [{}],
           });
         });
+
         it('is configured correctly for NextJS', () => {
           process.env.NEXTJS = 'true';
           const loggerNode = require('./logger.node');

--- a/src/app/lib/logger.node.test.js
+++ b/src/app/lib/logger.node.test.js
@@ -196,8 +196,7 @@ describe('Logger node - for the server', () => {
 
           expect(winston.format.combine).toHaveBeenNthCalledWith(
             2,
-            'PrettyPrint Mock',
-            'Printf Mock',
+            'Json Mock',
           );
 
           expect(winston.format.combine).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-550](https://jira.dev.bbc.co.uk/browse/WSTEAM1-550)

Overall changes
======
Changes NextJS format from: 
```
2023-11-07 11:01:36.956 [32minfo[39m {"file":"[id]/[[...variant]].js"} 

```
to 
```
{
   "level":"info",
   "message":{}
}
```

This aligns the NextJS format to that of Simorgh logs.

Code changes
======

- _Colourise configuration removed from `/src/app/lib/logger.node.js`, as it is causing a formatting issue with logs._

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
