### PR TITLE
correct flourish domain

### DIFF
--- a/src/server/utilities/cspHeader/index.js
+++ b/src/server/utilities/cspHeader/index.js
@@ -140,7 +140,7 @@ const directives = {
       'https://bbc-maps.carto.com', // STY include maps
       'https://flo.uri.sh', // STY includes
       'https://www.riddle.com', // STY Includes
-      'https://publish.flourish.studio', // Flourish embeds
+      'https://public.flourish.studio', // Flourish embeds
       ...advertisingDirectives.frameSrc,
       "'self'",
     ],
@@ -170,7 +170,7 @@ const directives = {
       'https://bbc-maps.carto.com', // STY include maps
       'https://flo.uri.sh', // STY includes
       'https://www.riddle.com', // STY Includes
-      'https://publish.flourish.studio', // Flourish embeds
+      'https://public.flourish.studio', // Flourish embeds
       ...advertisingDirectives.frameSrc,
       "'self'",
     ],

--- a/src/server/utilities/cspHeader/index.test.js
+++ b/src/server/utilities/cspHeader/index.test.js
@@ -175,7 +175,7 @@ describe('cspHeader', () => {
         'https://*.facebook.com',
         'https://*.google.com',
         'https://cdn.privacy-mgmt.com',
-        'https://publish.flourish.studio',
+        'https://public.flourish.studio',
         "'self'",
       ].sort(),
       imgSrcExpectation: [
@@ -378,7 +378,7 @@ describe('cspHeader', () => {
         'https://*.facebook.com',
         'https://*.google.com',
         'https://cdn.privacy-mgmt.com',
-        'https://publish.flourish.studio',
+        'https://public.flourish.studio',
         "'self'",
       ].sort(),
       imgSrcExpectation: [


### PR DESCRIPTION
**Same as https://github.com/bbc/simorgh/pull/11194 but domain is corrected from `https://publish.flourish.studio/` to `https://public.flourish.studio/`**

Overall changes
======
Should fix issue where 'tabbed' flourish embeds will not allow different tabs to be selected and viewed, the issue can be observed here: https://www.test.bbc.com/mundo/articles/cvlm6p8r9zqo

Code changes
======
Adds `https://public.flourish.studio/` into our `frame-src` directive to mitigate the following error:
`Content-Security-Policy: The page's settings blocked the loading of a resource at https://public.flourish.studio/visualisation/15858773/embed ("frame-src").`

Testing
======
Visit the page above and click the grey buttons below:
![image](https://github.com/bbc/simorgh/assets/9645462/21804447-9fbe-4a13-9193-d5464c6ace26)

Observe the tabbed pages open successfully and the error above is not displayed in the console.

Helpful Links
======
[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
