### PR TITLE
WSTEAM1:717: Add high contrast border

### DIFF
--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -2,10 +2,12 @@ import { css, Theme } from '@emotion/react';
 import pixelsToRem from '../../../../../../src/app/utilities/pixelsToRem';
 
 export default {
-  backgroundColor: ({ palette }: Theme) =>
+  backgroundColor: ({ palette, mq }: Theme) =>
     css({
       backgroundColor: palette.GREY_10,
-      borderBottom: `solid ${pixelsToRem(3)}rem transparent`,
+      [mq.HIGH_CONTRAST]: {
+        borderBottom: `solid ${pixelsToRem(3)}rem transparent`,
+      },
     }),
   outerGrid: ({ mq, gridWidths }: Theme) =>
     css({

--- a/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
+++ b/ws-nextjs-app/pages/[service]/live/[id]/Header/styles.tsx
@@ -5,6 +5,7 @@ export default {
   backgroundColor: ({ palette }: Theme) =>
     css({
       backgroundColor: palette.GREY_10,
+      borderBottom: `solid ${pixelsToRem(3)}rem transparent`,
     }),
   outerGrid: ({ mq, gridWidths }: Theme) =>
     css({

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -3,7 +3,12 @@
 exports[`Live Page creates snapshot of the live page 1`] = `
 .emotion-0 {
   background-color: #141414;
-  border-bottom: solid 0.1875rem transparent;
+}
+
+@media screen and (forced-colors: active) {
+  .emotion-0 {
+    border-bottom: solid 0.1875rem transparent;
+  }
 }
 
 .emotion-1 {

--- a/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
+++ b/ws-nextjs-app/pages/[service]/live/[id]/__snapshots__/live.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Live Page creates snapshot of the live page 1`] = `
 .emotion-0 {
   background-color: #141414;
+  border-bottom: solid 0.1875rem transparent;
 }
 
 .emotion-1 {


### PR DESCRIPTION
Resolves JIRA [WSTEAM-717](https://jira.dev.bbc.co.uk/browse/WSTEAM1-717)

Overall changes
======
Adds a border to the heading like so (only on high contrast):
<img width="1512" alt="Screenshot 2023-11-30 at 15 49 13" src="https://github.com/bbc/simorgh/assets/32307964/2a1548a9-f2b4-4798-993c-d6236e662d13">


Code changes
======

- _Minor CSS changes._

Testing
======
1. _Visit `/pidgin/live/c07zr0zwjnnt`._
2._Turn on user colour overrides._
3._Make sure that there is a border at the bottom of the Heading._ 

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
