### PR TITLE
Add missing latestMediaTitle property to Brasil config

### DIFF
--- a/src/app/lib/config/services/portuguese.ts
+++ b/src/app/lib/config/services/portuguese.ts
@@ -270,6 +270,7 @@ export const service: DefaultServiceConfig = {
       },
       topStoriesTitle: 'Principais notícias',
       featuresAnalysisTitle: 'Leia mais',
+      latestMediaTitle: 'Mais recentes',
     },
     mostRead: {
       header: 'Mais lidas',


### PR DESCRIPTION
Resolves JIRA [number]

Overall changes
======
Add missing latestMediaTitle property to Brasil config as the title of the latest videos onward journey module on video pages is showing in English as Latest.

Code changes
======

Property with relevant key/value pair added to src/app/lib/config/services/portuguese.ts

Testing
======
1. _List the steps used to test this PR._

Helpful Links
======
_Add Links to useful resources related to this PR if applicable._

[Coding Standards](https://github.com/bbc/simorgh/blob/latest/docs/Coding-Standards/README.md)

[Repository use guidelines](https://github.com/bbc/simorgh-infrastructure/blob/latest/documentation/repository-guidelines.md)
