### PR TITLE
WSTEAM1-501 - Live page paginated title

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -53,14 +53,13 @@ const LivePage = ({ pageData }: ComponentProps) => {
     ...translations.pagination,
   };
 
-  const paginatedPageTitle =
-    activePage && pageCount
-      ? `Test Live Page, ${pageXOfY
-          .replace('{x}', activePage.toString())
-          .replace('{y}', pageCount.toString())}`
-      : 'Test Live Page';
+  const showPaginatedTitle = pageCount && activePage && activePage >= 2;
 
-  const pageTitle = activePage && activePage >= 2 ? paginatedPageTitle : title;
+  const pageTitle = showPaginatedTitle
+    ? `${title}, ${pageXOfY
+        .replace('{x}', activePage.toString())
+        .replace('{y}', pageCount.toString())}`
+    : title;
 
   return (
     <>

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -64,16 +64,17 @@ describe('Live Page', () => {
     expect(screen.getByText('Pidgin test 2')).toBeInTheDocument();
   });
 
-  it('should render the live page og:title ', async () => {
+  it('should use the title value from the data response as the page title', async () => {
     await act(async () => {
       render(<Live pageData={mockPageData} />, { service: 'pidgin' });
     });
+
     const { title: helmetTitle } = Helmet.peek();
 
     expect(helmetTitle).toEqual(`${mockPageData.title} - BBC News Pidgin`);
   });
 
-  it('should render the live page og:title with pagination', async () => {
+  it('should use the title value combined with the pagination value as the page title', async () => {
     const paginatedData = {
       ...mockPageData,
       liveTextStream: {

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
+
 import {
   render,
   screen,
@@ -60,6 +62,43 @@ describe('Live Page', () => {
     });
 
     expect(screen.getByText('Pidgin test 2')).toBeInTheDocument();
+  });
+
+  it('should render the live page og:title ', async () => {
+    await act(async () => {
+      render(<Live pageData={mockPageData} />, { service: 'pidgin' });
+    });
+    const { title: helmetTitle } = Helmet.peek();
+
+    expect(helmetTitle).toEqual(`${mockPageData.title} - BBC News Pidgin`);
+  });
+
+  it('should render the live page og:title with pagination', async () => {
+    const paginatedData = {
+      ...mockPageData,
+      liveTextStream: {
+        content: {
+          data: {
+            results: [],
+            page: {
+              index: 2,
+              total: 3,
+            },
+          },
+        },
+        contributors: 'Not a random dude',
+      },
+    };
+
+    await act(async () => {
+      render(<Live pageData={paginatedData} />, { service: 'pidgin' });
+    });
+
+    const { title: helmetTitle } = Helmet.peek();
+
+    expect(helmetTitle).toEqual(
+      `${mockPageData.title}, Page 2 of 3 - BBC News Pidgin`,
+    );
   });
 
   it('should render the live page description', async () => {


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/WSTEAM1-501

Overall changes
======
- Removes `Test Live Page` and includes the page title from the data response in the page title when the page is paginated

Testing
======
1. Navigate to the paginated page, e.g: http://localhost:7081/pidgin/live/c07zr0zwjnnt
2. Confirm the page title is set with no additional pagination values
3. Navigate to the next page
4. Confirm the page title is set and the pagination values are also included

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
