### PR TITLE
WSTEAM1-509: Populate 'headline' Schema field

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/LivePageLayout.tsx
@@ -81,7 +81,11 @@ const LivePage = ({ pageData }: ComponentProps) => {
         openGraphType="website"
         hasAmpPage={false}
       />
-      <LinkedDataContainer type="CollectionPage" seoTitle="Test Live Page" />
+      <LinkedDataContainer
+        type="CollectionPage"
+        seoTitle={pageTitle}
+        headline={pageTitle}
+      />
       <main>
         <Header
           showLiveLabel={isLive}

--- a/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/live.test.tsx
@@ -125,6 +125,27 @@ describe('Live Page', () => {
     },
   );
 
+  it.each`
+    title             | seoTitle             | info                      | expected
+    ${'I am a Title'} | ${'I am a seoTitle'} | ${'seoTitle'}             | ${'I am a seoTitle'}
+    ${'I am a Title'} | ${undefined}         | ${'title if no seoTitle'} | ${'I am a Title'}
+  `(
+    'should use $info as the schema headline',
+    async ({ title, seoTitle, expected }) => {
+      await act(async () => {
+        render(
+          <Live pageData={mockPageDataWithMetadata({ title, seoTitle })} />,
+        );
+      });
+
+      const schemaHeadline = Helmet.peek().scriptTags.find(({ innerHTML }) =>
+        innerHTML?.includes(`"headline":"${expected}"`),
+      );
+
+      expect(schemaHeadline).toBeTruthy();
+    },
+  );
+
   it('should use the title value combined with the pagination value as the page title', async () => {
     const paginatedData = {
       ...mockPageData,


### PR DESCRIPTION
Resolves JIRA [WSTEAM1-509](https://jira.dev.bbc.co.uk/browse/WSTEAM1-509) - SEO:'headline' Schema field to be populated by Title/SEO Title

Overall changes
======
Sets value for the schema Headline field for the Live Page

Code changes
======

- LinkedData component 'headline' prop takes seoTitle if it is provided, otherwise falls back to title.
- Adds a unit test (Is this a bit overkill?)

Testing
======

1. Pull down this branch, cd into ws-nextjs-app and use yarn dev to run locally.
2. Visit the following links and check the SEO by using the 'Detailed SEO extension'. Go to the Schema tab and find 'headline' field.

Should see seoTitle
http://localhost:7081/mundo/live/c448yp9nm96t
"seo": { "seoTitle": "This is an SEO title - a headline primarily for search - it should not appear on the page."}

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
