### PR TITLE
WSTEAM1-550: Add metric log

### DIFF
--- a/ws-nextjs-app/pages/[service]/[[...]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/[[...]].page.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import logResponseTime from '#server/utilities/logResponseTime';
 import { Services, Variants } from '../../../src/app/models/types/global';
 import extractHeaders from '../../../src/server/utilities/extractHeaders';
 
@@ -13,6 +14,8 @@ type PageDataParams = {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  logResponseTime(context.req, context.res, () => null);
+
   const { service, variant } = context.query as PageDataParams;
 
   const { headers: reqHeaders } = context.req;

--- a/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx
@@ -5,6 +5,8 @@ import constructPageFetchUrl from '#app/routes/utils/constructPageFetchUrl';
 import getToggles from '#app/lib/utilities/getToggles/withCache';
 import { LIVE_PAGE } from '#app/routes/utils/pageTypes';
 import nodeLogger from '#lib/logger.node';
+import logResponseTime from '#server/utilities/logResponseTime';
+
 import {
   ROUTING_INFORMATION,
   SERVER_SIDE_RENDER_REQUEST_RECEIVED,
@@ -92,6 +94,8 @@ const getPageData = async ({
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  logResponseTime(context.req, context.res, () => null);
+
   const {
     id,
     service,

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import type { AppProps, NextWebVitalsMetric } from 'next/app';
-import { SERVER_RESPONSE_TIME } from '#app/lib/logger.const';
-import nodeLogger from '#lib/logger.node';
+import type { AppProps } from 'next/app';
 import { ToggleContextProvider } from '../../src/app/contexts/ToggleContext';
 import { ServiceContextProvider } from '../../src/app/contexts/ServiceContext';
 import { RequestContextProvider } from '../../src/app/contexts/RequestContext';
@@ -42,16 +40,6 @@ interface Props extends AppProps {
     variant?: Variants;
     isUK?: boolean;
   };
-}
-
-const logger = nodeLogger(__filename);
-
-export function reportWebVitals(metric: NextWebVitalsMetric) {
-  const nanoseconds = metric.startTime * 1000000;
-  logger.info(SERVER_RESPONSE_TIME, {
-    path: 'TEST_PATH',
-    nanoseconds,
-  });
 }
 
 export default function App({ Component, pageProps }: Props) {

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import type { AppProps } from 'next/app';
+import type { AppProps, NextWebVitalsMetric } from 'next/app';
+import { SERVER_RESPONSE_TIME } from '#app/lib/logger.const';
+import nodeLogger from '#lib/logger.node';
 import { ToggleContextProvider } from '../../src/app/contexts/ToggleContext';
 import { ServiceContextProvider } from '../../src/app/contexts/ServiceContext';
 import { RequestContextProvider } from '../../src/app/contexts/RequestContext';
@@ -40,6 +42,17 @@ interface Props extends AppProps {
     variant?: Variants;
     isUK?: boolean;
   };
+}
+
+const logger = nodeLogger(__filename);
+
+export function reportWebVitals(metric: NextWebVitalsMetric) {
+  if (metric.name === 'LCP') {
+    const nanoseconds = metric.startTime * 1000000;
+    logger.info(SERVER_RESPONSE_TIME, {
+      nanoseconds,
+    });
+  }
 }
 
 export default function App({ Component, pageProps }: Props) {

--- a/ws-nextjs-app/pages/_app.page.tsx
+++ b/ws-nextjs-app/pages/_app.page.tsx
@@ -47,12 +47,11 @@ interface Props extends AppProps {
 const logger = nodeLogger(__filename);
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {
-  if (metric.name === 'LCP') {
-    const nanoseconds = metric.startTime * 1000000;
-    logger.info(SERVER_RESPONSE_TIME, {
-      nanoseconds,
-    });
-  }
+  const nanoseconds = metric.startTime * 1000000;
+  logger.info(SERVER_RESPONSE_TIME, {
+    path: 'TEST_PATH',
+    nanoseconds,
+  });
 }
 
 export default function App({ Component, pageProps }: Props) {


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-550](https://jira.dev.bbc.co.uk/browse/WSTEAM1-550)

Overall changes
======
Adds server response time logs to NextJS app. 
This aligns the NextJS format to that of Simorgh logs.

Code changes
======
- _`logResponseTime()` added to `ws-nextjs-app/pages/[service]/live/[id]/[[...variant]].page.tsx`._
- _`logResponseTime()` added to `ws-nextjs-app/pages/[service]/[[...]].page.tsx`._

This approach is the best possible case since middleware functions in NextJS are different to that of Express and do not give us access to the end response object, therefore using middleware functions for response time is not entirely possible using NextJS alone, [community agrees](https://github.com/vercel/next.js/discussions/34420). 

In addition, using AWS's Lamda report logs require paths to be correlated to report logs before they can be processed. Although this is doable, it wouldn't allow us to run log insights on both the Express app and NodeJS app using the same query. 

Overall, logging response times using this method is accurate within 7%: 
Typically, AWS Lamda Reports would say an invocation would take: `73 milliseconds.`
Whereas this PR, would say an response would take: `68 milliseconds.`

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
