### PR TITLE
Update Japanese Nav to add Gaza conflict link

### DIFF
--- a/src/app/lib/config/services/japanese.ts
+++ b/src/app/lib/config/services/japanese.ts
@@ -300,6 +300,10 @@ export const service: DefaultServiceConfig = {
         url: '/japanese',
       },
       {
+        title: 'イスラエル・ガザ戦争',
+        url: '/japanese/topics/cw5wn2e9rpnt',
+      },
+      {
         title: 'ウクライナ侵攻',
         url: '/japanese/60631515',
       },


### PR DESCRIPTION
Resolves JIRA n/a

Overall changes
======
Updated BBC Japanese navigation bar to add link to Gaza conflic topic

Code changes
======
 - added link to /japanese/topics/cw5wn2e9rpnt link to the navigation section of src/app/lib/config/services/japanese.ts



Testing
======
1. Open the BBC Japanese front page: the second item in the navigation bar should be イスラエル・ガザ戦争 (/japanese/topics/cw5wn2e9rpnt)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
