### PR TITLE
WSTEAM1-507: Set metadata title & description for Live Page

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -27,6 +27,10 @@ type ComponentProps = {
       content: StreamResponse | null;
       contributors: string | null;
     };
+    seo: {
+      seoTitle?: string;
+      seoDescription?: string;
+    };
     atiAnalytics: ATIData;
   };
 };
@@ -36,6 +40,7 @@ const LivePage = ({ pageData }: ComponentProps) => {
   const {
     title,
     description,
+    seo: { seoTitle, seoDescription },
     isLive,
     summaryPoints: { content: keyPoints },
     liveTextStream,
@@ -55,11 +60,15 @@ const LivePage = ({ pageData }: ComponentProps) => {
 
   const showPaginatedTitle = pageCount && activePage && activePage >= 2;
 
+  const pageSeoTitle = seoTitle || title;
+
   const pageTitle = showPaginatedTitle
-    ? `${title}, ${pageXOfY
+    ? `${pageSeoTitle}, ${pageXOfY
         .replace('{x}', activePage.toString())
         .replace('{y}', pageCount.toString())}`
-    : title;
+    : pageSeoTitle;
+
+  const pageDescription = seoDescription || description || pageSeoTitle;
 
   return (
     <>
@@ -68,7 +77,7 @@ const LivePage = ({ pageData }: ComponentProps) => {
       <MetadataContainer
         title={pageTitle}
         lang={lang}
-        description="A test Live Page using Next.JS"
+        description={pageDescription}
         openGraphType="website"
         hasAmpPage={false}
       />

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -55,24 +55,75 @@ const mockPageDataWithoutKeyPoints = {
   },
 };
 
+const mockPageDataWithMetadata = ({
+  title,
+  description,
+  seoTitle,
+  seoDescription,
+}: {
+  title: string;
+  description?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+}) => {
+  return {
+    ...mockPageData,
+    title,
+    description,
+    seo: {
+      seoTitle,
+      seoDescription,
+    },
+  };
+};
+
 describe('Live Page', () => {
-  it('should render the live page title', async () => {
-    await act(async () => {
-      render(<Live pageData={mockPageData} />);
-    });
+  it.each`
+    title             | seoTitle             | info                      | expected
+    ${'I am a Title'} | ${'I am a seoTitle'} | ${'seoTitle'}             | ${'I am a seoTitle - BBC News Pidgin'}
+    ${'I am a Title'} | ${undefined}         | ${'title if no seoTitle'} | ${'I am a Title - BBC News Pidgin'}
+  `(
+    'should use $info as the meta title',
+    async ({ title, seoTitle, expected }) => {
+      await act(async () => {
+        render(
+          <Live pageData={mockPageDataWithMetadata({ title, seoTitle })} />,
+          { service: 'pidgin' },
+        );
+      });
 
-    expect(screen.getByText('Pidgin test 2')).toBeInTheDocument();
-  });
+      const { title: helmetTitle } = Helmet.peek();
+      expect(helmetTitle).toEqual(expected);
+    },
+  );
 
-  it('should use the title value from the data response as the page title', async () => {
-    await act(async () => {
-      render(<Live pageData={mockPageData} />, { service: 'pidgin' });
-    });
+  it.each`
+    description             | seoDescription             | info                                  | expected
+    ${'I am a Description'} | ${'I am a seoDescription'} | ${'seoDescription'}                   | ${'I am a seoDescription'}
+    ${'I am a Description'} | ${undefined}               | ${'description if no seoDescription'} | ${'I am a Description'}
+    ${undefined}            | ${undefined}               | ${'title as a fallback'}              | ${'title'}
+  `(
+    'should use $info as the meta description',
+    async ({ description, seoDescription, expected }) => {
+      await act(async () => {
+        render(
+          <Live
+            pageData={mockPageDataWithMetadata({
+              title: 'title',
+              description,
+              seoDescription,
+            })}
+          />,
+        );
+      });
 
-    const { title: helmetTitle } = Helmet.peek();
-
-    expect(helmetTitle).toEqual(`${mockPageData.title} - BBC News Pidgin`);
-  });
+      const helmetContent = Helmet.peek();
+      const findDescription = helmetContent.metaTags.find(
+        ({ name }) => name === 'description',
+      );
+      expect(findDescription?.content).toEqual(expected);
+    },
+  );
 
   it('should use the title value combined with the pagination value as the page title', async () => {
     const paginatedData = {
@@ -100,6 +151,14 @@ describe('Live Page', () => {
     expect(helmetTitle).toEqual(
       `${mockPageData.title}, Page 2 of 3 - BBC News Pidgin`,
     );
+  });
+
+  it('should render the live page title', async () => {
+    await act(async () => {
+      render(<Live pageData={mockPageData} />);
+    });
+
+    expect(screen.getByText('Pidgin test 2')).toBeInTheDocument();
   });
 
   it('should render the live page description', async () => {


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-507](https://jira.dev.bbc.co.uk/browse/WSTEAM1-507) - SEO:SEO headline - <title> and summary field for WS Live

Overall changes
======
Sets values for title and description in the metadata component for the Live Page

Code changes
======

- Meta Title is seoTitle if it is provided, otherwise falls back to title. Includes pagination.
- Meta Description is seoDescription if it is provided, otherwise it is description if it is provided. Otherwise falls back to seoTitle if provided or else Title.
- Add unit tests.

Testing
======
1. Pull down this branch, `cd` into `ws-nextjs-app` and use `yarn dev` to run locally. 
2. Visit the following links and check the SEO by using the 'Detailed SEO extension'

Should see seoTitle. Description falls back to seoTitle
http://localhost:7081/pidgin/live/cx747l228kjt
 "seo": { "seoTitle": "Live page - 1 Promo", "seoDescription": null },

Should see seoTitle and seoDescription
http://localhost:7081/mundo/live/c448yp9nm96t
 "seo": { "seoTitle": "This is an SEO title - a headline primarily for search - it should not appear on the page.", "seoDescription": "This is an SEO description - a description for search. It should not appear on the page." },

(Note Optimo auto-fills the seoTitle field with the title so there is no asset available with a Title & description but no seoTitle & seoDescription)

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
